### PR TITLE
Release: dev → master for v2.1.0

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,79 @@
+# clang-tidy baseline for the YSE Sound Engine.
+#
+# Goal: surface real bugs without drowning in stylistic noise. The check set
+# is opt-in (-* first) rather than opt-out, so adding a new check is a
+# deliberate decision rather than a surprise.
+#
+# RT-thread performance is non-negotiable in this codebase — checks that
+# push toward heavier abstractions on the audio callback path (std::function
+# over function pointer, virtual dispatch, atomic-with-default-memory-order)
+# are intentionally OFF. See CLAUDE.md and the fix-issues skill for the
+# project stance.
+#
+# A handful of high-volume categories with low signal-to-noise on this
+# codebase are also disabled below; they represent pre-existing tech debt
+# that won't be paid down per-commit (modernize-use-nullptr across the
+# legacy DSP code, etc.). Re-enable a specific check if a focused cleanup
+# pass is planned.
+#
+# Vendored deps under dependencies/ and generated code under build*/ are
+# excluded via HeaderFilterRegex.
+
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-branch-clone,
+  -bugprone-macro-parentheses,
+  -bugprone-throwing-static-initialization,
+  -bugprone-exception-escape,
+  -bugprone-reserved-identifier,
+  clang-analyzer-core.*,
+  clang-analyzer-cplusplus.*,
+  clang-analyzer-deadcode.*,
+  clang-analyzer-nullability.*,
+  clang-analyzer-optin.cplusplus.VirtualCall,
+  clang-analyzer-security.insecureAPI.*,
+  clang-analyzer-unix.*,
+  cert-dcl21-cpp,
+  cert-dcl50-cpp,
+  cert-dcl58-cpp,
+  cert-err34-c,
+  cert-flp30-c,
+  cert-mem57-cpp,
+  cert-msc50-cpp,
+  cert-msc51-cpp,
+  cert-oop54-cpp,
+  cert-str34-c,
+  cppcoreguidelines-slicing,
+  cppcoreguidelines-virtual-class-destructor,
+  misc-definitions-in-headers,
+  misc-unused-using-decls,
+  misc-misleading-bidirectional,
+  misc-misleading-identifier,
+  modernize-use-override,
+  modernize-redundant-void-arg,
+  performance-faster-string-find,
+  performance-for-range-copy,
+  performance-implicit-conversion-in-loop,
+  performance-inefficient-string-concatenation,
+  performance-inefficient-vector-operation,
+  performance-move-const-arg,
+  performance-noexcept-move-constructor,
+  performance-trivially-destructible,
+  performance-unnecessary-copy-initialization,
+  readability-misleading-indentation,
+  readability-redundant-control-flow,
+  readability-redundant-smartptr-get,
+  readability-string-compare,
+
+WarningsAsErrors: ''
+
+# Apply checks only to our own headers under YseEngine/ and Tests/.
+HeaderFilterRegex: '.*(YseEngine|Tests)[/\\][^/\\]*\.h(pp)?$'
+
+CheckOptions:
+  - key: performance-move-const-arg.CheckTriviallyCopyableMove
+    value: 'false'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,8 @@
       "mcp__sonarqube__get_duplications",
       "Read(//tmp/**)",
       "Read(//d/tmp/**)",
-      "Edit(/.claude/skills/c-api-extend/**)"
+      "Edit(/.claude/skills/c-api-extend/**)",
+      "Edit(/.claude/skills/fix-issues/**)"
     ],
     "additionalDirectories": [
       "\\tmp\\gh-issues",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,8 @@
       "mcp__sonarqube__search_duplicated_files",
       "mcp__sonarqube__get_duplications",
       "Read(//tmp/**)",
-      "Read(//d/tmp/**)"
+      "Read(//d/tmp/**)",
+      "Edit(/.claude/skills/c-api-extend/**)"
     ],
     "additionalDirectories": [
       "\\tmp\\gh-issues",

--- a/.claude/skills/c-api-extend/SKILL.md
+++ b/.claude/skills/c-api-extend/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: c-api-extend
+description: Use when extending the C API at YseEngine/c_api/ — wrapping a new engine class, method, enum, or callback — or when auditing the C API for drift from the engine's public surface. Applies the project's RT-safety, ownership, and ABI conventions established in PRs #63–#67. Triggers on phrases like "wrap X in the C API", "update the C API after I added Y to the engine", "audit C API drift", "expose <thing> to Dart", and similar. Do NOT trigger for engine-internal changes that don't need FFI exposure, or for modifications to existing C-API entry points that don't add surface.
+---
+
+# Extending the YSE C API for new engine surface
+
+`YseEngine/c_api/` is the only entry point for FFI consumers (Dart, Python, …).
+The C API has explicit rules — RT-safe callback bridges, opaque-handle
+ownership, null-safe no-op semantics, `YSE_C_CALLBACK` ABI defence,
+exception-to-`YseStatus` translation, enum drift guard — that the engine's
+own public C++ API does not enforce. New wrapping must follow all of them; a
+careless callback bridge can stall the audio thread.
+
+This skill governs how to wrap new engine surface in the C API. Read it
+fully before editing any file under `YseEngine/c_api/`.
+
+## Issue tracking — GitHub Issues first
+
+CLAUDE.md mandates an issue before code. For this skill:
+
+- **File the issue first** with `gh issue create --title "c-api: ..."`. Use
+  the `enhancement` or `task` template; tag the layer as `c-api`.
+- **Branch from `dev`** as `<issue-number>-c-api-<short-slug>` and PR back
+  to `dev`. Not `master` — see CLAUDE.md §1.
+- **Read context** with `gh issue view <n>` before starting if the
+  request mentions an existing issue number.
+
+The `gh` CLI is authenticated in the project environment.
+
+## When to invoke this skill
+
+Yes:
+- A new engine class / method / enum was added and needs C-ABI exposure.
+- The user asks to audit the C API for drift from the engine.
+- The user is starting a new C-API milestone (M3 buffer overloads,
+  M5 patcher sources, etc. — see `yse_sound.h`'s top-of-file note).
+
+No:
+- Modifying behaviour of an *existing* C-API function without adding
+  surface — that's a regular fix, use the normal workflow.
+- Internal engine refactors that don't change the public C++ surface.
+- Adding audio-thread-reachable callbacks (occlusion,
+  `dspSourceObject` user callback, `customFileReader`) on a casual
+  wrapping pass. Those need design work — see the "Callback bridge
+  rules" block in [yse_c_internal.hpp](../../../YseEngine/c_api/yse_c_internal.hpp).
+
+## The six conventions
+
+Every new C-API entry point must respect all six.
+
+### 1. Opaque handle shape and ownership
+
+Each engine type that gets a C handle is declared with `typedef struct
+YseFoo YseFoo;` and accessed only via `YseFoo*` pointers. The `.cpp` file
+does `reinterpret_cast<YSE::foo*>(handle)`. **Never expose any C++ type,
+class, namespace, reference, or template across the C ABI.**
+
+Every typedef in its home header carries a one-line ownership comment:
+
+```c
+/* Owned — release with yse_foo_destroy. */
+typedef struct YseFoo YseFoo;
+```
+
+```c
+/* Borrowed singleton — owned by the engine, never destroy.
+   Obtain via yse_foo_get(). */
+typedef struct YseFoo YseFoo;
+```
+
+```c
+/* Borrowed — owned by parent YsePatcher. Release with
+   yse_patcher_delete_object(patcher, handle); never call a destroy on
+   the handle directly. */
+typedef struct YsePHandle YsePHandle;
+```
+
+Dual-shape types (e.g. `YseChannel` is owned via `yse_channel_create` but
+borrowed via the pre-built accessors) get both lines.
+
+Forward-declaration typedefs (in headers that don't own the type) point
+the reader at the home header rather than duplicating the ownership note:
+
+```c
+/* Forward declarations — see yse_channel.h / yse_dsp.h for ownership. */
+typedef struct YseChannel YseChannel;
+typedef struct YseDspBuffer YseDspBuffer;
+```
+
+Canonical examples: [yse_patcher.h](../../../YseEngine/c_api/include/yse_c/yse_patcher.h)
+(owned + borrowed pair), [yse_reverb.h](../../../YseEngine/c_api/include/yse_c/yse_reverb.h)
+(dual-shape).
+
+### 2. Header layout
+
+Every `include/yse_c/yse_<module>.h`:
+
+- Top-of-file block comment naming purpose, the mirrored engine source,
+  scope notes, and the null-safe-no-op convention statement.
+- `#ifndef` / `#define` / `#endif` include guards. No `#pragma once`.
+- `#include "yse_common.h"` (and `yse_enums.h` if needed) — never an
+  engine C++ header.
+- `#ifdef __cplusplus / extern "C" { ... } / #endif` wraps the body.
+- `YSE_C_API` on every exported function declaration.
+- `YSE_C_CALLBACK` on every callback typedef.
+- All booleans as `int` (0/1), never `bool`. All sizes as `size_t` or
+  `unsigned int`. Strings as `const char*` (in) or `char* + size_t`
+  (snprintf-style out).
+
+Canonical example: [yse_sound.h](../../../YseEngine/c_api/include/yse_c/yse_sound.h).
+
+### 3. Function shape
+
+| Engine signature                                | C API shape                                                                       |
+| ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| `void play()` — can't fail                      | `void yse_x_play(YseX* h)` — null-safe no-op                                      |
+| `void setFoo(T v)`                              | `void yse_x_set_foo(YseX* h, T v)` — null-safe no-op                              |
+| `T getFoo() const`                              | `T yse_x_get_foo(YseX* h)` — return `0` / `false` / `NULL` on null                |
+| `bool create(...)` — can fail                   | `YseStatus yse_x_load_...(...)` — `set_last_error` on failure                     |
+| `const char* getName() const`                   | `size_t yse_x_get_name(YseX* h, char* buf, size_t cap)` — snprintf style          |
+| `std::string getBlob() const` (engine-internal) | Same as above; never return `const char*` to engine-owned storage that can free   |
+
+The header-top convention paragraph captures the void-no-op rule once for
+the whole header. Per-function comments are reserved for genuinely surprising
+behaviour.
+
+**Body pattern for fallible operations** (lift from [yse_sound.cpp](../../../YseEngine/c_api/yse_sound.cpp)):
+
+```cpp
+YSE_C_API YseStatus yse_x_load(YseX* h, const char* arg) {
+  if (!h) return YSE_ERR_INVALID_HANDLE;
+  if (!arg) return YSE_ERR_INVALID_ARGUMENT;
+  try {
+    if (!to_cpp(h)->load(arg)) {
+      yse_c::set_last_error(std::string("x load failed for: ") + arg);
+      return YSE_ERR_<specific>;
+    }
+    return YSE_OK;
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return YSE_ERR_EXCEPTION;
+  } catch (...) {
+    yse_c::set_last_error("yse_x_load: unknown C++ exception");
+    return YSE_ERR_EXCEPTION;
+  }
+}
+```
+
+**Body pattern for void state-change**:
+
+```cpp
+YSE_C_API void yse_x_play(YseX* h) { if (h) to_cpp(h)->play(); }
+```
+
+**Body pattern for string-out**:
+
+```cpp
+YSE_C_API size_t yse_x_get_name(YseX* h, char* buf, size_t cap) {
+  if (!h) { if (buf && cap > 0) buf[0] = '\0'; return 0; }
+  return copy_string(to_cpp(h)->getName(), buf, cap);
+}
+```
+
+Canonical example for the snprintf pattern: [yse_device.cpp](../../../YseEngine/c_api/yse_device.cpp).
+
+### 4. Callback bridges — RT-safe shape
+
+When the engine invokes a user-provided callback on a **non-host thread**
+(audio callback, RtMidi input thread, file streaming worker, future
+occlusion / `dspSourceObject` / `customFileReader` paths), the bridge:
+
+1. Holds the callback + user_data pair as `std::atomic<>`. **Never
+   `std::mutex` or `std::lock_guard`.**
+2. Installs with `memory_order_release` stores (user_data first, then cb).
+3. Dispatches with `memory_order_acquire` loads (cb first; return if null;
+   then user_data).
+4. **Does not `malloc` / `new` / construct `std::string` on dispatch when
+   the bridge can fire from the audio callback.** For raw byte buffers
+   needed by an async-Dart host, preallocate a per-handle pool keyed by
+   the handle.
+5. Uses `YSE_C_CALLBACK` on the typedef.
+6. If the bridge transfers heap ownership to the host (Dart's
+   `NativeCallable.listener` requires this), pair the callback with a
+   `yse_<module>_free_message` function and document the contract beside
+   the typedef.
+
+Canonical examples:
+- [yse_midi.cpp](../../../YseEngine/c_api/yse_midi.cpp) — `c_raw_bridge`,
+  atomic-swap, malloc per call is acceptable because the RtMidi input
+  thread is not the audio callback.
+- [yse_log.cpp](../../../YseEngine/c_api/yse_log.cpp) — `CallbackBridge`,
+  same atomic-swap shape, same Dart-ownership malloc.
+
+The "Callback bridge rules" block at the head of
+[yse_c_internal.hpp](../../../YseEngine/c_api/yse_c_internal.hpp) restates
+these rules in detail. Read it before designing any new bridge.
+
+### 5. Enum mirroring + drift guard
+
+When the engine adds an enum value that should be visible from the C API:
+
+1. Add a matching `Yse<Name>_<VALUE>` entry to
+   [yse_enums.h](../../../YseEngine/c_api/include/yse_c/yse_enums.h).
+   Mirror the integer value exactly. Use C-compatible `typedef enum {...}
+   Yse<Name>;` syntax (not `enum class`).
+2. Add a `YSE_ASSERT_ENUM(YSE_..., YSE::...);` line to
+   [yse_enums_check.cpp](../../../YseEngine/c_api/yse_enums_check.cpp).
+   The build fails loudly if the values drift.
+
+If the engine adds a brand-new enum, add the full mirror block + a full
+set of `YSE_ASSERT_ENUM` lines. The drift guard is the only safety net
+until a generator replaces the hand-mirrored file.
+
+### 6. Build + test integration
+
+- **New `.cpp` file** → append to `YSE_C_API_SRCS` in
+  [c_api/CMakeLists.txt](../../../YseEngine/c_api/CMakeLists.txt).
+- **New public functions** → add at least one smoke test under
+  `Tests/<module>/`. The doctest harness picks up `TEST_CASE` without
+  further wiring; see existing tests for patterns. Tests that need a
+  null device use [`TestHelpers::engineInit()`](../../../Tests/support/null_device.hpp).
+- **Build with the project wrapper**, never raw cmake invocations:
+  `python yse.py build && python yse.py test`. CTest must stay green
+  across all 14 entries.
+
+## Workflow
+
+1. **Inventory the new engine surface.** Read the engine header (e.g.
+   `YseEngine/sound/soundInterface.hpp`); list every public method,
+   enum, and callback. Skip private helpers and the implementation
+   pimpls.
+2. **Map ownership.** For each new class, decide: *owned* (user
+   create/destroy), *borrowed singleton*, or *borrowed by parent*.
+3. **Plan the module file.** New subsystem → new `yse_<module>.h` +
+   `yse_<module>.cpp` pair + CMakeLists entry. Extending an existing
+   subsystem → add to the existing pair.
+4. **Apply the six conventions** as you write. Lift bodies from the
+   canonical examples — don't re-invent the shape.
+5. **Update the enum mirror + drift guard** if any new enum value
+   landed in the engine.
+6. **Update [c_api/CMakeLists.txt](../../../YseEngine/c_api/CMakeLists.txt)**
+   if new files were added.
+7. **Add a test stub** under `Tests/<module>/`. At minimum: a
+   `TEST_CASE` that exercises create/destroy and one method.
+8. **Build + test:** `python yse.py build && python yse.py test`. Must
+   be green.
+9. **PR to `dev`** with a body that references the closing issue and
+   lists every new public function in the summary.
+
+## Hard refusals
+
+Stop and surface a design note rather than emit code that:
+
+- Contains `std::mutex` or `std::lock_guard` in any callback bridge body.
+  (PR #63 had to remove these from `yse_log.cpp`; do not put them back.)
+- Allocates memory (`malloc`, `new`, `std::string` construction) in a
+  callback that fires on the audio thread. If the host genuinely needs
+  byte ownership, design a preallocated pool.
+- Exposes any C++ type, namespace, reference, or template in a public
+  `yse_c/*.h` header.
+- Catches `std::exception` and rethrows, swallows, or returns 0/NULL
+  without first calling `yse_c::set_last_error`.
+- Adds a void function that throws on null instead of being a null-safe
+  no-op.
+- Adds a callback typedef without `YSE_C_CALLBACK`.
+- Adds an enum to `yse_enums.h` without a matching `YSE_ASSERT_ENUM` in
+  `yse_enums_check.cpp`.
+
+If the engine's design genuinely requires one of these (rare), file an
+issue describing the conflict and wait for a decision before proceeding.
+
+## Things this skill DOES NOT do
+
+- Modify vendored dependencies under `dependencies/` or `build*/_deps/`.
+- Add new public methods, classes, or enums to the engine. Engine changes
+  go through the engine's own workflow first; this skill mirrors them.
+- Refactor existing C-API surface unless the engine change requires it.
+- Wrap callbacks that fire on the audio thread (occlusion,
+  `dspSourceObject`, `customFileReader`) — those need additional design
+  work (preallocated pools, stack-only return paths) per
+  [yse_c_internal.hpp](../../../YseEngine/c_api/yse_c_internal.hpp)'s
+  rules block. Surface a design proposal first.
+- Modify CLAUDE.md or PROJECT_OVERVIEW.md unless the wrapping pass
+  introduces a structural change worth documenting at the project root.
+
+## Verification
+
+Before reporting the wrapping task complete:
+
+- `python yse.py build` succeeds with **no new warnings**.
+- `python yse.py test` passes **14/14 CTest entries** (the project's
+  full suite, not just the new test).
+- `grep "std::mutex\|std::lock_guard" YseEngine/c_api/` returns
+  **nothing** beyond pre-existing lines (there should be none after
+  PR #63).
+- Every new public function in `include/yse_c/*.h` is either covered by
+  the header-top void-no-op convention or carries its own explanatory
+  comment.
+- Every new opaque typedef has the ownership one-liner.
+- Every new callback typedef has `YSE_C_CALLBACK`.
+- Every new enum value has a matching `YSE_ASSERT_ENUM` line.
+
+If any of these fail, the wrapping is incomplete — keep iterating rather
+than reporting done.

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -172,13 +172,31 @@ when the warning only exists on one toolchain.
 7. **Report.** Summarize: groups fixed, mechanism used per group, any items
    deferred and why, any audio-thread-adjacent code touched.
 
+## Running clang-tidy locally
+
+A baseline check set lives at [.clang-tidy](../../../.clang-tidy). Invoke
+analysis through the project wrapper rather than calling `clang-tidy`
+directly — the wrapper picks the right `compile_commands.json` and avoids
+the "doctest/doctest.h not found" failure mode on test files:
+
+```powershell
+python yse.py analyze YseEngine/dsp/lfo.cpp        # one file
+python yse.py analyze YseEngine/device/            # one directory
+python yse.py analyze                              # whole project (slow)
+```
+
+Per CLAUDE.md item 6, run `python yse.py analyze <changed-files>` before
+committing and clear any **new** findings on the modified code. The
+baseline (~50 pre-existing findings across `YseEngine/`) is tracked as
+backlog — don't fix in passing during unrelated work.
+
 ## Things that are out of scope for this skill
 
-- Adding new warnings to the build (enabling `-Wfoo` that wasn't on before)
+- Adding new compiler warnings to the build (enabling `-Wfoo` that wasn't
+  on before) without an accompanying issue
 - Migrating to a newer C++ standard
 - Replacing project utilities (`aFlt`, `MULTICHANNELBUFFER`, the message
   queue, `dspObject::link()`) with standard-library equivalents
-- Adding clang-tidy or sanitizers to the build pipeline
 - Reformatting code that happens to be near a warning
 
 If any of those would actually help, raise them as a separate proposal,

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,6 +25,12 @@ permissions:
 
 jobs:
   benchmark:
+    # Skip the PR-event run when the head branch is `dev` (i.e. dev → master
+    # release PRs). The push to dev that brought the SHA in already triggered
+    # the same bench workflow against the same commit and wrote results to
+    # bench-history; the PR-event run would only compare against that same
+    # baseline. PRs from feature branches still run normally.
+    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
     name: Run benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,13 @@ jobs:
           build-wrapper-linux-x86-64 --out-dir "$BUILD_WRAPPER_OUT_DIR" cmake --build build
       - name: Run tests
         run: ctest --test-dir build --output-on-failure
+      - name: Run tests at forced 48 kHz
+        # Cross-checks that DSP code and tests are rate-agnostic. Honoured by
+        # Tests/main.cpp:applyForcedSampleRateFromEnv() which writes
+        # YSE::SAMPLERATE before any DSP object is constructed. See #72.
+        env:
+          YSE_TEST_FORCED_RATE: "48000"
+        run: ctest --test-dir build --output-on-failure
       - name: Generate coverage report
         run: |
           gcovr \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,12 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
+    # Skip the PR-event run when the head branch is `dev` (i.e. dev → master
+    # release PRs). The push to dev that brought the SHA in has already run
+    # this workflow against the same commit — running it again via the PR
+    # trigger is pure duplication. PRs from feature branches (→ dev or →
+    # master) still run normally because their head_ref is not 'dev'.
+    if: github.event_name == 'push' || github.head_ref != 'dev'
     name: Build and analyze
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -87,7 +93,9 @@ jobs:
     # on PRs that target master (release gate). Skip on PRs that target dev so
     # day-to-day feature work doesn't burn ~5 min of NDK cross-compile per push
     # — Android-specific regressions get caught at the dev → master step.
-    if: github.event_name == 'push' || github.base_ref == 'master'
+    # Additionally skip when the PR's head is `dev` (release PRs): the push
+    # to dev that brought the SHA in has already run this workflow.
+    if: github.event_name == 'push' || (github.base_ref == 'master' && github.head_ref != 'dev')
     name: Android build (${{ matrix.abi }})
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ session start. Pair with [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md).
 ## How we work
 
 1. **Issues first.** Every bug, feature, or enhancement is filed as a
-   GitHub issue *before* code is written. Branch from `master` as
-   `<issue-number>-<short-slug>`. PR through CI. The only exception is a
-   trivial doc fix.
+   GitHub issue *before* code is written. Branch from `dev` as
+   `<issue-number>-<short-slug>` and PR back to `dev`. `dev` is the
+   integration branch; periodic PRs from `dev` to `master` cut releases.
+   The only exception is a trivial doc fix.
 2. **Tests where sensible** (not dogmatically). DSP nodes, the C API
    surface, lifecycle/threading code, and reverb get tests first. Demos
    and one-off scripts don't need tests. The broader plan lives in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,14 @@ session start. Pair with [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md).
 5. **Layered structure.** Engine internals → C API → bindings/demos.
    `YseEngine/c_api/` is the only entry point for FFI consumers. Keep
    `PROJECT_OVERVIEW.md` current after structural changes.
+6. **Analyze before committing.** Run `python yse.py analyze <changed-files>`
+   on the files touched in a commit and address any **new** findings. The
+   project's [.clang-tidy](.clang-tidy) baseline keeps the noise floor low
+   (~50 pre-existing findings across `YseEngine/`, tracked as backlog —
+   don't fix in passing). New findings in *modified* code should be cleared
+   before the commit, fixing or with a focused `// NOLINT(check-name): why`
+   when the check is genuinely wrong for that line. The `fix-issues` skill
+   governs how to triage findings.
 
 ## Issue templates
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,21 @@ option(YSE_ENABLE_COVERAGE
 option(YSE_BUILD_C_API
   "Build the extern \"C\" ABI bridge (yse_*) inside libyse so language bindings (Dart, Python, ...) can consume the DLL without C++ ABI compatibility"
   ON)
+# YSE_ENABLE_MIDI_DEVICE: gate the RtMidi-backed MIDI device backend. Default
+# ON on Windows/Linux desktop (preserves the prior unconditional behavior),
+# OFF on Android (RtMidi isn't built there anyway) and Mac (already excluded
+# in source). When OFF, RtMidi is not required at configure time and the
+# midi/device.cpp + midi/midiDeviceManager.cpp sources are dropped — the rest
+# of the engine (MIDI file playback, midiNote, etc.) is unaffected.
+if(WIN32 OR (UNIX AND NOT APPLE AND NOT ANDROID))
+  set(_yse_midi_device_default ON)
+else()
+  set(_yse_midi_device_default OFF)
+endif()
+option(YSE_ENABLE_MIDI_DEVICE
+  "Build the RtMidi-backed MIDI device backend (Windows/Linux). When OFF, libyse builds without MIDI device I/O and does not require RtMidi at configure time."
+  ${_yse_midi_device_default})
+unset(_yse_midi_device_default)
 
 # Export compile_commands.json for SonarCloud's C++ analyser and clangd.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -111,13 +126,16 @@ else()
   pkg_check_modules(PortAudio REQUIRED IMPORTED_TARGET portaudio-2.0)
   pkg_check_modules(SndFile   REQUIRED IMPORTED_TARGET sndfile)
 
-  # RtMidi is required on every desktop platform we build for here (Windows and
-  # Linux).  The MIDI device source files (device.cpp, midiDeviceManager.cpp)
-  # need RtMidi symbols; they are guarded by `#if YSE_WINDOWS || YSE_LINUX` so
-  # they remain compiled-out on Android, but the CMake build does not target
-  # Android, so the dependency is unconditionally required here.
-  pkg_check_modules(RtMidi REQUIRED IMPORTED_TARGET rtmidi)
-  message(STATUS "RtMidi found — MIDI device backend enabled")
+  # RtMidi is the dependency of the MIDI device backend (midi/device.cpp,
+  # midi/midiDeviceManager.cpp). Required when YSE_ENABLE_MIDI_DEVICE is ON,
+  # which is the default on Windows/Linux. Set the option OFF to build libyse
+  # on a desktop without RtMidi installed — at the cost of no MIDI device I/O.
+  if(YSE_ENABLE_MIDI_DEVICE)
+    pkg_check_modules(RtMidi REQUIRED IMPORTED_TARGET rtmidi)
+    message(STATUS "RtMidi found — MIDI device backend enabled")
+  else()
+    message(STATUS "YSE_ENABLE_MIDI_DEVICE=OFF — skipping RtMidi dependency")
+  endif()
 endif()
 
 # yse::sndfile — uniform interface target so YseEngine/CMakeLists.txt doesn't

--- a/Demo.Windows.Native/CMakeLists.txt
+++ b/Demo.Windows.Native/CMakeLists.txt
@@ -69,10 +69,14 @@ add_yse_demo(Demo14 Demo14_LoadPatcher     DemoLoadPatcher)
 add_yse_demo(Demo15 Demo15_RestartAudio    DemoRestartAudio)
 add_yse_demo(Test01 Test01_Pitch           Test01_Pitch)
 
-# Demo16 and Demo17 use YSE::midiOut which requires the RtMidi backend.
-# RtMidi is now an unconditional dependency on every desktop platform, so
-# these are always built.
-add_yse_demo(Demo16 Demo16_Midi        DemoMidi)
+# Demo16 directly uses YSE::midiOut which is gated behind the
+# YSE_ENABLE_MIDI_DEVICE CMake option (default ON). When that's OFF the
+# DemoMidi class doesn't compile, so the standalone executable is skipped.
+# Demo17 uses the patcher M_OUT object via pHandle — that compiles fine,
+# the patcher registry just won't have M_OUT to instantiate at runtime.
+if(YSE_ENABLE_MIDI_DEVICE)
+  add_yse_demo(Demo16 Demo16_Midi DemoMidi)
+endif()
 add_yse_demo(Demo17 Demo17_MidiPatcher DemoMidiPatcher)
 
 # ── Combined Demo executable (all pages via menu) ─────────────────────────────

--- a/Demo.Windows.Native/Demo10_FilePosition.cpp
+++ b/Demo.Windows.Native/Demo10_FilePosition.cpp
@@ -34,50 +34,50 @@ void DemoFilePosition::ExplainDemo()
 
 void DemoFilePosition::Zero()
 {
-  sound.time(11.2f * 44100);
+  sound.time(11.2f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::One()
 {
-  sound.time(10.0f * 44100);
+  sound.time(10.0f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Two()
 {
-  sound.time(9.0f * 44100);
+  sound.time(9.0f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Three()
 {
-  sound.time(8.0f * 44100);
+  sound.time(8.0f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Four()
 {
-  sound.time(6.7f * 44100);
+  sound.time(6.7f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Five()
 {
-  sound.time(5.5f * 44100);
+  sound.time(5.5f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Six()
 {
-  sound.time(4.3f * 44100);
+  sound.time(4.3f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Seven()
 {
-  sound.time(3.2f * 44100);
+  sound.time(3.2f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Eight()
 {
-  sound.time(2.0f * 44100);
+  sound.time(2.0f * YSE::SAMPLERATE);
 }
 
 void DemoFilePosition::Nine()
 {
-  sound.time(1.0f * 44100);
+  sound.time(1.0f * YSE::SAMPLERATE);
 }

--- a/Demo.Windows.Native/Demo16_Midi.cpp
+++ b/Demo.Windows.Native/Demo16_Midi.cpp
@@ -3,6 +3,7 @@
 #include "Demo16_Midi.h"
 #include <iostream>
 
+#if YSE_ENABLE_MIDI_DEVICE
 DemoMidi::DemoMidi()
 	: firstNote(true)
 {
@@ -63,4 +64,5 @@ void DemoMidi::AllNotesOff() {
 	output1.NoteOn(YSE::MIDI::CH_01, 60, 0);
 	output2.NoteOn(YSE::MIDI::CH_01, YSE::MIDI::D4, 0);
 }
+#endif // YSE_ENABLE_MIDI_DEVICE
 

--- a/Demo.Windows.Native/Demo16_Midi.h
+++ b/Demo.Windows.Native/Demo16_Midi.h
@@ -3,6 +3,11 @@
 #include "basePage.h"
 #include "../YseEngine/yse.hpp"
 
+// The DemoMidi page exercises the RtMidi-backed device backend. When libyse
+// is built with YSE_ENABLE_MIDI_DEVICE=OFF the underlying YSE::midiOut type
+// is not declared, so this whole class compiles out. MenuOther guards the
+// matching `MidiDemo()` call site.
+#if YSE_ENABLE_MIDI_DEVICE
 class DemoMidi : public basePage {
 public:
 	DemoMidi();
@@ -16,3 +21,4 @@ public:
 	YSE::midiOut output2;
 	bool firstNote;
 };
+#endif

--- a/Demo.Windows.Native/MenuOther.cpp
+++ b/Demo.Windows.Native/MenuOther.cpp
@@ -50,8 +50,13 @@ void OtherMenu::RestartAudioDemo() {
 
 void OtherMenu::MidiDemo()
 {
+#if YSE_ENABLE_MIDI_DEVICE
 	DemoMidi demo;
 	demo.Run();
+#else
+	std::cout << "MIDI device backend was disabled at build time "
+	          << "(YSE_ENABLE_MIDI_DEVICE=OFF)." << std::endl;
+#endif
 	ShowMenu();
 }
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(YSE_TEST_SOURCES
   dsp/test_filters.cpp
   dsp/test_delay.cpp
   dsp/test_envelope.cpp
+  dsp/test_lfo_rate_robustness.cpp
   dsp/test_fourier.cpp
   dsp/test_modules.cpp
   dsp/test_module_filters.cpp

--- a/Tests/dsp/test_envelope.cpp
+++ b/Tests/dsp/test_envelope.cpp
@@ -124,19 +124,28 @@ TEST_CASE("ADSRenvelope: ATTACK resets phase to the beginning") {
     CHECK(buf.getPtr()[0] == doctest::Approx(0.0f).epsilon(1e-4f));
 }
 
+// 0.1 s envelope length expressed in 128-sample blocks at the live SAMPLERATE.
+// ceil(0.1 * SAMPLERATE / STANDARD_BUFFERSIZE):
+//   - 44100 Hz: 4410 samples → 35 blocks (block 34 still <4410; block 35 crosses)
+//   - 48000 Hz: 4800 samples → 38 blocks
+static inline int blocksToExhaustTenthSecond() {
+    const unsigned samples = (unsigned)(0.1f * (float)YSE::SAMPLERATE);
+    return (int)((samples + YSE::STANDARD_BUFFERSIZE - 1) / YSE::STANDARD_BUFFERSIZE);
+}
+
 TEST_CASE("ADSRenvelope: isAtEnd false during playback, true after envelope exhausted") {
     YSE::DSP::ADSRenvelope adsr;
     adsr.addPoint({0.0f, 0.0f, 1.0f});
     adsr.addPoint({0.1f, 1.0f, 1.0f});
     adsr.generate();
-    // 34 calls × 128 = 4352 < 4410 → not done.
-    // 35th call crosses envelopeEnd → endReached = true.
-    adsr(YSE::DSP::ADSRenvelope::ATTACK);
+    const int total = blocksToExhaustTenthSecond();
+    adsr(YSE::DSP::ADSRenvelope::ATTACK);  // counts as block 1
     CHECK(!adsr.isAtEnd());
-    for (int i = 0; i < 33; ++i)
+    // Process up to but not including the block that crosses envelopeEnd.
+    for (int i = 1; i < total - 1; ++i)
         adsr(YSE::DSP::ADSRenvelope::RESUME);
     CHECK(!adsr.isAtEnd());
-    adsr(YSE::DSP::ADSRenvelope::RESUME);  // 35th call
+    adsr(YSE::DSP::ADSRenvelope::RESUME);  // crossing block
     CHECK(adsr.isAtEnd());
 }
 
@@ -145,8 +154,9 @@ TEST_CASE("ADSRenvelope: output is silent after envelope exhausted") {
     adsr.addPoint({0.0f, 0.0f, 1.0f});
     adsr.addPoint({0.1f, 1.0f, 1.0f});
     adsr.generate();
+    const int total = blocksToExhaustTenthSecond();
     adsr(YSE::DSP::ADSRenvelope::ATTACK);
-    for (int i = 0; i < 34; ++i)
+    for (int i = 1; i < total; ++i)
         adsr(YSE::DSP::ADSRenvelope::RESUME);
     REQUIRE(adsr.isAtEnd());
     YSE::DSP::buffer& buf = adsr(YSE::DSP::ADSRenvelope::RESUME);

--- a/Tests/dsp/test_lfo_rate_robustness.cpp
+++ b/Tests/dsp/test_lfo_rate_robustness.cpp
@@ -1,0 +1,33 @@
+// Regression test for issue #48: LFO_SAW_REVERSED SIGSEGV on Pixel 7 Pro at
+// the Oboe-negotiated 48 kHz. Root cause was the static LfoSawTable being
+// sized at first construction (then 44100) while per-sample wrap math used
+// the live SAMPLERATE (48000) — reading past the table end.
+//
+// PR #71 fixed the LFO constructor to rebuild the tables on any
+// SAMPLERATE mismatch. This test exercises the path under a forced
+// non-default rate so ASAN on Linux (and MTE on Android) would catch a
+// regression at this exact site.
+
+#include <doctest/doctest.h>
+#include "dsp/lfo.hpp"
+
+TEST_SUITE("dsp") {
+
+TEST_CASE("lfo: LFO_SAW_REVERSED stays in bounds at the current SAMPLERATE") {
+    // Construct ten LFO instances and pump 128 samples through each — the
+    // first construction sizes the static tables to the live SAMPLERATE,
+    // subsequent constructions hit the size-match early-out path, and every
+    // operator() exercises the cursor wrap. Any OOB read here would either
+    // crash under ASAN/MTE or read garbage > 1.0.
+    for (int call = 0; call < 10; ++call) {
+        YSE::DSP::lfo osc;
+        YSE::DSP::buffer& buf = osc(YSE::DSP::LFO_SAW_REVERSED, 2.0f);
+        float* ptr = buf.getPtr();
+        for (unsigned i = 0; i < buf.getLength(); ++i) {
+            CHECK(ptr[i] >= 0.0f);
+            CHECK(ptr[i] <= 1.0f);
+        }
+    }
+}
+
+} // TEST_SUITE("dsp")

--- a/Tests/dsp/test_oscillators.cpp
+++ b/Tests/dsp/test_oscillators.cpp
@@ -24,18 +24,25 @@ TEST_CASE("sine: all samples bounded in [-1, +1]") {
     }
 }
 
-TEST_CASE("sine: output is periodic at 441 Hz (period = 100 samples at 44100 Hz)") {
-    // 44100 / 441 = 100 exactly; 400 samples = 4 full periods.
+// Pick a frequency that divides SAMPLERATE exactly so 100 samples cover
+// exactly one period. At 44100 Hz this is 441 Hz; at 48000 Hz it's 480 Hz.
+// The choice keeps the test rate-agnostic while still hitting integer samples
+// per period (so the periodicity / zero-mean checks don't drift on FP rounding).
+static inline float oneHundredSamplePeriodFreq() {
+    return (float)YSE::SAMPLERATE / 100.0f;
+}
+
+TEST_CASE("sine: output is periodic with period = 100 samples") {
     YSE::DSP::sine osc;
     osc.reset();
-    YSE::DSP::buffer& buf = osc(441.0f, 400);
+    YSE::DSP::buffer& buf = osc(oneHundredSamplePeriodFreq(), 400);
     CHECK(TestHelpers::checkPeriodicity(buf, 100, 0.01f));
 }
 
-TEST_CASE("sine: zero mean over a full 441 Hz period (100 samples)") {
+TEST_CASE("sine: zero mean over a full period (100 samples)") {
     YSE::DSP::sine osc;
     osc.reset();
-    YSE::DSP::buffer& buf = osc(441.0f, 100);
+    YSE::DSP::buffer& buf = osc(oneHundredSamplePeriodFreq(), 100);
     float* ptr = buf.getPtr();
     float sum = 0.0f;
     for (unsigned i = 0; i < buf.getLength(); ++i) sum += ptr[i];

--- a/Tests/integration/test_device.cpp
+++ b/Tests/integration/test_device.cpp
@@ -153,6 +153,24 @@ TEST_CASE("engine: cpuLoad returns a non-negative value") {
     CHECK(YSE::System().cpuLoad() >= 0.0f);
 }
 
+// Issue #82: cpuLoad() is our own callback wall-clock / buffer-period EMA.
+// Without any user graph attached, the engine's per-callback work is tiny;
+// the smoothed reading should sit well below 1.0 (would mean callback taking
+// the entire buffer period). 0.5 is a generous ceiling that catches a
+// totally broken measurement without being flaky on slow CI machines.
+TEST_CASE("engine: cpuLoad stays bounded with no graph activity") {
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+    // Let callbacks fire long enough for the ~1 s EMA to settle.
+    for (int i = 0; i < 30; i++) {
+        YSE::System().sleep(50);
+        YSE::System().update();
+    }
+    const float load = YSE::System().cpuLoad();
+    CHECK(load >= 0.0f);
+    CHECK(load < 0.5f);
+}
+
 // ─── Audio callback ───────────────────────────────────────────────────────────
 
 TEST_CASE("engine: audio callback fires within 100ms on a real output device") {

--- a/Tests/integration/test_device.cpp
+++ b/Tests/integration/test_device.cpp
@@ -106,9 +106,9 @@ TEST_CASE("device: default device name is non-empty when devices exist") {
     CHECK_FALSE(YSE::System().getDefaultDevice().empty());
 }
 
-// ─── MIDI device enumeration (Windows only) ───────────────────────────────────
+// ─── MIDI device enumeration (gated on YSE_ENABLE_MIDI_DEVICE) ───────────────
 
-#if YSE_WINDOWS
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
 TEST_CASE("midi: getNumMidiInDevices does not crash") {
     if (!TestHelpers::engineInit()) return;
     (void)YSE::System().getNumMidiInDevices();
@@ -129,7 +129,7 @@ TEST_CASE("midi: device names are accessible without crash") {
     for (unsigned int i = 0; i < nOut; i++) (void)YSE::System().getMidiOutDeviceName(i);
     CHECK(true);
 }
-#endif // YSE_WINDOWS
+#endif // YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
 
 // ─── Engine lifecycle ─────────────────────────────────────────────────────────
 

--- a/Tests/listener/test_listener.cpp
+++ b/Tests/listener/test_listener.cpp
@@ -216,32 +216,27 @@ TEST_CASE("listener impl: stationary position over two updates yields zero veloc
     CHECK(v.z == doctest::Approx(0.f));
 }
 
-TEST_CASE("listener impl: distanceFactor=2 doubles the effective velocity vs factor=1") {
+TEST_CASE("listener impl: velocity is positive on a one-unit step under either distanceFactor") {
     if (!TestHelpers::engineInit()) return;
 
-    // Run the same one-unit step twice — once with distanceFactor=1, once with
-    // distanceFactor=2 — and compare the resulting vel.x.  Time().delta() will
-    // vary between the two runs, so use a loose ratio check: vel scales with
-    // distanceFactor (newPos = pos * distanceFactor), so factor=2 should be
-    // strictly greater for the same pos delta.
+    // We previously asserted vWithFactor2 > vWithFactor1 across two independent
+    // update() calls. Both velocities are 1/Time().delta() and 2/Time().delta()
+    // in form, but Time().delta() varies between iterations (especially on
+    // mobile/Android schedulers) and the cross-iteration comparison races the
+    // clock — see issue #75. The "factor scales position" property is already
+    // covered by "getPos() returns position scaled by distanceFactor" below.
     resetListenerState();
     advanceClock();
     YSE::Listener().pos(YSE::Pos(1.f, 0.f, 0.f));
     YSE::INTERNAL::ListenerImpl().update();
-    const float vWithFactor1 = YSE::Listener().vel().x;
+    CHECK(YSE::Listener().vel().x > 0.f);
 
     resetListenerState();
     YSE::INTERNAL::Settings().distanceFactor = 2.f;
-    // After resetListenerState() the impl's lastPos is (0,0,0) scaled by the
-    // CURRENT distanceFactor (now 2) — but pos was set to (0,0,0), so
-    // lastPos = (0,0,0) * 2 = (0,0,0).  Safe.
     advanceClock();
     YSE::Listener().pos(YSE::Pos(1.f, 0.f, 0.f));
     YSE::INTERNAL::ListenerImpl().update();
-    const float vWithFactor2 = YSE::Listener().vel().x;
-
-    CHECK(vWithFactor1 > 0.f);
-    CHECK(vWithFactor2 > vWithFactor1);
+    CHECK(YSE::Listener().vel().x > 0.f);
 
     YSE::INTERNAL::Settings().distanceFactor = 1.f;
 }

--- a/Tests/main.cpp
+++ b/Tests/main.cpp
@@ -26,11 +26,32 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
+#include <cstdlib>
+
+// Honour YSE_TEST_FORCED_RATE before any test (or doctest's discovery pass)
+// can construct an SAMPLERATE-baking DSP object. The variable is read on the
+// first call into the test binary so it works in both the desktop main()
+// below and the Android NativeActivity entry in android_entry.hpp.
+namespace TestHelpers {
+    void applyForcedSampleRateFromEnv() {
+        const char* forced = std::getenv("YSE_TEST_FORCED_RATE");
+        if (!forced || !*forced) return;
+        unsigned long parsed = std::strtoul(forced, nullptr, 10);
+        if (parsed == 0) return;
+        // SAMPLERATE has its default static-init value at this point; no engine
+        // session is open yet, so the lock in INTERNAL::Global() is still false
+        // and this write is permitted.
+        YSE::SAMPLERATE = (UInt)parsed;
+    }
+}
+
 #if defined(__ANDROID__)
 #  include "support/android_entry.hpp"
 #else
 
 int main(int argc, char** argv) {
+    TestHelpers::applyForcedSampleRateFromEnv();
+
     doctest::Context context;
     context.applyCommandLine(argc, argv);
     const int res = context.run();

--- a/Tests/midi/test_devicemanager.cpp
+++ b/Tests/midi/test_devicemanager.cpp
@@ -13,9 +13,9 @@
 //     no device is attached
 //   - Raw(string) handles 0/1/2/3+ byte inputs without out-of-bounds reads
 //
-// The whole TU is guarded by the same YSE_WINDOWS || YSE_LINUX condition that
-// gates midiDeviceManager.cpp and device.cpp — on platforms where those files
-// are not compiled, the deviceManager / midiOut symbols don't exist.
+// The whole TU is guarded by the same YSE_ENABLE_MIDI_DEVICE option that
+// gates midiDeviceManager.cpp and device.cpp — when the option is OFF those
+// files are not compiled and the deviceManager / midiOut symbols don't exist.
 //
 // No engine initialisation is required.  The MIDI singleton stands on its own
 // and does not depend on PortAudio.
@@ -23,7 +23,7 @@
 #include <doctest/doctest.h>
 #include "headers/defines.hpp"
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include "midi/midiDeviceManager.h"
 #include "midi/device.hpp"
@@ -269,4 +269,4 @@ TEST_CASE("midiOut::create on an out-of-range port leaves device null") {
 
 } // TEST_SUITE("midi")
 
-#endif // YSE_WINDOWS || YSE_LINUX
+#endif // YSE_ENABLE_MIDI_DEVICE

--- a/Tests/midi/test_midi_in.cpp
+++ b/Tests/midi/test_midi_in.cpp
@@ -23,7 +23,7 @@
 #include <cstring>
 #include "headers/defines.hpp"
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include "midi/device.hpp"
 #include "yse_c/yse_midi.h"
@@ -288,4 +288,4 @@ TEST_CASE("yse_midi_in C API: NULL handle returns 0 on is_open")
 
 } // TEST_SUITE("midi")
 
-#endif // YSE_WINDOWS || YSE_LINUX
+#endif // YSE_ENABLE_MIDI_DEVICE

--- a/Tests/system/test_system_active_state.cpp
+++ b/Tests/system/test_system_active_state.cpp
@@ -53,6 +53,18 @@ TEST_CASE("system: active sample rate is 0 while engine is paused")
     CHECK(YSE::System().getActiveSampleRate() == doctest::Approx(0.0));
 }
 
+// ─── Session sample rate: locked at init(), survives pause ──────────────────
+
+TEST_CASE("system: session sample rate is positive after init even while paused")
+{
+    if (!TestHelpers::engineInit()) return;
+    // Distinct from getActiveSampleRate(): the session rate is the engine-wide
+    // value locked during initShared() and stays constant across the session.
+    // engineInit() leaves the device paused — the session getter should still
+    // report a positive value.
+    CHECK(YSE::System().getSampleRate() > 0.0);
+}
+
 TEST_CASE("system: active buffer size is 0 while engine is paused")
 {
     if (!TestHelpers::engineInit()) return;
@@ -83,6 +95,16 @@ TEST_CASE("system: active output latency is positive after resuming audio")
     CHECK(YSE::System().getActiveOutputLatency() > 0);
 }
 
+TEST_CASE("system: session sample rate matches active rate when audio is resumed")
+{
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+    // When the device is open, the session rate and the active (live) rate
+    // return the same locked value.
+    CHECK(YSE::System().getSampleRate()
+          == doctest::Approx(YSE::System().getActiveSampleRate()));
+}
+
 TEST_CASE("system: active buffer size is positive after at least one audio callback")
 {
     if (!TestHelpers::engineInitWithAudio()) return;
@@ -111,6 +133,15 @@ TEST_CASE("system: active output latency yields a believable ms value")
 
 // ─── C API mirror agrees with the C++ getters ────────────────────────────────
 
+TEST_CASE("system: C API getSampleRate mirrors the C++ value")
+{
+    if (!TestHelpers::engineInit()) return;
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    CHECK(yse_system_get_sample_rate(sys)
+          == doctest::Approx(YSE::System().getSampleRate()));
+}
+
 TEST_CASE("system: C API getActiveSampleRate mirrors the C++ value")
 {
     if (!TestHelpers::engineInit()) return;
@@ -138,6 +169,7 @@ TEST_CASE("system: C API getActiveOutputLatency mirrors the C++ value")
 
 TEST_CASE("system: C API getters return 0 on a NULL system handle")
 {
+    CHECK(yse_system_get_sample_rate(nullptr) == doctest::Approx(0.0));
     CHECK(yse_system_get_active_sample_rate(nullptr) == doctest::Approx(0.0));
     CHECK(yse_system_get_active_buffer_size(nullptr) == 0);
     CHECK(yse_system_get_active_output_latency(nullptr) == 0);

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -150,13 +150,18 @@ set(YSE_SRCS
   patcher/midi/mMidiProgramChange.cpp
   # midiNote is a plain data class with no platform dependencies.
   midi/midiNote.cpp
-  # MIDI device I/O (RtMidi-backed). The sources themselves carry a
-  # `#if YSE_WINDOWS || YSE_LINUX` guard so they compile to empty TUs on
-  # Android; on the desktop platforms this CMake build targets they are
-  # always built.
-  midi/midiDeviceManager.cpp
-  midi/device.cpp
 )
+
+# MIDI device backend (RtMidi-backed). Gated behind YSE_ENABLE_MIDI_DEVICE
+# (default ON on Windows/Linux, OFF on Android/Mac). The sources still carry
+# a `#if YSE_ENABLE_MIDI_DEVICE` guard so accidental inclusion produces empty
+# TUs, but the canonical path adds them only when the option is ON.
+if(YSE_ENABLE_MIDI_DEVICE)
+  list(APPEND YSE_SRCS
+    midi/midiDeviceManager.cpp
+    midi/device.cpp
+  )
+endif()
 
 # ── Source-file-scoped warning suppressions ───────────────────────────────────
 # cJSON is a vendored C file; suppress all its warnings rather than patching it.
@@ -268,11 +273,16 @@ target_include_directories(yse_objects
     # shipped by the MSYS2 portaudio package; the vendored copies fill the gap.
     # We still link against the system library — only the headers are borrowed.
     ${CMAKE_SOURCE_DIR}/dependencies/portaudio/include
+)
+
+if(YSE_ENABLE_MIDI_DEVICE)
+  target_include_directories(yse_objects PRIVATE
     # midiDeviceManager.h uses "../dependencies/rtmidi/include/RtMidi.h" as a
     # relative path; device.cpp uses a bare "RtMidi.h". Both resolve once this
     # directory is in the include search path.
     ${CMAKE_SOURCE_DIR}/dependencies/rtmidi/include
-)
+  )
+endif()
 
 target_compile_definitions(yse_objects
   PRIVATE
@@ -299,6 +309,14 @@ else()
   target_compile_definitions(yse_objects PRIVATE YSE_ANDROID=1)
 endif()
 
+# YSE_ENABLE_MIDI_DEVICE: propagated PUBLIC so it reaches both the engine TUs
+# and any consumer that includes the public headers (system.hpp, midi/device.hpp,
+# yse_c/yse_midi.h). When 0/undefined, the MIDI device APIs are compiled out
+# of every layer (engine, C API, public headers, tests).
+if(YSE_ENABLE_MIDI_DEVICE)
+  target_compile_definitions(yse_objects PUBLIC YSE_ENABLE_MIDI_DEVICE=1)
+endif()
+
 # External deps are PUBLIC so both yse (SHARED) and yse_tests inherit them.
 target_link_libraries(yse_objects
   PUBLIC
@@ -307,11 +325,10 @@ target_link_libraries(yse_objects
 )
 
 if(NOT ANDROID)
-  target_link_libraries(yse_objects
-    PUBLIC
-      PkgConfig::PortAudio
-      PkgConfig::RtMidi
-  )
+  target_link_libraries(yse_objects PUBLIC PkgConfig::PortAudio)
+  if(YSE_ENABLE_MIDI_DEVICE)
+    target_link_libraries(yse_objects PUBLIC PkgConfig::RtMidi)
+  endif()
 else()
   # Oboe is the audio I/O backend (transparently uses AAudio on API 26+ and
   # falls back to OpenSL ES on rare devices). `log` provides __android_log_print
@@ -354,3 +371,11 @@ target_compile_definitions(yse
   INTERFACE
     YSE_DLL   # activate __declspec(dllimport) for consumers linking against the shared library
 )
+
+# Mirror YSE_ENABLE_MIDI_DEVICE to consumers of the shared library — yse_objects
+# is linked PRIVATE above, so its PUBLIC definitions don't transit through.
+# Demos and language bindings need to know whether the MIDI device APIs are
+# declared on the engine they're linking against.
+if(YSE_ENABLE_MIDI_DEVICE)
+  target_compile_definitions(yse INTERFACE YSE_ENABLE_MIDI_DEVICE=1)
+endif()

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -251,6 +251,18 @@ add_library(yse_objects OBJECT ${YSE_SRCS})
 # the shared library on Linux.
 set_target_properties(yse_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+# Hide every symbol by default on ELF/Mach-O platforms (Linux, macOS, iOS,
+# BSD, Android) so libyse.so / .dylib exports only the API-tagged surface
+# reachable from yse.hpp. Windows is unaffected — its DLL export model uses
+# __declspec(dllexport) annotations directly from the API macro and has no
+# fpvisibility equivalent. Issue #34.
+if(NOT WIN32)
+  set_target_properties(yse_objects PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+  )
+endif()
+
 target_compile_features(yse_objects PUBLIC cxx_std_17)
 
 # Expose YseEngine/ as the public include root so consumers can use
@@ -338,11 +350,17 @@ endif()
 # Consumers (demos, external code) link against this target only.
 add_library(yse SHARED)
 
-set_target_properties(yse PROPERTIES
-  OUTPUT_NAME yse
-  CXX_VISIBILITY_PRESET default
-  VISIBILITY_INLINES_HIDDEN OFF
-)
+set_target_properties(yse PROPERTIES OUTPUT_NAME yse)
+
+# Mirror the visibility settings applied to yse_objects so the linked
+# shared library exports the same API surface. See the comment on
+# yse_objects above. Issue #34.
+if(NOT WIN32)
+  set_target_properties(yse PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+  )
+endif()
 
 # Pull in the compiled objects and their transitive link dependencies.
 target_link_libraries(yse PRIVATE yse_objects)

--- a/YseEngine/c_api/CMakeLists.txt
+++ b/YseEngine/c_api/CMakeLists.txt
@@ -7,6 +7,11 @@
 # Included from YseEngine/CMakeLists.txt via include() AFTER yse_objects has
 # been defined; never add_subdirectory()'d (the goal is to extend an existing
 # target, not create a new one).
+#
+# Adding a new callback that the engine invokes on a non-host thread?
+# Read the "Callback bridge rules" block at the top of yse_c_internal.hpp
+# first. The short version: atomic-swap callback pointer (no mutex), no
+# malloc on audio-callback-reachable paths, YSE_C_CALLBACK on the typedef.
 
 set(YSE_C_API_SRCS
   yse_common.cpp

--- a/YseEngine/c_api/CMakeLists.txt
+++ b/YseEngine/c_api/CMakeLists.txt
@@ -23,6 +23,7 @@ set(YSE_C_API_SRCS
   yse_music.cpp
   yse_log.cpp
   yse_buffer_io.cpp
+  yse_enums_check.cpp
 )
 list(TRANSFORM YSE_C_API_SRCS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
 

--- a/YseEngine/c_api/include/yse_c/yse_buffer_io.h
+++ b/YseEngine/c_api/include/yse_c/yse_buffer_io.h
@@ -17,6 +17,7 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_buffer_io_destroy. */
 typedef struct YseBufferIO YseBufferIO;
 
 /* store_copy=1 copies the supplied bytes; store_copy=0 keeps a pointer

--- a/YseEngine/c_api/include/yse_c/yse_channel.h
+++ b/YseEngine/c_api/include/yse_c/yse_channel.h
@@ -3,6 +3,10 @@
   C ABI mirror of YseEngine/channel/channelInterface.hpp (YSE::channel + pre-built
   free-function accessors ChannelMaster, ChannelFX, ChannelMusic, ChannelAmbient,
   ChannelVoice, ChannelGui).
+
+  Convention: every void-returning function in this header is a null-safe
+  no-op when called with a NULL handle. Status queries (is_valid, get_*)
+  return 0 / false / NULL on NULL.
 */
 
 #ifndef YSE_C_CHANNEL_H_INCLUDED

--- a/YseEngine/c_api/include/yse_c/yse_channel.h
+++ b/YseEngine/c_api/include/yse_c/yse_channel.h
@@ -15,6 +15,9 @@ extern "C"
 {
 #endif
 
+	/* Owned via yse_channel_create — release with yse_channel_destroy.
+	   Borrowed via the yse_channel_master / _fx / _music / _ambient /
+	   _voice / _gui pre-built accessors — never destroy those. */
 	typedef struct YseChannel YseChannel;
 
 	/* Pre-built channels — borrowed pointers, never destroy. */

--- a/YseEngine/c_api/include/yse_c/yse_common.h
+++ b/YseEngine/c_api/include/yse_c/yse_common.h
@@ -49,6 +49,10 @@ typedef struct yse_pos_t {
 
 YSE_C_API const char* yse_version(void);
 
+/* Returns the last error message recorded on the calling thread (the
+   slot is thread-local). The returned pointer is valid until the next
+   yse_* call from the same thread; copy the string if you need to hold
+   onto it. Empty string when no error has been recorded. */
 YSE_C_API const char* yse_last_error(void);
 YSE_C_API void        yse_clear_last_error(void);
 

--- a/YseEngine/c_api/include/yse_c/yse_common.h
+++ b/YseEngine/c_api/include/yse_c/yse_common.h
@@ -25,6 +25,16 @@
   #endif
 #endif
 
+/* Calling-convention marker for callback function pointer typedefs that
+   the engine invokes across the C ABI. Made explicit on Windows so the
+   ABI is unambiguous across compilers (MSVC, Clang, MinGW); a no-op on
+   x64 / ARM64 / non-Windows where only one C calling convention exists. */
+#if defined(_WIN32) || defined(_WIN64)
+  #define YSE_C_CALLBACK __cdecl
+#else
+  #define YSE_C_CALLBACK
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/YseEngine/c_api/include/yse_c/yse_device.h
+++ b/YseEngine/c_api/include/yse_c/yse_device.h
@@ -21,7 +21,10 @@
 extern "C" {
 #endif
 
+/* Borrowed — read-only descriptor enumerated from the engine via
+   yse_system_get_device(). Never destroy. */
 typedef struct YseDevice      YseDevice;
+/* Owned — release with yse_device_setup_destroy. */
 typedef struct YseDeviceSetup YseDeviceSetup;
 
 /* Device descriptor — read-only. */

--- a/YseEngine/c_api/include/yse_c/yse_dsp.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp.h
@@ -22,6 +22,9 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_dsp_buffer_destroy. Covers all four buffer
+   subclasses (plain, drawable, file, wavetable); the same destroy frees
+   the correct backing storage via dynamic_cast. */
 typedef struct YseDspBuffer YseDspBuffer;
 
 /* Constructors — one per subclass. The returned handle owns its native

--- a/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
@@ -21,6 +21,8 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_dsp_object_destroy. Covers every effect
+   subclass via the shared handle type. */
 typedef struct YseDspObject YseDspObject;
 
 /* ─── constructors ────────────────────────────────────────────────────── */

--- a/YseEngine/c_api/include/yse_c/yse_listener.h
+++ b/YseEngine/c_api/include/yse_c/yse_listener.h
@@ -12,6 +12,8 @@
 extern "C" {
 #endif
 
+/* Borrowed singleton — owned by the engine, never destroy.
+   Obtain via yse_listener_get(). */
 typedef struct YseListener YseListener;
 
 /* Borrowed singleton pointer — never destroy. */

--- a/YseEngine/c_api/include/yse_c/yse_log.h
+++ b/YseEngine/c_api/include/yse_c/yse_log.h
@@ -36,7 +36,7 @@ YSE_C_API size_t        yse_log_get_logfile(YseLog* log, char* buf, size_t cap);
 /* The receiver OWNS msg and must release it with yse_log_free_message
    when finished. The pointer is allocated with malloc by the bridge so
    any C client can free() it directly if preferred. */
-typedef void (*YseLogCallback)(char* msg, void* user_data);
+typedef void (YSE_C_CALLBACK *YseLogCallback)(char* msg, void* user_data);
 
 /* Replaces the default file sink. Pass NULL for cb to restore the default.
    user_data is opaque — forwarded to every callback invocation. */

--- a/YseEngine/c_api/include/yse_c/yse_log.h
+++ b/YseEngine/c_api/include/yse_c/yse_log.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif
 
+/* Borrowed singleton — owned by the engine, never destroy.
+   Obtain via yse_log_get(). */
 typedef struct YseLog YseLog;
 
 YSE_C_API YseLog*       yse_log_get(void);

--- a/YseEngine/c_api/include/yse_c/yse_midi.h
+++ b/YseEngine/c_api/include/yse_c/yse_midi.h
@@ -28,9 +28,13 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_midi_file_destroy. */
 typedef struct YseMidiFile YseMidiFile;
+/* Owned — release with yse_midi_out_destroy. */
 typedef struct YseMidiOut  YseMidiOut;
+/* Owned — release with yse_midi_in_destroy. */
 typedef struct YseMidiIn   YseMidiIn;
+/* Owned — release with yse_midi_note_destroy. */
 typedef struct YseMidiNote YseMidiNote;
 
 /* ─── standard MIDI file playback ─────────────────────────────────── */

--- a/YseEngine/c_api/include/yse_c/yse_midi.h
+++ b/YseEngine/c_api/include/yse_c/yse_midi.h
@@ -70,20 +70,20 @@ YSE_C_API void         yse_midi_out_raw3(YseMidiOut* m, unsigned char a, unsigne
 
 /* Raw-bytes callback. `bytes` is malloc'd by the engine; the receiver owns
    it and must release with yse_midi_in_free_message. Length is in bytes. */
-typedef void (*YseMidiInRawCallback)(double               timestamp_sec,
-                                     unsigned char*       bytes,
-                                     size_t               len,
-                                     void*                user_data);
+typedef void (YSE_C_CALLBACK *YseMidiInRawCallback)(double               timestamp_sec,
+                                                    unsigned char*       bytes,
+                                                    size_t               len,
+                                                    void*                user_data);
 
 /* Parsed callback. status/channel are pre-split from the first byte; data1
    and data2 are zero for messages shorter than 3 bytes. No ownership
    transfer. */
-typedef void (*YseMidiInParsedCallback)(double               timestamp_sec,
-                                        unsigned char        status,
-                                        unsigned char        channel,
-                                        unsigned char        data1,
-                                        unsigned char        data2,
-                                        void*                user_data);
+typedef void (YSE_C_CALLBACK *YseMidiInParsedCallback)(double               timestamp_sec,
+                                                       unsigned char        status,
+                                                       unsigned char        channel,
+                                                       unsigned char        data1,
+                                                       unsigned char        data2,
+                                                       void*                user_data);
 
 YSE_C_API YseMidiIn*   yse_midi_in_create(void);
 YSE_C_API void         yse_midi_in_destroy(YseMidiIn* m);

--- a/YseEngine/c_api/include/yse_c/yse_music.h
+++ b/YseEngine/c_api/include/yse_c/yse_music.h
@@ -22,10 +22,15 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_note_destroy. */
 typedef struct YseNote   YseNote;
+/* Owned — release with yse_pnote_destroy. */
 typedef struct YsePNote  YsePNote;
+/* Owned — release with yse_scale_destroy. */
 typedef struct YseScale  YseScale;
+/* Owned — release with yse_motif_destroy. */
 typedef struct YseMotif  YseMotif;
+/* Owned — release with yse_player_destroy. */
 typedef struct YsePlayer YsePlayer;
 
 /* ─── note ────────────────────────────────────────────────────────── */

--- a/YseEngine/c_api/include/yse_c/yse_patcher.h
+++ b/YseEngine/c_api/include/yse_c/yse_patcher.h
@@ -11,6 +11,10 @@
 
   Object type identifiers are the same strings YSE::OBJ exposes
   ("~sine", ".+", "~lp", etc.). See patcher/pObjectList.hpp upstream.
+
+  Convention: every void-returning function in this header is a null-safe
+  no-op when called with a NULL handle (patcher or phandle). Status
+  queries return 0 / false / NULL on NULL.
 */
 
 #ifndef YSE_C_PATCHER_H_INCLUDED

--- a/YseEngine/c_api/include/yse_c/yse_patcher.h
+++ b/YseEngine/c_api/include/yse_c/yse_patcher.h
@@ -23,7 +23,11 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_patcher_destroy. */
 typedef struct YsePatcher YsePatcher;
+/* Borrowed — owned by the parent YsePatcher. Release with
+   yse_patcher_delete_object(patcher, handle); never call a destroy on
+   the handle directly. */
 typedef struct YsePHandle YsePHandle;
 
 /* ─── patcher lifecycle ────────────────────────────────────────────── */

--- a/YseEngine/c_api/include/yse_c/yse_reverb.h
+++ b/YseEngine/c_api/include/yse_c/yse_reverb.h
@@ -20,6 +20,8 @@
 extern "C" {
 #endif
 
+/* Owned via yse_reverb_create — release with yse_reverb_destroy.
+   Borrowed via yse_system_get_global_reverb — never destroy that. */
 typedef struct YseReverb YseReverb;
 
 /* Owned reverb zone — yse_reverb_create() runs both the C++ constructor

--- a/YseEngine/c_api/include/yse_c/yse_reverb.h
+++ b/YseEngine/c_api/include/yse_c/yse_reverb.h
@@ -8,6 +8,10 @@
     - Borrowed: yse_system_get_global_reverb() → YseReverb*. Never destroy.
                 The global reverb is the fallback wherever no positioned zone
                 reaches; rolled-off positioned zones mix against it.
+
+  Convention: every void-returning function in this header is a null-safe
+  no-op when called with a NULL handle. Status queries return 0 / false on
+  NULL.
 */
 
 #ifndef YSE_C_REVERB_H_INCLUDED

--- a/YseEngine/c_api/include/yse_c/yse_sound.h
+++ b/YseEngine/c_api/include/yse_c/yse_sound.h
@@ -13,7 +13,10 @@
 extern "C" {
 #endif
 
+/* Owned — release with yse_sound_destroy. */
 typedef struct YseSound      YseSound;
+/* Forward declarations — see yse_channel.h / yse_dsp.h / yse_dsp_modules.h /
+   yse_patcher.h for ownership semantics. */
 typedef struct YseChannel    YseChannel;
 typedef struct YseDspBuffer  YseDspBuffer;
 typedef struct YseDspObject  YseDspObject;

--- a/YseEngine/c_api/include/yse_c/yse_sound.h
+++ b/YseEngine/c_api/include/yse_c/yse_sound.h
@@ -2,6 +2,11 @@
   yse_sound.h — playable audio source.
   C ABI mirror of YseEngine/sound/soundInterface.hpp (YSE::sound).
   M1 scope: file-based create only. Buffer/DSP-source/patcher overloads land in M3/M5.
+
+  Convention: every void-returning function in this header is a null-safe
+  no-op when called with a NULL handle. Status queries return 0 / false
+  on NULL. Loads that can fail return YseStatus and populate
+  yse_last_error() on failure.
 */
 
 #ifndef YSE_C_SOUND_H_INCLUDED

--- a/YseEngine/c_api/include/yse_c/yse_system.h
+++ b/YseEngine/c_api/include/yse_c/yse_system.h
@@ -13,7 +13,11 @@
 extern "C" {
 #endif
 
+/* Borrowed singleton — owned by the engine, never destroy.
+   Obtain via yse_system_get(). */
 typedef struct YseSystem  YseSystem;
+/* Forward declarations — see yse_channel.h / yse_reverb.h / yse_device.h
+   for ownership semantics. */
 typedef struct YseChannel YseChannel;
 typedef struct YseReverb  YseReverb;
 typedef struct YseDevice  YseDevice;

--- a/YseEngine/c_api/include/yse_c/yse_system.h
+++ b/YseEngine/c_api/include/yse_c/yse_system.h
@@ -39,6 +39,13 @@ YSE_C_API void       yse_system_resume(YseSystem* sys);
 YSE_C_API int        yse_system_missed_callbacks(YseSystem* sys);
 YSE_C_API float      yse_system_cpu_load(YseSystem* sys);
 
+/* Engine session sample rate in Hz. Stays constant for the lifetime of an
+   init()/close() session, including across pause/resume cycles where the
+   live "active" rate transiently drops to 0. Returns 0 before init(). Use
+   this for sample-count-driven scheduling that must outlive a pause; use
+   yse_system_get_active_sample_rate() for live device-state UI. */
+YSE_C_API double     yse_system_get_sample_rate(YseSystem* sys);
+
 /* Live state of the currently open audio device. Returns 0 when no device
    is open (pre-init, after close, or initOffline path). Buffer size is the
    device's frames-per-callback, NOT the engine block size. Output latency

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -1,6 +1,16 @@
 /*
   yse_c_internal.hpp — private helpers shared across the c_api translation units.
   Not installed; never included by Dart or any C ABI consumer.
+
+  C API conventions (apply to all new functions):
+
+    - Void-returning state-change functions (play / pause / stop, setters,
+      etc.) are null-safe no-ops when called with a NULL handle. Status
+      queries that return int / float / pointer return zero / false / NULL
+      on NULL handles.
+    - Functions that can fail meaningfully (file load, create, parse) use
+      YseStatus and populate yse_last_error() on failure.
+    - Document any deviation from these defaults explicitly in the header.
 */
 
 #pragma once

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -1,6 +1,46 @@
 /*
   yse_c_internal.hpp — private helpers shared across the c_api translation units.
   Not installed; never included by Dart or any C ABI consumer.
+
+  ─── Callback bridge rules ───────────────────────────────────────────────────
+
+  Several C API entry points install user-provided C function pointers that
+  the engine then invokes from a non-host thread (audio callback, RtMidi
+  input thread, future occlusion / dspSourceObject / customFileReader paths).
+  These bridges sit on RT-sensitive paths even when they don't realise it.
+
+  The canonical pattern lives in yse_midi.cpp's c_raw_bridge. Any new bridge
+  must follow the same rules:
+
+    1. Callback + user_data live as std::atomic<>. Install stores both with
+       release ordering (user_data first, then cb); dispatch loads with
+       acquire ordering (cb first, returns if null, then user_data). No
+       mutex, no lock_guard.
+
+    2. No malloc / new / std::string / container ops on the dispatch path
+       when the bridge can fire from the audio callback. For occlusion and
+       dspSourceObject, pass values by stack copy. For raw byte buffers
+       (file reader, MIDI raw), preallocate a per-handle pool — do not
+       malloc per call.
+
+       The current log + MIDI raw bridges allocate a malloc'd copy because
+       Dart's NativeCallable.listener marshals by pointer value (the
+       std::string / std::vector backing dies before the Dart handler
+       runs). That's acceptable today because neither path lives on the
+       audio callback. If an audio-callback emit is ever wired up, those
+       bridges must switch to a preallocated pool.
+
+    3. Public callback typedefs in the include/yse_c headers use the
+       YSE_C_CALLBACK macro (from yse_common.h) so the calling convention
+       is unambiguous across compilers — __cdecl on Win32, no-op elsewhere.
+
+    4. When the bridge transfers ownership of a heap buffer to the host
+       (e.g. MIDI raw bytes, log strings), pair the callback with a
+       yse_<module>_free_message function so the host can release it.
+       Document the contract in the header next to the typedef.
+
+    5. Never throw across the C ABI boundary. Wrap any C++ surface that
+       can throw in try/catch and translate to YseStatus + set_last_error.
 */
 
 #pragma once

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -1,6 +1,22 @@
 /*
   yse_c_internal.hpp — private helpers shared across the c_api translation units.
   Not installed; never included by Dart or any C ABI consumer.
+
+  Handle ownership convention: every opaque Yse* typedef in the public
+  headers carries a one-line ownership comment of one of these shapes:
+
+    - "Owned — release with yse_<module>_destroy."
+      Pair every yse_<module>_create with the corresponding destroy. The
+      C API never frees these for you.
+
+    - "Borrowed — owned by <source>, never destroy."
+      Singletons (yse_system_get, yse_listener_get, yse_log_get), pre-built
+      channels, device descriptors enumerated from the engine, and pHandles
+      that belong to a parent YsePatcher. Calling the home destroy on these
+      is undefined behaviour.
+
+  When adding a new opaque type, follow the same shape so Dart's finaliser
+  bookkeeping stays straight.
 */
 
 #pragma once

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -13,7 +13,7 @@
       Singletons (yse_system_get, yse_listener_get, yse_log_get), pre-built
       channels, device descriptors enumerated from the engine, and pHandles
       that belong to a parent YsePatcher. Calling the home destroy on these
-       is undefined behaviour.
+       is undefined behavior.
 
   When adding a new opaque type, follow the same shape so Dart's finaliser
   bookkeeping stays straight.

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -13,7 +13,7 @@
       Singletons (yse_system_get, yse_listener_get, yse_log_get), pre-built
       channels, device descriptors enumerated from the engine, and pHandles
       that belong to a parent YsePatcher. Calling the home destroy on these
-  is undefined behaviour.
+       is undefined behaviour.
 
   When adding a new opaque type, follow the same shape so Dart's finaliser
   bookkeeping stays straight.

--- a/YseEngine/c_api/yse_enums_check.cpp
+++ b/YseEngine/c_api/yse_enums_check.cpp
@@ -1,0 +1,85 @@
+/*
+  yse_enums_check.cpp — compile-time drift guard between the C enum mirror
+  (yse_c/yse_enums.h) and the underlying YSE engine enums.
+
+  Folded into yse_objects but exports nothing. Any static_assert failure
+  here means yse_enums.h is out of sync with the engine — update one
+  side or the other and re-build. See issue #61.
+*/
+
+#include "yse_c/yse_enums.h"
+
+#include "../headers/enums.hpp"
+#include "../dsp/lfo.hpp"
+#include "../dsp/modules/filters/sweep.hpp"
+#include "../dsp/modules/delay/basicDelay.hpp"
+
+namespace {
+
+#define YSE_ASSERT_ENUM(c_value, cpp_value)                             \
+  static_assert(static_cast<int>(c_value) ==                            \
+                static_cast<int>(cpp_value),                            \
+                "C ABI enum drift: " #c_value " != " #cpp_value         \
+                " — update yse_c/yse_enums.h or the engine enum")
+
+// YseChannelType ↔ YSE::CHANNEL_TYPE
+YSE_ASSERT_ENUM(YSE_CT_AUTO,    YSE::CT_AUTO);
+YSE_ASSERT_ENUM(YSE_CT_MONO,    YSE::CT_MONO);
+YSE_ASSERT_ENUM(YSE_CT_STEREO,  YSE::CT_STEREO);
+YSE_ASSERT_ENUM(YSE_CT_QUAD,    YSE::CT_QUAD);
+YSE_ASSERT_ENUM(YSE_CT_51,      YSE::CT_51);
+YSE_ASSERT_ENUM(YSE_CT_51SIDE,  YSE::CT_51SIDE);
+YSE_ASSERT_ENUM(YSE_CT_61,      YSE::CT_61);
+YSE_ASSERT_ENUM(YSE_CT_71,      YSE::CT_71);
+YSE_ASSERT_ENUM(YSE_CT_CUSTOM,  YSE::CT_CUSTOM);
+
+// YseErrorLevel ↔ YSE::ERROR_LEVEL
+YSE_ASSERT_ENUM(YSE_EL_NONE,    YSE::EL_NONE);
+YSE_ASSERT_ENUM(YSE_EL_ERROR,   YSE::EL_ERROR);
+YSE_ASSERT_ENUM(YSE_EL_WARNING, YSE::EL_WARNING);
+YSE_ASSERT_ENUM(YSE_EL_DEBUG,   YSE::EL_DEBUG);
+
+// YseOutType ↔ YSE::OUT_TYPE
+YSE_ASSERT_ENUM(YSE_OUT_INVALID, YSE::INVALID);
+YSE_ASSERT_ENUM(YSE_OUT_BANG,    YSE::BANG);
+YSE_ASSERT_ENUM(YSE_OUT_FLOAT,   YSE::FLOAT);
+YSE_ASSERT_ENUM(YSE_OUT_INT,     YSE::INT);
+YSE_ASSERT_ENUM(YSE_OUT_BUFFER,  YSE::BUFFER);
+YSE_ASSERT_ENUM(YSE_OUT_LIST,    YSE::LIST);
+YSE_ASSERT_ENUM(YSE_OUT_ANY,     YSE::ANY);
+
+// YseLfoType ↔ YSE::DSP::LFO_TYPE
+YSE_ASSERT_ENUM(YSE_LFO_NONE,         YSE::DSP::LFO_NONE);
+YSE_ASSERT_ENUM(YSE_LFO_SAW,          YSE::DSP::LFO_SAW);
+YSE_ASSERT_ENUM(YSE_LFO_SAW_REVERSED, YSE::DSP::LFO_SAW_REVERSED);
+YSE_ASSERT_ENUM(YSE_LFO_TRIANGLE,     YSE::DSP::LFO_TRIANGLE);
+YSE_ASSERT_ENUM(YSE_LFO_SINE,         YSE::DSP::LFO_SINE);
+YSE_ASSERT_ENUM(YSE_LFO_SQUARE,       YSE::DSP::LFO_SQUARE);
+YSE_ASSERT_ENUM(YSE_LFO_RANDOM,       YSE::DSP::LFO_RANDOM);
+
+// YseDspSweepShape ↔ YSE::DSP::MODULES::sweepFilter::SHAPE
+YSE_ASSERT_ENUM(YSE_SWEEP_TRIANGLE, YSE::DSP::MODULES::sweepFilter::TRIANGLE);
+YSE_ASSERT_ENUM(YSE_SWEEP_SAW,      YSE::DSP::MODULES::sweepFilter::SAW);
+YSE_ASSERT_ENUM(YSE_SWEEP_SQUARE,   YSE::DSP::MODULES::sweepFilter::SQUARE);
+
+// YseDspDelayTap ↔ YSE::DSP::MODULES::basicDelay::DELAY_NR
+YSE_ASSERT_ENUM(YSE_DELAY_TAP_FIRST,  YSE::DSP::MODULES::basicDelay::FIRST);
+YSE_ASSERT_ENUM(YSE_DELAY_TAP_SECOND, YSE::DSP::MODULES::basicDelay::SECOND);
+YSE_ASSERT_ENUM(YSE_DELAY_TAP_THIRD,  YSE::DSP::MODULES::basicDelay::THIRD);
+
+// YseReverbPreset ↔ YSE::REVERB_PRESET
+YSE_ASSERT_ENUM(YSE_REVERB_OFF,        YSE::REVERB_OFF);
+YSE_ASSERT_ENUM(YSE_REVERB_GENERIC,    YSE::REVERB_GENERIC);
+YSE_ASSERT_ENUM(YSE_REVERB_PADDED,     YSE::REVERB_PADDED);
+YSE_ASSERT_ENUM(YSE_REVERB_ROOM,       YSE::REVERB_ROOM);
+YSE_ASSERT_ENUM(YSE_REVERB_BATHROOM,   YSE::REVERB_BATHROOM);
+YSE_ASSERT_ENUM(YSE_REVERB_STONEROOM,  YSE::REVERB_STONEROOM);
+YSE_ASSERT_ENUM(YSE_REVERB_LARGEROOM,  YSE::REVERB_LARGEROOM);
+YSE_ASSERT_ENUM(YSE_REVERB_HALL,       YSE::REVERB_HALL);
+YSE_ASSERT_ENUM(YSE_REVERB_CAVE,       YSE::REVERB_CAVE);
+YSE_ASSERT_ENUM(YSE_REVERB_SEWERPIPE,  YSE::REVERB_SEWERPIPE);
+YSE_ASSERT_ENUM(YSE_REVERB_UNDERWATER, YSE::REVERB_UNDERWATER);
+
+#undef YSE_ASSERT_ENUM
+
+} // namespace

--- a/YseEngine/c_api/yse_log.cpp
+++ b/YseEngine/c_api/yse_log.cpp
@@ -4,9 +4,9 @@
 #include "../log.hpp"
 #include "../headers/enums.hpp"
 
+#include <atomic>
 #include <cstdlib>
 #include <cstring>
-#include <mutex>
 #include <string>
 
 namespace {
@@ -25,30 +25,33 @@ namespace {
 
   // Bridge from YSE's virtual logHandler to a C function pointer.
   // Only one bridge instance exists for the singleton Log(); installing
-  // a new callback replaces the slot. The mutex serialises installation
-  // against the audio / engine threads that may be calling AddMessage.
+  // a new callback replaces the slot. The callback + user_data pair lives
+  // as atomics so AddMessage (called from whichever thread emitted the
+  // log) never blocks on installer state — mirrors the pattern used by
+  // the midiIn raw bridge in yse_midi.cpp. See issue #58.
   class CallbackBridge : public YSE::logHandler {
   public:
     void install(YseLogCallback cb, void* user_data) {
-      std::lock_guard<std::mutex> lock(mu);
-      this->cb = cb;
-      this->user_data = user_data;
+      // Publish user_data first; AddMessage gates on a non-null cb, so
+      // any reader that observes the new cb is guaranteed to also see
+      // the matching user_data via the acquire/release pair.
+      this->user_data.store(user_data, std::memory_order_release);
+      this->cb.store(cb, std::memory_order_release);
     }
     void AddMessage(const std::string& msg) override {
-      YseLogCallback fn;
-      void* ud;
-      {
-        std::lock_guard<std::mutex> lock(mu);
-        fn = cb;
-        ud = user_data;
-      }
+      auto fn = cb.load(std::memory_order_acquire);
       if (!fn) return;
+      auto ud = user_data.load(std::memory_order_acquire);
       // Strings passed across NativeCallable.listener bridges to Dart
       // are marshalled by pointer value, not deep copy — by the time
       // the Dart handler runs, the std::string backing this pointer
       // has long been destroyed. Allocate a fresh malloc'd copy that
       // the receiver is contractually obliged to release via
       // yse_log_free_message.
+      //
+      // malloc on this path is acceptable today because log emits never
+      // originate on the audio callback. If that ever changes, this
+      // bridge needs a preallocated message pool — see issue #62.
       char* copy = static_cast<char*>(std::malloc(msg.size() + 1));
       if (!copy) return;
       std::memcpy(copy, msg.c_str(), msg.size());
@@ -56,9 +59,8 @@ namespace {
       fn(copy, ud);
     }
   private:
-    std::mutex mu;
-    YseLogCallback cb = nullptr;
-    void* user_data = nullptr;
+    std::atomic<YseLogCallback> cb{nullptr};
+    std::atomic<void*>          user_data{nullptr};
   };
 
   CallbackBridge& bridge() {

--- a/YseEngine/c_api/yse_midi.cpp
+++ b/YseEngine/c_api/yse_midi.cpp
@@ -5,7 +5,7 @@
 #include "../midi/midiNote.hpp"
 #include "../headers/enums.hpp"
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   #include "../midi/device.hpp"
   #define YSE_C_HAVE_MIDI_OUT 1
 #else

--- a/YseEngine/c_api/yse_system.cpp
+++ b/YseEngine/c_api/yse_system.cpp
@@ -207,7 +207,7 @@ YSE_C_API size_t yse_system_default_host(YseSystem* sys, char* buf, size_t cap) 
 // ─── MIDI device enumeration ───────────────────────────────────────────────
 
 YSE_C_API unsigned int yse_system_num_midi_in_devices(YseSystem* sys) {
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   if (!sys) return 0;
   return to_cpp(sys)->getNumMidiInDevices();
 #else
@@ -216,7 +216,7 @@ YSE_C_API unsigned int yse_system_num_midi_in_devices(YseSystem* sys) {
 }
 
 YSE_C_API unsigned int yse_system_num_midi_out_devices(YseSystem* sys) {
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   if (!sys) return 0;
   return to_cpp(sys)->getNumMidiOutDevices();
 #else
@@ -226,7 +226,7 @@ YSE_C_API unsigned int yse_system_num_midi_out_devices(YseSystem* sys) {
 
 YSE_C_API size_t yse_system_midi_in_device_name(YseSystem* sys, unsigned int id, char* buf, size_t cap) {
   if (buf && cap > 0) buf[0] = '\0';
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   if (!sys) return 0;
   try { return copy_string(to_cpp(sys)->getMidiInDeviceName(id), buf, cap); }
   catch (const std::exception&) { return 0; }
@@ -237,7 +237,7 @@ YSE_C_API size_t yse_system_midi_in_device_name(YseSystem* sys, unsigned int id,
 
 YSE_C_API size_t yse_system_midi_out_device_name(YseSystem* sys, unsigned int id, char* buf, size_t cap) {
   if (buf && cap > 0) buf[0] = '\0';
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
   if (!sys) return 0;
   try { return copy_string(to_cpp(sys)->getMidiOutDeviceName(id), buf, cap); }
   catch (const std::exception&) { return 0; }

--- a/YseEngine/c_api/yse_system.cpp
+++ b/YseEngine/c_api/yse_system.cpp
@@ -107,6 +107,11 @@ YSE_C_API float yse_system_cpu_load(YseSystem* sys) {
   return to_cpp(sys)->cpuLoad();
 }
 
+YSE_C_API double yse_system_get_sample_rate(YseSystem* sys) {
+  if (!sys) return 0.0;
+  return to_cpp(sys)->getSampleRate();
+}
+
 YSE_C_API double yse_system_get_active_sample_rate(YseSystem* sys) {
   if (!sys) return 0.0;
   return to_cpp(sys)->getActiveSampleRate();

--- a/YseEngine/device/androidDeviceManager.cpp
+++ b/YseEngine/device/androidDeviceManager.cpp
@@ -53,10 +53,16 @@ void YSE::DEVICE::managerObject::updateDeviceList() {
 
 void YSE::DEVICE::managerObject::pause() {
 	implementation.Suspend();
+	// Mirror the PortAudio observable behavior: while paused, the live
+	// getActive* getters report 0. We don't tear down the Oboe stream (resume
+	// would otherwise have to re-negotiate against the device), we only flip
+	// the manager's `open` flag the getters gate on. Issue #74.
+	open = false;
 }
 
 void YSE::DEVICE::managerObject::resume() {
 	implementation.Resume();
+	open = true;
 }
 
 void YSE::DEVICE::managerObject::addCallback() {
@@ -77,8 +83,10 @@ void YSE::DEVICE::managerObject::close() {
   //YSE::Log().sendMessage("androidDeviceManager: Close started");
 
   if (!initDone) return;
-  if (!open) return;
 
+  // implementation.Stop() is idempotent (guarded on mStream != nullptr) so a
+  // close() after pause() — which now clears `open` but leaves the Oboe stream
+  // suspended — still tears the stream down on the engine-shutdown path.
   implementation.Stop();
   initDone = open = false;
   //YSE::Log().sendMessage("androidDeviceManager: Close done");
@@ -96,7 +104,12 @@ int YSE::DEVICE::managerObject::getActiveOutputLatency() const {
   if (!open) return 0;
   const int32_t ms   = implementation.getNegotiatedOutputLatencyMs();
   const int32_t rate = implementation.getNegotiatedSampleRate();
-  return (int)((double)ms * (double)rate / 1000.0);
+  const int samplesFromMs = (int)((double)ms * (double)rate / 1000.0);
+  if (samplesFromMs > 0) return samplesFromMs;
+  // Some Pixel hardware reports ErrorUnimplemented for calculateLatencyMillis;
+  // fall back to a single burst worth of frames as a coarse latency estimate
+  // so the live API stays non-zero on an open stream. Issue #74.
+  return (int)implementation.getNegotiatedBufferSize();
 }
 
 

--- a/YseEngine/device/androidDeviceManager.h
+++ b/YseEngine/device/androidDeviceManager.h
@@ -19,7 +19,7 @@ namespace YSE {
 
       virtual bool init(bool openDevice = true);
       virtual void close();
-      virtual float cpuLoad() { return 0.f; } // not implemented for android
+      virtual float cpuLoad() { return implementation.cpuLoad(); }
 
 			virtual void pause();
 			virtual void resume();

--- a/YseEngine/device/oboeImplementation.cpp
+++ b/YseEngine/device/oboeImplementation.cpp
@@ -2,9 +2,16 @@
 
 #if YSE_ANDROID
 
+#include <chrono>
+#include <cmath>
 #include "../implementations/logImplementation.h"
 #include "../internalHeaders.h"
 #include "../internal/denormalGuard.h"
+
+namespace {
+  // See portaudioDeviceManager.cpp for the rationale on the time constant.
+  constexpr double kCpuLoadTau = 1.0;
+}
 
 OboeImplementation::OboeImplementation()
   : bufferPos(YSE::STANDARD_BUFFERSIZE)
@@ -81,6 +88,7 @@ void OboeImplementation::Stop() {
   mStream->stop();
   mStream->close();
   mStream.reset();
+  cpuLoadEma.store(0.f, std::memory_order_relaxed);
 }
 
 void OboeImplementation::Suspend() {
@@ -112,12 +120,17 @@ oboe::DataCallbackResult OboeImplementation::onAudioReady(oboe::AudioStream * /*
                                                           void * audioData,
                                                           int32_t numFrames) {
   YSE::INTERNAL::enableFlushToZero();
+  // Issue #82: our own callback wall-clock measurement, mirroring the
+  // PortAudio path so system::cpuLoad() reports a consistent number
+  // across backends.
+  const auto cbStart = std::chrono::steady_clock::now();
   ++callbacksSinceLastUpdate;
 
   float * dest = static_cast<float *>(audioData);
 
   if (!YSE::DEVICE::Manager().doOnCallback(numFrames)) {
     std::memset(dest, 0, sizeof(float) * numFrames * numChannels);
+    updateCpuLoadEma(cbStart, numFrames);
     return oboe::DataCallbackResult::Continue;
   }
 
@@ -152,7 +165,22 @@ oboe::DataCallbackResult OboeImplementation::onAudioReady(oboe::AudioStream * /*
     pos += size;
   }
 
+  updateCpuLoadEma(cbStart, numFrames);
   return oboe::DataCallbackResult::Continue;
+}
+
+void OboeImplementation::updateCpuLoadEma(
+    std::chrono::steady_clock::time_point cbStart,
+    int32_t numFrames) {
+  const auto cbEnd = std::chrono::steady_clock::now();
+  const double elapsedSec = std::chrono::duration<double>(cbEnd - cbStart).count();
+  const double bufferSec = double(numFrames) / double(YSE::SAMPLERATE);
+  if (bufferSec <= 0.0) return;
+
+  const float sample = float(elapsedSec / bufferSec);
+  const float alpha = float(1.0 - std::exp(-bufferSec / kCpuLoadTau));
+  const float prev = cpuLoadEma.load(std::memory_order_relaxed);
+  cpuLoadEma.store(prev + alpha * (sample - prev), std::memory_order_relaxed);
 }
 
 void OboeImplementation::onErrorAfterClose(oboe::AudioStream * /*stream*/, oboe::Result error) {

--- a/YseEngine/device/oboeImplementation.cpp
+++ b/YseEngine/device/oboeImplementation.cpp
@@ -4,6 +4,7 @@
 
 #include "../implementations/logImplementation.h"
 #include "../internalHeaders.h"
+#include "../internal/denormalGuard.h"
 
 OboeImplementation::OboeImplementation()
   : bufferPos(YSE::STANDARD_BUFFERSIZE)
@@ -98,6 +99,7 @@ int32_t OboeImplementation::getNegotiatedOutputLatencyMs() const {
 oboe::DataCallbackResult OboeImplementation::onAudioReady(oboe::AudioStream * /*stream*/,
                                                           void * audioData,
                                                           int32_t numFrames) {
+  YSE::INTERNAL::enableFlushToZero();
   ++callbacksSinceLastUpdate;
 
   float * dest = static_cast<float *>(audioData);

--- a/YseEngine/device/oboeImplementation.cpp
+++ b/YseEngine/device/oboeImplementation.cpp
@@ -40,7 +40,19 @@ bool OboeImplementation::openStream(int channels) {
   }
 
   negotiatedSampleRate = mStream->getSampleRate();
-  YSE::SAMPLERATE = (UInt)negotiatedSampleRate;
+  // Session-locked: once the lock is set at the end of system::initShared(),
+  // SAMPLERATE can only be re-written to its current value (e.g. by the
+  // pause()/resume() reopen path, or onErrorAfterClose rebuild on the same
+  // device). A debug assert catches genuine mid-session rate-change attempts
+  // (e.g. headphone-disconnect landing on a different rate); the write is
+  // skipped so SAMPLERATE-derived caches stay coherent.
+  {
+    const UInt newRate = (UInt)negotiatedSampleRate;
+    assert(!YSE::INTERNAL::Global().isSampleRateLocked() || newRate == YSE::SAMPLERATE);
+    if (!YSE::INTERNAL::Global().isSampleRateLocked()) {
+      YSE::SAMPLERATE = newRate;
+    }
+  }
 
   delete[] sourceChannels;
   sourceChannels = new float * [numChannels];

--- a/YseEngine/device/oboeImplementation.h
+++ b/YseEngine/device/oboeImplementation.h
@@ -4,6 +4,7 @@
 
 #include <oboe/Oboe.h>
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include "../headers/types.hpp"
 
@@ -29,6 +30,10 @@ public:
   int32_t getNegotiatedBufferSize() const;
   int32_t getNegotiatedOutputLatencyMs() const;
 
+  // EMA-smoothed callback wall-clock load (issue #82), mirroring the
+  // PortAudio path. Read by managerObject::cpuLoad() on the control thread.
+  float cpuLoad() const { return cpuLoadEma.load(std::memory_order_relaxed); }
+
   oboe::DataCallbackResult onAudioReady(oboe::AudioStream * stream,
                                         void * audioData,
                                         int32_t numFrames) override;
@@ -40,6 +45,12 @@ public:
 private:
   bool openStream(int channels);
 
+  // Fold one callback's wall-clock elapsed time into cpuLoadEma.
+  // Called by onAudioReady on every exit path. Single producer
+  // (the Oboe callback thread), so relaxed atomics are sufficient.
+  void updateCpuLoadEma(std::chrono::steady_clock::time_point cbStart,
+                        int32_t numFrames);
+
   std::shared_ptr<oboe::AudioStream> mStream;
   int numChannels = 2;
   int32_t negotiatedSampleRate = 44100;
@@ -47,6 +58,7 @@ private:
   float ** sourceChannels = nullptr;
 
   std::atomic<unsigned int> callbacksSinceLastUpdate{0};
+  std::atomic<float>        cpuLoadEma{0.f};
 };
 
 #endif

--- a/YseEngine/device/portaudioDeviceManager.cpp
+++ b/YseEngine/device/portaudioDeviceManager.cpp
@@ -12,6 +12,7 @@
 
 #include "portaudioDeviceManager.h"
 #include "internalHeaders.h"
+#include "internal/denormalGuard.h"
 #ifdef __WINDOWS__
 #include "pa_asio.h"
 #endif
@@ -44,6 +45,7 @@ int YSE::DEVICE::managerObject::paCallback(
   , const PaStreamCallbackTimeInfo* /*timeInfo*/
   , PaStreamCallbackFlags /*statusFlags*/
   , void * userData) {
+  YSE::INTERNAL::enableFlushToZero();
   YSE::DEVICE::managerObject * manager = (YSE::DEVICE::managerObject *)userData;
 	manager->callbacksSinceLastUpdate++;
 

--- a/YseEngine/device/portaudioDeviceManager.cpp
+++ b/YseEngine/device/portaudioDeviceManager.cpp
@@ -13,9 +13,17 @@
 #include "portaudioDeviceManager.h"
 #include "internalHeaders.h"
 #include "internal/denormalGuard.h"
+#include <chrono>
+#include <cmath>
 #ifdef __WINDOWS__
 #include "pa_asio.h"
 #endif
+
+namespace {
+  // Time constant for the cpuLoad EMA, in seconds. ~1 s means the reading
+  // settles within a few seconds and isn't dominated by per-callback jitter.
+  constexpr double kCpuLoadTau = 1.0;
+}
 
 UInt YSE::SAMPLERATE = 44100;
 
@@ -46,6 +54,10 @@ int YSE::DEVICE::managerObject::paCallback(
   , PaStreamCallbackFlags /*statusFlags*/
   , void * userData) {
   YSE::INTERNAL::enableFlushToZero();
+  // Issue #82: Pa_GetStreamCpuLoad was unreliable under WASAPI shared mode
+  // (plateaued at ~50% after silence). Time the callback ourselves with
+  // steady_clock; cpuLoad() returns the EMA of (elapsed / buffer-period).
+  const auto cbStart = std::chrono::steady_clock::now();
   YSE::DEVICE::managerObject * manager = (YSE::DEVICE::managerObject *)userData;
 	manager->callbacksSinceLastUpdate++;
 
@@ -57,7 +69,10 @@ int YSE::DEVICE::managerObject::paCallback(
     manager->activeBufferSize.store((int)numSamples, std::memory_order_release);
   }
 
-  if (!manager->doOnCallback(numSamples)) return 0;
+  if (!manager->doOnCallback(numSamples)) {
+    manager->updateCpuLoadEma(cbStart, numSamples);
+    return 0;
+  }
 
   UInt pos = 0;
   while (pos < static_cast<UInt>(numSamples)) {
@@ -93,8 +108,24 @@ int YSE::DEVICE::managerObject::paCallback(
 
   }
 
-	
+  manager->updateCpuLoadEma(cbStart, numSamples);
   return 0;
+}
+
+void YSE::DEVICE::managerObject::updateCpuLoadEma(
+    std::chrono::steady_clock::time_point cbStart,
+    unsigned long numSamples) {
+  const auto cbEnd = std::chrono::steady_clock::now();
+  const double elapsedSec = std::chrono::duration<double>(cbEnd - cbStart).count();
+  const double bufferSec = double(numSamples) / double(SAMPLERATE);
+  if (bufferSec <= 0.0) return;
+
+  const float sample = float(elapsedSec / bufferSec);
+  // First-order EMA with tau ≈ kCpuLoadTau. alpha = 1 - exp(-dt/tau) keeps
+  // the smoothing time constant stable regardless of buffer size.
+  const float alpha = float(1.0 - std::exp(-bufferSec / kCpuLoadTau));
+  const float prev = cpuLoadEma.load(std::memory_order_relaxed);
+  cpuLoadEma.store(prev + alpha * (sample - prev), std::memory_order_relaxed);
 }
 
 
@@ -214,6 +245,7 @@ void YSE::DEVICE::managerObject::close() {
   // No active device — the live getters report 0 until the next open.
   activeBufferSize.store(0, std::memory_order_release);
   activeOutputLatencySamples.store(0, std::memory_order_release);
+  cpuLoadEma.store(0.f, std::memory_order_relaxed);
 }
 
 void YSE::DEVICE::managerObject::terminate() {
@@ -351,10 +383,7 @@ void YSE::DEVICE::managerObject::audioDeviceError(PaError /*error*/) {
 }
 
 Flt YSE::DEVICE::managerObject::cpuLoad() {
-  if (stream != nullptr) {
-    return (Flt)Pa_GetStreamCpuLoad(stream);
-  }
-  return 0.f;
+  return cpuLoadEma.load(std::memory_order_relaxed);
 }
 
 double YSE::DEVICE::managerObject::getActiveSampleRate() const {

--- a/YseEngine/device/portaudioDeviceManager.cpp
+++ b/YseEngine/device/portaudioDeviceManager.cpp
@@ -143,7 +143,19 @@ void YSE::DEVICE::managerObject::addCallback() {
   }
 #endif
   params.hostApiSpecificStreamInfo = nullptr;
-  SAMPLERATE = (UInt)info->defaultSampleRate;
+  // Session-locked: once the lock is set at the end of system::initShared(),
+  // SAMPLERATE can only be re-written to its current value (e.g. by
+  // pause()/resume() cycles which reopen the stream against the same device).
+  // A debug assert catches genuine mid-session rate-change attempts; the
+  // write itself is skipped so SAMPLERATE-derived caches (LFO tables, reverb
+  // tunings, ADSR breakpoints) stay coherent.
+  {
+    const UInt newRate = (UInt)info->defaultSampleRate;
+    assert(!INTERNAL::Global().isSampleRateLocked() || newRate == SAMPLERATE);
+    if (!INTERNAL::Global().isSampleRateLocked()) {
+      SAMPLERATE = newRate;
+    }
+  }
 
   err = Pa_OpenStream(
     &stream
@@ -289,7 +301,14 @@ void YSE::DEVICE::managerObject::openDevice(const YSE::deviceSetup & object) {
   }
 #endif
   params.hostApiSpecificStreamInfo = nullptr;
-  SAMPLERATE = (UInt)info->defaultSampleRate;
+  // See note at the addCallback() writer above.
+  {
+    const UInt newRate = (UInt)info->defaultSampleRate;
+    assert(!INTERNAL::Global().isSampleRateLocked() || newRate == SAMPLERATE);
+    if (!INTERNAL::Global().isSampleRateLocked()) {
+      SAMPLERATE = newRate;
+    }
+  }
 
   err = Pa_OpenStream(
     &stream

--- a/YseEngine/device/portaudioDeviceManager.h
+++ b/YseEngine/device/portaudioDeviceManager.h
@@ -19,6 +19,7 @@
 #include "headers/types.hpp"
 #include "deviceManager.h"
 #include "portaudio.h"
+#include <chrono>
 
 namespace YSE {
   
@@ -57,6 +58,12 @@ namespace YSE {
     private:
         void terminate();
 
+        // Fold one callback's wall-clock elapsed time into cpuLoadEma.
+        // Called by paCallback on every exit path. Single producer (the
+        // PortAudio callback thread), so relaxed atomics are sufficient.
+        void updateCpuLoadEma(std::chrono::steady_clock::time_point cbStart,
+                              unsigned long numSamples);
+
         void audioDeviceError(PaError err);
         PaStream * stream;
         PaError err;
@@ -70,6 +77,13 @@ namespace YSE {
         // because we open the stream with paFramesPerBufferUnspecified.
         std::atomic<int> activeBufferSize{0};
         std::atomic<int> activeOutputLatencySamples{0};
+
+        // EMA-smoothed callback wall-clock load (issue #82). Written by
+        // paCallback at the end of each render (relaxed, single producer),
+        // read by cpuLoad() on the control thread (relaxed — no
+        // synchronisation needed, callers just want a recent value).
+        // Reset to 0 on close() so a fresh device starts clean.
+        std::atomic<float> cpuLoadEma{0.f};
     };
 
     managerObject & Manager();

--- a/YseEngine/dsp/lfo.cpp
+++ b/YseEngine/dsp/lfo.cpp
@@ -19,9 +19,14 @@ YSE::DSP::fileBuffer LfoSineTable(0);
 
 YSE::DSP::lfo::lfo() : cursor(0.f), previousType(LFO_NONE) {
   result = 1;
-  if (LfoSawTable.getLength() == 0) {
-    // This is the first lfo object in use.
-    // Initialize all lookup tables now.
+  // Rebuild the static tables whenever their size diverges from the live
+  // SAMPLERATE. On Android with Oboe, SAMPLERATE can be overwritten when the
+  // device stream opens (e.g. 44100 → 48000 on a Pixel 7), and the per-sample
+  // wrap math reads the current SAMPLERATE — so tables sized at an earlier
+  // rate read past their end. The rebuild runs on the control thread (every
+  // lfo() caller is control-thread); audio-thread readers only race during
+  // operator(), never during construction.
+  if (LfoSawTable.getLength() != SAMPLERATE) {
     LfoSawTable.resize(SAMPLERATE);
     LfoSawTable.drawLine(0, SAMPLERATE - 200, 1.f, 0.f);
     LfoSawTable.drawLine(SAMPLERATE - 200, SAMPLERATE, 0.f, 1.f);
@@ -122,9 +127,12 @@ YSE::DSP::buffer & YSE::DSP::lfo::operator()(LFO_TYPE type, Flt frequency, UInt 
       Flt * out = result.getPtr();
       Flt * in = LfoSawTable.getPtr();
       while (samplesToProcess) {
+        // Wrap before the cast: (UInt)negative-float is implementation-
+        // defined and on arm64 produces a huge index that reads past the
+        // table (SIGSEGV on Android, garbage > 1.0 elsewhere).
+        if (cursor < 0) cursor += SAMPLERATE;
         *out++ = in[(UInt)cursor];
         cursor -= frequency;
-        if (cursor < 0) cursor += SAMPLERATE;
         samplesToProcess--;
       }
       break;

--- a/YseEngine/dsp/modules/granulator.hpp
+++ b/YseEngine/dsp/modules/granulator.hpp
@@ -40,10 +40,11 @@ namespace YSE {
          *
          *  @param poolSize  Size of the circular input buffer in samples.
          *                   Limits how far back into the input the granulator
-         *                   can reach. Default is 5 seconds at 44.1 kHz.
+         *                   can reach. Default is 5 seconds at the engine's
+         *                   current sample rate.
          *  @param maxGrains Maximum number of grains alive simultaneously.
          */
-        granulator(UInt poolSize = 44100 * 5, UInt maxGrains = 16);
+        granulator(UInt poolSize = SAMPLERATE * 5, UInt maxGrains = 16);
         virtual ~granulator() {};
 
         /** @brief dspObject lifecycle hook — allocates buffers. */

--- a/YseEngine/headers/constants.hpp
+++ b/YseEngine/headers/constants.hpp
@@ -15,8 +15,22 @@
 
 namespace YSE {
   const UInt STANDARD_BUFFERSIZE = 128;
+
+  // Default streaming-chunk size in samples. Sized as ~1 s of audio at 44.1
+  // kHz; at other negotiated sample rates the wall-clock duration scales
+  // accordingly (~0.92 s at 48 kHz, ~0.46 s at 96 kHz). Used as a fixed
+  // sample-count by file/streaming subsystems; not intended to track
+  // SAMPLERATE.
   const UInt STREAM_BUFFERSIZE = 44100;
-  extern API UInt SAMPLERATE; // this used to be a constant. It is now declared in devicemanager
+
+  // The active engine sample rate. Initialised to 44100 by the device
+  // manager's translation unit; written exactly once per session by the
+  // audio backend (PortAudio default device on desktop, Oboe-negotiated
+  // rate on Android) before INTERNAL::Global().sampleRateLocked is set at
+  // the end of system::initShared(). Treat as immutable within a session;
+  // see the lock contract enforced in portaudioDeviceManager.cpp /
+  // oboeImplementation.cpp.
+  extern API UInt SAMPLERATE;
 }
   
   

--- a/YseEngine/headers/defines.hpp
+++ b/YseEngine/headers/defines.hpp
@@ -147,7 +147,18 @@
 
 
 //==============================================================================
-// DLL building settings on Windows (Clang/MinGW)
+// Public-API export / visibility annotation.
+//
+// Windows DLL builds (Clang/MinGW) use __declspec(dllexport / dllimport): the
+// consumer side picks "import" via the YSE_DLL define configured by CMake's
+// INTERFACE compile definitions on the `yse` target.
+//
+// ELF / Mach-O builds (Linux, macOS, iOS, BSD, Android) use the GCC/Clang
+// visibility attribute. Pair with CXX_VISIBILITY_PRESET=hidden on the library
+// target so the only exported symbols are the ones explicitly tagged here.
+// The YSE_DLL leg is a no-op because ELF has no "import" counterpart —
+// visibility is a producer-side concept; consumers see all default-visibility
+// symbols automatically.
 #if YSE_WINDOWS && YSE_CLANG
   #ifdef YSE_DLL_BUILD
     #define API __declspec(dllexport)
@@ -156,11 +167,7 @@
     #define API __declspec(dllimport)
     #define EXTERN extern
   #endif
-#endif
-
-//==============================================================================
-// DLL building on mac
-#if YSE_MAC
+#elif YSE_LINUX || YSE_MAC || YSE_IOS || YSE_BSD || YSE_ANDROID
   #ifdef YSE_DLL_BUILD
     #define API __attribute__((visibility("default")))
     #define EXTERN

--- a/YseEngine/internal/denormalGuard.h
+++ b/YseEngine/internal/denormalGuard.h
@@ -1,0 +1,50 @@
+/*
+  ==============================================================================
+
+    denormalGuard.h
+    Flush-to-zero / denormals-are-zero for the audio thread.
+
+    Without this, any IIR feedback path (one-pole filters, reverb tails) can
+    decay into subnormal floats which slow x86/ARM FPU arithmetic by 10-100x,
+    pegging the audio callback at high CPU even when the graph is effectively
+    silent. See issue #53.
+
+    Call enableFlushToZero() once at the top of every audio callback. It is a
+    single MXCSR / FPCR write (per-thread state). Re-setting on every callback
+    is safe and keeps us robust to backends that recycle callback threads.
+
+  ==============================================================================
+*/
+
+#ifndef DENORMAL_GUARD_H_INCLUDED
+#define DENORMAL_GUARD_H_INCLUDED
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+  #include <pmmintrin.h>
+  #include <xmmintrin.h>
+#elif defined(__aarch64__) || defined(__arm__)
+  #include <cstdint>
+#endif
+
+namespace YSE { namespace INTERNAL {
+
+inline void enableFlushToZero() {
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+  _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+  _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+#elif defined(__aarch64__)
+  std::uint64_t fpcr;
+  asm volatile("mrs %0, fpcr" : "=r"(fpcr));
+  fpcr |= (std::uint64_t(1) << 24);
+  asm volatile("msr fpcr, %0" : : "r"(fpcr));
+#elif defined(__arm__)
+  std::uint32_t fpscr;
+  asm volatile("vmrs %0, fpscr" : "=r"(fpscr));
+  fpscr |= (std::uint32_t(1) << 24);
+  asm volatile("vmsr fpscr, %0" : : "r"(fpscr));
+#endif
+}
+
+}}
+
+#endif

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -24,7 +24,7 @@ void YSE::INTERNAL::global::addFastJob(threadPoolJob * job) {
   fastThreads.addJob(job);
 }
 
-YSE::INTERNAL::global::global() : slowThreads(1), fastThreads(), update(false), active(false) {}
+YSE::INTERNAL::global::global() : slowThreads(1), fastThreads(), update(false), active(false), sampleRateLocked(false) {}
 
 void YSE::INTERNAL::global::init() {
   REVERB::Manager().create();

--- a/YseEngine/internal/global.h
+++ b/YseEngine/internal/global.h
@@ -23,11 +23,19 @@ namespace YSE {
     public:
       bool isActive() { return active; }
 
+      // True between the end of system::initShared() and the start of
+      // system::close(). Within a session, SAMPLERATE is immutable: the device
+      // writers in portaudioDeviceManager.cpp / oboeImplementation.cpp assert
+      // !isSampleRateLocked() before mutating SAMPLERATE. Lookup tables and
+      // other SAMPLERATE-derived caches across the engine rely on this
+      // contract.
+      bool isSampleRateLocked() { return sampleRateLocked; }
+
       void addSlowJob(threadPoolJob * job);
       void addFastJob(threadPoolJob * job);
-      
-      void flagForUpdate() { 
-        update++; 
+
+      void flagForUpdate() {
+        update++;
       }
       bool needsUpdate() { return update > 0;  }
       void updateDone() { update--; }
@@ -44,6 +52,7 @@ namespace YSE {
 
       aInt update;
       aBool active; // set true after System().init(), false at System().close()
+      aBool sampleRateLocked;
 
 
       friend class YSE::system; // system needs access to the init and close method

--- a/YseEngine/internal/reverbDSP.cpp
+++ b/YseEngine/internal/reverbDSP.cpp
@@ -43,6 +43,12 @@ the values were obtained by listening tests.                */
 static const int combtuning[8] = { 1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617 };
 static const int allpasstuning[4] = { 556, 441, 341, 225 };
 
+// The combtuning / allpasstuning arrays above are calibrated for this
+// reference sample rate. At runtime the tunings are scaled by
+// (SAMPLERATE / kReverbTuningReferenceRate) so the perceived reverb
+// character stays consistent across device-negotiated sample rates.
+static constexpr float kReverbTuningReferenceRate = 44100.0f;
+
 // static inline functions and pointer for speed optimisation
 UInt ch;
 Int filterIndex;
@@ -369,11 +375,11 @@ YSE::INTERNAL::reverbChannel::reverbChannel() : delayline(3000), bufComb(COMBS),
   Int rnd = Random(50);
   // recalculate the reverb parameters in case we don't run at 44.1kHz
   for (Int i = 0; i < COMBS; i++) {
-    combTuning[i] = (Int)((combtuning[i] + rnd) * (SAMPLERATE / 44100.0f));
+    combTuning[i] = (Int)((combtuning[i] + rnd) * (SAMPLERATE / kReverbTuningReferenceRate));
   }
 
   for (int i = 0; i < APASS; i++) {
-    allTuning[i] = (Int)((allpasstuning[i] + rnd) * (SAMPLERATE / 44100.0f));
+    allTuning[i] = (Int)((allpasstuning[i] + rnd) * (SAMPLERATE / kReverbTuningReferenceRate));
   }
 
   // get memory for delay lines
@@ -404,11 +410,11 @@ YSE::INTERNAL::reverbChannel::reverbChannel(const reverbChannel& /*source*/): de
     Int rnd = Random(50);
   // recalculate the reverb parameters in case we don't run at 44.1kHz
   for (Int i = 0; i < COMBS; i++) {
-    combTuning[i] = (Int)((combtuning[i] + rnd) * (SAMPLERATE / 44100.0f));
+    combTuning[i] = (Int)((combtuning[i] + rnd) * (SAMPLERATE / kReverbTuningReferenceRate));
   }
 
   for (int i = 0; i < APASS; i++) {
-    allTuning[i] = (Int)((allpasstuning[i] + rnd) * (SAMPLERATE / 44100.0f));
+    allTuning[i] = (Int)((allpasstuning[i] + rnd) * (SAMPLERATE / kReverbTuningReferenceRate));
   }
 
   // get memory for delay lines

--- a/YseEngine/internal/threadPool.cpp
+++ b/YseEngine/internal/threadPool.cpp
@@ -11,6 +11,7 @@
 #include "threadPool.h"
 #include <assert.h>
 #include "../system.hpp"
+#include "denormalGuard.h"
 
 YSE::INTERNAL::threadPoolJob::threadPoolJob() : shouldStop(false), inQueue(false), isDone(false) {}
 
@@ -36,6 +37,12 @@ void YSE::INTERNAL::threadPoolJob::activate() {
 YSE::INTERNAL::threadPoolThread::threadPoolThread(threadPool * pool) : pool(pool) {}
 
 void YSE::INTERNAL::threadPoolThread::run() {
+  // Worker threads also run DSP (CHANNEL::implementationObject::run dispatches
+  // child-channel dsp() here via addFastJob). MXCSR/FPCR is per-thread, so the
+  // FTZ/DAZ set on the audio callback thread does not reach us — set it once
+  // when the worker starts. See issue #81 and denormalGuard.h.
+  enableFlushToZero();
+
   while (!threadShouldExit()) {
     threadPoolJob * job = pool->getJob();
     if (job == nullptr) return;

--- a/YseEngine/midi/device.cpp
+++ b/YseEngine/midi/device.cpp
@@ -1,5 +1,5 @@
 #include "headers/defines.hpp"
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 #include "device.hpp"
 #include "RtMidi.h"
 #include "midiDeviceManager.h"

--- a/YseEngine/midi/device.hpp
+++ b/YseEngine/midi/device.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../headers/defines.hpp"
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include <atomic>
 #include <cstddef>

--- a/YseEngine/midi/midiDeviceManager.cpp
+++ b/YseEngine/midi/midiDeviceManager.cpp
@@ -1,6 +1,6 @@
 #include "headers/defines.hpp"
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include "midiDeviceManager.h"
 #include "internalHeaders.h"

--- a/YseEngine/midi/midiDeviceManager.h
+++ b/YseEngine/midi/midiDeviceManager.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "headers/defines.hpp"
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 
 #include "../dependencies/rtmidi/include/RtMidi.h"
 #include "../midi/midiMessage.hpp"

--- a/YseEngine/patcher/midi/mMidiOut.cpp
+++ b/YseEngine/patcher/midi/mMidiOut.cpp
@@ -1,5 +1,6 @@
 #include "headers/defines.hpp"
-#if YSE_WINDOWS
+// See the matching guard in mMidiOut.h.
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
 #include "mMidiOut.h"
 #include "../pObjectList.hpp"
 #include "../patcherImplementation.h"

--- a/YseEngine/patcher/midi/mMidiOut.h
+++ b/YseEngine/patcher/midi/mMidiOut.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "headers/defines.hpp"
-#if YSE_WINDOWS
+// Patcher midi-out object: Windows-only AND requires the RtMidi-backed MIDI
+// device backend (YSE_ENABLE_MIDI_DEVICE). When the option is OFF the
+// underlying YSE::midiOut type doesn't exist, so this file is empty.
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
 #include "../pObject.h"
 #include "../../midi/device.hpp"
 

--- a/YseEngine/patcher/pRegistry.cpp
+++ b/YseEngine/patcher/pRegistry.cpp
@@ -49,9 +49,13 @@
 #include "midi/mMidiControl.h"
 #include "midi/mMidiNoteOff.h"
 #include "midi/mMidiNoteOn.h"
-#include "midi/mMidiOut.h"
 #include "midi/mMidiPolyPressure.h"
 #include "midi/mMidiProgramChange.h"
+#endif
+// mMidiOut is the only patcher midi object that depends on the RtMidi-backed
+// device backend; the other six just emit MIDI bytes and don't need it.
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
+#include "midi/mMidiOut.h"
 #endif
 
 using namespace YSE::PATCHER;
@@ -114,9 +118,11 @@ pRegistry::pRegistry() {
   Add(OBJ::M_CONTROL, mMidiControl::Create);
   Add(OBJ::M_NOTEOFF, mMidiNoteOff::Create);
   Add(OBJ::M_NOTEON, mMidiNoteOn::Create);
-  Add(OBJ::M_OUT, mMidiOut::Create);
   Add(OBJ::M_POLYPRESS, mMidiPolyPressure::Create);
   Add(OBJ::M_PROGCHANGE, mMidiProgramChange::Create);
+#endif
+#if YSE_WINDOWS && YSE_ENABLE_MIDI_DEVICE
+  Add(OBJ::M_OUT, mMidiOut::Create);
 #endif
 }
 

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -230,7 +230,7 @@ const std::string & YSE::system::getDefaultHost() {
   return DEVICE::Manager().getDefaultTypeName();
 }
 
-#if YSE_WINDOWS || YSE_LINUX
+#if YSE_ENABLE_MIDI_DEVICE
 unsigned int YSE::system::getNumMidiInDevices()
 {
 	return MIDI::DeviceManager().getNumMidiInDevices();

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -169,6 +169,13 @@ Flt YSE::system::cpuLoad() {
   return DEVICE::Manager().cpuLoad();
 }
 
+double YSE::system::getSampleRate() {
+  // The session lock is set at the end of initShared(); before that, SAMPLERATE
+  // still holds its 44100 default and reporting it would mislead hosts that
+  // start sample-count-driven work pre-init.
+  return INTERNAL::Global().isSampleRateLocked() ? (double)SAMPLERATE : 0.0;
+}
+
 double YSE::system::getActiveSampleRate() {
   return DEVICE::Manager().getActiveSampleRate();
 }

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -68,6 +68,12 @@ Bool YSE::system::initShared(bool openDevice) {
 			DEVICE::Manager().addCallback();
 		}
 
+		// addCallback() is the last point at which the backend can negotiate
+		// SAMPLERATE (PortAudio on desktop, Oboe on Android). After this, lock
+		// SAMPLERATE for the rest of the session — DSP lookup tables and other
+		// derived caches assume a stable rate per session.
+		INTERNAL::Global().sampleRateLocked = true;
+
 #ifdef YSE_WINDOWS
     timeBeginPeriod(1);
 #endif
@@ -97,6 +103,9 @@ void YSE::system::close() {
   YSE::PATCHER::TimerThread().Clear();
 
   if (INTERNAL::Global().active) {
+    // Release the SAMPLERATE lock first so the next init() pass can rewrite
+    // SAMPLERATE if the host opens a device with a different negotiated rate.
+    INTERNAL::Global().sampleRateLocked = false;
     INTERNAL::Global().active = false;
     DEVICE::Manager().close();
     INTERNAL::Global().close();

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -209,9 +209,21 @@ namespace YSE {
      */
     system& autoReconnect(bool on, int delay);
 
-    /** @brief CPU load of the audio thread as a fraction of the callback budget.
+    /** @brief Audio callback wall-clock load as a fraction of the buffer period.
      *
-     *  Distinct from the cost of ``update()`` on the main thread.
+     *  Measured by YSE: timestamps taken at the entry/exit of each backend
+     *  callback (PortAudio's ``paCallback`` or Oboe's ``onAudioReady``) and
+     *  divided by the buffer's audio time. EMA-smoothed with a ~1 s time
+     *  constant. Returns 0 when no device is open.
+     *
+     *  This is a **dropout-risk** indicator: 1.0 means the callback is taking
+     *  as long as the buffer it produces, i.e. the next buffer will arrive
+     *  late. It does NOT reflect total engine CPU across the threadpool
+     *  workers — for that, see issue #84.
+     *
+     *  Distinct from the cost of ``update()`` on the main thread. Replaces
+     *  the previous pass-through of ``Pa_GetStreamCpuLoad``, which read as
+     *  inflated under WASAPI shared mode after periods of silence (see #82).
      */
     float cpuLoad();
 

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -140,11 +140,16 @@ namespace YSE {
     /** @brief Name of the platform default audio host (e.g. WASAPI, ALSA). */
     const std::string & getDefaultHost();
 
-#if YSE_WINDOWS || YSE_LINUX
-    /** @brief Number of MIDI input devices available. (Windows / Linux only.) */
+#if YSE_ENABLE_MIDI_DEVICE
+    /** @brief Number of MIDI input devices available.
+     *
+     *  Present only when libyse was built with ``YSE_ENABLE_MIDI_DEVICE=ON``
+     *  (default on Windows/Linux). When the option is OFF the function is
+     *  not declared at all — gate consumer code on ``#if YSE_ENABLE_MIDI_DEVICE``.
+     */
     unsigned int getNumMidiInDevices();
 
-    /** @brief Number of MIDI output devices available. (Windows / Linux only.) */
+    /** @brief Number of MIDI output devices available. */
     unsigned int getNumMidiOutDevices();
 
     /** @brief Name of the MIDI input device with the given ID. */

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -210,6 +210,18 @@ namespace YSE {
      */
     float cpuLoad();
 
+    /** @brief Engine session sample rate in Hz.
+     *
+     *  The rate the engine locked to when ``init()`` / ``initOffline()`` ran.
+     *  Stays constant across the entire session, including pause / resume
+     *  cycles where ``getActiveSampleRate()`` transiently drops to 0. Returns
+     *  0 before the lock is established (pre-init).
+     *
+     *  Use this when scheduling sample-count-driven work that must outlive a
+     *  pause; use ``getActiveSampleRate()`` for live device-state UI.
+     */
+    double getSampleRate();
+
     /// @name Active device readouts
     /// Live state of the currently open audio device. Each returns 0 when no
     /// device is open (pre-init, after ``close()``, or under ``initOffline()``).

--- a/tools/ci-linux/inspect_exports.sh
+++ b/tools/ci-linux/inspect_exports.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Inspect libyse.so exports for issue #34 verification.
+set -e
+
+SO=${1:-/workspace/build-linux/bin/libyse.so}
+
+echo "=== total defined exports ==="
+nm -D --defined-only "$SO" | wc -l
+
+echo
+echo "=== by symbol type ==="
+nm -D --defined-only "$SO" | awk '{print $2}' | sort | uniq -c | sort -rn
+
+# Demangle and break down by namespace.
+TMP=$(mktemp)
+nm -D --defined-only "$SO" | c++filt > "$TMP"
+
+echo
+echo "=== T (text) symbols, namespace breakdown ==="
+awk '$2=="T"{print $0}' "$TMP" \
+  | sed -E 's/^[^ ]+ T //' \
+  | sed -E 's/\(.*$//' \
+  | sed -E 's/<.*//' \
+  | sed -E 's/::[^:]+$//' \
+  | sort | uniq -c | sort -rn | head -25
+
+echo
+echo "=== INTERNAL:: T-symbols (should be 0 — internal namespace, never tagged) ==="
+awk '$2=="T"{print $0}' "$TMP" | grep -c "YSE::INTERNAL::" || true
+
+echo
+echo "=== PATCHER:: T-symbols (should be 0 — internal namespace) ==="
+awk '$2=="T"{print $0}' "$TMP" | grep -c "YSE::PATCHER::" || true
+
+echo
+echo "=== SOUND::Manager / CHANNEL::Manager T-symbols (internal singletons) ==="
+awk '$2=="T"{print $0}' "$TMP" | grep -cE "YSE::(SOUND|CHANNEL|REVERB|MIDI|MOTIF|SCALE|PLAYER|DEVICE)::Manager" || true
+
+rm -f "$TMP"

--- a/yse.py
+++ b/yse.py
@@ -282,10 +282,12 @@ def cmd_clean(args):
 
 
 def cmd_analyze(args):
-    # Find compile_commands.json — prefer debug, fall back to tests or release.
+    # Find compile_commands.json. Prefer build-tests because it includes both
+    # engine and test sources; build-debug omits the Tests/ targets and would
+    # fail clang-tidy on test files with "doctest/doctest.h not found".
     candidates = [
-        ROOT / "build-debug" / "compile_commands.json",
         ROOT / "build-tests" / "compile_commands.json",
+        ROOT / "build-debug" / "compile_commands.json",
         ROOT / "build" / "compile_commands.json",
     ]
     compile_commands_dir = None


### PR DESCRIPTION
Cuts v2.1.0 from `dev`. 65 commits, no breaking C++ API changes.

## Highlights

### New public surface

- **`system::getSampleRate()`** / **`yse_system_get_sample_rate`** (#72) — session-locked sample rate, distinct from the live `getActiveSampleRate()` that drops to 0 on pause.
- **Active device-state getters** — `getActiveSampleRate`, `getActiveBufferSize`, `getActiveOutputLatency` on both C++ and C surfaces.
- **MIDI input wrapper** — `midiIn` with raw + parsed callbacks.
- **Per-output channel peak metering** on `channel` (pre/post-volume) + C API.
- **C API milestones M2-M8 completed** — reverb, device enumeration, DSP buffers + chainable effects, patcher graph, MIDI device output, MIDI file playback, music primitives + generative player, log + BufferIO.
- **Android backend** — NDK + CMake + Oboe + NativeActivity test APK.

### Behavior changes

- **SAMPLERATE locked for the lifetime of a session** — rate caches (LFO tables, reverb tunings, ADSR breakpoints) stay coherent across pause/resume.
- **FTZ/DAZ enabled on every audio-thread entry point** — PortAudio callback (#53/#70), Oboe callback (#70), and fast-pool worker threads (#81). Protects user IIRs from denormal slowdown.
- **`system::cpuLoad()` reimplemented** (#82) — was passing PortAudio's `Pa_GetStreamCpuLoad` through unchanged; that number was unreliable under WASAPI shared mode (plateaued at ~50% post-silence). Now measured by YSE: `steady_clock` brackets around each callback, divided by buffer period, EMA-smoothed with ~1 s time constant. Same instrumentation mirrored on Oboe; Android `cpuLoad()` no longer a stub.

### Fixes

- LFO saw-reversed wrap when LFO table size diverges from live SAMPLERATE (#48)
- Android live device-state getters reset on pause (#74)
- Flaky cross-iteration velocity comparison in listener tests (#75)
- C-API log-callback bridge: mutex → atomics; explicit string-ownership transfer (#58, plus follow-up)

### Build / infra

- ELF: `-fvisibility=hidden` + explicit visibility attrs on the public C surface (#34) — narrows the exported symbol set on Linux/Android.
- MIDI device backend gated behind `YSE_ENABLE_MIDI_DEVICE` (#35).
- `.clang-tidy` baseline + `python yse.py analyze` integration; analyze-before-commit workflow rule.
- `c-api-extend` Claude Code skill for C-API additions.
- C-API documentation sweep: handle ownership, void-no-op convention, callback-bridge rules, static-assert enum drift guard.
- CI: also run tests at `YSE_TEST_FORCED_RATE=48000` so SAMPLERATE-dependent code isn't only exercised at 44.1 kHz.

## Test plan

- [x] Full `python yse.py test` suite passes (14/14, multiple sample rates)
- [x] `python yse.py analyze` baseline tracked; no new findings in this cycle
- [ ] Release CI: Linux + Windows packages build cleanly on tag push
- [ ] Manual: phi consumer confirms cpuLoad no longer reads inflated on WASAPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)