### PR TITLE
system: expose active sample rate / buffer size / output latency

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(YSE_TEST_SOURCES
   music/test_motif.cpp
   listener/test_listener.cpp
   io/test_bufferIO.cpp
+  system/test_system_active_state.cpp
   integration/test_device.cpp
 )
 
@@ -180,6 +181,13 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_io PROPERTIES LABELS io)
+
+add_test(
+  NAME    yse_tests_system
+  COMMAND yse_tests --test-suite=system
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_system PROPERTIES LABELS system)
 
 # Concurrency stress tests for the SOUND/CHANNEL/REVERB managers.  These live
 # in the sound/channel/reverb test suites but each test case name starts with

--- a/Tests/system/test_system_active_state.cpp
+++ b/Tests/system/test_system_active_state.cpp
@@ -1,0 +1,146 @@
+// Tests for the YSE::system live device-state getters
+// (Phase B of dart-yse#2 engine support, tracked in
+//  yvanvds/yse-soundengine#51).
+//
+// Covers:
+//   - Active sample rate / buffer size / output latency report 0 when the
+//     audio device is closed (paused) and positive values when an audio
+//     callback is running.
+//   - C++ getters and the C API mirror agree on the same values.
+//
+// The engine state is a process-static singleton. engineInit() opens the
+// device synchronously then calls pause() — which on the PortAudio backend
+// is implemented by close() — so all three live getters read 0 in that
+// state. engineInitWithAudio() then resumes (re-opens) the device, after
+// which sample rate and output latency are populated immediately; buffer
+// size is populated on the first audio callback. We pump the engine for a
+// few sleep+update cycles before reading buffer size.
+//
+// On CI without an audio device, engineInit() returns false and every test
+// case bails out — doctest counts that as a pass.
+
+#include <doctest/doctest.h>
+#include "yse.hpp"
+#include "yse_c/yse_system.h"
+#include "support/null_device.hpp"
+
+namespace
+{
+
+// Pump update + sleep a few times so the first audio callback can fire and
+// the buffer-size atomic gets populated.
+void waitForCallback(int iterations = 5, unsigned int sleepMs = 20)
+{
+    for (int i = 0; i < iterations; ++i)
+    {
+        YSE::System().sleep(sleepMs);
+        YSE::System().update();
+    }
+}
+
+} // namespace
+
+TEST_SUITE("system")
+{
+
+// ─── Paused-engine baseline: all three getters report 0 ─────────────────────
+
+TEST_CASE("system: active sample rate is 0 while engine is paused")
+{
+    if (!TestHelpers::engineInit()) return;
+    // engineInit() leaves the device closed via pause(); the live getter
+    // gates on the device's open flag and reports 0.
+    CHECK(YSE::System().getActiveSampleRate() == doctest::Approx(0.0));
+}
+
+TEST_CASE("system: active buffer size is 0 while engine is paused")
+{
+    if (!TestHelpers::engineInit()) return;
+    CHECK(YSE::System().getActiveBufferSize() == 0);
+}
+
+TEST_CASE("system: active output latency is 0 while engine is paused")
+{
+    if (!TestHelpers::engineInit()) return;
+    CHECK(YSE::System().getActiveOutputLatency() == 0);
+}
+
+// ─── Resumed engine: live values become positive ─────────────────────────────
+
+TEST_CASE("system: active sample rate is positive after resuming audio")
+{
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+    CHECK(YSE::System().getActiveSampleRate() > 0.0);
+}
+
+TEST_CASE("system: active output latency is positive after resuming audio")
+{
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+    // PortAudio's negotiated output latency is multiplied by SAMPLERATE in
+    // the manager — for any realistic device this lands well above zero.
+    CHECK(YSE::System().getActiveOutputLatency() > 0);
+}
+
+TEST_CASE("system: active buffer size is positive after at least one audio callback")
+{
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+    waitForCallback();
+    // If the audio thread never fired (some CI runners), skip the assertion
+    // rather than reporting a flake.
+    if (YSE::System().missedCallbacks() != 0) return;
+    CHECK(YSE::System().getActiveBufferSize() > 0);
+}
+
+// ─── Latency-in-samples sanity: round-trip ms calc fits a believable range ──
+
+TEST_CASE("system: active output latency yields a believable ms value")
+{
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+    const double rate = YSE::System().getActiveSampleRate();
+    const int    samples = YSE::System().getActiveOutputLatency();
+    if (rate <= 0.0 || samples <= 0) return;
+    const double ms = (double)samples / rate * 1000.0;
+    // A real device should produce *some* latency but nowhere near a second.
+    CHECK(ms > 0.0);
+    CHECK(ms < 1000.0);
+}
+
+// ─── C API mirror agrees with the C++ getters ────────────────────────────────
+
+TEST_CASE("system: C API getActiveSampleRate mirrors the C++ value")
+{
+    if (!TestHelpers::engineInit()) return;
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    CHECK(yse_system_get_active_sample_rate(sys)
+          == doctest::Approx(YSE::System().getActiveSampleRate()));
+}
+
+TEST_CASE("system: C API getActiveBufferSize mirrors the C++ value")
+{
+    if (!TestHelpers::engineInit()) return;
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    CHECK(yse_system_get_active_buffer_size(sys) == YSE::System().getActiveBufferSize());
+}
+
+TEST_CASE("system: C API getActiveOutputLatency mirrors the C++ value")
+{
+    if (!TestHelpers::engineInit()) return;
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    CHECK(yse_system_get_active_output_latency(sys) == YSE::System().getActiveOutputLatency());
+}
+
+TEST_CASE("system: C API getters return 0 on a NULL system handle")
+{
+    CHECK(yse_system_get_active_sample_rate(nullptr) == doctest::Approx(0.0));
+    CHECK(yse_system_get_active_buffer_size(nullptr) == 0);
+    CHECK(yse_system_get_active_output_latency(nullptr) == 0);
+}
+
+} // TEST_SUITE("system")

--- a/YseEngine/c_api/include/yse_c/yse_system.h
+++ b/YseEngine/c_api/include/yse_c/yse_system.h
@@ -35,6 +35,14 @@ YSE_C_API void       yse_system_resume(YseSystem* sys);
 YSE_C_API int        yse_system_missed_callbacks(YseSystem* sys);
 YSE_C_API float      yse_system_cpu_load(YseSystem* sys);
 
+/* Live state of the currently open audio device. Returns 0 when no device
+   is open (pre-init, after close, or initOffline path). Buffer size is the
+   device's frames-per-callback, NOT the engine block size. Output latency
+   is in samples; convert to ms with (latency / sample_rate) * 1000. */
+YSE_C_API double     yse_system_get_active_sample_rate(YseSystem* sys);
+YSE_C_API int        yse_system_get_active_buffer_size(YseSystem* sys);
+YSE_C_API int        yse_system_get_active_output_latency(YseSystem* sys);
+
 /* Convenience. */
 YSE_C_API void       yse_system_sleep(YseSystem* sys, unsigned int ms);
 

--- a/YseEngine/c_api/yse_system.cpp
+++ b/YseEngine/c_api/yse_system.cpp
@@ -107,6 +107,21 @@ YSE_C_API float yse_system_cpu_load(YseSystem* sys) {
   return to_cpp(sys)->cpuLoad();
 }
 
+YSE_C_API double yse_system_get_active_sample_rate(YseSystem* sys) {
+  if (!sys) return 0.0;
+  return to_cpp(sys)->getActiveSampleRate();
+}
+
+YSE_C_API int yse_system_get_active_buffer_size(YseSystem* sys) {
+  if (!sys) return 0;
+  return to_cpp(sys)->getActiveBufferSize();
+}
+
+YSE_C_API int yse_system_get_active_output_latency(YseSystem* sys) {
+  if (!sys) return 0;
+  return to_cpp(sys)->getActiveOutputLatency();
+}
+
 YSE_C_API void yse_system_sleep(YseSystem* sys, unsigned int ms) {
   if (!sys) return;
   to_cpp(sys)->sleep(ms);

--- a/YseEngine/device/androidDeviceManager.cpp
+++ b/YseEngine/device/androidDeviceManager.cpp
@@ -84,5 +84,20 @@ void YSE::DEVICE::managerObject::close() {
   //YSE::Log().sendMessage("androidDeviceManager: Close done");
 }
 
+double YSE::DEVICE::managerObject::getActiveSampleRate() const {
+  return open ? (double)implementation.getNegotiatedSampleRate() : 0.0;
+}
+
+int YSE::DEVICE::managerObject::getActiveBufferSize() const {
+  return open ? implementation.getNegotiatedBufferSize() : 0;
+}
+
+int YSE::DEVICE::managerObject::getActiveOutputLatency() const {
+  if (!open) return 0;
+  const int32_t ms   = implementation.getNegotiatedOutputLatencyMs();
+  const int32_t rate = implementation.getNegotiatedSampleRate();
+  return (int)((double)ms * (double)rate / 1000.0);
+}
+
 
 #endif

--- a/YseEngine/device/androidDeviceManager.h
+++ b/YseEngine/device/androidDeviceManager.h
@@ -29,6 +29,11 @@ namespace YSE {
       virtual void openDevice(const YSE::deviceSetup & object);
       virtual void addCallback();
 
+      // Live device-state getters (see deviceManager.h for contract).
+      virtual double getActiveSampleRate()    const;
+      virtual int    getActiveBufferSize()    const;
+      virtual int    getActiveOutputLatency() const;
+
     private:
 
       OboeImplementation implementation;

--- a/YseEngine/device/deviceManager.h
+++ b/YseEngine/device/deviceManager.h
@@ -47,6 +47,20 @@ namespace YSE {
          for testing.
       */
 	  virtual Flt cpuLoad() { return 0.f; };
+
+      /* Live values for the currently open audio device. All three return
+         0 when no device is open — host applications can use that to drive
+         "device disconnected" UI states. Sample rate is the engine's
+         negotiated rate (typically YSE::SAMPLERATE) cast to double for ABI
+         stability across the C interface. Buffer size is the device's
+         frames-per-callback (PortAudio's framesPerBuffer / Oboe's
+         framesPerBurst), NOT YSE::STANDARD_BUFFERSIZE — they may differ.
+         Output latency is reported in samples (frames) to match the existing
+         YSE::device descriptor unit; convert to ms with
+         (latency / sampleRate * 1000) on the consumer side. */
+      virtual double getActiveSampleRate()    const { return 0.0; }
+      virtual int    getActiveBufferSize()    const { return 0; }
+      virtual int    getActiveOutputLatency() const { return 0; }
       
       /* this method should populate the devices vector.
       */

--- a/YseEngine/device/oboeImplementation.cpp
+++ b/YseEngine/device/oboeImplementation.cpp
@@ -82,6 +82,19 @@ unsigned int OboeImplementation::GetCallbacksSinceLastUpdate() {
   return callbacksSinceLastUpdate.exchange(0);
 }
 
+int32_t OboeImplementation::getNegotiatedBufferSize() const {
+  return mStream ? mStream->getFramesPerBurst() : 0;
+}
+
+int32_t OboeImplementation::getNegotiatedOutputLatencyMs() const {
+  if (!mStream) return 0;
+  auto result = mStream->calculateLatencyMillis();
+  // result is a ResultWithValue<double>; only return the value when the
+  // underlying calculation succeeded (some streams report ErrorUnimplemented
+  // when the hardware can't sample timestamps).
+  return result ? (int32_t)result.value() : 0;
+}
+
 oboe::DataCallbackResult OboeImplementation::onAudioReady(oboe::AudioStream * /*stream*/,
                                                           void * audioData,
                                                           int32_t numFrames) {

--- a/YseEngine/device/oboeImplementation.h
+++ b/YseEngine/device/oboeImplementation.h
@@ -25,6 +25,10 @@ public:
 
   int32_t getNegotiatedSampleRate() const { return negotiatedSampleRate; }
 
+  // Live values queried from the open Oboe stream; 0 when no stream is open.
+  int32_t getNegotiatedBufferSize() const;
+  int32_t getNegotiatedOutputLatencyMs() const;
+
   oboe::DataCallbackResult onAudioReady(oboe::AudioStream * stream,
                                         void * audioData,
                                         int32_t numFrames) override;

--- a/YseEngine/device/portaudioDeviceManager.cpp
+++ b/YseEngine/device/portaudioDeviceManager.cpp
@@ -47,6 +47,14 @@ int YSE::DEVICE::managerObject::paCallback(
   YSE::DEVICE::managerObject * manager = (YSE::DEVICE::managerObject *)userData;
 	manager->callbacksSinceLastUpdate++;
 
+  // PortAudio is opened with paFramesPerBufferUnspecified — capture whatever
+  // framesPerBuffer the backend negotiated on the first callback so the live
+  // getter can report it. Relaxed: any callback after the first will overwrite
+  // with the same value when the device is stable.
+  if (manager->activeBufferSize.load(std::memory_order_relaxed) == 0) {
+    manager->activeBufferSize.store((int)numSamples, std::memory_order_release);
+  }
+
   if (!manager->doOnCallback(numSamples)) return 0;
 
   UInt pos = 0;
@@ -151,6 +159,13 @@ void YSE::DEVICE::managerObject::addCallback() {
     return;
   } else open = true;
 
+  // Cache the negotiated output latency in samples for the live API.
+  if (const PaStreamInfo * sinfo = Pa_GetStreamInfo(stream)) {
+    activeOutputLatencySamples.store(
+      (int)(sinfo->outputLatency * (double)SAMPLERATE),
+      std::memory_order_release);
+  }
+
   err = Pa_StartStream(stream);
   if (err != paNoError) {
     audioDeviceError(err);
@@ -181,6 +196,10 @@ void YSE::DEVICE::managerObject::close() {
     }
     open = false;
   }
+
+  // No active device — the live getters report 0 until the next open.
+  activeBufferSize.store(0, std::memory_order_release);
+  activeOutputLatencySamples.store(0, std::memory_order_release);
 }
 
 void YSE::DEVICE::managerObject::terminate() {
@@ -287,6 +306,17 @@ void YSE::DEVICE::managerObject::openDevice(const YSE::deviceSetup & object) {
   }
   else open = true;
 
+  // Cache live device state. When the caller pinned a non-zero bufferSize we
+  // can populate it immediately; otherwise the first paCallback captures it.
+  if (object.bufferSize != 0) {
+    activeBufferSize.store((int)object.bufferSize, std::memory_order_release);
+  }
+  if (const PaStreamInfo * sinfo = Pa_GetStreamInfo(stream)) {
+    activeOutputLatencySamples.store(
+      (int)(sinfo->outputLatency * (double)SAMPLERATE),
+      std::memory_order_release);
+  }
+
   err = Pa_StartStream(stream);
   if (err != paNoError) {
     audioDeviceError(err);
@@ -304,6 +334,20 @@ Flt YSE::DEVICE::managerObject::cpuLoad() {
     return (Flt)Pa_GetStreamCpuLoad(stream);
   }
   return 0.f;
+}
+
+double YSE::DEVICE::managerObject::getActiveSampleRate() const {
+  // SAMPLERATE retains its last value across close(); gate on the open flag so
+  // consumers see a clean "no device" → 0 transition.
+  return open ? (double)SAMPLERATE : 0.0;
+}
+
+int YSE::DEVICE::managerObject::getActiveBufferSize() const {
+  return activeBufferSize.load(std::memory_order_acquire);
+}
+
+int YSE::DEVICE::managerObject::getActiveOutputLatency() const {
+  return activeOutputLatencySamples.load(std::memory_order_acquire);
 }
 
 #endif // PORTAUDIO_BACKEND

--- a/YseEngine/device/portaudioDeviceManager.h
+++ b/YseEngine/device/portaudioDeviceManager.h
@@ -41,6 +41,11 @@ namespace YSE {
         virtual void openDevice(const YSE::deviceSetup & object);
         virtual void addCallback();
 
+        // Live device-state getters (see deviceManager.h for contract).
+        virtual double getActiveSampleRate()    const;
+        virtual int    getActiveBufferSize()    const;
+        virtual int    getActiveOutputLatency() const;
+
         static int paCallback(
                 const void *input
                 , void *output
@@ -59,6 +64,12 @@ namespace YSE {
         bool initDone, open, started;
 
         std::atomic<unsigned int> callbacksSinceLastUpdate;
+
+        // Cached live device state, populated post-Pa_OpenStream and reset on
+        // close(). Buffer size is captured on the first paCallback invocation
+        // because we open the stream with paFramesPerBufferUnspecified.
+        std::atomic<int> activeBufferSize{0};
+        std::atomic<int> activeOutputLatencySamples{0};
     };
 
     managerObject & Manager();

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -160,6 +160,18 @@ Flt YSE::system::cpuLoad() {
   return DEVICE::Manager().cpuLoad();
 }
 
+double YSE::system::getActiveSampleRate() {
+  return DEVICE::Manager().getActiveSampleRate();
+}
+
+int YSE::system::getActiveBufferSize() {
+  return DEVICE::Manager().getActiveBufferSize();
+}
+
+int YSE::system::getActiveOutputLatency() {
+  return DEVICE::Manager().getActiveOutputLatency();
+}
+
 void YSE::system::sleep(unsigned int ms) {
 #if defined YSE_WINDOWS
   Sleep(ms);

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -210,6 +210,33 @@ namespace YSE {
      */
     float cpuLoad();
 
+    /// @name Active device readouts
+    /// Live state of the currently open audio device. Each returns 0 when no
+    /// device is open (pre-init, after ``close()``, or under ``initOffline()``).
+    /// Host applications use these to render device-info UI without having to
+    /// re-enumerate ``YSE::device`` descriptors, and to survive device
+    /// reconnects cleanly.
+    /// @{
+
+    /** @brief Currently negotiated sample rate in Hz. */
+    double getActiveSampleRate();
+
+    /** @brief Currently negotiated audio buffer size in frames.
+     *
+     *  This is the device's frames-per-callback (PortAudio's
+     *  ``framesPerBuffer`` / Oboe's ``framesPerBurst``) — NOT the engine's
+     *  internal ``STANDARD_BUFFERSIZE``, which may differ.
+     */
+    int getActiveBufferSize();
+
+    /** @brief Currently negotiated output latency in samples.
+     *
+     *  Convert to milliseconds with ``(latency / sampleRate) * 1000``.
+     */
+    int getActiveOutputLatency();
+
+    /// @}
+
     /** @brief Sleep the calling thread for ``ms`` milliseconds.
      *
      *  Convenience for console applications that don't otherwise yield


### PR DESCRIPTION
## Summary
- Adds three live device-state getters on `YSE::system` (sample rate, buffer size, output latency in samples) plus C API mirrors so host applications can render audio info UI against the running engine without re-enumerating `YSE::device` descriptors.
- Each backend (PortAudio + Oboe) caches its negotiated values at device open and resets to 0 on close — the abstract `DEVICE::managerObject` declares the three virtual getters with 0-returning defaults so the offline path trivially conforms.
- Output latency is reported in samples to match the existing `YSE::device.outputLatency` unit; convert to ms with `(samples / rate) * 1000`.

## What changed
**PortAudio**
- `activeBufferSize` captured on the first `paCallback` (we open the stream with `paFramesPerBufferUnspecified`).
- `activeOutputLatencySamples` read from `Pa_GetStreamInfo` after `Pa_OpenStream`, converted seconds → samples.
- `getActiveSampleRate()` gates on the existing `open` flag so a closed device reports 0 even though `YSE::SAMPLERATE` retains its last value.

**Oboe (Android)**
- `OboeImplementation` exposes the negotiated buffer size (`getFramesPerBurst`) and latency (`calculateLatencyMillis`).
- `androidDeviceManager` converts ms → samples for the C API and gates every getter on its open flag.

## Test plan
- [x] `python yse.py build` — clean
- [x] `python yse.py test` — 100% pass (14 suites; new `system` suite added)
- [x] `Tests/system/test_system_active_state.cpp` — 11 new cases covering paused-engine baseline (all three return 0), resumed-engine state (sample rate / latency positive immediately, buffer size positive after first callback), believable ms round-trip, and C API parity with the C++ getters
- [x] Audio-dependent cases skip gracefully when `engineInitWithAudio` fails (CI without device)
- [ ] Manual smoke on Android (Oboe backend untested locally — desktop CI doesn't cover the Oboe path)

Closes the engine-side blocker for part 1 of:
- yvanvds/dart-yse#2
- #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)