### PR TITLE
c_api: document the void-returning null-safe-no-op convention

### DIFF
--- a/YseEngine/c_api/include/yse_c/yse_channel.h
+++ b/YseEngine/c_api/include/yse_c/yse_channel.h
@@ -3,6 +3,10 @@
   C ABI mirror of YseEngine/channel/channelInterface.hpp (YSE::channel + pre-built
   free-function accessors ChannelMaster, ChannelFX, ChannelMusic, ChannelAmbient,
   ChannelVoice, ChannelGui).
+
+  Convention: every void-returning function in this header is a null-safe
+  no-op when called with a NULL handle. Status queries (is_valid, get_*)
+  return 0 / false / NULL on NULL.
 */
 
 #ifndef YSE_C_CHANNEL_H_INCLUDED

--- a/YseEngine/c_api/include/yse_c/yse_patcher.h
+++ b/YseEngine/c_api/include/yse_c/yse_patcher.h
@@ -11,6 +11,10 @@
 
   Object type identifiers are the same strings YSE::OBJ exposes
   ("~sine", ".+", "~lp", etc.). See patcher/pObjectList.hpp upstream.
+
+  Convention: every void-returning function in this header is a null-safe
+  no-op when called with a NULL handle (patcher or phandle). Status
+  queries return 0 / false / NULL on NULL.
 */
 
 #ifndef YSE_C_PATCHER_H_INCLUDED

--- a/YseEngine/c_api/include/yse_c/yse_reverb.h
+++ b/YseEngine/c_api/include/yse_c/yse_reverb.h
@@ -8,6 +8,10 @@
     - Borrowed: yse_system_get_global_reverb() → YseReverb*. Never destroy.
                 The global reverb is the fallback wherever no positioned zone
                 reaches; rolled-off positioned zones mix against it.
+
+  Convention: every void-returning function in this header is a null-safe
+  no-op when called with a NULL handle. Status queries return 0 / false on
+  NULL.
 */
 
 #ifndef YSE_C_REVERB_H_INCLUDED

--- a/YseEngine/c_api/include/yse_c/yse_sound.h
+++ b/YseEngine/c_api/include/yse_c/yse_sound.h
@@ -2,6 +2,11 @@
   yse_sound.h — playable audio source.
   C ABI mirror of YseEngine/sound/soundInterface.hpp (YSE::sound).
   M1 scope: file-based create only. Buffer/DSP-source/patcher overloads land in M3/M5.
+
+  Convention: every void-returning function in this header is a null-safe
+  no-op when called with a NULL handle. Status queries return 0 / false
+  on NULL. Loads that can fail return YseStatus and populate
+  yse_last_error() on failure.
 */
 
 #ifndef YSE_C_SOUND_H_INCLUDED

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -1,6 +1,16 @@
 /*
   yse_c_internal.hpp — private helpers shared across the c_api translation units.
   Not installed; never included by Dart or any C ABI consumer.
+
+  C API conventions (apply to all new functions):
+
+    - Void-returning state-change functions (play / pause / stop, setters,
+      etc.) are null-safe no-ops when called with a NULL handle. Status
+      queries that return int / float / pointer return zero / false / NULL
+      on NULL handles.
+    - Functions that can fail meaningfully (file load, create, parse) use
+      YseStatus and populate yse_last_error() on failure.
+    - Document any deviation from these defaults explicitly in the header.
 */
 
 #pragma once


### PR DESCRIPTION
## Summary

- Top-of-header note added to `yse_sound.h`, `yse_channel.h`, `yse_reverb.h`, `yse_patcher.h`: every `void`-returning function in the header is a null-safe no-op; status queries return zero on NULL.
- `yse_c_internal.hpp` gains a "C API conventions" block restating the rule for new contributors.
- Doc-only — no ABI change. Promotion of individual functions to `YseStatus` is deferred to a future PR if a Dart consumer hits real ambiguity.

Closes #60.

## Test plan

- [x] `python yse.py build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)