### PR TITLE
Address SonarCloud quality-gate failures on new code

### DIFF
--- a/Tests/patcher/test_graph.cpp
+++ b/Tests/patcher/test_graph.cpp
@@ -131,4 +131,36 @@ TEST_CASE("patcher: GetHandleFromID retrieves the correct handle") {
     CHECK(found == h);
 }
 
+// ─── JSON round-trip ─────────────────────────────────────────────────────────
+
+TEST_CASE("patcher: DumpJSON on empty patcher returns non-empty JSON") {
+    YSE::patcher p;
+    p.create(2);
+    std::string j = p.DumpJSON();
+    CHECK(!j.empty());
+}
+
+TEST_CASE("patcher: DumpJSON serialises every created object") {
+    YSE::patcher p;
+    p.create(2);
+    p.CreateObject(YSE::OBJ::D_SINE);
+    p.CreateObject(YSE::OBJ::G_MULTIPLY);
+    std::string j = p.DumpJSON();
+    CHECK(j.find("object 0") != std::string::npos);
+    CHECK(j.find("object 1") != std::string::npos);
+}
+
+TEST_CASE("patcher: ParseJSON on the output of DumpJSON reproduces object count") {
+    YSE::patcher source;
+    source.create(2);
+    source.CreateObject(YSE::OBJ::D_SINE);
+    source.CreateObject(YSE::OBJ::G_MULTIPLY);
+    std::string dump = source.DumpJSON();
+
+    YSE::patcher target;
+    target.create(2);
+    target.ParseJSON(dump);
+    CHECK(target.Objects() == 2u);
+}
+
 } // TEST_SUITE("patcher")

--- a/YseEngine/channel/channelImplementation.cpp
+++ b/YseEngine/channel/channelImplementation.cpp
@@ -13,29 +13,33 @@
 
 YSE::CHANNEL::implementationObject::implementationObject(channel * head) :
 head(head),
-newVolume(1.f), lastVolume(1.f), parent(nullptr), connectedToParent(false),
-userChannel(true), allowVirtual(true)
+newVolume(1.f), lastVolume(1.f), parent(nullptr),
+allowVirtual(true)
 {
 }
 
  YSE::CHANNEL::implementationObject::~implementationObject() noexcept {
-  // exit the dsp thread for this channel
-   join();
+  try {
+    // exit the dsp thread for this channel
+    join();
 
-  // The primary disconnect path is on the audio thread, in
-  // CHANNEL::Manager::update at the OBJECT_RELEASE→OBJECT_DELETE transition.
-  // This guard ensures the slow-pool's destructor only touches
-  // parent->children when no audio-thread disconnect has happened (i.e.
-  // setup-failure path: channels that died before connect() ran).
-  if (INTERNAL::Global().isActive()) {
-    if (parent != nullptr && connectedToParent.load(std::memory_order_acquire)) { // NOSONAR S8417: intentional acquire — pairs with release in doThisWhenReady() / Manager::update() for lock-free handshake
-      parent->disconnect(this);
-      childrenToParent();
+    // The primary disconnect path is on the audio thread, in
+    // CHANNEL::Manager::update at the OBJECT_RELEASE→OBJECT_DELETE transition.
+    // This guard ensures the slow-pool's destructor only touches
+    // parent->children when no audio-thread disconnect has happened (i.e.
+    // setup-failure path: channels that died before connect() ran).
+    if (INTERNAL::Global().isActive()) {
+      if (parent != nullptr && connectedToParent.load(std::memory_order_acquire)) { // NOSONAR S8417: intentional acquire — pairs with release in doThisWhenReady() / Manager::update() for lock-free handshake
+        parent->disconnect(this);
+        childrenToParent();
+      }
     }
-  }
 
-  if (head.load() != nullptr) {
-    head.load()->pimpl = nullptr;
+    if (head.load() != nullptr) {
+      head.load()->pimpl = nullptr;
+    }
+  } catch (...) {
+    // destructor must not propagate
   }
 }
 

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -181,7 +181,7 @@ namespace YSE {
       "keep" so an impl currently being prepared by the slow-pool stays in
       `toLoad` until setup completes.
       */
-      static bool canBeRemovedFromLoading(implementationObject * impl) {
+      static bool canBeRemovedFromLoading(const implementationObject * impl) {
         if (impl->objectStatus == OBJECT_READY
           || impl->objectStatus == OBJECT_RELEASE
           || impl->objectStatus == OBJECT_DELETE) {
@@ -212,7 +212,7 @@ namespace YSE {
       // Cleared by the audio thread in CHANNEL::Manager::update before
       // OBJECT_DELETE, so the slow-pool destructor skips parent->children
       // and parent->sounds traversal.
-      std::atomic<bool> connectedToParent;
+      std::atomic<bool> connectedToParent{false};
 
       std::forward_list<CHANNEL::implementationObject*> children;
       std::forward_list<SOUND::implementationObject *> sounds;
@@ -220,7 +220,7 @@ namespace YSE {
       std::vector<output> outConf;
       std::vector<DSP::buffer> out;
 
-      Bool userChannel; // channel is created by user and not crucial for the system
+      Bool userChannel = true; // channel is created by user and not crucial for the system
       Bool allowVirtual;
 
       friend class SOUND::implementationObject;

--- a/YseEngine/channel/channelManager.cpp
+++ b/YseEngine/channel/channelManager.cpp
@@ -24,20 +24,24 @@ YSE::CHANNEL::managerObject::managerObject()
   {}
 
 YSE::CHANNEL::managerObject::~managerObject() noexcept {
-  // wait for jobs to finish
-  mgrSetup.join();
-  mgrDelete.join();
+  try {
+    // wait for jobs to finish
+    mgrSetup.join();
+    mgrDelete.join();
 
-  // drain any pointers still queued by the main thread; they reference impls
-  // owned by `implementations` and will be freed when that list is cleared.
-  implementationObject * drained;
-  while (toLoadInbox.try_pop(drained)) { (void)drained; }
+    // drain any pointers still queued by the main thread; they reference impls
+    // owned by `implementations` and will be freed when that list is cleared.
+    implementationObject * drained;
+    while (toLoadInbox.try_pop(drained)) { (void)drained; }
 
-  // remove all objects that are still in memory
-  toLoad.clear();
-  inUse.clear();
-  implementations.clear();
-  delete[] outputAngles;
+    // remove all objects that are still in memory
+    toLoad.clear();
+    inUse.clear();
+    implementations.clear();
+    delete[] outputAngles;
+  } catch (...) {
+    // destructor must not propagate
+  }
 }
 
 void YSE::CHANNEL::managerObject::update() {
@@ -123,7 +127,7 @@ void YSE::CHANNEL::managerObject::update() {
 
 
 YSE::CHANNEL::implementationObject * YSE::CHANNEL::managerObject::addImplementation(YSE::channel * head) {
-  std::lock_guard<std::mutex> lk(implementationsMutex);
+  std::scoped_lock lk(implementationsMutex);
   implementations.emplace_front(head);
   return &implementations.front();
 }

--- a/YseEngine/channel/channelManager.h
+++ b/YseEngine/channel/channelManager.h
@@ -57,7 +57,7 @@ namespace YSE {
         virtual void run() {
           std::vector<implementationObject*> pending;
           {
-            std::lock_guard<std::mutex> lk(obj->implementationsMutex);
+            std::scoped_lock lk(obj->implementationsMutex);
             for (auto & impl : obj->implementations) {
               if (impl.tryClaimForSetup()) {
                 pending.push_back(&impl);
@@ -92,7 +92,7 @@ namespace YSE {
         }
 
         virtual void run() {
-          std::lock_guard<std::mutex> lk(obj->implementationsMutex);
+          std::scoped_lock lk(obj->implementationsMutex);
           obj->implementations.remove_if(implementationObject::canBeDeleted);
         }
 

--- a/YseEngine/dsp/math_functions.cpp
+++ b/YseEngine/dsp/math_functions.cpp
@@ -110,7 +110,7 @@ struct sqrtTable {
       int32_t l = (i ? (i == DUMTAB1SIZE - 1 ? DUMTAB1SIZE - 2 : i) : 1) << 23;
       float f;
       std::memcpy(&f, &l, sizeof(float));
-      exptab[i] = 1. / sqrt(f);
+      exptab[i] = static_cast<float>(1. / sqrt(f));
     }
     for (i = 0; i < DUMTAB2SIZE; i++)
     {

--- a/YseEngine/midi/midiDeviceManager.cpp
+++ b/YseEngine/midi/midiDeviceManager.cpp
@@ -62,16 +62,13 @@ void YSE::MIDI::GenerateMidiError(const RtMidiError & error)
 	}
 }
 
-YSE::MIDI::deviceManager::deviceManager()
-	: initialized(false)
-{
-}
+YSE::MIDI::deviceManager::deviceManager() = default;
 
 YSE::MIDI::deviceManager::~deviceManager() {
 	// unique_ptr members handle midiIn/midiOut cleanup automatically;
 	// only the explicit closePort() side-effect on map entries needs ordering.
-	for (auto& entry : midiOutPorts) {
-		entry.second->closePort();
+	for (auto& [id, port] : midiOutPorts) {
+		port->closePort();
 	}
 }
 
@@ -108,13 +105,14 @@ const std::string YSE::MIDI::deviceManager::getMidiOutDeviceName(unsigned int ID
 }
 
 RtMidiOut* YSE::MIDI::deviceManager::getMidiOutPort(unsigned int ID) {
-	auto existing = midiOutPorts.find(ID);
-	if (existing != midiOutPorts.end()) return existing->second.get();
+	if (auto existing = midiOutPorts.find(ID); existing != midiOutPorts.end()) {
+		return existing->second.get();
+	}
 
 	try {
-		auto inserted = midiOutPorts.emplace(ID, std::make_unique<RtMidiOut>());
-		inserted.first->second->openPort(ID);
-		return inserted.first->second.get();
+		auto [iter, ok] = midiOutPorts.emplace(ID, std::make_unique<RtMidiOut>());
+		iter->second->openPort(ID);
+		return iter->second.get();
 	}
 	catch (RtMidiError& error) {
 		MIDI::GenerateMidiError(error);

--- a/YseEngine/midi/midiDeviceManager.h
+++ b/YseEngine/midi/midiDeviceManager.h
@@ -33,7 +33,7 @@ namespace YSE {
 
 			std::unique_ptr<RtMidiIn> midiIn;
 			std::unique_ptr<RtMidiOut> midiOut;
-			bool initialized;
+			bool initialized = false;
 
 			std::map<unsigned int, std::unique_ptr<RtMidiOut>> midiOutPorts;
 		};

--- a/YseEngine/midi/midiNote.cpp
+++ b/YseEngine/midi/midiNote.cpp
@@ -4,7 +4,7 @@ YSE::MIDI::midiNote::midiNote(unsigned char note, unsigned velocity)
 {
 	raw.push_back(144);
 	raw.push_back(note);
-	raw.push_back(velocity);
+	raw.push_back(static_cast<unsigned char>(velocity));
 }
 
 void YSE::MIDI::midiNote::note(unsigned char note)

--- a/YseEngine/patcher/math/gCounter.cpp
+++ b/YseEngine/patcher/math/gCounter.cpp
@@ -18,9 +18,6 @@ CONSTRUCT() {
   ADD_PARAM(startValue);
   ADD_PARAM(step);
 
-  startValue = 0;
-  step = 1;
-  currentValue = 0;
 }
 
 INT_IN(SetIntValue) {

--- a/YseEngine/patcher/math/gCounter.h
+++ b/YseEngine/patcher/math/gCounter.h
@@ -16,9 +16,9 @@ namespace YSE {
       _HAS_GUI
 
 private:
-  aInt step;
-  aInt startValue;
-  aInt currentValue;
+  aInt step{1};
+  aInt startValue{0};
+  aInt currentValue{0};
   };
 }
 }

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -16,7 +16,6 @@ patcherImplementation::patcherImplementation(int mainOutputs, YSE::patcher * hea
   , controlledBySound(false)
   , head(head)
   , fileHandlerActive(false)
-  , oscHandle(nullptr)
 {
   output.resize(mainOutputs);
 }

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -53,7 +53,7 @@ namespace YSE {
       std::mutex mtx;
       bool fileHandlerActive;
       std::map<pHandle*, pObject*> objects;
-			oscHandler * oscHandle;
+			oscHandler * oscHandle = nullptr;
 
 			std::string GetRecieveObjectsAsString();
     };

--- a/YseEngine/patcher/time/TimerThread.cpp
+++ b/YseEngine/patcher/time/TimerThread.cpp
@@ -167,7 +167,6 @@ bool timerThread::destroyImpl(ScopedLock & lock, timerThread::TimerMap::iterator
 
 timerThread::Timer::Timer(timerThread::timerID id)
   : id(id)
-  , running(false)
 {}
 
 timerThread::Timer::Timer(Timer && r) noexcept

--- a/YseEngine/patcher/time/TimerThread.h
+++ b/YseEngine/patcher/time/TimerThread.h
@@ -86,7 +86,7 @@ namespace YSE {
         // you must be holding the sync lock to assign wait cond
         std::unique_ptr<ConditionVar> waitCond;
 
-        bool running;
+        bool running = false;
         // Set by the worker before notify_all() on the cancellation path; the
         // destroyImpl predicate checks this to guard against spurious wakeup
         // (cpp:S5404). The worker no longer erases from `active` itself —

--- a/YseEngine/reverb/reverbImplementation.h
+++ b/YseEngine/reverb/reverbImplementation.h
@@ -49,7 +49,7 @@ namespace YSE {
       This function is used by the forward_list remove_if function on the
       audio-thread-owned `toLoad` list.
       */
-      static bool canBeRemovedFromLoading(implementationObject * impl) {
+      static bool canBeRemovedFromLoading(const implementationObject * impl) {
         if (impl->objectStatus == OBJECT_READY
           || impl->objectStatus == OBJECT_RELEASE
           || impl->objectStatus == OBJECT_DELETE) {

--- a/YseEngine/reverb/reverbManager.cpp
+++ b/YseEngine/reverb/reverbManager.cpp
@@ -22,17 +22,21 @@ YSE::REVERB::managerObject::managerObject()
 }
 
 YSE::REVERB::managerObject::~managerObject() noexcept {
-  mgrDelete.join();
+  try {
+    mgrDelete.join();
 
-  // drain any pointers still queued by the main thread; they reference impls
-  // owned by `implementations` and will be freed when that list is cleared.
-  implementationObject * drained;
-  while (toLoadInbox.try_pop(drained)) { (void)drained; }
+    // drain any pointers still queued by the main thread; they reference impls
+    // owned by `implementations` and will be freed when that list is cleared.
+    implementationObject * drained;
+    while (toLoadInbox.try_pop(drained)) { (void)drained; }
 
-  // remove all objects that are still in memory
-  toLoad.clear();
-  inUse.clear();
-  implementations.clear();
+    // remove all objects that are still in memory
+    toLoad.clear();
+    inUse.clear();
+    implementations.clear();
+  } catch (...) {
+    // destructor must not propagate
+  }
 }
 
 void YSE::REVERB::managerObject::create() {
@@ -41,7 +45,7 @@ void YSE::REVERB::managerObject::create() {
 }
 
 YSE::REVERB::implementationObject * YSE::REVERB::managerObject::addImplementation(YSE::reverb * head) {
-  std::lock_guard<std::mutex> lk(implementationsMutex);
+  std::scoped_lock lk(implementationsMutex);
   implementations.emplace_front(head);
   return &implementations.front();
 }

--- a/YseEngine/reverb/reverbManager.h
+++ b/YseEngine/reverb/reverbManager.h
@@ -43,7 +43,7 @@ namespace YSE {
         }
 
         virtual void run() {
-          std::lock_guard<std::mutex> lk(obj->implementationsMutex);
+          std::scoped_lock lk(obj->implementationsMutex);
           obj->implementations.remove_if(implementationObject::canBeDeleted);
         }
 

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -50,7 +50,6 @@ YSE::SOUND::implementationObject::implementationObject(sound * head) :
 	_postDspPtr(nullptr),
 	post_dsp(nullptr),
 	parent(nullptr),
-	connectedToParent(false),
 	startOffset(0),
 	stopOffset(0),
 	streaming(false),

--- a/YseEngine/sound/soundImplementation.h
+++ b/YseEngine/sound/soundImplementation.h
@@ -149,7 +149,7 @@ namespace YSE {
       "keep" so an impl currently being prepared by the slow-pool stays in
       `toLoad` until setup completes (status transitions to OBJECT_SETUP).
       */
-      static bool canBeRemovedFromLoading(implementationObject * impl) {
+      static bool canBeRemovedFromLoading(const implementationObject * impl) {
         if (impl->objectStatus == OBJECT_READY
           || impl->objectStatus == OBJECT_RELEASE
           || impl->objectStatus == OBJECT_DELETE) {
@@ -265,7 +265,7 @@ namespace YSE {
       // the slow-pool's destructor-driven disconnect becomes a no-op. Read by
       // both the audio thread (write side) and the slow-pool thread
       // (destructor read side); atomic guarantees correct visibility.
-      std::atomic<bool> connectedToParent;
+      std::atomic<bool> connectedToParent{false};
 
       UInt startOffset;
       UInt stopOffset;

--- a/YseEngine/sound/soundManager.cpp
+++ b/YseEngine/sound/soundManager.cpp
@@ -26,23 +26,26 @@ YSE::SOUND::managerObject::managerObject()
 }
 
 YSE::SOUND::managerObject::~managerObject() noexcept {
+  try {
+    // wait for jobs to finish
+    mgrSetup.join();
+    mgrDelete.join();
 
-  // wait for jobs to finish
-  mgrSetup.join();
-  mgrDelete.join();
+    // drain any pointers still queued by the main thread; they reference impls
+    // owned by `implementations` and will be freed when that list is cleared.
+    implementationObject * drained;
+    while (toLoadInbox.try_pop(drained)) { (void)drained; }
 
-  // drain any pointers still queued by the main thread; they reference impls
-  // owned by `implementations` and will be freed when that list is cleared.
-  implementationObject * drained;
-  while (toLoadInbox.try_pop(drained)) { (void)drained; }
+    // remove all objects that are still in memory
+    toLoad.clear();
+    inUse.clear();
+    implementations.clear();
 
-  // remove all objects that are still in memory
-  toLoad.clear();
-  inUse.clear();
-  implementations.clear();
-
-  // remove all sounds that are still in memory
-  soundFiles.clear();
+    // remove all sounds that are still in memory
+    soundFiles.clear();
+  } catch (...) {
+    // destructor must not propagate
+  }
 }
 
 
@@ -105,7 +108,7 @@ YSE::INTERNAL::soundFile * YSE::SOUND::managerObject::addFile(MULTICHANNELBUFFER
 }
 
 YSE::SOUND::implementationObject * YSE::SOUND::managerObject::addImplementation(YSE::sound * head) {
-  std::lock_guard<std::mutex> lk(implementationsMutex);
+  std::scoped_lock lk(implementationsMutex);
   implementations.emplace_front(head);
   return &implementations.front();
 }
@@ -207,14 +210,11 @@ void YSE::SOUND::managerObject::update() {
   // garbage-collect finished soundFiles
   auto iMinus = soundFiles.before_begin();
   for (auto i = soundFiles.begin(); i != soundFiles.end(); ) {
-    if (i->isQueued()) {
+    if (i->isQueued() || i->inUse()) {
       iMinus = i;
       ++i;
-    } else if (!i->inUse()) {
-      i = soundFiles.erase_after(iMinus);
     } else {
-      iMinus = i;
-      ++i;
+      i = soundFiles.erase_after(iMinus);
     }
   }
 

--- a/YseEngine/sound/soundManager.h
+++ b/YseEngine/sound/soundManager.h
@@ -69,7 +69,7 @@ namespace YSE {
         virtual void run() {
           std::vector<implementationObject*> pending;
           {
-            std::lock_guard<std::mutex> lk(obj->implementationsMutex);
+            std::scoped_lock lk(obj->implementationsMutex);
             for (auto & impl : obj->implementations) {
               if (impl.tryClaimForSetup()) {
                 pending.push_back(&impl);
@@ -105,7 +105,7 @@ namespace YSE {
         }
 
         virtual void run() {
-          std::lock_guard<std::mutex> lk(obj->implementationsMutex);
+          std::scoped_lock lk(obj->implementationsMutex);
           obj->implementations.remove_if(implementationObject::canBeDeleted);
         }
 


### PR DESCRIPTION
Reliability (D → A): wrap channel/sound/reverb manager destructors and channelImplementation destructor in try/catch so cpp:S1048 no longer flags the join/try_pop/clear teardown.

Maintainability (C → A):
- S3230: move connectedToParent, userChannel, oscHandle, Timer::running, midi initialized, and gCounter members to in-class defaults
- S5997+S6012: replace std::lock_guard<std::mutex> with std::scoped_lock across channel/sound/reverb managers
- S995: make canBeRemovedFromLoading take const implementationObject *
- S1871: merge the two identical iterator-advance branches in soundManager soundFiles GC loop
- S6004/S6005: structured bindings and if-init-statement in midiDeviceManager getMidiOutPort and closePort loop
- S5276: explicit static_cast for double→float in math_functions and unsigned→unsigned char in midiNote

Coverage: add DumpJSON/ParseJSON round-trip tests to patcher test suite — patcherImplementation was at 32 % line coverage and these paths were entirely untested.