### PR TITLE
Enable FTZ/DAZ on threadpool worker threads (fixes #81)

### DIFF
--- a/YseEngine/internal/threadPool.cpp
+++ b/YseEngine/internal/threadPool.cpp
@@ -11,6 +11,7 @@
 #include "threadPool.h"
 #include <assert.h>
 #include "../system.hpp"
+#include "denormalGuard.h"
 
 YSE::INTERNAL::threadPoolJob::threadPoolJob() : shouldStop(false), inQueue(false), isDone(false) {}
 
@@ -36,6 +37,12 @@ void YSE::INTERNAL::threadPoolJob::activate() {
 YSE::INTERNAL::threadPoolThread::threadPoolThread(threadPool * pool) : pool(pool) {}
 
 void YSE::INTERNAL::threadPoolThread::run() {
+  // Worker threads also run DSP (CHANNEL::implementationObject::run dispatches
+  // child-channel dsp() here via addFastJob). MXCSR/FPCR is per-thread, so the
+  // FTZ/DAZ set on the audio callback thread does not reach us — set it once
+  // when the worker starts. See issue #81 and denormalGuard.h.
+  enableFlushToZero();
+
   while (!threadShouldExit()) {
     threadPoolJob * job = pool->getJob();
     if (job == nullptr) return;


### PR DESCRIPTION
Closes #81.

## Summary

- Adds `YSE::INTERNAL::enableFlushToZero()` at the top of
  [threadPoolThread::run()](YseEngine/internal/threadPool.cpp#L40-L46).

PR #70 set FTZ/DAZ on the audio callback thread, but child-channel
DSP is dispatched to the fast threadpool via
[addFastJob](YseEngine/channel/channelImplementation.cpp#L104-L108).
MXCSR/FPCR is per-thread, so the workers ran with default denormal
handling — any IIR/reverb tail on a child channel could decay into
subnormals on a worker thread and slow it 10-100x once the channel
went silent.

One call at worker-thread entry protects every job that worker ever
processes. The slow pool reuses the same entry point and does not
run DSP, but the call is a single register write so the uniform
setup is preferable to branching on pool type.

## Test plan

- [x] `python yse.py build` — clean
- [x] `python yse.py analyze YseEngine/internal/threadPool.cpp` — no new findings (21 warnings all suppressed in non-user code)
- [ ] Smoke-test a graph with a child channel carrying an IIR on Windows to confirm callback timing stays flat post-silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)