### PR TITLE
c_api: add static_assert drift guard for the enum mirror

### DIFF
--- a/YseEngine/c_api/CMakeLists.txt
+++ b/YseEngine/c_api/CMakeLists.txt
@@ -23,6 +23,7 @@ set(YSE_C_API_SRCS
   yse_music.cpp
   yse_log.cpp
   yse_buffer_io.cpp
+  yse_enums_check.cpp
 )
 list(TRANSFORM YSE_C_API_SRCS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
 

--- a/YseEngine/c_api/yse_enums_check.cpp
+++ b/YseEngine/c_api/yse_enums_check.cpp
@@ -1,0 +1,85 @@
+/*
+  yse_enums_check.cpp — compile-time drift guard between the C enum mirror
+  (yse_c/yse_enums.h) and the underlying YSE engine enums.
+
+  Folded into yse_objects but exports nothing. Any static_assert failure
+  here means yse_enums.h is out of sync with the engine — update one
+  side or the other and re-build. See issue #61.
+*/
+
+#include "yse_c/yse_enums.h"
+
+#include "../headers/enums.hpp"
+#include "../dsp/lfo.hpp"
+#include "../dsp/modules/filters/sweep.hpp"
+#include "../dsp/modules/delay/basicDelay.hpp"
+
+namespace {
+
+#define YSE_ASSERT_ENUM(c_value, cpp_value)                             \
+  static_assert(static_cast<int>(c_value) ==                            \
+                static_cast<int>(cpp_value),                            \
+                "C ABI enum drift: " #c_value " != " #cpp_value         \
+                " — update yse_c/yse_enums.h or the engine enum")
+
+// YseChannelType ↔ YSE::CHANNEL_TYPE
+YSE_ASSERT_ENUM(YSE_CT_AUTO,    YSE::CT_AUTO);
+YSE_ASSERT_ENUM(YSE_CT_MONO,    YSE::CT_MONO);
+YSE_ASSERT_ENUM(YSE_CT_STEREO,  YSE::CT_STEREO);
+YSE_ASSERT_ENUM(YSE_CT_QUAD,    YSE::CT_QUAD);
+YSE_ASSERT_ENUM(YSE_CT_51,      YSE::CT_51);
+YSE_ASSERT_ENUM(YSE_CT_51SIDE,  YSE::CT_51SIDE);
+YSE_ASSERT_ENUM(YSE_CT_61,      YSE::CT_61);
+YSE_ASSERT_ENUM(YSE_CT_71,      YSE::CT_71);
+YSE_ASSERT_ENUM(YSE_CT_CUSTOM,  YSE::CT_CUSTOM);
+
+// YseErrorLevel ↔ YSE::ERROR_LEVEL
+YSE_ASSERT_ENUM(YSE_EL_NONE,    YSE::EL_NONE);
+YSE_ASSERT_ENUM(YSE_EL_ERROR,   YSE::EL_ERROR);
+YSE_ASSERT_ENUM(YSE_EL_WARNING, YSE::EL_WARNING);
+YSE_ASSERT_ENUM(YSE_EL_DEBUG,   YSE::EL_DEBUG);
+
+// YseOutType ↔ YSE::OUT_TYPE
+YSE_ASSERT_ENUM(YSE_OUT_INVALID, YSE::INVALID);
+YSE_ASSERT_ENUM(YSE_OUT_BANG,    YSE::BANG);
+YSE_ASSERT_ENUM(YSE_OUT_FLOAT,   YSE::FLOAT);
+YSE_ASSERT_ENUM(YSE_OUT_INT,     YSE::INT);
+YSE_ASSERT_ENUM(YSE_OUT_BUFFER,  YSE::BUFFER);
+YSE_ASSERT_ENUM(YSE_OUT_LIST,    YSE::LIST);
+YSE_ASSERT_ENUM(YSE_OUT_ANY,     YSE::ANY);
+
+// YseLfoType ↔ YSE::DSP::LFO_TYPE
+YSE_ASSERT_ENUM(YSE_LFO_NONE,         YSE::DSP::LFO_NONE);
+YSE_ASSERT_ENUM(YSE_LFO_SAW,          YSE::DSP::LFO_SAW);
+YSE_ASSERT_ENUM(YSE_LFO_SAW_REVERSED, YSE::DSP::LFO_SAW_REVERSED);
+YSE_ASSERT_ENUM(YSE_LFO_TRIANGLE,     YSE::DSP::LFO_TRIANGLE);
+YSE_ASSERT_ENUM(YSE_LFO_SINE,         YSE::DSP::LFO_SINE);
+YSE_ASSERT_ENUM(YSE_LFO_SQUARE,       YSE::DSP::LFO_SQUARE);
+YSE_ASSERT_ENUM(YSE_LFO_RANDOM,       YSE::DSP::LFO_RANDOM);
+
+// YseDspSweepShape ↔ YSE::DSP::MODULES::sweepFilter::SHAPE
+YSE_ASSERT_ENUM(YSE_SWEEP_TRIANGLE, YSE::DSP::MODULES::sweepFilter::TRIANGLE);
+YSE_ASSERT_ENUM(YSE_SWEEP_SAW,      YSE::DSP::MODULES::sweepFilter::SAW);
+YSE_ASSERT_ENUM(YSE_SWEEP_SQUARE,   YSE::DSP::MODULES::sweepFilter::SQUARE);
+
+// YseDspDelayTap ↔ YSE::DSP::MODULES::basicDelay::DELAY_NR
+YSE_ASSERT_ENUM(YSE_DELAY_TAP_FIRST,  YSE::DSP::MODULES::basicDelay::FIRST);
+YSE_ASSERT_ENUM(YSE_DELAY_TAP_SECOND, YSE::DSP::MODULES::basicDelay::SECOND);
+YSE_ASSERT_ENUM(YSE_DELAY_TAP_THIRD,  YSE::DSP::MODULES::basicDelay::THIRD);
+
+// YseReverbPreset ↔ YSE::REVERB_PRESET
+YSE_ASSERT_ENUM(YSE_REVERB_OFF,        YSE::REVERB_OFF);
+YSE_ASSERT_ENUM(YSE_REVERB_GENERIC,    YSE::REVERB_GENERIC);
+YSE_ASSERT_ENUM(YSE_REVERB_PADDED,     YSE::REVERB_PADDED);
+YSE_ASSERT_ENUM(YSE_REVERB_ROOM,       YSE::REVERB_ROOM);
+YSE_ASSERT_ENUM(YSE_REVERB_BATHROOM,   YSE::REVERB_BATHROOM);
+YSE_ASSERT_ENUM(YSE_REVERB_STONEROOM,  YSE::REVERB_STONEROOM);
+YSE_ASSERT_ENUM(YSE_REVERB_LARGEROOM,  YSE::REVERB_LARGEROOM);
+YSE_ASSERT_ENUM(YSE_REVERB_HALL,       YSE::REVERB_HALL);
+YSE_ASSERT_ENUM(YSE_REVERB_CAVE,       YSE::REVERB_CAVE);
+YSE_ASSERT_ENUM(YSE_REVERB_SEWERPIPE,  YSE::REVERB_SEWERPIPE);
+YSE_ASSERT_ENUM(YSE_REVERB_UNDERWATER, YSE::REVERB_UNDERWATER);
+
+#undef YSE_ASSERT_ENUM
+
+} // namespace


### PR DESCRIPTION
## Summary

- New TU `YseEngine/c_api/yse_enums_check.cpp`, added to `YSE_C_API_SRCS` in `c_api/CMakeLists.txt`.
- Contains no exported symbols — only `static_assert` pairs that pin each `Yse*` enum value (in `yse_c/yse_enums.h`) to its underlying engine equivalent. Covers `YseChannelType`, `YseErrorLevel`, `YseOutType`, `YseLfoType`, `YseDspSweepShape`, `YseDspDelayTap`, `YseReverbPreset`.
- Any silent change to either side now fails the build with a self-describing diagnostic naming both names involved.

Closes #61.

## Test plan

- [x] `python yse.py build` — clean (the new TU compiles at step 7/36; all asserts pass).
- [x] Spot-check: deliberately mismatch one assert locally, build fails with the named pair (verified, not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)