### PR TITLE
c_api: document the callback-bridge rules in yse_c_internal.hpp

### DIFF
--- a/YseEngine/c_api/CMakeLists.txt
+++ b/YseEngine/c_api/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Included from YseEngine/CMakeLists.txt via include() AFTER yse_objects has
 # been defined; never add_subdirectory()'d (the goal is to extend an existing
 # target, not create a new one).
+#
+# Adding a new callback that the engine invokes on a non-host thread?
+# Read the "Callback bridge rules" block at the top of yse_c_internal.hpp
+# first. The short version: atomic-swap callback pointer (no mutex), no
+# malloc on audio-callback-reachable paths, YSE_C_CALLBACK on the typedef.
 
 set(YSE_C_API_SRCS
   yse_common.cpp

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -1,6 +1,46 @@
 /*
   yse_c_internal.hpp — private helpers shared across the c_api translation units.
   Not installed; never included by Dart or any C ABI consumer.
+
+  ─── Callback bridge rules ───────────────────────────────────────────────────
+
+  Several C API entry points install user-provided C function pointers that
+  the engine then invokes from a non-host thread (audio callback, RtMidi
+  input thread, future occlusion / dspSourceObject / customFileReader paths).
+  These bridges sit on RT-sensitive paths even when they don't realise it.
+
+  The canonical pattern lives in yse_midi.cpp's c_raw_bridge. Any new bridge
+  must follow the same rules:
+
+    1. Callback + user_data live as std::atomic<>. Install stores both with
+       release ordering (user_data first, then cb); dispatch loads with
+       acquire ordering (cb first, returns if null, then user_data). No
+       mutex, no lock_guard.
+
+    2. No malloc / new / std::string / container ops on the dispatch path
+       when the bridge can fire from the audio callback. For occlusion and
+       dspSourceObject, pass values by stack copy. For raw byte buffers
+       (file reader, MIDI raw), preallocate a per-handle pool — do not
+       malloc per call.
+
+       The current log + MIDI raw bridges allocate a malloc'd copy because
+       Dart's NativeCallable.listener marshals by pointer value (the
+       std::string / std::vector backing dies before the Dart handler
+       runs). That's acceptable today because neither path lives on the
+       audio callback. If an audio-callback emit is ever wired up, those
+       bridges must switch to a preallocated pool.
+
+    3. Public callback typedefs in the include/yse_c headers use the
+       YSE_C_CALLBACK macro (from yse_common.h) so the calling convention
+       is unambiguous across compilers — __cdecl on Win32, no-op elsewhere.
+
+    4. When the bridge transfers ownership of a heap buffer to the host
+       (e.g. MIDI raw bytes, log strings), pair the callback with a
+       yse_<module>_free_message function so the host can release it.
+       Document the contract in the header next to the typedef.
+
+    5. Never throw across the C ABI boundary. Wrap any C++ surface that
+       can throw in try/catch and translate to YseStatus + set_last_error.
 */
 
 #pragma once


### PR DESCRIPTION
## Summary

- New "Callback bridge rules" block at the head of `YseEngine/c_api/yse_c_internal.hpp` listing the five rules a new C-API callback bridge must follow (atomic-swap pointer, no malloc on audio-callback paths, `YSE_C_CALLBACK` on the typedef, free-pair contract for heap buffers, no throws across the boundary).
- `YseEngine/c_api/CMakeLists.txt` top-of-file note points contributors at the block.
- No code change; just convention documentation. Lands before the audio-thread-reachable callbacks (occlusion, dspSourceObject, customFileReader) are wired up so they don't repeat the mutex+malloc shape that issue #58 had to fix.

Closes #62.

## Test plan

- [x] `python yse.py build` — clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)