### PR TITLE
build: gate MIDI device backend behind YSE_ENABLE_MIDI_DEVICE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,21 @@ option(YSE_ENABLE_COVERAGE
 option(YSE_BUILD_C_API
   "Build the extern \"C\" ABI bridge (yse_*) inside libyse so language bindings (Dart, Python, ...) can consume the DLL without C++ ABI compatibility"
   ON)
+# YSE_ENABLE_MIDI_DEVICE: gate the RtMidi-backed MIDI device backend. Default
+# ON on Windows/Linux desktop (preserves the prior unconditional behavior),
+# OFF on Android (RtMidi isn't built there anyway) and Mac (already excluded
+# in source). When OFF, RtMidi is not required at configure time and the
+# midi/device.cpp + midi/midiDeviceManager.cpp sources are dropped — the rest
+# of the engine (MIDI file playback, midiNote, etc.) is unaffected.
+if(WIN32 OR (UNIX AND NOT APPLE AND NOT ANDROID))
+  set(_yse_midi_device_default ON)
+else()
+  set(_yse_midi_device_default OFF)
+endif()
+option(YSE_ENABLE_MIDI_DEVICE
+  "Build the RtMidi-backed MIDI device backend (Windows/Linux). When OFF, libyse builds without MIDI device I/O and does not require RtMidi at configure time."
+  ${_yse_midi_device_default})
+unset(_yse_midi_device_default)
 
 # Export compile_commands.json for SonarCloud's C++ analyser and clangd.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -111,13 +126,16 @@ else()
   pkg_check_modules(PortAudio REQUIRED IMPORTED_TARGET portaudio-2.0)
   pkg_check_modules(SndFile   REQUIRED IMPORTED_TARGET sndfile)
 
-  # RtMidi is required on every desktop platform we build for here (Windows and
-  # Linux).  The MIDI device source files (device.cpp, midiDeviceManager.cpp)
-  # need RtMidi symbols; they are guarded by `#if YSE_WINDOWS || YSE_LINUX` so
-  # they remain compiled-out on Android, but the CMake build does not target
-  # Android, so the dependency is unconditionally required here.
-  pkg_check_modules(RtMidi REQUIRED IMPORTED_TARGET rtmidi)
-  message(STATUS "RtMidi found — MIDI device backend enabled")
+  # RtMidi is the dependency of the MIDI device backend (midi/device.cpp,
+  # midi/midiDeviceManager.cpp). Required when YSE_ENABLE_MIDI_DEVICE is ON,
+  # which is the default on Windows/Linux. Set the option OFF to build libyse
+  # on a desktop without RtMidi installed — at the cost of no MIDI device I/O.
+  if(YSE_ENABLE_MIDI_DEVICE)
+    pkg_check_modules(RtMidi REQUIRED IMPORTED_TARGET rtmidi)
+    message(STATUS "RtMidi found — MIDI device backend enabled")
+  else()
+    message(STATUS "YSE_ENABLE_MIDI_DEVICE=OFF — skipping RtMidi dependency")
+  endif()
 endif()
 
 # yse::sndfile — uniform interface target so YseEngine/CMakeLists.txt doesn't

--- a/Demo.Windows.Native/CMakeLists.txt
+++ b/Demo.Windows.Native/CMakeLists.txt
@@ -69,10 +69,14 @@ add_yse_demo(Demo14 Demo14_LoadPatcher     DemoLoadPatcher)
 add_yse_demo(Demo15 Demo15_RestartAudio    DemoRestartAudio)
 add_yse_demo(Test01 Test01_Pitch           Test01_Pitch)
 
-# Demo16 and Demo17 use YSE::midiOut which requires the RtMidi backend.
-# RtMidi is now an unconditional dependency on every desktop platform, so
-# these are always built.
-add_yse_demo(Demo16 Demo16_Midi        DemoMidi)
+# Demo16 directly uses YSE::midiOut which is gated behind the
+# YSE_ENABLE_MIDI_DEVICE CMake option (default ON). When that's OFF the
+# DemoMidi class doesn't compile, so the standalone executable is skipped.
+# Demo17 uses the patcher M_OUT object via pHandle — that compiles fine,
+# the patcher registry just won't have M_OUT to instantiate at runtime.
+if(YSE_ENABLE_MIDI_DEVICE)
+  add_yse_demo(Demo16 Demo16_Midi DemoMidi)
+endif()
 add_yse_demo(Demo17 Demo17_MidiPatcher DemoMidiPatcher)
 
 # ── Combined Demo executable (all pages via menu) ─────────────────────────────

--- a/Demo.Windows.Native/Demo16_Midi.cpp
+++ b/Demo.Windows.Native/Demo16_Midi.cpp
@@ -3,6 +3,7 @@
 #include "Demo16_Midi.h"
 #include <iostream>
 
+#if YSE_ENABLE_MIDI_DEVICE
 DemoMidi::DemoMidi()
 	: firstNote(true)
 {
@@ -63,4 +64,5 @@ void DemoMidi::AllNotesOff() {
 	output1.NoteOn(YSE::MIDI::CH_01, 60, 0);
 	output2.NoteOn(YSE::MIDI::CH_01, YSE::MIDI::D4, 0);
 }
+#endif // YSE_ENABLE_MIDI_DEVICE
 

--- a/Demo.Windows.Native/Demo16_Midi.h
+++ b/Demo.Windows.Native/Demo16_Midi.h
@@ -3,6 +3,11 @@
 #include "basePage.h"
 #include "../YseEngine/yse.hpp"
 
+// The DemoMidi page exercises the RtMidi-backed device backend. When libyse
+// is built with YSE_ENABLE_MIDI_DEVICE=OFF the underlying YSE::midiOut type
+// is not declared, so this whole class compiles out. MenuOther guards the
+// matching `MidiDemo()` call site.
+#if YSE_ENABLE_MIDI_DEVICE
 class DemoMidi : public basePage {
 public:
 	DemoMidi();
@@ -16,3 +21,4 @@ public:
 	YSE::midiOut output2;
 	bool firstNote;
 };
+#endif

--- a/Demo.Windows.Native/MenuOther.cpp
+++ b/Demo.Windows.Native/MenuOther.cpp
@@ -50,8 +50,13 @@ void OtherMenu::RestartAudioDemo() {
 
 void OtherMenu::MidiDemo()
 {
+#if YSE_ENABLE_MIDI_DEVICE
 	DemoMidi demo;
 	demo.Run();
+#else
+	std::cout << "MIDI device backend was disabled at build time "
+	          << "(YSE_ENABLE_MIDI_DEVICE=OFF)." << std::endl;
+#endif
 	ShowMenu();
 }
 

--- a/Tests/integration/test_device.cpp
+++ b/Tests/integration/test_device.cpp
@@ -106,9 +106,9 @@ TEST_CASE("device: default device name is non-empty when devices exist") {
     CHECK_FALSE(YSE::System().getDefaultDevice().empty());
 }
 
-// ─── MIDI device enumeration (Windows only) ───────────────────────────────────
+// ─── MIDI device enumeration (gated on YSE_ENABLE_MIDI_DEVICE) ───────────────
 
-#if YSE_WINDOWS
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
 TEST_CASE("midi: getNumMidiInDevices does not crash") {
     if (!TestHelpers::engineInit()) return;
     (void)YSE::System().getNumMidiInDevices();
@@ -129,7 +129,7 @@ TEST_CASE("midi: device names are accessible without crash") {
     for (unsigned int i = 0; i < nOut; i++) (void)YSE::System().getMidiOutDeviceName(i);
     CHECK(true);
 }
-#endif // YSE_WINDOWS
+#endif // YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
 
 // ─── Engine lifecycle ─────────────────────────────────────────────────────────
 

--- a/Tests/midi/test_devicemanager.cpp
+++ b/Tests/midi/test_devicemanager.cpp
@@ -13,9 +13,9 @@
 //     no device is attached
 //   - Raw(string) handles 0/1/2/3+ byte inputs without out-of-bounds reads
 //
-// The whole TU is guarded by the same YSE_WINDOWS || YSE_LINUX condition that
-// gates midiDeviceManager.cpp and device.cpp — on platforms where those files
-// are not compiled, the deviceManager / midiOut symbols don't exist.
+// The whole TU is guarded by the same YSE_ENABLE_MIDI_DEVICE option that
+// gates midiDeviceManager.cpp and device.cpp — when the option is OFF those
+// files are not compiled and the deviceManager / midiOut symbols don't exist.
 //
 // No engine initialisation is required.  The MIDI singleton stands on its own
 // and does not depend on PortAudio.
@@ -23,7 +23,7 @@
 #include <doctest/doctest.h>
 #include "headers/defines.hpp"
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include "midi/midiDeviceManager.h"
 #include "midi/device.hpp"
@@ -269,4 +269,4 @@ TEST_CASE("midiOut::create on an out-of-range port leaves device null") {
 
 } // TEST_SUITE("midi")
 
-#endif // YSE_WINDOWS || YSE_LINUX
+#endif // YSE_ENABLE_MIDI_DEVICE

--- a/Tests/midi/test_midi_in.cpp
+++ b/Tests/midi/test_midi_in.cpp
@@ -23,7 +23,7 @@
 #include <cstring>
 #include "headers/defines.hpp"
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include "midi/device.hpp"
 #include "yse_c/yse_midi.h"
@@ -288,4 +288,4 @@ TEST_CASE("yse_midi_in C API: NULL handle returns 0 on is_open")
 
 } // TEST_SUITE("midi")
 
-#endif // YSE_WINDOWS || YSE_LINUX
+#endif // YSE_ENABLE_MIDI_DEVICE

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -150,13 +150,18 @@ set(YSE_SRCS
   patcher/midi/mMidiProgramChange.cpp
   # midiNote is a plain data class with no platform dependencies.
   midi/midiNote.cpp
-  # MIDI device I/O (RtMidi-backed). The sources themselves carry a
-  # `#if YSE_WINDOWS || YSE_LINUX` guard so they compile to empty TUs on
-  # Android; on the desktop platforms this CMake build targets they are
-  # always built.
-  midi/midiDeviceManager.cpp
-  midi/device.cpp
 )
+
+# MIDI device backend (RtMidi-backed). Gated behind YSE_ENABLE_MIDI_DEVICE
+# (default ON on Windows/Linux, OFF on Android/Mac). The sources still carry
+# a `#if YSE_ENABLE_MIDI_DEVICE` guard so accidental inclusion produces empty
+# TUs, but the canonical path adds them only when the option is ON.
+if(YSE_ENABLE_MIDI_DEVICE)
+  list(APPEND YSE_SRCS
+    midi/midiDeviceManager.cpp
+    midi/device.cpp
+  )
+endif()
 
 # ── Source-file-scoped warning suppressions ───────────────────────────────────
 # cJSON is a vendored C file; suppress all its warnings rather than patching it.
@@ -268,11 +273,16 @@ target_include_directories(yse_objects
     # shipped by the MSYS2 portaudio package; the vendored copies fill the gap.
     # We still link against the system library — only the headers are borrowed.
     ${CMAKE_SOURCE_DIR}/dependencies/portaudio/include
+)
+
+if(YSE_ENABLE_MIDI_DEVICE)
+  target_include_directories(yse_objects PRIVATE
     # midiDeviceManager.h uses "../dependencies/rtmidi/include/RtMidi.h" as a
     # relative path; device.cpp uses a bare "RtMidi.h". Both resolve once this
     # directory is in the include search path.
     ${CMAKE_SOURCE_DIR}/dependencies/rtmidi/include
-)
+  )
+endif()
 
 target_compile_definitions(yse_objects
   PRIVATE
@@ -299,6 +309,14 @@ else()
   target_compile_definitions(yse_objects PRIVATE YSE_ANDROID=1)
 endif()
 
+# YSE_ENABLE_MIDI_DEVICE: propagated PUBLIC so it reaches both the engine TUs
+# and any consumer that includes the public headers (system.hpp, midi/device.hpp,
+# yse_c/yse_midi.h). When 0/undefined, the MIDI device APIs are compiled out
+# of every layer (engine, C API, public headers, tests).
+if(YSE_ENABLE_MIDI_DEVICE)
+  target_compile_definitions(yse_objects PUBLIC YSE_ENABLE_MIDI_DEVICE=1)
+endif()
+
 # External deps are PUBLIC so both yse (SHARED) and yse_tests inherit them.
 target_link_libraries(yse_objects
   PUBLIC
@@ -307,11 +325,10 @@ target_link_libraries(yse_objects
 )
 
 if(NOT ANDROID)
-  target_link_libraries(yse_objects
-    PUBLIC
-      PkgConfig::PortAudio
-      PkgConfig::RtMidi
-  )
+  target_link_libraries(yse_objects PUBLIC PkgConfig::PortAudio)
+  if(YSE_ENABLE_MIDI_DEVICE)
+    target_link_libraries(yse_objects PUBLIC PkgConfig::RtMidi)
+  endif()
 else()
   # Oboe is the audio I/O backend (transparently uses AAudio on API 26+ and
   # falls back to OpenSL ES on rare devices). `log` provides __android_log_print
@@ -354,3 +371,11 @@ target_compile_definitions(yse
   INTERFACE
     YSE_DLL   # activate __declspec(dllimport) for consumers linking against the shared library
 )
+
+# Mirror YSE_ENABLE_MIDI_DEVICE to consumers of the shared library — yse_objects
+# is linked PRIVATE above, so its PUBLIC definitions don't transit through.
+# Demos and language bindings need to know whether the MIDI device APIs are
+# declared on the engine they're linking against.
+if(YSE_ENABLE_MIDI_DEVICE)
+  target_compile_definitions(yse INTERFACE YSE_ENABLE_MIDI_DEVICE=1)
+endif()

--- a/YseEngine/c_api/yse_midi.cpp
+++ b/YseEngine/c_api/yse_midi.cpp
@@ -5,7 +5,7 @@
 #include "../midi/midiNote.hpp"
 #include "../headers/enums.hpp"
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   #include "../midi/device.hpp"
   #define YSE_C_HAVE_MIDI_OUT 1
 #else

--- a/YseEngine/c_api/yse_system.cpp
+++ b/YseEngine/c_api/yse_system.cpp
@@ -207,7 +207,7 @@ YSE_C_API size_t yse_system_default_host(YseSystem* sys, char* buf, size_t cap) 
 // ─── MIDI device enumeration ───────────────────────────────────────────────
 
 YSE_C_API unsigned int yse_system_num_midi_in_devices(YseSystem* sys) {
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   if (!sys) return 0;
   return to_cpp(sys)->getNumMidiInDevices();
 #else
@@ -216,7 +216,7 @@ YSE_C_API unsigned int yse_system_num_midi_in_devices(YseSystem* sys) {
 }
 
 YSE_C_API unsigned int yse_system_num_midi_out_devices(YseSystem* sys) {
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   if (!sys) return 0;
   return to_cpp(sys)->getNumMidiOutDevices();
 #else
@@ -226,7 +226,7 @@ YSE_C_API unsigned int yse_system_num_midi_out_devices(YseSystem* sys) {
 
 YSE_C_API size_t yse_system_midi_in_device_name(YseSystem* sys, unsigned int id, char* buf, size_t cap) {
   if (buf && cap > 0) buf[0] = '\0';
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   if (!sys) return 0;
   try { return copy_string(to_cpp(sys)->getMidiInDeviceName(id), buf, cap); }
   catch (const std::exception&) { return 0; }
@@ -237,7 +237,7 @@ YSE_C_API size_t yse_system_midi_in_device_name(YseSystem* sys, unsigned int id,
 
 YSE_C_API size_t yse_system_midi_out_device_name(YseSystem* sys, unsigned int id, char* buf, size_t cap) {
   if (buf && cap > 0) buf[0] = '\0';
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   if (!sys) return 0;
   try { return copy_string(to_cpp(sys)->getMidiOutDeviceName(id), buf, cap); }
   catch (const std::exception&) { return 0; }

--- a/YseEngine/midi/device.cpp
+++ b/YseEngine/midi/device.cpp
@@ -1,5 +1,5 @@
 #include "headers/defines.hpp"
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 #include "device.hpp"
 #include "RtMidi.h"
 #include "midiDeviceManager.h"

--- a/YseEngine/midi/device.hpp
+++ b/YseEngine/midi/device.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../headers/defines.hpp"
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include <atomic>
 #include <cstddef>

--- a/YseEngine/midi/midiDeviceManager.cpp
+++ b/YseEngine/midi/midiDeviceManager.cpp
@@ -1,6 +1,6 @@
 #include "headers/defines.hpp"
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include "midiDeviceManager.h"
 #include "internalHeaders.h"

--- a/YseEngine/midi/midiDeviceManager.h
+++ b/YseEngine/midi/midiDeviceManager.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "headers/defines.hpp"
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include "../dependencies/rtmidi/include/RtMidi.h"
 #include "../midi/midiMessage.hpp"

--- a/YseEngine/patcher/midi/mMidiOut.cpp
+++ b/YseEngine/patcher/midi/mMidiOut.cpp
@@ -1,5 +1,6 @@
 #include "headers/defines.hpp"
-#if YSE_WINDOWS
+// See the matching guard in mMidiOut.h.
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
 #include "mMidiOut.h"
 #include "../pObjectList.hpp"
 #include "../patcherImplementation.h"

--- a/YseEngine/patcher/midi/mMidiOut.h
+++ b/YseEngine/patcher/midi/mMidiOut.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "headers/defines.hpp"
-#if YSE_WINDOWS
+// Patcher midi-out object: Windows-only AND requires the RtMidi-backed MIDI
+// device backend (YSE_ENABLE_MIDI_DEVICE). When the option is OFF the
+// underlying YSE::midiOut type doesn't exist, so this file is empty.
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
 #include "../pObject.h"
 #include "../../midi/device.hpp"
 

--- a/YseEngine/patcher/pRegistry.cpp
+++ b/YseEngine/patcher/pRegistry.cpp
@@ -49,9 +49,13 @@
 #include "midi/mMidiControl.h"
 #include "midi/mMidiNoteOff.h"
 #include "midi/mMidiNoteOn.h"
-#include "midi/mMidiOut.h"
 #include "midi/mMidiPolyPressure.h"
 #include "midi/mMidiProgramChange.h"
+#endif
+// mMidiOut is the only patcher midi object that depends on the RtMidi-backed
+// device backend; the other six just emit MIDI bytes and don't need it.
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
+#include "midi/mMidiOut.h"
 #endif
 
 using namespace YSE::PATCHER;
@@ -114,9 +118,11 @@ pRegistry::pRegistry() {
   Add(OBJ::M_CONTROL, mMidiControl::Create);
   Add(OBJ::M_NOTEOFF, mMidiNoteOff::Create);
   Add(OBJ::M_NOTEON, mMidiNoteOn::Create);
-  Add(OBJ::M_OUT, mMidiOut::Create);
   Add(OBJ::M_POLYPRESS, mMidiPolyPressure::Create);
   Add(OBJ::M_PROGCHANGE, mMidiProgramChange::Create);
+#endif
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
+  Add(OBJ::M_OUT, mMidiOut::Create);
 #endif
 }
 

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -230,7 +230,7 @@ const std::string & YSE::system::getDefaultHost() {
   return DEVICE::Manager().getDefaultTypeName();
 }
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 unsigned int YSE::system::getNumMidiInDevices()
 {
 	return MIDI::DeviceManager().getNumMidiInDevices();

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -140,11 +140,16 @@ namespace YSE {
     /** @brief Name of the platform default audio host (e.g. WASAPI, ALSA). */
     const std::string & getDefaultHost();
 
-#if YSE_WINDOWS || YSE_LINUX
-    /** @brief Number of MIDI input devices available. (Windows / Linux only.) */
+#if YSE_ENABLE_MIDI_DEVICE
+    /** @brief Number of MIDI input devices available.
+     *
+     *  Present only when libyse was built with ``YSE_ENABLE_MIDI_DEVICE=ON``
+     *  (default on Windows/Linux). When the option is OFF the function is
+     *  not declared at all — gate consumer code on ``#if YSE_ENABLE_MIDI_DEVICE``.
+     */
     unsigned int getNumMidiInDevices();
 
-    /** @brief Number of MIDI output devices available. (Windows / Linux only.) */
+    /** @brief Number of MIDI output devices available. */
     unsigned int getNumMidiOutDevices();
 
     /** @brief Name of the MIDI input device with the given ID. */


### PR DESCRIPTION
## Summary

RtMidi was an unconditional dependency on every Windows/Linux build, so libyse couldn't be configured on a desktop without it. Introduces `YSE_ENABLE_MIDI_DEVICE` as a CMake opt-out (default ON on Windows/Linux, OFF on Android/Mac) so the RtMidi-backed MIDI device backend can be excluded.

## Changes

- **Top-level CMake**: `YSE_ENABLE_MIDI_DEVICE` option; `pkg_check_modules(RtMidi ...)` only runs when ON; configure succeeds without RtMidi when OFF
- **YseEngine/CMakeLists.txt**: `midi/midiDeviceManager.cpp` + `midi/device.cpp` added to YSE_SRCS only when ON; `PkgConfig::RtMidi` linked conditionally; `YSE_ENABLE_MIDI_DEVICE=1` propagated PUBLIC on `yse_objects` and INTERFACE on `yse` so consumers (demos, bindings) see it
- **Source guards**: every `#if YSE_WINDOWS || YSE_LINUX` that protected MIDI device code switched to `#if YSE_ENABLE_MIDI_DEVICE` — engine, C API, tests
- **Patcher**: `mMidiOut` (the M_OUT patcher object — only one that directly uses `YSE::midiOut`) gated on `YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE`; the other six patcher midi types compile unconditionally (they just emit MIDI bytes)
- **Demos**: `Demo16_Midi` (uses `YSE::midiOut` directly) gated; `MenuOther::MidiDemo` prints a "disabled at build time" message when OFF. `Demo17_MidiPatcher` compiles unconditionally — patcher just won't find an M_OUT to instantiate at runtime

## Test plan — full 4-point matrix

- [x] Windows + `YSE_ENABLE_MIDI_DEVICE=ON` (default): build + 14 ctest pass
- [x] Windows + `YSE_ENABLE_MIDI_DEVICE=OFF`: build + 14 ctest pass
- [x] Linux + `YSE_ENABLE_MIDI_DEVICE=ON` (default, via `tools/ci-linux/run.ps1`): build + 14 ctest pass
- [x] Linux + `YSE_ENABLE_MIDI_DEVICE=OFF`: build + 14 ctest pass — CMake log confirms `YSE_ENABLE_MIDI_DEVICE=OFF — skipping RtMidi dependency`
- [x] `python yse.py analyze` clean on all touched engine files (per CLAUDE.md item 6)

## Install hints (for the issue's documentation note)

The RtMidi install commands from the issue remain valid when leaving the default ON:
- Windows (MSYS2 Clang64): `pacman -S mingw-w64-clang-x86_64-rtmidi`
- Debian/Ubuntu: `sudo apt install librtmidi-dev`
- Fedora/RHEL: `sudo dnf install rtmidi-devel`

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)