### PR TITLE
docs: read VERSION from YseEngine/system.hpp (fixes #89)

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -11,6 +11,7 @@ If the XML directory is missing, Sphinx will emit empty API pages — run
 Doxygen first.
 """
 
+import re
 from pathlib import Path
 
 # -- Project information -----------------------------------------------------
@@ -18,7 +19,34 @@ from pathlib import Path
 project = "libYSE"
 author = "Yvan Vander Sanden"
 copyright = "2014-2026, Yvan Vander Sanden"
-release = "2.1"
+
+
+def _read_engine_version():
+    """Parse the canonical VERSION literal out of YseEngine/system.hpp.
+
+    Single source of truth for the docs banner. ``yse.py release`` writes
+    to ``system.hpp`` only; this picks it up at Sphinx-build time so the
+    docs never lag a release. See issue #89.
+    """
+    engine_hpp = (
+        Path(__file__).resolve().parent.parent.parent / "YseEngine" / "system.hpp"
+    )
+    m = re.search(
+        r'VERSION\s*=\s*"(\d+)\.(\d+)\.(\d+)"',
+        engine_hpp.read_text(encoding="utf-8"),
+    )
+    if not m:
+        raise RuntimeError(
+            f"VERSION literal not found in {engine_hpp}; docs build cannot "
+            f"determine the release banner."
+        )
+    return m.group(1), m.group(2), m.group(3)
+
+
+_major, _minor, _patch = _read_engine_version()
+# Sphinx convention: ``version`` is short (X.Y), ``release`` is full (X.Y.Z).
+version = f"{_major}.{_minor}"
+release = f"{_major}.{_minor}.{_patch}"
 
 # -- General configuration ---------------------------------------------------
 
@@ -58,7 +86,7 @@ breathe_show_include = False
 # -- HTML output -------------------------------------------------------------
 
 html_theme = "sphinx_book_theme"
-html_title = "libYSE 2.1"
+html_title = f"libYSE {version}"
 html_static_path = ["_static"]
 
 # Logo and favicon are sourced from the repo-root `logo/` directory so the


### PR DESCRIPTION
Closes #89.

## Summary

[conf.py](documentation/source/conf.py) now parses `YseEngine/system.hpp` at Sphinx-build time and uses it for both `version` (short form `X.Y`) and `release` (full form `X.Y.Z`). `html_title` becomes `f"libYSE {version}"`. The release banner can no longer drift from the canonical engine VERSION.

After this lands, the release flow is one-step:

1. `python yse.py release {patch,minor,major}` updates `YseEngine/system.hpp`, commits, tags, pushes.
2. Master push fires `documentation.yml` → Sphinx → `conf.py` re-reads `system.hpp` → docs deploy with the new banner.

No second PR, no extra CI round.

## Test plan

- [x] Local sanity-check: load `conf.py` in Python, confirm `version="2.1"`, `release="2.1.0"`, `html_title="libYSE 2.1"` against the current `system.hpp`.
- [ ] CI: SonarQube build runs; docs workflow does not run on PRs-to-dev so the live verification happens after dev → master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)