### PR TITLE
Release v2.1.0

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -18,7 +18,7 @@
 #include <string>
 
 namespace YSE {
-  const std::string VERSION = "2.0.2";
+  const std::string VERSION = "2.1.0";
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *


### PR DESCRIPTION
Bumps `YSE::VERSION` from `2.0.2` to `2.1.0`.

After this merges, I'll tag the resulting master commit `v2.1.0` and push the tag, which fires [.github/workflows/release.yml](.github/workflows/release.yml) to build the Linux + Windows packages and publish the GitHub release with auto-generated notes.

Content of v2.1.0 is the dev → master merge from #86 — see that PR for the full changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)