### PR TITLE
tests: cpuLoad recovery regression test [issue #82]

### DIFF
--- a/Tests/integration/test_device.cpp
+++ b/Tests/integration/test_device.cpp
@@ -23,8 +23,12 @@
 // null_device.hpp and is not tested here; shutdown is exercised by process exit.
 
 #include <doctest/doctest.h>
+#include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <vector>
 #include "yse.hpp"
 #include "support/null_device.hpp"
 #include "headers/defines.hpp"
@@ -45,6 +49,40 @@ struct ConstantSource : YSE::DSP::dspSourceObject {
         UInt len = samples[0].getLength();
         for (UInt i = 0; i < len; i++) p[i] = 0.5f;
         intent = YSE::SS_PLAYING;
+    }
+    void frequency(float) override {}
+};
+
+// Multi-sine DSP source — 11 sine generators feeding a low-pass, modelled
+// on AudioTest's shepard tone (YseEngine/internal/AudioTest.cpp) and on
+// Demo07_DspSource. This is the canonical "several sines + IIR feedback"
+// shape that triggered the original #53 / #82 reports; using it in the
+// recovery test keeps the cpuLoad measurement honest against exactly the
+// graph topology the bug appeared with. File-scope for the same lifetime
+// reason as ConstantSource.
+struct MultiSineSource : YSE::DSP::dspSourceObject {
+    static constexpr int kNumGens = 11;
+    YSE::DSP::sine    generators[kNumGens];
+    YSE::DSP::lowPass lp;
+    YSE::DSP::buffer  out;
+    float             freq[kNumGens];
+
+    MultiSineSource() {
+        // Spread sines across the audible band — keeps every generator
+        // contributing real signal rather than collapsing into beating.
+        for (int i = 0; i < kNumGens; ++i) {
+            freq[i] = 110.f + (float)i * 87.f;
+        }
+        lp.setFrequency(1500.f);
+    }
+
+    void process(YSE::SOUND_STATUS& intent) override {
+        out = 0.0f;
+        for (int i = 0; i < kNumGens; ++i) out += generators[i](freq[i]);
+        out *= (1.f / (float)kNumGens);
+        YSE::DSP::buffer& result = lp(out);
+        for (UInt i = 0; i < samples.size(); ++i) samples[i] = result;
+        if (intent == YSE::SS_WANTSTOSTOP) intent = YSE::SS_STOPPED;
     }
     void frequency(float) override {}
 };
@@ -70,8 +108,9 @@ struct ProbeEffect : YSE::DSP::dspObject {
     }
 };
 
-static ConstantSource g_source;
-static ProbeEffect    g_probe;
+static ConstantSource  g_source;
+static MultiSineSource g_multi_sine;
+static ProbeEffect     g_probe;
 
 // Sleep briefly, pump one update tick, then report whether the audio callback
 // fired during that interval (missedCallbacks resets to 0 when callbacks arrive).
@@ -169,6 +208,100 @@ TEST_CASE("engine: cpuLoad stays bounded with no graph activity") {
     const float load = YSE::System().cpuLoad();
     CHECK(load >= 0.0f);
     CHECK(load < 0.5f);
+}
+
+// Issue #82 (reopened): the original report observed Pa_GetStreamCpuLoad
+// staying elevated after stopping AudioTest, and the phi client still sees
+// elevated cpuLoad after stopping its sine playback even after the timing
+// rewrite landed. Diagnose by sampling cpuLoad once per second through a
+// full idle → playing → stopped cycle and writing the trace to a CSV the
+// user can post-hoc correlate against an external probe (GetProcessTimes,
+// perf, etc.). The graph here mirrors AudioTest (11 sines + low-pass),
+// the same DSP shape that triggered both #53 and #82.
+//
+// Total runtime: ~13 s on a Release build. Run explicitly with:
+//
+//   python yse.py test --integration
+//   yse_tests --test-suite=integration --test-case='*cpuLoad recovers*'
+TEST_CASE("engine: cpuLoad recovers after multi-sine playback stops [issue #82]") {
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+
+    auto sample_cpu = []() { return YSE::System().cpuLoad(); };
+
+    // Let the EMA settle (~1 s time constant) before the trace begins so
+    // we have a clean idle baseline to compare the post-stop reading to.
+    for (int i = 0; i < 4; i++) {
+        YSE::System().sleep(500);
+        YSE::System().update();
+    }
+    const float idle_baseline = sample_cpu();
+
+    struct Sample {
+        int         t_secs;
+        const char* phase;
+        float       cpu;
+    };
+    std::vector<Sample> trace;
+    trace.push_back({0, "idle", idle_baseline});
+
+    YSE::sound s;
+    s.create(g_multi_sine);
+    s.relative(true);
+    s.play();
+
+    // 5 seconds of active playback.
+    for (int i = 1; i <= 5; i++) {
+        YSE::System().sleep(1000);
+        YSE::System().update();
+        trace.push_back({i, "playing", sample_cpu()});
+    }
+
+    s.stop();
+
+    // 5 seconds after stop. By the end of this window the ~1 s EMA should
+    // have decayed any "playing" contribution to under 1 %, so the final
+    // reading should sit very close to the idle baseline.
+    for (int i = 1; i <= 5; i++) {
+        YSE::System().sleep(1000);
+        YSE::System().update();
+        trace.push_back({5 + i, "stopped", sample_cpu()});
+    }
+
+    // Drop the trace to a deterministic temp path. Whoever runs the test
+    // can diff this against an external CPU probe to confirm whether the
+    // engine reading still drifts up under their setup.
+    const auto log_path = std::filesystem::temp_directory_path() / "yse_cpuload_issue82.csv";
+    {
+        std::ofstream csv(log_path);
+        csv << "t_secs,phase,cpu_load\n";
+        for (const auto& smp : trace) {
+            csv << smp.t_secs << "," << smp.phase << "," << smp.cpu << "\n";
+        }
+    }
+    MESSAGE("cpuLoad trace written to " << log_path.string());
+
+    float max_playing = 0.f;
+    for (int i = 1; i <= 5; i++) max_playing = std::max(max_playing, trace[i].cpu);
+    const float final_stopped = trace.back().cpu;
+
+    INFO("idle_baseline = " << idle_baseline);
+    INFO("max_playing   = " << max_playing);
+    INFO("final_stopped = " << final_stopped);
+
+    // Sanity bounds: nothing negative, no impossible (>1.0) values.
+    for (const auto& smp : trace) {
+        CHECK(smp.cpu >= 0.0f);
+        CHECK(smp.cpu < 1.5f);
+    }
+
+    // The recovery assertion. 5 s after stop with a ~1 s tau, the playing
+    // component has decayed by e^-5 ≈ 0.7 %, so the final reading must
+    // sit very close to the idle baseline. Allow a generous 25 % of
+    // max_playing as slack for slow machines and EMA noise; if the
+    // engine still reports half its playing value at this point, the
+    // bug from the original report is back.
+    CHECK(final_stopped <= max_playing * 0.25f + idle_baseline + 0.01f);
 }
 
 // ─── Audio callback ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Re #82 (reopened).

## Summary

Adds an integration test that exercises the original #53 / #82 repro on a real audio device:

1. ~2 s idle to settle the EMA baseline.
2. 5 s playing a multi-sine source (`MultiSineSource`: 11 sines + low-pass, modelled on AudioTest's shepard and Demo07_DspSource — the canonical IIR-feedback DSP shape that triggered the original reports).
3. 5 s after `sound.stop()`.

Samples `system::cpuLoad()` once per second across all three phases and writes the trace to `%TEMP%/yse_cpuload_issue82.csv` for post-hoc correlation with an external CPU probe.

## Findings on this machine

Run locally on Windows MSYS2 Clang64, default WASAPI device:

```
t   phase    cpu_load
0   idle     0.03%
1   playing  28%    ← start transient
2   playing  12%
3   playing  8%
4   playing  5%
5   playing  4%     ← steady state
6   stopped  26%
7   stopped  43%    ← rising, not decaying
8   stopped  43%
9   stopped  45%
10  stopped  41%
```

The test **fails** the recovery check (`final_stopped <= max_playing × 0.25 + idle_baseline + 0.01`). The cpuLoad EMA climbs to ~40-45 % after `sound.stop()` and plateaus there — well above the ~4 % steady-state playing cost.

So PR #85's timing rewrite changed the source of the elevated number (from `Pa_GetStreamCpuLoad` to our own `steady_clock` measurement), but the underlying callback wall-clock is genuinely longer post-stop. Whatever is happening on the audio thread after a sound stops is causing real CPU cost. This is exactly the regression the phi user reported.

## Why a failing test

The failure is intentional. It documents the regression with a deterministic trace path:

- Anyone running `python yse.py test --integration` sees the failure loudly.
- The CSV path is printed via doctest `MESSAGE` so diagnostics survive the failure.
- Once the underlying issue is root-caused, fixing it will turn the test green without any further code changes.

Integration tests are opt-in, so the default `python yse.py test` suite stays green; CI doesn't run integration tests at all, so no PR / push CI breaks.

## Next step (not in this PR)

Root-cause the post-stop callback cost spike. Suspects:

1. SOUND::Manager state-machine work (release → delete path) running on the audio callback thread while a stopped sound is being garbage-collected.
2. Something in the reverb manager or under-water FX getting touched per-callback on a graph that no longer has live sound.
3. The DSP source object's `process()` continuing to be invoked despite `SS_STOPPED` (would be a regression in `soundImplementation::dsp()`'s short-circuit).

Followed up separately under #82 once a candidate is identified.

## Test plan

- [x] `python yse.py test` — full default suite still green (14/14)
- [x] `python yse.py test --integration` — only the new test fails; 16 of 17 integration cases pass
- [x] CSV produced at `%TEMP%/yse_cpuload_issue82.csv` with all 11 rows
- [x] No new clang-tidy findings in `Tests/integration/test_device.cpp` (one pre-existing destructor warning matches the existing `ConstantSource` pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)