### PR TITLE
docs: bump version banner to 2.1

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -18,7 +18,7 @@ from pathlib import Path
 project = "libYSE"
 author = "Yvan Vander Sanden"
 copyright = "2014-2026, Yvan Vander Sanden"
-release = "2.0"
+release = "2.1"
 
 # -- General configuration ---------------------------------------------------
 
@@ -58,7 +58,7 @@ breathe_show_include = False
 # -- HTML output -------------------------------------------------------------
 
 html_theme = "sphinx_book_theme"
-html_title = "libYSE 2.0"
+html_title = "libYSE 2.1"
 html_static_path = ["_static"]
 
 # Logo and favicon are sourced from the repo-root `logo/` directory so the


### PR DESCRIPTION
Bumps the hardcoded version strings in `documentation/source/conf.py` for the v2.1.0 release. Triggers a GitHub Pages redeploy.

The API reference is auto-generated from header doxygen via the Doxygen → Breathe → Sphinx pipeline, so all the new surface in v2.1.0 (`system::getSampleRate`, `getActiveSampleRate/BufferSize/OutputLatency`, `midiIn`, per-output peak metering, the M2-M8 C-API milestones, the rewritten `cpuLoad`, ...) flows in without further changes here.

Branched off master (rather than the usual dev → master cycle) because the docs site shouldn't lag the release on the user-visible "libYSE 2.0" banner. After merge, I'll sync master back into dev so the docs bump and the v2.1.0 version commit aren't lost on the dev branch.

Future improvement: have `conf.py` read the version from `YseEngine/system.hpp` so this can't go stale again. Filed as a follow-up consideration; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)