### PR TITLE
c_api: replace mutex with atomics in log callback bridge; add YSE_C_CALLBACK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ session start. Pair with [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md).
 ## How we work
 
 1. **Issues first.** Every bug, feature, or enhancement is filed as a
-   GitHub issue *before* code is written. Branch from `master` as
-   `<issue-number>-<short-slug>`. PR through CI. The only exception is a
-   trivial doc fix.
+   GitHub issue *before* code is written. Branch from `dev` as
+   `<issue-number>-<short-slug>` and PR back to `dev`. `dev` is the
+   integration branch; periodic PRs from `dev` to `master` cut releases.
+   The only exception is a trivial doc fix.
 2. **Tests where sensible** (not dogmatically). DSP nodes, the C API
    surface, lifecycle/threading code, and reverb get tests first. Demos
    and one-off scripts don't need tests. The broader plan lives in

--- a/YseEngine/c_api/include/yse_c/yse_common.h
+++ b/YseEngine/c_api/include/yse_c/yse_common.h
@@ -25,6 +25,16 @@
   #endif
 #endif
 
+/* Calling-convention marker for callback function pointer typedefs that
+   the engine invokes across the C ABI. Made explicit on Windows so the
+   ABI is unambiguous across compilers (MSVC, Clang, MinGW); a no-op on
+   x64 / ARM64 / non-Windows where only one C calling convention exists. */
+#if defined(_WIN32) || defined(_WIN64)
+  #define YSE_C_CALLBACK __cdecl
+#else
+  #define YSE_C_CALLBACK
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/YseEngine/c_api/include/yse_c/yse_log.h
+++ b/YseEngine/c_api/include/yse_c/yse_log.h
@@ -36,7 +36,7 @@ YSE_C_API size_t        yse_log_get_logfile(YseLog* log, char* buf, size_t cap);
 /* The receiver OWNS msg and must release it with yse_log_free_message
    when finished. The pointer is allocated with malloc by the bridge so
    any C client can free() it directly if preferred. */
-typedef void (*YseLogCallback)(char* msg, void* user_data);
+typedef void (YSE_C_CALLBACK *YseLogCallback)(char* msg, void* user_data);
 
 /* Replaces the default file sink. Pass NULL for cb to restore the default.
    user_data is opaque — forwarded to every callback invocation. */

--- a/YseEngine/c_api/include/yse_c/yse_midi.h
+++ b/YseEngine/c_api/include/yse_c/yse_midi.h
@@ -70,20 +70,20 @@ YSE_C_API void         yse_midi_out_raw3(YseMidiOut* m, unsigned char a, unsigne
 
 /* Raw-bytes callback. `bytes` is malloc'd by the engine; the receiver owns
    it and must release with yse_midi_in_free_message. Length is in bytes. */
-typedef void (*YseMidiInRawCallback)(double               timestamp_sec,
-                                     unsigned char*       bytes,
-                                     size_t               len,
-                                     void*                user_data);
+typedef void (YSE_C_CALLBACK *YseMidiInRawCallback)(double               timestamp_sec,
+                                                    unsigned char*       bytes,
+                                                    size_t               len,
+                                                    void*                user_data);
 
 /* Parsed callback. status/channel are pre-split from the first byte; data1
    and data2 are zero for messages shorter than 3 bytes. No ownership
    transfer. */
-typedef void (*YseMidiInParsedCallback)(double               timestamp_sec,
-                                        unsigned char        status,
-                                        unsigned char        channel,
-                                        unsigned char        data1,
-                                        unsigned char        data2,
-                                        void*                user_data);
+typedef void (YSE_C_CALLBACK *YseMidiInParsedCallback)(double               timestamp_sec,
+                                                       unsigned char        status,
+                                                       unsigned char        channel,
+                                                       unsigned char        data1,
+                                                       unsigned char        data2,
+                                                       void*                user_data);
 
 YSE_C_API YseMidiIn*   yse_midi_in_create(void);
 YSE_C_API void         yse_midi_in_destroy(YseMidiIn* m);

--- a/YseEngine/c_api/yse_log.cpp
+++ b/YseEngine/c_api/yse_log.cpp
@@ -4,9 +4,9 @@
 #include "../log.hpp"
 #include "../headers/enums.hpp"
 
+#include <atomic>
 #include <cstdlib>
 #include <cstring>
-#include <mutex>
 #include <string>
 
 namespace {
@@ -25,30 +25,33 @@ namespace {
 
   // Bridge from YSE's virtual logHandler to a C function pointer.
   // Only one bridge instance exists for the singleton Log(); installing
-  // a new callback replaces the slot. The mutex serialises installation
-  // against the audio / engine threads that may be calling AddMessage.
+  // a new callback replaces the slot. The callback + user_data pair lives
+  // as atomics so AddMessage (called from whichever thread emitted the
+  // log) never blocks on installer state — mirrors the pattern used by
+  // the midiIn raw bridge in yse_midi.cpp. See issue #58.
   class CallbackBridge : public YSE::logHandler {
   public:
     void install(YseLogCallback cb, void* user_data) {
-      std::lock_guard<std::mutex> lock(mu);
-      this->cb = cb;
-      this->user_data = user_data;
+      // Publish user_data first; AddMessage gates on a non-null cb, so
+      // any reader that observes the new cb is guaranteed to also see
+      // the matching user_data via the acquire/release pair.
+      this->user_data.store(user_data, std::memory_order_release);
+      this->cb.store(cb, std::memory_order_release);
     }
     void AddMessage(const std::string& msg) override {
-      YseLogCallback fn;
-      void* ud;
-      {
-        std::lock_guard<std::mutex> lock(mu);
-        fn = cb;
-        ud = user_data;
-      }
+      auto fn = cb.load(std::memory_order_acquire);
       if (!fn) return;
+      auto ud = user_data.load(std::memory_order_acquire);
       // Strings passed across NativeCallable.listener bridges to Dart
       // are marshalled by pointer value, not deep copy — by the time
       // the Dart handler runs, the std::string backing this pointer
       // has long been destroyed. Allocate a fresh malloc'd copy that
       // the receiver is contractually obliged to release via
       // yse_log_free_message.
+      //
+      // malloc on this path is acceptable today because log emits never
+      // originate on the audio callback. If that ever changes, this
+      // bridge needs a preallocated message pool — see issue #62.
       char* copy = static_cast<char*>(std::malloc(msg.size() + 1));
       if (!copy) return;
       std::memcpy(copy, msg.c_str(), msg.size());
@@ -56,9 +59,8 @@ namespace {
       fn(copy, ud);
     }
   private:
-    std::mutex mu;
-    YseLogCallback cb = nullptr;
-    void* user_data = nullptr;
+    std::atomic<YseLogCallback> cb{nullptr};
+    std::atomic<void*>          user_data{nullptr};
   };
 
   CallbackBridge& bridge() {


### PR DESCRIPTION
## Summary

- Replace `std::mutex` in the log callback bridge (`yse_log.cpp`) with `std::atomic<>` swap — same release/acquire pattern the MIDI input bridge already uses. Log emits can fire from any engine thread; a control-thread `yse_log_set_callback` no longer blocks them and vice versa.
- Add `YSE_C_CALLBACK` macro to `yse_common.h`; apply to `YseLogCallback`, `YseMidiInRawCallback`, `YseMidiInParsedCallback`. `__cdecl` on Windows (pins the C default explicitly so MSVC/Clang/MinGW agree), no-op elsewhere.
- Update CLAUDE.md "branch from `master`" → "branch from `dev`" to match actual workflow.

The per-message `malloc` stays — required by Dart's `NativeCallable.listener` ownership contract, safe today because emits never originate on the audio callback. Tracked in #62 if that ever changes.

Closes #58.

## Test plan

- [x] `python yse.py build` — clean (246/246 targets)
- [x] `python yse.py test` — 14/14 CTest entries pass
- [ ] dart-yse smoke test (log handler + MIDI in) — recommend running once before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)