### PR TITLE
dsp: rebuild lfo tables when size diverges from SAMPLERATE (#48)

### DIFF
--- a/YseEngine/dsp/lfo.cpp
+++ b/YseEngine/dsp/lfo.cpp
@@ -19,9 +19,14 @@ YSE::DSP::fileBuffer LfoSineTable(0);
 
 YSE::DSP::lfo::lfo() : cursor(0.f), previousType(LFO_NONE) {
   result = 1;
-  if (LfoSawTable.getLength() == 0) {
-    // This is the first lfo object in use.
-    // Initialize all lookup tables now.
+  // Rebuild the static tables whenever their size diverges from the live
+  // SAMPLERATE. On Android with Oboe, SAMPLERATE can be overwritten when the
+  // device stream opens (e.g. 44100 → 48000 on a Pixel 7), and the per-sample
+  // wrap math reads the current SAMPLERATE — so tables sized at an earlier
+  // rate read past their end. The rebuild runs on the control thread (every
+  // lfo() caller is control-thread); audio-thread readers only race during
+  // operator(), never during construction.
+  if (LfoSawTable.getLength() != SAMPLERATE) {
     LfoSawTable.resize(SAMPLERATE);
     LfoSawTable.drawLine(0, SAMPLERATE - 200, 1.f, 0.f);
     LfoSawTable.drawLine(SAMPLERATE - 200, SAMPLERATE, 0.f, 1.f);
@@ -122,9 +127,12 @@ YSE::DSP::buffer & YSE::DSP::lfo::operator()(LFO_TYPE type, Flt frequency, UInt 
       Flt * out = result.getPtr();
       Flt * in = LfoSawTable.getPtr();
       while (samplesToProcess) {
+        // Wrap before the cast: (UInt)negative-float is implementation-
+        // defined and on arm64 produces a huge index that reads past the
+        // table (SIGSEGV on Android, garbage > 1.0 elsewhere).
+        if (cursor < 0) cursor += SAMPLERATE;
         *out++ = in[(UInt)cursor];
         cursor -= frequency;
-        if (cursor < 0) cursor += SAMPLERATE;
         samplesToProcess--;
       }
       break;


### PR DESCRIPTION
## Summary

- Fix issue #48: LFO_SAW_REVERSED SIGSEGV on Pixel 7 Pro caused by lookup tables sized at one SAMPLERATE while per-sample wrap math reads a different one.
- Constructor guard changed from "tables empty" to "tables size != SAMPLERATE", so the next ``lfo()`` after a rate change rebuilds them at the current rate. Safe: every ``lfo()`` caller is control-thread.
- Defensive wrap-before-cast in ``LFO_SAW_REVERSED`` — ``(UInt)negative-float`` is implementation-defined and arm64 can produce a huge index.

This is the minimum change to stop the crash. The broader "treat SAMPLERATE as a first-class session-locked setting" refactor (lock contract, reverb tuning cleanup, hardcoded-literal sweep, test parameterization, CI matrix at 48 kHz) will follow as a separate issue.

## Test plan

- [x] Desktop: ``python yse.py test`` — 14/14 passing.
- [x] Pixel 7 Pro / Android 16 / Oboe @ device rate: APK reinstalled, NativeActivity run, full doctest suite runs to completion. **Before:** crash after 58 cases (LFO_SAW_REVERSED SIGSEGV). **After:** 795 cases run, 788 pass, 7 fail — all 7 are SAMPLERATE-assumption failures already scoped in the follow-up plan (ADSR timing at line 140/151, sine periodicity at 32/42, Oboe-reports-active-device-state at 53/59/83).
- [ ] Reviewer to sanity-check that rebuilding the tables on rate change can't race with audio-thread reads in practice — the argument is that ``lfo()`` constructors only run on the control thread and audio-thread readers are read-only.