### PR TITLE
feat(c-api,engine): add session sample rate getter (#72 scope 2g)

### DIFF
--- a/Tests/system/test_system_active_state.cpp
+++ b/Tests/system/test_system_active_state.cpp
@@ -53,6 +53,18 @@ TEST_CASE("system: active sample rate is 0 while engine is paused")
     CHECK(YSE::System().getActiveSampleRate() == doctest::Approx(0.0));
 }
 
+// ─── Session sample rate: locked at init(), survives pause ──────────────────
+
+TEST_CASE("system: session sample rate is positive after init even while paused")
+{
+    if (!TestHelpers::engineInit()) return;
+    // Distinct from getActiveSampleRate(): the session rate is the engine-wide
+    // value locked during initShared() and stays constant across the session.
+    // engineInit() leaves the device paused — the session getter should still
+    // report a positive value.
+    CHECK(YSE::System().getSampleRate() > 0.0);
+}
+
 TEST_CASE("system: active buffer size is 0 while engine is paused")
 {
     if (!TestHelpers::engineInit()) return;
@@ -83,6 +95,16 @@ TEST_CASE("system: active output latency is positive after resuming audio")
     CHECK(YSE::System().getActiveOutputLatency() > 0);
 }
 
+TEST_CASE("system: session sample rate matches active rate when audio is resumed")
+{
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+    // When the device is open, the session rate and the active (live) rate
+    // return the same locked value.
+    CHECK(YSE::System().getSampleRate()
+          == doctest::Approx(YSE::System().getActiveSampleRate()));
+}
+
 TEST_CASE("system: active buffer size is positive after at least one audio callback")
 {
     if (!TestHelpers::engineInitWithAudio()) return;
@@ -111,6 +133,15 @@ TEST_CASE("system: active output latency yields a believable ms value")
 
 // ─── C API mirror agrees with the C++ getters ────────────────────────────────
 
+TEST_CASE("system: C API getSampleRate mirrors the C++ value")
+{
+    if (!TestHelpers::engineInit()) return;
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    CHECK(yse_system_get_sample_rate(sys)
+          == doctest::Approx(YSE::System().getSampleRate()));
+}
+
 TEST_CASE("system: C API getActiveSampleRate mirrors the C++ value")
 {
     if (!TestHelpers::engineInit()) return;
@@ -138,6 +169,7 @@ TEST_CASE("system: C API getActiveOutputLatency mirrors the C++ value")
 
 TEST_CASE("system: C API getters return 0 on a NULL system handle")
 {
+    CHECK(yse_system_get_sample_rate(nullptr) == doctest::Approx(0.0));
     CHECK(yse_system_get_active_sample_rate(nullptr) == doctest::Approx(0.0));
     CHECK(yse_system_get_active_buffer_size(nullptr) == 0);
     CHECK(yse_system_get_active_output_latency(nullptr) == 0);

--- a/YseEngine/c_api/include/yse_c/yse_system.h
+++ b/YseEngine/c_api/include/yse_c/yse_system.h
@@ -39,6 +39,13 @@ YSE_C_API void       yse_system_resume(YseSystem* sys);
 YSE_C_API int        yse_system_missed_callbacks(YseSystem* sys);
 YSE_C_API float      yse_system_cpu_load(YseSystem* sys);
 
+/* Engine session sample rate in Hz. Stays constant for the lifetime of an
+   init()/close() session, including across pause/resume cycles where the
+   live "active" rate transiently drops to 0. Returns 0 before init(). Use
+   this for sample-count-driven scheduling that must outlive a pause; use
+   yse_system_get_active_sample_rate() for live device-state UI. */
+YSE_C_API double     yse_system_get_sample_rate(YseSystem* sys);
+
 /* Live state of the currently open audio device. Returns 0 when no device
    is open (pre-init, after close, or initOffline path). Buffer size is the
    device's frames-per-callback, NOT the engine block size. Output latency

--- a/YseEngine/c_api/yse_system.cpp
+++ b/YseEngine/c_api/yse_system.cpp
@@ -107,6 +107,11 @@ YSE_C_API float yse_system_cpu_load(YseSystem* sys) {
   return to_cpp(sys)->cpuLoad();
 }
 
+YSE_C_API double yse_system_get_sample_rate(YseSystem* sys) {
+  if (!sys) return 0.0;
+  return to_cpp(sys)->getSampleRate();
+}
+
 YSE_C_API double yse_system_get_active_sample_rate(YseSystem* sys) {
   if (!sys) return 0.0;
   return to_cpp(sys)->getActiveSampleRate();

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -169,6 +169,13 @@ Flt YSE::system::cpuLoad() {
   return DEVICE::Manager().cpuLoad();
 }
 
+double YSE::system::getSampleRate() {
+  // The session lock is set at the end of initShared(); before that, SAMPLERATE
+  // still holds its 44100 default and reporting it would mislead hosts that
+  // start sample-count-driven work pre-init.
+  return INTERNAL::Global().isSampleRateLocked() ? (double)SAMPLERATE : 0.0;
+}
+
 double YSE::system::getActiveSampleRate() {
   return DEVICE::Manager().getActiveSampleRate();
 }

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -210,6 +210,18 @@ namespace YSE {
      */
     float cpuLoad();
 
+    /** @brief Engine session sample rate in Hz.
+     *
+     *  The rate the engine locked to when ``init()`` / ``initOffline()`` ran.
+     *  Stays constant across the entire session, including pause / resume
+     *  cycles where ``getActiveSampleRate()`` transiently drops to 0. Returns
+     *  0 before the lock is established (pre-init).
+     *
+     *  Use this when scheduling sample-count-driven work that must outlive a
+     *  pause; use ``getActiveSampleRate()`` for live device-state UI.
+     */
+    double getSampleRate();
+
     /// @name Active device readouts
     /// Live state of the currently open audio device. Each returns 0 when no
     /// device is open (pre-init, after ``close()``, or under ``initOffline()``).


### PR DESCRIPTION
## Summary

Optional 2g sub-task from #72 — expose the session-locked SAMPLERATE through a stable getter so host code can schedule sample-count-driven work that needs to outlive a `pause()` (where `getActiveSampleRate()` transiently reports 0).

- `YSE::system::getSampleRate()` — gated on `INTERNAL::Global().isSampleRateLocked()`, so it returns 0 before `init()` / `initOffline()` rather than the static-init 44100 default. Post-init it returns the locked rate
- `yse_system_get_sample_rate(YseSystem*)` — C ABI mirror; returns 0 on a NULL handle, matching the `get_active_*` family convention

## Distinction from `getActiveSampleRate`

| Getter | Lifetime | Pre-init | Paused | Resumed |
|---|---|---|---|---|
| `getSampleRate()` | Session-locked, immutable post-init | 0 | rate | rate |
| `getActiveSampleRate()` | Live device state | 0 | 0 (PortAudio close; Oboe via PR #77) | rate |

## Test plan

- [x] `python yse.py test` — all 14 ctest jobs pass; the new system suite tests cover paused/resumed states + C API mirror + NULL handle
- [x] On-device run on Pixel 7 Pro to confirm Oboe path reports the same locked rate (44100 default or 48000 negotiated)

Closes the optional 2g sub-task of #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)