### PR TITLE
c_api: document handle ownership consistently across public headers

### DIFF
--- a/YseEngine/c_api/include/yse_c/yse_buffer_io.h
+++ b/YseEngine/c_api/include/yse_c/yse_buffer_io.h
@@ -17,6 +17,7 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_buffer_io_destroy. */
 typedef struct YseBufferIO YseBufferIO;
 
 /* store_copy=1 copies the supplied bytes; store_copy=0 keeps a pointer

--- a/YseEngine/c_api/include/yse_c/yse_channel.h
+++ b/YseEngine/c_api/include/yse_c/yse_channel.h
@@ -15,6 +15,9 @@ extern "C"
 {
 #endif
 
+	/* Owned via yse_channel_create — release with yse_channel_destroy.
+	   Borrowed via the yse_channel_master / _fx / _music / _ambient /
+	   _voice / _gui pre-built accessors — never destroy those. */
 	typedef struct YseChannel YseChannel;
 
 	/* Pre-built channels — borrowed pointers, never destroy. */

--- a/YseEngine/c_api/include/yse_c/yse_common.h
+++ b/YseEngine/c_api/include/yse_c/yse_common.h
@@ -49,6 +49,10 @@ typedef struct yse_pos_t {
 
 YSE_C_API const char* yse_version(void);
 
+/* Returns the last error message recorded on the calling thread (the
+   slot is thread-local). The returned pointer is valid until the next
+   yse_* call from the same thread; copy the string if you need to hold
+   onto it. Empty string when no error has been recorded. */
 YSE_C_API const char* yse_last_error(void);
 YSE_C_API void        yse_clear_last_error(void);
 

--- a/YseEngine/c_api/include/yse_c/yse_device.h
+++ b/YseEngine/c_api/include/yse_c/yse_device.h
@@ -21,7 +21,10 @@
 extern "C" {
 #endif
 
+/* Borrowed — read-only descriptor enumerated from the engine via
+   yse_system_get_device(). Never destroy. */
 typedef struct YseDevice      YseDevice;
+/* Owned — release with yse_device_setup_destroy. */
 typedef struct YseDeviceSetup YseDeviceSetup;
 
 /* Device descriptor — read-only. */

--- a/YseEngine/c_api/include/yse_c/yse_dsp.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp.h
@@ -22,6 +22,9 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_dsp_buffer_destroy. Covers all four buffer
+   subclasses (plain, drawable, file, wavetable); the same destroy frees
+   the correct backing storage via dynamic_cast. */
 typedef struct YseDspBuffer YseDspBuffer;
 
 /* Constructors — one per subclass. The returned handle owns its native

--- a/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
@@ -21,6 +21,8 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_dsp_object_destroy. Covers every effect
+   subclass via the shared handle type. */
 typedef struct YseDspObject YseDspObject;
 
 /* ─── constructors ────────────────────────────────────────────────────── */

--- a/YseEngine/c_api/include/yse_c/yse_listener.h
+++ b/YseEngine/c_api/include/yse_c/yse_listener.h
@@ -12,6 +12,8 @@
 extern "C" {
 #endif
 
+/* Borrowed singleton — owned by the engine, never destroy.
+   Obtain via yse_listener_get(). */
 typedef struct YseListener YseListener;
 
 /* Borrowed singleton pointer — never destroy. */

--- a/YseEngine/c_api/include/yse_c/yse_log.h
+++ b/YseEngine/c_api/include/yse_c/yse_log.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif
 
+/* Borrowed singleton — owned by the engine, never destroy.
+   Obtain via yse_log_get(). */
 typedef struct YseLog YseLog;
 
 YSE_C_API YseLog*       yse_log_get(void);

--- a/YseEngine/c_api/include/yse_c/yse_midi.h
+++ b/YseEngine/c_api/include/yse_c/yse_midi.h
@@ -28,9 +28,13 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_midi_file_destroy. */
 typedef struct YseMidiFile YseMidiFile;
+/* Owned — release with yse_midi_out_destroy. */
 typedef struct YseMidiOut  YseMidiOut;
+/* Owned — release with yse_midi_in_destroy. */
 typedef struct YseMidiIn   YseMidiIn;
+/* Owned — release with yse_midi_note_destroy. */
 typedef struct YseMidiNote YseMidiNote;
 
 /* ─── standard MIDI file playback ─────────────────────────────────── */

--- a/YseEngine/c_api/include/yse_c/yse_music.h
+++ b/YseEngine/c_api/include/yse_c/yse_music.h
@@ -22,10 +22,15 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_note_destroy. */
 typedef struct YseNote   YseNote;
+/* Owned — release with yse_pnote_destroy. */
 typedef struct YsePNote  YsePNote;
+/* Owned — release with yse_scale_destroy. */
 typedef struct YseScale  YseScale;
+/* Owned — release with yse_motif_destroy. */
 typedef struct YseMotif  YseMotif;
+/* Owned — release with yse_player_destroy. */
 typedef struct YsePlayer YsePlayer;
 
 /* ─── note ────────────────────────────────────────────────────────── */

--- a/YseEngine/c_api/include/yse_c/yse_patcher.h
+++ b/YseEngine/c_api/include/yse_c/yse_patcher.h
@@ -23,7 +23,11 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_patcher_destroy. */
 typedef struct YsePatcher YsePatcher;
+/* Borrowed — owned by the parent YsePatcher. Release with
+   yse_patcher_delete_object(patcher, handle); never call a destroy on
+   the handle directly. */
 typedef struct YsePHandle YsePHandle;
 
 /* ─── patcher lifecycle ────────────────────────────────────────────── */

--- a/YseEngine/c_api/include/yse_c/yse_reverb.h
+++ b/YseEngine/c_api/include/yse_c/yse_reverb.h
@@ -20,6 +20,8 @@
 extern "C" {
 #endif
 
+/* Owned via yse_reverb_create — release with yse_reverb_destroy.
+   Borrowed via yse_system_get_global_reverb — never destroy that. */
 typedef struct YseReverb YseReverb;
 
 /* Owned reverb zone — yse_reverb_create() runs both the C++ constructor

--- a/YseEngine/c_api/include/yse_c/yse_sound.h
+++ b/YseEngine/c_api/include/yse_c/yse_sound.h
@@ -13,7 +13,10 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_sound_destroy. */
 typedef struct YseSound      YseSound;
+/* Forward declarations — see yse_channel.h / yse_dsp.h / yse_dsp_modules.h /
+   yse_patcher.h for ownership semantics. */
 typedef struct YseChannel    YseChannel;
 typedef struct YseDspBuffer  YseDspBuffer;
 typedef struct YseDspObject  YseDspObject;

--- a/YseEngine/c_api/include/yse_c/yse_system.h
+++ b/YseEngine/c_api/include/yse_c/yse_system.h
@@ -13,7 +13,11 @@
 extern "C" {
 #endif
 
+/* Borrowed singleton — owned by the engine, never destroy.
+   Obtain via yse_system_get(). */
 typedef struct YseSystem  YseSystem;
+/* Forward declarations — see yse_channel.h / yse_reverb.h / yse_device.h
+   for ownership semantics. */
 typedef struct YseChannel YseChannel;
 typedef struct YseReverb  YseReverb;
 typedef struct YseDevice  YseDevice;

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -1,6 +1,22 @@
 /*
   yse_c_internal.hpp — private helpers shared across the c_api translation units.
   Not installed; never included by Dart or any C ABI consumer.
+
+  Handle ownership convention: every opaque Yse* typedef in the public
+  headers carries a one-line ownership comment of one of these shapes:
+
+    - "Owned — release with yse_<module>_destroy."
+      Pair every yse_<module>_create with the corresponding destroy. The
+      C API never frees these for you.
+
+    - "Borrowed — owned by <source>, never destroy."
+      Singletons (yse_system_get, yse_listener_get, yse_log_get), pre-built
+      channels, device descriptors enumerated from the engine, and pHandles
+      that belong to a parent YsePatcher. Calling the home destroy on these
+      is undefined behaviour.
+
+  When adding a new opaque type, follow the same shape so Dart's finaliser
+  bookkeeping stays straight.
 */
 
 #pragma once

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -13,7 +13,7 @@
       Singletons (yse_system_get, yse_listener_get, yse_log_get), pre-built
       channels, device descriptors enumerated from the engine, and pHandles
       that belong to a parent YsePatcher. Calling the home destroy on these
-       is undefined behaviour.
+       is undefined behavior.
 
   When adding a new opaque type, follow the same shape so Dart's finaliser
   bookkeeping stays straight.

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -13,7 +13,7 @@
       Singletons (yse_system_get, yse_listener_get, yse_log_get), pre-built
       channels, device descriptors enumerated from the engine, and pHandles
       that belong to a parent YsePatcher. Calling the home destroy on these
-  is undefined behaviour.
+       is undefined behaviour.
 
   When adding a new opaque type, follow the same shape so Dart's finaliser
   bookkeeping stays straight.


### PR DESCRIPTION
## Summary

- One-line ownership comment above every opaque `Yse*` typedef in its home header:
  - **Owned** (release with the matching `yse_<module>_destroy`): `YseSound`, `YseChannel` (via `_create`), `YseReverb` (via `_create`), `YsePatcher`, `YseMidiFile`/`Out`/`In`/`Note`, `YseDspBuffer`, `YseDspObject`, `YseDeviceSetup`, `YseNote`/`PNote`/`Scale`/`Motif`/`Player`, `YseBufferIO`.
  - **Borrowed** (never destroy): `YseSystem`, `YseListener`, `YseLog` (singletons); `YseDevice` (engine-enumerated descriptor); `YsePHandle` (owned by parent `YsePatcher`); `YseChannel` via `yse_channel_master`/`_fx`/etc.; `YseReverb` via `yse_system_get_global_reverb`.
- `yse_last_error` documented: pointer valid until the next `yse_*` call from the same thread.
- `yse_c_internal.hpp` gains a "Handle ownership convention" block so the rule survives author turnover.
- Forward-declaration typedefs (`YseChannel` in `yse_sound.h`, etc.) point readers to the home header rather than duplicating the ownership line.

Doc-only — no ABI change.

Closes #59.

## Test plan

- [x] `python yse.py build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)