### PR TITLE
Time audio callbacks ourselves for cpuLoad (fixes #82)

### DIFF
--- a/Tests/integration/test_device.cpp
+++ b/Tests/integration/test_device.cpp
@@ -153,6 +153,24 @@ TEST_CASE("engine: cpuLoad returns a non-negative value") {
     CHECK(YSE::System().cpuLoad() >= 0.0f);
 }
 
+// Issue #82: cpuLoad() is our own callback wall-clock / buffer-period EMA.
+// Without any user graph attached, the engine's per-callback work is tiny;
+// the smoothed reading should sit well below 1.0 (would mean callback taking
+// the entire buffer period). 0.5 is a generous ceiling that catches a
+// totally broken measurement without being flaky on slow CI machines.
+TEST_CASE("engine: cpuLoad stays bounded with no graph activity") {
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+    // Let callbacks fire long enough for the ~1 s EMA to settle.
+    for (int i = 0; i < 30; i++) {
+        YSE::System().sleep(50);
+        YSE::System().update();
+    }
+    const float load = YSE::System().cpuLoad();
+    CHECK(load >= 0.0f);
+    CHECK(load < 0.5f);
+}
+
 // ─── Audio callback ───────────────────────────────────────────────────────────
 
 TEST_CASE("engine: audio callback fires within 100ms on a real output device") {

--- a/YseEngine/device/androidDeviceManager.h
+++ b/YseEngine/device/androidDeviceManager.h
@@ -19,7 +19,7 @@ namespace YSE {
 
       virtual bool init(bool openDevice = true);
       virtual void close();
-      virtual float cpuLoad() { return 0.f; } // not implemented for android
+      virtual float cpuLoad() { return implementation.cpuLoad(); }
 
 			virtual void pause();
 			virtual void resume();

--- a/YseEngine/device/oboeImplementation.cpp
+++ b/YseEngine/device/oboeImplementation.cpp
@@ -2,9 +2,16 @@
 
 #if YSE_ANDROID
 
+#include <chrono>
+#include <cmath>
 #include "../implementations/logImplementation.h"
 #include "../internalHeaders.h"
 #include "../internal/denormalGuard.h"
+
+namespace {
+  // See portaudioDeviceManager.cpp for the rationale on the time constant.
+  constexpr double kCpuLoadTau = 1.0;
+}
 
 OboeImplementation::OboeImplementation()
   : bufferPos(YSE::STANDARD_BUFFERSIZE)
@@ -81,6 +88,7 @@ void OboeImplementation::Stop() {
   mStream->stop();
   mStream->close();
   mStream.reset();
+  cpuLoadEma.store(0.f, std::memory_order_relaxed);
 }
 
 void OboeImplementation::Suspend() {
@@ -112,12 +120,17 @@ oboe::DataCallbackResult OboeImplementation::onAudioReady(oboe::AudioStream * /*
                                                           void * audioData,
                                                           int32_t numFrames) {
   YSE::INTERNAL::enableFlushToZero();
+  // Issue #82: our own callback wall-clock measurement, mirroring the
+  // PortAudio path so system::cpuLoad() reports a consistent number
+  // across backends.
+  const auto cbStart = std::chrono::steady_clock::now();
   ++callbacksSinceLastUpdate;
 
   float * dest = static_cast<float *>(audioData);
 
   if (!YSE::DEVICE::Manager().doOnCallback(numFrames)) {
     std::memset(dest, 0, sizeof(float) * numFrames * numChannels);
+    updateCpuLoadEma(cbStart, numFrames);
     return oboe::DataCallbackResult::Continue;
   }
 
@@ -152,7 +165,22 @@ oboe::DataCallbackResult OboeImplementation::onAudioReady(oboe::AudioStream * /*
     pos += size;
   }
 
+  updateCpuLoadEma(cbStart, numFrames);
   return oboe::DataCallbackResult::Continue;
+}
+
+void OboeImplementation::updateCpuLoadEma(
+    std::chrono::steady_clock::time_point cbStart,
+    int32_t numFrames) {
+  const auto cbEnd = std::chrono::steady_clock::now();
+  const double elapsedSec = std::chrono::duration<double>(cbEnd - cbStart).count();
+  const double bufferSec = double(numFrames) / double(YSE::SAMPLERATE);
+  if (bufferSec <= 0.0) return;
+
+  const float sample = float(elapsedSec / bufferSec);
+  const float alpha = float(1.0 - std::exp(-bufferSec / kCpuLoadTau));
+  const float prev = cpuLoadEma.load(std::memory_order_relaxed);
+  cpuLoadEma.store(prev + alpha * (sample - prev), std::memory_order_relaxed);
 }
 
 void OboeImplementation::onErrorAfterClose(oboe::AudioStream * /*stream*/, oboe::Result error) {

--- a/YseEngine/device/oboeImplementation.h
+++ b/YseEngine/device/oboeImplementation.h
@@ -4,6 +4,7 @@
 
 #include <oboe/Oboe.h>
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include "../headers/types.hpp"
 
@@ -29,6 +30,10 @@ public:
   int32_t getNegotiatedBufferSize() const;
   int32_t getNegotiatedOutputLatencyMs() const;
 
+  // EMA-smoothed callback wall-clock load (issue #82), mirroring the
+  // PortAudio path. Read by managerObject::cpuLoad() on the control thread.
+  float cpuLoad() const { return cpuLoadEma.load(std::memory_order_relaxed); }
+
   oboe::DataCallbackResult onAudioReady(oboe::AudioStream * stream,
                                         void * audioData,
                                         int32_t numFrames) override;
@@ -40,6 +45,12 @@ public:
 private:
   bool openStream(int channels);
 
+  // Fold one callback's wall-clock elapsed time into cpuLoadEma.
+  // Called by onAudioReady on every exit path. Single producer
+  // (the Oboe callback thread), so relaxed atomics are sufficient.
+  void updateCpuLoadEma(std::chrono::steady_clock::time_point cbStart,
+                        int32_t numFrames);
+
   std::shared_ptr<oboe::AudioStream> mStream;
   int numChannels = 2;
   int32_t negotiatedSampleRate = 44100;
@@ -47,6 +58,7 @@ private:
   float ** sourceChannels = nullptr;
 
   std::atomic<unsigned int> callbacksSinceLastUpdate{0};
+  std::atomic<float>        cpuLoadEma{0.f};
 };
 
 #endif

--- a/YseEngine/device/portaudioDeviceManager.cpp
+++ b/YseEngine/device/portaudioDeviceManager.cpp
@@ -13,9 +13,17 @@
 #include "portaudioDeviceManager.h"
 #include "internalHeaders.h"
 #include "internal/denormalGuard.h"
+#include <chrono>
+#include <cmath>
 #ifdef __WINDOWS__
 #include "pa_asio.h"
 #endif
+
+namespace {
+  // Time constant for the cpuLoad EMA, in seconds. ~1 s means the reading
+  // settles within a few seconds and isn't dominated by per-callback jitter.
+  constexpr double kCpuLoadTau = 1.0;
+}
 
 UInt YSE::SAMPLERATE = 44100;
 
@@ -46,6 +54,10 @@ int YSE::DEVICE::managerObject::paCallback(
   , PaStreamCallbackFlags /*statusFlags*/
   , void * userData) {
   YSE::INTERNAL::enableFlushToZero();
+  // Issue #82: Pa_GetStreamCpuLoad was unreliable under WASAPI shared mode
+  // (plateaued at ~50% after silence). Time the callback ourselves with
+  // steady_clock; cpuLoad() returns the EMA of (elapsed / buffer-period).
+  const auto cbStart = std::chrono::steady_clock::now();
   YSE::DEVICE::managerObject * manager = (YSE::DEVICE::managerObject *)userData;
 	manager->callbacksSinceLastUpdate++;
 
@@ -57,7 +69,10 @@ int YSE::DEVICE::managerObject::paCallback(
     manager->activeBufferSize.store((int)numSamples, std::memory_order_release);
   }
 
-  if (!manager->doOnCallback(numSamples)) return 0;
+  if (!manager->doOnCallback(numSamples)) {
+    manager->updateCpuLoadEma(cbStart, numSamples);
+    return 0;
+  }
 
   UInt pos = 0;
   while (pos < static_cast<UInt>(numSamples)) {
@@ -93,8 +108,24 @@ int YSE::DEVICE::managerObject::paCallback(
 
   }
 
-	
+  manager->updateCpuLoadEma(cbStart, numSamples);
   return 0;
+}
+
+void YSE::DEVICE::managerObject::updateCpuLoadEma(
+    std::chrono::steady_clock::time_point cbStart,
+    unsigned long numSamples) {
+  const auto cbEnd = std::chrono::steady_clock::now();
+  const double elapsedSec = std::chrono::duration<double>(cbEnd - cbStart).count();
+  const double bufferSec = double(numSamples) / double(SAMPLERATE);
+  if (bufferSec <= 0.0) return;
+
+  const float sample = float(elapsedSec / bufferSec);
+  // First-order EMA with tau ≈ kCpuLoadTau. alpha = 1 - exp(-dt/tau) keeps
+  // the smoothing time constant stable regardless of buffer size.
+  const float alpha = float(1.0 - std::exp(-bufferSec / kCpuLoadTau));
+  const float prev = cpuLoadEma.load(std::memory_order_relaxed);
+  cpuLoadEma.store(prev + alpha * (sample - prev), std::memory_order_relaxed);
 }
 
 
@@ -214,6 +245,7 @@ void YSE::DEVICE::managerObject::close() {
   // No active device — the live getters report 0 until the next open.
   activeBufferSize.store(0, std::memory_order_release);
   activeOutputLatencySamples.store(0, std::memory_order_release);
+  cpuLoadEma.store(0.f, std::memory_order_relaxed);
 }
 
 void YSE::DEVICE::managerObject::terminate() {
@@ -351,10 +383,7 @@ void YSE::DEVICE::managerObject::audioDeviceError(PaError /*error*/) {
 }
 
 Flt YSE::DEVICE::managerObject::cpuLoad() {
-  if (stream != nullptr) {
-    return (Flt)Pa_GetStreamCpuLoad(stream);
-  }
-  return 0.f;
+  return cpuLoadEma.load(std::memory_order_relaxed);
 }
 
 double YSE::DEVICE::managerObject::getActiveSampleRate() const {

--- a/YseEngine/device/portaudioDeviceManager.h
+++ b/YseEngine/device/portaudioDeviceManager.h
@@ -19,6 +19,7 @@
 #include "headers/types.hpp"
 #include "deviceManager.h"
 #include "portaudio.h"
+#include <chrono>
 
 namespace YSE {
   
@@ -57,6 +58,12 @@ namespace YSE {
     private:
         void terminate();
 
+        // Fold one callback's wall-clock elapsed time into cpuLoadEma.
+        // Called by paCallback on every exit path. Single producer (the
+        // PortAudio callback thread), so relaxed atomics are sufficient.
+        void updateCpuLoadEma(std::chrono::steady_clock::time_point cbStart,
+                              unsigned long numSamples);
+
         void audioDeviceError(PaError err);
         PaStream * stream;
         PaError err;
@@ -70,6 +77,13 @@ namespace YSE {
         // because we open the stream with paFramesPerBufferUnspecified.
         std::atomic<int> activeBufferSize{0};
         std::atomic<int> activeOutputLatencySamples{0};
+
+        // EMA-smoothed callback wall-clock load (issue #82). Written by
+        // paCallback at the end of each render (relaxed, single producer),
+        // read by cpuLoad() on the control thread (relaxed — no
+        // synchronisation needed, callers just want a recent value).
+        // Reset to 0 on close() so a fresh device starts clean.
+        std::atomic<float> cpuLoadEma{0.f};
     };
 
     managerObject & Manager();

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -209,9 +209,21 @@ namespace YSE {
      */
     system& autoReconnect(bool on, int delay);
 
-    /** @brief CPU load of the audio thread as a fraction of the callback budget.
+    /** @brief Audio callback wall-clock load as a fraction of the buffer period.
      *
-     *  Distinct from the cost of ``update()`` on the main thread.
+     *  Measured by YSE: timestamps taken at the entry/exit of each backend
+     *  callback (PortAudio's ``paCallback`` or Oboe's ``onAudioReady``) and
+     *  divided by the buffer's audio time. EMA-smoothed with a ~1 s time
+     *  constant. Returns 0 when no device is open.
+     *
+     *  This is a **dropout-risk** indicator: 1.0 means the callback is taking
+     *  as long as the buffer it produces, i.e. the next buffer will arrive
+     *  late. It does NOT reflect total engine CPU across the threadpool
+     *  workers — for that, see issue #84.
+     *
+     *  Distinct from the cost of ``update()`` on the main thread. Replaces
+     *  the previous pass-through of ``Pa_GetStreamCpuLoad``, which read as
+     *  inflated under WASAPI shared mode after periods of silence (see #82).
      */
     float cpuLoad();
 


### PR DESCRIPTION
Closes #82.

## Summary

Replaces the pass-through of `Pa_GetStreamCpuLoad` with our own callback wall-clock measurement. `Pa_GetStreamCpuLoad` was unreliable on WASAPI shared mode — it plateaued at ~50% after a period of silence, while `GetProcessTimes` showed flat ~3% process CPU (cross-checked under #53). Since YSE was passing the number through unchanged, consumers (phi, demos) got the artifact directly.

- [portaudioDeviceManager.cpp](YseEngine/device/portaudioDeviceManager.cpp) — `paCallback` brackets its work with `std::chrono::steady_clock::now()`, computes `(elapsed / buffer-period)`, folds into an EMA with a ~1 s time constant (`alpha = 1 - exp(-dt/tau)`, so the smoothing window is independent of buffer size). EMA stored relaxed-atomically on `managerObject::cpuLoadEma`, reset to 0 on `close()`.
- [oboeImplementation.cpp](YseEngine/device/oboeImplementation.cpp) — same instrumentation mirrored on `onAudioReady`. The Android device manager's `cpuLoad()` was previously a `return 0.f` stub; it's now wired to the Oboe path's EMA.
- [system.hpp](YseEngine/system.hpp) — doxygen rewritten to describe the new semantics. Notes that this is a **dropout-risk** indicator (callback wall-clock / buffer period), not total engine CPU across worker threads — for that, points at #84.

## Test plan

- [x] `python yse.py build` — clean
- [x] `python yse.py analyze YseEngine/device/portaudioDeviceManager.cpp` — no new findings (3 warnings all pre-existing: classes.hpp namespace shadow, destructor virtual-call at line 45)
- [x] `python yse.py analyze Tests/integration/test_device.cpp` — no new findings (1 warning pre-existing on `ConstantSource`)
- [x] `python yse.py test` — full ctest suite passes (14/14)
- [x] New test `engine: cpuLoad stays bounded with no graph activity` exercises the EMA path on a real device — 2 cpuLoad cases / 3 assertions, all pass on Windows MSYS2 Clang64
- [ ] Cross-check against `GetProcessTimes` on Windows WASAPI to confirm the artifact is gone (manual, on the reporter's side from #53)
- [ ] Smoke-test on Android (Oboe path compiles + reports a sane number)

🤖 Generated with [Claude Code](https://claude.com/claude-code)