### PR TITLE
Enable FTZ/DAZ in audio callbacks (fixes #53)

### DIFF
--- a/YseEngine/device/oboeImplementation.cpp
+++ b/YseEngine/device/oboeImplementation.cpp
@@ -4,6 +4,7 @@
 
 #include "../implementations/logImplementation.h"
 #include "../internalHeaders.h"
+#include "../internal/denormalGuard.h"
 
 OboeImplementation::OboeImplementation()
   : bufferPos(YSE::STANDARD_BUFFERSIZE)
@@ -98,6 +99,7 @@ int32_t OboeImplementation::getNegotiatedOutputLatencyMs() const {
 oboe::DataCallbackResult OboeImplementation::onAudioReady(oboe::AudioStream * /*stream*/,
                                                           void * audioData,
                                                           int32_t numFrames) {
+  YSE::INTERNAL::enableFlushToZero();
   ++callbacksSinceLastUpdate;
 
   float * dest = static_cast<float *>(audioData);

--- a/YseEngine/device/portaudioDeviceManager.cpp
+++ b/YseEngine/device/portaudioDeviceManager.cpp
@@ -12,6 +12,7 @@
 
 #include "portaudioDeviceManager.h"
 #include "internalHeaders.h"
+#include "internal/denormalGuard.h"
 #ifdef __WINDOWS__
 #include "pa_asio.h"
 #endif
@@ -44,6 +45,7 @@ int YSE::DEVICE::managerObject::paCallback(
   , const PaStreamCallbackTimeInfo* /*timeInfo*/
   , PaStreamCallbackFlags /*statusFlags*/
   , void * userData) {
+  YSE::INTERNAL::enableFlushToZero();
   YSE::DEVICE::managerObject * manager = (YSE::DEVICE::managerObject *)userData;
 	manager->callbacksSinceLastUpdate++;
 

--- a/YseEngine/internal/denormalGuard.h
+++ b/YseEngine/internal/denormalGuard.h
@@ -1,0 +1,50 @@
+/*
+  ==============================================================================
+
+    denormalGuard.h
+    Flush-to-zero / denormals-are-zero for the audio thread.
+
+    Without this, any IIR feedback path (one-pole filters, reverb tails) can
+    decay into subnormal floats which slow x86/ARM FPU arithmetic by 10-100x,
+    pegging the audio callback at high CPU even when the graph is effectively
+    silent. See issue #53.
+
+    Call enableFlushToZero() once at the top of every audio callback. It is a
+    single MXCSR / FPCR write (per-thread state). Re-setting on every callback
+    is safe and keeps us robust to backends that recycle callback threads.
+
+  ==============================================================================
+*/
+
+#ifndef DENORMAL_GUARD_H_INCLUDED
+#define DENORMAL_GUARD_H_INCLUDED
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+  #include <pmmintrin.h>
+  #include <xmmintrin.h>
+#elif defined(__aarch64__) || defined(__arm__)
+  #include <cstdint>
+#endif
+
+namespace YSE { namespace INTERNAL {
+
+inline void enableFlushToZero() {
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+  _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+  _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+#elif defined(__aarch64__)
+  std::uint64_t fpcr;
+  asm volatile("mrs %0, fpcr" : "=r"(fpcr));
+  fpcr |= (std::uint64_t(1) << 24);
+  asm volatile("msr fpcr, %0" : : "r"(fpcr));
+#elif defined(__arm__)
+  std::uint32_t fpscr;
+  asm volatile("vmrs %0, fpscr" : "=r"(fpscr));
+  fpscr |= (std::uint32_t(1) << 24);
+  asm volatile("vmsr fpscr, %0" : : "r"(fpscr));
+#endif
+}
+
+}}
+
+#endif


### PR DESCRIPTION
Closes #53.

## Summary

- Adds `YSE::INTERNAL::enableFlushToZero()` in a new
  [internal/denormalGuard.h](YseEngine/internal/denormalGuard.h)
- Calls it at the top of both audio-thread entry points:
  [paCallback](YseEngine/device/portaudioDeviceManager.cpp) and
  [onAudioReady](YseEngine/device/oboeImplementation.cpp)

Without FTZ/DAZ, any IIR feedback path can decay into subnormal floats
once its input goes silent, and subnormal arithmetic slows x86/ARM FPUs
by 10-100x. Issue #53 measured the PortAudio callback pegging at ~50%
CPU after `AudioTest(false)` (vs. ~19% while actively playing) — the
classic signature of `realOnePole::lastSample` decaying into the
denormal range.

This is fix option 1 from the issue: cheapest blast radius, also
protects every other IIR/reverb in the user graph, not just AudioTest.
Per-thread MXCSR / FPCR state is set on every callback — a single
register write that is robust to backends recycling callback threads.

x86, ARM64 and ARM32 paths are covered; non-supported architectures
fall through to a no-op (header still compiles).

## Test plan

- [x] `python yse.py build` — clean on Windows MSYS2 Clang64
- [ ] Repro from yvanvds/phi#15: confirm CPU drops back to idle after
  `AudioTest(false)` on Windows WASAPI
- [ ] Smoke test Android build (Oboe path) — header compiles for both
  aarch64 and armv7

🤖 Generated with [Claude Code](https://claude.com/claude-code)