### PR TITLE
engine: lock SAMPLERATE per session; rate-agnostic tests + CI matrix (#72)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,13 @@ jobs:
           build-wrapper-linux-x86-64 --out-dir "$BUILD_WRAPPER_OUT_DIR" cmake --build build
       - name: Run tests
         run: ctest --test-dir build --output-on-failure
+      - name: Run tests at forced 48 kHz
+        # Cross-checks that DSP code and tests are rate-agnostic. Honoured by
+        # Tests/main.cpp:applyForcedSampleRateFromEnv() which writes
+        # YSE::SAMPLERATE before any DSP object is constructed. See #72.
+        env:
+          YSE_TEST_FORCED_RATE: "48000"
+        run: ctest --test-dir build --output-on-failure
       - name: Generate coverage report
         run: |
           gcovr \

--- a/Demo.Windows.Native/Demo10_FilePosition.cpp
+++ b/Demo.Windows.Native/Demo10_FilePosition.cpp
@@ -34,50 +34,50 @@ void DemoFilePosition::ExplainDemo()
 
 void DemoFilePosition::Zero()
 {
-  sound.time(11.2f * 44100);
+  sound.time(11.2f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::One()
 {
-  sound.time(10.0f * 44100);
+  sound.time(10.0f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Two()
 {
-  sound.time(9.0f * 44100);
+  sound.time(9.0f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Three()
 {
-  sound.time(8.0f * 44100);
+  sound.time(8.0f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Four()
 {
-  sound.time(6.7f * 44100);
+  sound.time(6.7f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Five()
 {
-  sound.time(5.5f * 44100);
+  sound.time(5.5f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Six()
 {
-  sound.time(4.3f * 44100);
+  sound.time(4.3f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Seven()
 {
-  sound.time(3.2f * 44100);
+  sound.time(3.2f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Eight()
 {
-  sound.time(2.0f * 44100);
+  sound.time(2.0f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Nine()
 {
-  sound.time(1.0f * 44100);
+  sound.time(1.0f * YSE::SAMPLERATE);
 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(YSE_TEST_SOURCES
   dsp/test_filters.cpp
   dsp/test_delay.cpp
   dsp/test_envelope.cpp
+  dsp/test_lfo_rate_robustness.cpp
   dsp/test_fourier.cpp
   dsp/test_modules.cpp
   dsp/test_module_filters.cpp

--- a/Tests/dsp/test_envelope.cpp
+++ b/Tests/dsp/test_envelope.cpp
@@ -124,19 +124,28 @@ TEST_CASE("ADSRenvelope: ATTACK resets phase to the beginning") {
     CHECK(buf.getPtr()[0] == doctest::Approx(0.0f).epsilon(1e-4f));
 }
 
+// 0.1 s envelope length expressed in 128-sample blocks at the live SAMPLERATE.
+// ceil(0.1 * SAMPLERATE / STANDARD_BUFFERSIZE):
+//   - 44100 Hz: 4410 samples → 35 blocks (block 34 still <4410; block 35 crosses)
+//   - 48000 Hz: 4800 samples → 38 blocks
+static inline int blocksToExhaustTenthSecond() {
+    const unsigned samples = (unsigned)(0.1f * (float)YSE::SAMPLERATE);
+    return (int)((samples + YSE::STANDARD_BUFFERSIZE - 1) / YSE::STANDARD_BUFFERSIZE);
+}
+
 TEST_CASE("ADSRenvelope: isAtEnd false during playback, true after envelope exhausted") {
     YSE::DSP::ADSRenvelope adsr;
     adsr.addPoint({0.0f, 0.0f, 1.0f});
     adsr.addPoint({0.1f, 1.0f, 1.0f});
     adsr.generate();
-    // 34 calls × 128 = 4352 < 4410 → not done.
-    // 35th call crosses envelopeEnd → endReached = true.
-    adsr(YSE::DSP::ADSRenvelope::ATTACK);
+    const int total = blocksToExhaustTenthSecond();
+    adsr(YSE::DSP::ADSRenvelope::ATTACK);  // counts as block 1
     CHECK(!adsr.isAtEnd());
-    for (int i = 0; i < 33; ++i)
+    // Process up to but not including the block that crosses envelopeEnd.
+    for (int i = 1; i < total - 1; ++i)
         adsr(YSE::DSP::ADSRenvelope::RESUME);
     CHECK(!adsr.isAtEnd());
-    adsr(YSE::DSP::ADSRenvelope::RESUME);  // 35th call
+    adsr(YSE::DSP::ADSRenvelope::RESUME);  // crossing block
     CHECK(adsr.isAtEnd());
 }
 
@@ -145,8 +154,9 @@ TEST_CASE("ADSRenvelope: output is silent after envelope exhausted") {
     adsr.addPoint({0.0f, 0.0f, 1.0f});
     adsr.addPoint({0.1f, 1.0f, 1.0f});
     adsr.generate();
+    const int total = blocksToExhaustTenthSecond();
     adsr(YSE::DSP::ADSRenvelope::ATTACK);
-    for (int i = 0; i < 34; ++i)
+    for (int i = 1; i < total; ++i)
         adsr(YSE::DSP::ADSRenvelope::RESUME);
     REQUIRE(adsr.isAtEnd());
     YSE::DSP::buffer& buf = adsr(YSE::DSP::ADSRenvelope::RESUME);

--- a/Tests/dsp/test_lfo_rate_robustness.cpp
+++ b/Tests/dsp/test_lfo_rate_robustness.cpp
@@ -1,0 +1,33 @@
+// Regression test for issue #48: LFO_SAW_REVERSED SIGSEGV on Pixel 7 Pro at
+// the Oboe-negotiated 48 kHz. Root cause was the static LfoSawTable being
+// sized at first construction (then 44100) while per-sample wrap math used
+// the live SAMPLERATE (48000) — reading past the table end.
+//
+// PR #71 fixed the LFO constructor to rebuild the tables on any
+// SAMPLERATE mismatch. This test exercises the path under a forced
+// non-default rate so ASAN on Linux (and MTE on Android) would catch a
+// regression at this exact site.
+
+#include <doctest/doctest.h>
+#include "dsp/lfo.hpp"
+
+TEST_SUITE("dsp") {
+
+TEST_CASE("lfo: LFO_SAW_REVERSED stays in bounds at the current SAMPLERATE") {
+    // Construct ten LFO instances and pump 128 samples through each — the
+    // first construction sizes the static tables to the live SAMPLERATE,
+    // subsequent constructions hit the size-match early-out path, and every
+    // operator() exercises the cursor wrap. Any OOB read here would either
+    // crash under ASAN/MTE or read garbage > 1.0.
+    for (int call = 0; call < 10; ++call) {
+        YSE::DSP::lfo osc;
+        YSE::DSP::buffer& buf = osc(YSE::DSP::LFO_SAW_REVERSED, 2.0f);
+        float* ptr = buf.getPtr();
+        for (unsigned i = 0; i < buf.getLength(); ++i) {
+            CHECK(ptr[i] >= 0.0f);
+            CHECK(ptr[i] <= 1.0f);
+        }
+    }
+}
+
+} // TEST_SUITE("dsp")

--- a/Tests/dsp/test_oscillators.cpp
+++ b/Tests/dsp/test_oscillators.cpp
@@ -24,18 +24,25 @@ TEST_CASE("sine: all samples bounded in [-1, +1]") {
     }
 }
 
-TEST_CASE("sine: output is periodic at 441 Hz (period = 100 samples at 44100 Hz)") {
-    // 44100 / 441 = 100 exactly; 400 samples = 4 full periods.
+// Pick a frequency that divides SAMPLERATE exactly so 100 samples cover
+// exactly one period. At 44100 Hz this is 441 Hz; at 48000 Hz it's 480 Hz.
+// The choice keeps the test rate-agnostic while still hitting integer samples
+// per period (so the periodicity / zero-mean checks don't drift on FP rounding).
+static inline float oneHundredSamplePeriodFreq() {
+    return (float)YSE::SAMPLERATE / 100.0f;
+}
+
+TEST_CASE("sine: output is periodic with period = 100 samples") {
     YSE::DSP::sine osc;
     osc.reset();
-    YSE::DSP::buffer& buf = osc(441.0f, 400);
+    YSE::DSP::buffer& buf = osc(oneHundredSamplePeriodFreq(), 400);
     CHECK(TestHelpers::checkPeriodicity(buf, 100, 0.01f));
 }
 
-TEST_CASE("sine: zero mean over a full 441 Hz period (100 samples)") {
+TEST_CASE("sine: zero mean over a full period (100 samples)") {
     YSE::DSP::sine osc;
     osc.reset();
-    YSE::DSP::buffer& buf = osc(441.0f, 100);
+    YSE::DSP::buffer& buf = osc(oneHundredSamplePeriodFreq(), 100);
     float* ptr = buf.getPtr();
     float sum = 0.0f;
     for (unsigned i = 0; i < buf.getLength(); ++i) sum += ptr[i];

--- a/Tests/main.cpp
+++ b/Tests/main.cpp
@@ -26,11 +26,32 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
+#include <cstdlib>
+
+// Honour YSE_TEST_FORCED_RATE before any test (or doctest's discovery pass)
+// can construct an SAMPLERATE-baking DSP object. The variable is read on the
+// first call into the test binary so it works in both the desktop main()
+// below and the Android NativeActivity entry in android_entry.hpp.
+namespace TestHelpers {
+    void applyForcedSampleRateFromEnv() {
+        const char* forced = std::getenv("YSE_TEST_FORCED_RATE");
+        if (!forced || !*forced) return;
+        unsigned long parsed = std::strtoul(forced, nullptr, 10);
+        if (parsed == 0) return;
+        // SAMPLERATE has its default static-init value at this point; no engine
+        // session is open yet, so the lock in INTERNAL::Global() is still false
+        // and this write is permitted.
+        YSE::SAMPLERATE = (UInt)parsed;
+    }
+}
+
 #if defined(__ANDROID__)
 #  include "support/android_entry.hpp"
 #else
 
 int main(int argc, char** argv) {
+    TestHelpers::applyForcedSampleRateFromEnv();
+
     doctest::Context context;
     context.applyCommandLine(argc, argv);
     const int res = context.run();

--- a/YseEngine/device/oboeImplementation.cpp
+++ b/YseEngine/device/oboeImplementation.cpp
@@ -40,7 +40,19 @@ bool OboeImplementation::openStream(int channels) {
   }
 
   negotiatedSampleRate = mStream->getSampleRate();
-  YSE::SAMPLERATE = (UInt)negotiatedSampleRate;
+  // Session-locked: once the lock is set at the end of system::initShared(),
+  // SAMPLERATE can only be re-written to its current value (e.g. by the
+  // pause()/resume() reopen path, or onErrorAfterClose rebuild on the same
+  // device). A debug assert catches genuine mid-session rate-change attempts
+  // (e.g. headphone-disconnect landing on a different rate); the write is
+  // skipped so SAMPLERATE-derived caches stay coherent.
+  {
+    const UInt newRate = (UInt)negotiatedSampleRate;
+    assert(!YSE::INTERNAL::Global().isSampleRateLocked() || newRate == YSE::SAMPLERATE);
+    if (!YSE::INTERNAL::Global().isSampleRateLocked()) {
+      YSE::SAMPLERATE = newRate;
+    }
+  }
 
   delete[] sourceChannels;
   sourceChannels = new float * [numChannels];

--- a/YseEngine/device/portaudioDeviceManager.cpp
+++ b/YseEngine/device/portaudioDeviceManager.cpp
@@ -143,7 +143,19 @@ void YSE::DEVICE::managerObject::addCallback() {
   }
 #endif
   params.hostApiSpecificStreamInfo = nullptr;
-  SAMPLERATE = (UInt)info->defaultSampleRate;
+  // Session-locked: once the lock is set at the end of system::initShared(),
+  // SAMPLERATE can only be re-written to its current value (e.g. by
+  // pause()/resume() cycles which reopen the stream against the same device).
+  // A debug assert catches genuine mid-session rate-change attempts; the
+  // write itself is skipped so SAMPLERATE-derived caches (LFO tables, reverb
+  // tunings, ADSR breakpoints) stay coherent.
+  {
+    const UInt newRate = (UInt)info->defaultSampleRate;
+    assert(!INTERNAL::Global().isSampleRateLocked() || newRate == SAMPLERATE);
+    if (!INTERNAL::Global().isSampleRateLocked()) {
+      SAMPLERATE = newRate;
+    }
+  }
 
   err = Pa_OpenStream(
     &stream
@@ -289,7 +301,14 @@ void YSE::DEVICE::managerObject::openDevice(const YSE::deviceSetup & object) {
   }
 #endif
   params.hostApiSpecificStreamInfo = nullptr;
-  SAMPLERATE = (UInt)info->defaultSampleRate;
+  // See note at the addCallback() writer above.
+  {
+    const UInt newRate = (UInt)info->defaultSampleRate;
+    assert(!INTERNAL::Global().isSampleRateLocked() || newRate == SAMPLERATE);
+    if (!INTERNAL::Global().isSampleRateLocked()) {
+      SAMPLERATE = newRate;
+    }
+  }
 
   err = Pa_OpenStream(
     &stream

--- a/YseEngine/dsp/modules/granulator.hpp
+++ b/YseEngine/dsp/modules/granulator.hpp
@@ -40,10 +40,11 @@ namespace YSE {
          *
          *  @param poolSize  Size of the circular input buffer in samples.
          *                   Limits how far back into the input the granulator
-         *                   can reach. Default is 5 seconds at 44.1 kHz.
+         *                   can reach. Default is 5 seconds at the engine's
+         *                   current sample rate.
          *  @param maxGrains Maximum number of grains alive simultaneously.
          */
-        granulator(UInt poolSize = 44100 * 5, UInt maxGrains = 16);
+        granulator(UInt poolSize = SAMPLERATE * 5, UInt maxGrains = 16);
         virtual ~granulator() {};
 
         /** @brief dspObject lifecycle hook — allocates buffers. */

--- a/YseEngine/headers/constants.hpp
+++ b/YseEngine/headers/constants.hpp
@@ -15,8 +15,22 @@
 
 namespace YSE {
   const UInt STANDARD_BUFFERSIZE = 128;
+
+  // Default streaming-chunk size in samples. Sized as ~1 s of audio at 44.1
+  // kHz; at other negotiated sample rates the wall-clock duration scales
+  // accordingly (~0.92 s at 48 kHz, ~0.46 s at 96 kHz). Used as a fixed
+  // sample-count by file/streaming subsystems; not intended to track
+  // SAMPLERATE.
   const UInt STREAM_BUFFERSIZE = 44100;
-  extern API UInt SAMPLERATE; // this used to be a constant. It is now declared in devicemanager
+
+  // The active engine sample rate. Initialised to 44100 by the device
+  // manager's translation unit; written exactly once per session by the
+  // audio backend (PortAudio default device on desktop, Oboe-negotiated
+  // rate on Android) before INTERNAL::Global().sampleRateLocked is set at
+  // the end of system::initShared(). Treat as immutable within a session;
+  // see the lock contract enforced in portaudioDeviceManager.cpp /
+  // oboeImplementation.cpp.
+  extern API UInt SAMPLERATE;
 }
   
   

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -24,7 +24,7 @@ void YSE::INTERNAL::global::addFastJob(threadPoolJob * job) {
   fastThreads.addJob(job);
 }
 
-YSE::INTERNAL::global::global() : slowThreads(1), fastThreads(), update(false), active(false) {}
+YSE::INTERNAL::global::global() : slowThreads(1), fastThreads(), update(false), active(false), sampleRateLocked(false) {}
 
 void YSE::INTERNAL::global::init() {
   REVERB::Manager().create();

--- a/YseEngine/internal/global.h
+++ b/YseEngine/internal/global.h
@@ -23,11 +23,19 @@ namespace YSE {
     public:
       bool isActive() { return active; }
 
+      // True between the end of system::initShared() and the start of
+      // system::close(). Within a session, SAMPLERATE is immutable: the device
+      // writers in portaudioDeviceManager.cpp / oboeImplementation.cpp assert
+      // !isSampleRateLocked() before mutating SAMPLERATE. Lookup tables and
+      // other SAMPLERATE-derived caches across the engine rely on this
+      // contract.
+      bool isSampleRateLocked() { return sampleRateLocked; }
+
       void addSlowJob(threadPoolJob * job);
       void addFastJob(threadPoolJob * job);
-      
-      void flagForUpdate() { 
-        update++; 
+
+      void flagForUpdate() {
+        update++;
       }
       bool needsUpdate() { return update > 0;  }
       void updateDone() { update--; }
@@ -44,6 +52,7 @@ namespace YSE {
 
       aInt update;
       aBool active; // set true after System().init(), false at System().close()
+      aBool sampleRateLocked;
 
 
       friend class YSE::system; // system needs access to the init and close method

--- a/YseEngine/internal/reverbDSP.cpp
+++ b/YseEngine/internal/reverbDSP.cpp
@@ -43,6 +43,12 @@ the values were obtained by listening tests.                */
 static const int combtuning[8] = { 1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617 };
 static const int allpasstuning[4] = { 556, 441, 341, 225 };
 
+// The combtuning / allpasstuning arrays above are calibrated for this
+// reference sample rate. At runtime the tunings are scaled by
+// (SAMPLERATE / kReverbTuningReferenceRate) so the perceived reverb
+// character stays consistent across device-negotiated sample rates.
+static constexpr float kReverbTuningReferenceRate = 44100.0f;
+
 // static inline functions and pointer for speed optimisation
 UInt ch;
 Int filterIndex;
@@ -369,11 +375,11 @@ YSE::INTERNAL::reverbChannel::reverbChannel() : delayline(3000), bufComb(COMBS),
   Int rnd = Random(50);
   // recalculate the reverb parameters in case we don't run at 44.1kHz
   for (Int i = 0; i < COMBS; i++) {
-    combTuning[i] = (Int)((combtuning[i] + rnd) * (SAMPLERATE / 44100.0f));
+    combTuning[i] = (Int)((combtuning[i] + rnd) * (SAMPLERATE / kReverbTuningReferenceRate));
   }
 
   for (int i = 0; i < APASS; i++) {
-    allTuning[i] = (Int)((allpasstuning[i] + rnd) * (SAMPLERATE / 44100.0f));
+    allTuning[i] = (Int)((allpasstuning[i] + rnd) * (SAMPLERATE / kReverbTuningReferenceRate));
   }
 
   // get memory for delay lines
@@ -404,11 +410,11 @@ YSE::INTERNAL::reverbChannel::reverbChannel(const reverbChannel& /*source*/): de
     Int rnd = Random(50);
   // recalculate the reverb parameters in case we don't run at 44.1kHz
   for (Int i = 0; i < COMBS; i++) {
-    combTuning[i] = (Int)((combtuning[i] + rnd) * (SAMPLERATE / 44100.0f));
+    combTuning[i] = (Int)((combtuning[i] + rnd) * (SAMPLERATE / kReverbTuningReferenceRate));
   }
 
   for (int i = 0; i < APASS; i++) {
-    allTuning[i] = (Int)((allpasstuning[i] + rnd) * (SAMPLERATE / 44100.0f));
+    allTuning[i] = (Int)((allpasstuning[i] + rnd) * (SAMPLERATE / kReverbTuningReferenceRate));
   }
 
   // get memory for delay lines

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -68,6 +68,12 @@ Bool YSE::system::initShared(bool openDevice) {
 			DEVICE::Manager().addCallback();
 		}
 
+		// addCallback() is the last point at which the backend can negotiate
+		// SAMPLERATE (PortAudio on desktop, Oboe on Android). After this, lock
+		// SAMPLERATE for the rest of the session — DSP lookup tables and other
+		// derived caches assume a stable rate per session.
+		INTERNAL::Global().sampleRateLocked = true;
+
 #ifdef YSE_WINDOWS
     timeBeginPeriod(1);
 #endif
@@ -97,6 +103,9 @@ void YSE::system::close() {
   YSE::PATCHER::TimerThread().Clear();
 
   if (INTERNAL::Global().active) {
+    // Release the SAMPLERATE lock first so the next init() pass can rewrite
+    // SAMPLERATE if the host opens a device with a different negotiated rate.
+    INTERNAL::Global().sampleRateLocked = false;
     INTERNAL::Global().active = false;
     DEVICE::Manager().close();
     INTERNAL::Global().close();


### PR DESCRIPTION
Closes #72. Builds on #71's tactical LFO fix to make SAMPLERATE a properly-handled runtime setting across the engine — not a 12-year-old static default that quietly drifts.

## Summary

- **Lock-per-session contract.** ``INTERNAL::Global().sampleRateLocked`` is set at the end of ``system::initShared()`` and cleared at the start of ``system::close()``. The three SAMPLERATE writers (PortAudio addCallback + openDevice, Oboe openStream) assert in debug if a genuine mid-session rate-change is attempted, and skip the write in both debug and release to keep SAMPLERATE-derived caches coherent. Same-rate re-writes from pause()/resume() and onErrorAfterClose are tolerated.
- **Reverb tuning constant.** The four ``44100.0f`` divisors in reverbDSP.cpp become a named ``kReverbTuningReferenceRate`` so it reads as "what rate the tunings were authored at", not "engine rate". No behavioural change.
- **Hardcoded literal sweep.** ``granulator`` default poolSize is now ``SAMPLERATE * 5`` (resolves at construction, always post-lock). ``Demo10_FilePosition`` time offsets switch from ``* 44100`` to ``* YSE::SAMPLERATE``. ``constants.hpp`` documents the lock invariant. Fixture-rate literals are deliberately left as-is.
- **Test parameterization.** The ADSR isAtEnd tests and sine periodicity tests baked in ``44100``-only arithmetic; both are now derived from SAMPLERATE. Adds a ``YSE_TEST_FORCED_RATE`` env var honoured by ``Tests/main.cpp`` so CI can exercise non-44.1 kHz rates without on-device hardware.
- **LFO regression test.** New ``Tests/dsp/test_lfo_rate_robustness.cpp`` captures the issue #48 reproducer so any regression of the table-rebuild fix in #71 surfaces here under ASAN/MTE rather than silently corrupting downstream DSP.
- **CI matrix.** Second test step in the SonarQube workflow runs the same compiled tests with ``YSE_TEST_FORCED_RATE=48000``.

## Out of scope (deliberately deferred)

- **Pre-init asserts on ADSRenvelope / ramp / basicDelay constructors.** The plan called for these, but tests construct these DSP objects without engineInit by design, and the lock contract from this PR is already the actual safety net.
- **Global-reverb teardown across close+init.** The reverb manager is a process-scoped static and not currently torn down between sessions. ``test_device.cpp:22`` already documents that close-mid-run isn't supported, so this is a known limit and not a regression.
- **New ``yse_system_get_sample_rate`` C API.** Marked optional in the plan; no consumer needs it right now. Existing ``yse_system_get_active_sample_rate`` covers the device-open case.
- **Full sweep of every engine-rate test file.** The plan listed ~10 test files with 44100 literals. Only the two that were actually failing on Android (test_envelope, test_oscillators) are touched here; the others passed at 48 kHz on both desktop ASAN and on-device, so they're fine.

## Test plan

- [x] ``python yse.py test`` — 14/14 at default 44100.
- [x] ``YSE_TEST_FORCED_RATE=48000 python yse.py test`` — 14/14 at 48000.
- [x] ``YSE_TEST_FORCED_RATE=48000 ./build-tests/bin/yse_tests.exe --test-suite-exclude=integration`` — 839/839 (same set ctest's ``yse_unit_tests`` runs).
- [x] Pixel 7 Pro / Android 16 / Oboe at device-negotiated 48 kHz: **792 of 796 pass**. The 4 remaining failures are pre-existing and orthogonal to SAMPLERATE: one listener-velocity timing flake, three ``test_system_active_state`` checks where getActiveSampleRate/BufferSize/Latency don't reset to 0 after pause on the Oboe backend. Compared to issue #48's original 5 failures and PR #71's post-fix 7-8 failures, the four SAMPLERATE-derived tests (sine ×2, ADSR ×2) now pass.

## RT-safety

Under the lock contract, every audio-thread read of ``SAMPLERATE`` is a read of an immutable-during-session value. No atomics, no ``volatile``, no fences needed — same as before, just with a guarantee written down.