### PR TITLE
build: -fvisibility=hidden + explicit visibility attrs on ELF

### DIFF
--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -251,6 +251,18 @@ add_library(yse_objects OBJECT ${YSE_SRCS})
 # the shared library on Linux.
 set_target_properties(yse_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+# Hide every symbol by default on ELF/Mach-O platforms (Linux, macOS, iOS,
+# BSD, Android) so libyse.so / .dylib exports only the API-tagged surface
+# reachable from yse.hpp. Windows is unaffected — its DLL export model uses
+# __declspec(dllexport) annotations directly from the API macro and has no
+# fpvisibility equivalent. Issue #34.
+if(NOT WIN32)
+  set_target_properties(yse_objects PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+  )
+endif()
+
 target_compile_features(yse_objects PUBLIC cxx_std_17)
 
 # Expose YseEngine/ as the public include root so consumers can use
@@ -338,11 +350,17 @@ endif()
 # Consumers (demos, external code) link against this target only.
 add_library(yse SHARED)
 
-set_target_properties(yse PROPERTIES
-  OUTPUT_NAME yse
-  CXX_VISIBILITY_PRESET default
-  VISIBILITY_INLINES_HIDDEN OFF
-)
+set_target_properties(yse PROPERTIES OUTPUT_NAME yse)
+
+# Mirror the visibility settings applied to yse_objects so the linked
+# shared library exports the same API surface. See the comment on
+# yse_objects above. Issue #34.
+if(NOT WIN32)
+  set_target_properties(yse PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+  )
+endif()
 
 # Pull in the compiled objects and their transitive link dependencies.
 target_link_libraries(yse PRIVATE yse_objects)

--- a/YseEngine/headers/defines.hpp
+++ b/YseEngine/headers/defines.hpp
@@ -147,7 +147,18 @@
 
 
 //==============================================================================
-// DLL building settings on Windows (Clang/MinGW)
+// Public-API export / visibility annotation.
+//
+// Windows DLL builds (Clang/MinGW) use __declspec(dllexport / dllimport): the
+// consumer side picks "import" via the YSE_DLL define configured by CMake's
+// INTERFACE compile definitions on the `yse` target.
+//
+// ELF / Mach-O builds (Linux, macOS, iOS, BSD, Android) use the GCC/Clang
+// visibility attribute. Pair with CXX_VISIBILITY_PRESET=hidden on the library
+// target so the only exported symbols are the ones explicitly tagged here.
+// The YSE_DLL leg is a no-op because ELF has no "import" counterpart —
+// visibility is a producer-side concept; consumers see all default-visibility
+// symbols automatically.
 #if YSE_WINDOWS && YSE_CLANG
   #ifdef YSE_DLL_BUILD
     #define API __declspec(dllexport)
@@ -156,11 +167,7 @@
     #define API __declspec(dllimport)
     #define EXTERN extern
   #endif
-#endif
-
-//==============================================================================
-// DLL building on mac
-#if YSE_MAC
+#elif YSE_LINUX || YSE_MAC || YSE_IOS || YSE_BSD || YSE_ANDROID
   #ifdef YSE_DLL_BUILD
     #define API __attribute__((visibility("default")))
     #define EXTERN

--- a/tools/ci-linux/inspect_exports.sh
+++ b/tools/ci-linux/inspect_exports.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Inspect libyse.so exports for issue #34 verification.
+set -e
+
+SO=${1:-/workspace/build-linux/bin/libyse.so}
+
+echo "=== total defined exports ==="
+nm -D --defined-only "$SO" | wc -l
+
+echo
+echo "=== by symbol type ==="
+nm -D --defined-only "$SO" | awk '{print $2}' | sort | uniq -c | sort -rn
+
+# Demangle and break down by namespace.
+TMP=$(mktemp)
+nm -D --defined-only "$SO" | c++filt > "$TMP"
+
+echo
+echo "=== T (text) symbols, namespace breakdown ==="
+awk '$2=="T"{print $0}' "$TMP" \
+  | sed -E 's/^[^ ]+ T //' \
+  | sed -E 's/\(.*$//' \
+  | sed -E 's/<.*//' \
+  | sed -E 's/::[^:]+$//' \
+  | sort | uniq -c | sort -rn | head -25
+
+echo
+echo "=== INTERNAL:: T-symbols (should be 0 — internal namespace, never tagged) ==="
+awk '$2=="T"{print $0}' "$TMP" | grep -c "YSE::INTERNAL::" || true
+
+echo
+echo "=== PATCHER:: T-symbols (should be 0 — internal namespace) ==="
+awk '$2=="T"{print $0}' "$TMP" | grep -c "YSE::PATCHER::" || true
+
+echo
+echo "=== SOUND::Manager / CHANNEL::Manager T-symbols (internal singletons) ==="
+awk '$2=="T"{print $0}' "$TMP" | grep -cE "YSE::(SOUND|CHANNEL|REVERB|MIDI|MOTIF|SCALE|PLAYER|DEVICE)::Manager" || true
+
+rm -f "$TMP"


### PR DESCRIPTION
## Summary

Bring Linux + macOS builds to parity with the Windows DLL export model — hide all symbols by default, explicitly tag the public surface via the existing `API` / `YSE_C_API` macros.

- `headers/defines.hpp`: GCC/Clang `__attribute__((visibility("default")))` branch was Mac-only; extended to Linux, BSD, iOS, Android. `YSE_C_API` was already correct
- `YseEngine/CMakeLists.txt`: `CXX_VISIBILITY_PRESET=hidden` + `VISIBILITY_INLINES_HIDDEN=ON` on `yse_objects` and `yse` when `NOT WIN32`. Windows DLL export model is untouched (`__declspec` from the `API` macro)
- `tools/ci-linux/inspect_exports.sh`: helper to verify the export table

## Verification

Linux build via `tools/ci-linux/run.ps1`:

- All 14 ctest jobs pass under `YSE_ENABLE_COVERAGE=ON`
- `nm -D --defined-only libyse.so | grep 'YSE::INTERNAL::'` → **0** matches
- `nm -D --defined-only libyse.so | grep '::Manager'` → **0** matches (SOUND, CHANNEL, REVERB, MIDI, etc. all hidden)
- Public C++ API (`YSE::System()`, `YSE::Listener()`, `YSE::system::init`) and full C API (`yse_system_*`, `yse_listener_*`, ...) all exported as expected
- Tests link directly against `yse_objects` (not via the shared library), so hidden visibility doesn't affect internal-symbol test access

Windows verification: `python yse.py test` passes locally — the `NOT WIN32` guard means Windows builds are unchanged.

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)