### PR TITLE
channel: skip fast-pool dispatch for empty child channels (fixes #82)

### DIFF
--- a/Tests/integration/test_device.cpp
+++ b/Tests/integration/test_device.cpp
@@ -210,14 +210,23 @@ TEST_CASE("engine: cpuLoad stays bounded with no graph activity") {
     CHECK(load < 0.5f);
 }
 
-// Issue #82 (reopened): the original report observed Pa_GetStreamCpuLoad
-// staying elevated after stopping AudioTest, and the phi client still sees
-// elevated cpuLoad after stopping its sine playback even after the timing
-// rewrite landed. Diagnose by sampling cpuLoad once per second through a
-// full idle → playing → stopped cycle and writing the trace to a CSV the
-// user can post-hoc correlate against an external probe (GetProcessTimes,
-// perf, etc.). The graph here mirrors AudioTest (11 sines + low-pass),
-// the same DSP shape that triggered both #53 and #82.
+// Issue #82 regression guard. Original report: cpuLoad stayed elevated for
+// seconds after sound.stop(), then was eventually root-caused to YSE's
+// default empty child channels (ambient/fx/music/gui/voice — see
+// system.cpp's initShared) being dispatched to the fast threadpool every
+// render. The audio thread's join() on those workers spin-slept in 2 ms
+// increments, adding ~10 ms of fake wall-clock per callback once the
+// source was silent (during playback the source work hid the wait).
+//
+// Fixed by skipping addFastJob for children with no work in
+// channelImplementation::dsp(); this test samples cpuLoad once per
+// second through idle → playing → stopped phases and asserts the
+// stopped reading decays back to the idle baseline. CSV trace written
+// to a deterministic temp path for offline correlation.
+//
+// The graph mirrors AudioTest (11 sines + low-pass), the same DSP
+// shape from the original repro, so the test also exercises the
+// FTZ/DAZ path on the audio thread (issue #53 / PR #70).
 //
 // Total runtime: ~13 s on a Release build. Run explicitly with:
 //

--- a/YseEngine/channel/channelImplementation.cpp
+++ b/YseEngine/channel/channelImplementation.cpp
@@ -104,6 +104,19 @@ void YSE::CHANNEL::implementationObject::dsp()
 	// calculate child channels if there are any
 	for (auto i = children.begin(); i != children.end(); ++i)
 	{
+		// Skip the fast-pool dispatch for children that have no work this
+		// render. Their dsp() would early-return at the top of this same
+		// function anyway, but the dispatch + matching join() in
+		// buffersToParent() would otherwise spin-sleep in 2 ms increments
+		// waiting for the worker to wake up and signal isDone. YSE's
+		// System().init() creates five default child channels of master
+		// (ambient/fx/music/gui/voice — see system.cpp); apps that don't
+		// use them — and especially silent / post-stop graphs where the
+		// audio thread has no source work to fill the dispatch→join gap —
+		// were losing ~10 ms of fake wall-clock per callback waiting for
+		// those no-op workers. Observed as the cpuLoad post-stop spike in
+		// issue #82.
+		if ((*i)->children.empty() && (*i)->sounds.empty()) continue;
 		INTERNAL::Global().addFastJob(*i);
 	}
 

--- a/YseEngine/device/portaudioDeviceManager.cpp
+++ b/YseEngine/device/portaudioDeviceManager.cpp
@@ -54,9 +54,10 @@ int YSE::DEVICE::managerObject::paCallback(
   , PaStreamCallbackFlags /*statusFlags*/
   , void * userData) {
   YSE::INTERNAL::enableFlushToZero();
-  // Issue #82: Pa_GetStreamCpuLoad was unreliable under WASAPI shared mode
-  // (plateaued at ~50% after silence). Time the callback ourselves with
-  // steady_clock; cpuLoad() returns the EMA of (elapsed / buffer-period).
+  // cpuLoad() reports a wall-clock ratio (time in callback / buffer period),
+  // EMA-smoothed. We time it ourselves with steady_clock rather than reading
+  // Pa_GetStreamCpuLoad so the Oboe path can report a comparable number
+  // (PortAudio's number doesn't exist on the Android backend).
   const auto cbStart = std::chrono::steady_clock::now();
   YSE::DEVICE::managerObject * manager = (YSE::DEVICE::managerObject *)userData;
 	manager->callbacksSinceLastUpdate++;

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -218,12 +218,12 @@ namespace YSE {
      *
      *  This is a **dropout-risk** indicator: 1.0 means the callback is taking
      *  as long as the buffer it produces, i.e. the next buffer will arrive
-     *  late. It does NOT reflect total engine CPU across the threadpool
-     *  workers — for that, see issue #84.
+     *  late.
      *
-     *  Distinct from the cost of ``update()`` on the main thread. Replaces
-     *  the previous pass-through of ``Pa_GetStreamCpuLoad``, which read as
-     *  inflated under WASAPI shared mode after periods of silence (see #82).
+     *  Distinct from the cost of ``update()`` on the main thread. Timed
+     *  ourselves (rather than reading ``Pa_GetStreamCpuLoad``) so the Oboe /
+     *  Android backend can report a comparable number — that API doesn't
+     *  exist there.
      */
     float cpuLoad();
 


### PR DESCRIPTION
Closes #82.

## Summary

Root-cause for the cpuLoad post-stop spike. **It was a dispatch–join race, not a denormal, IIR-tail, or PortAudio reporting issue.** The wall-clock measurement was correct all along — the callback genuinely spent the time spin-sleeping in `join()` waiting for idle worker threads to wake up.

## What was actually happening

[YSE::System().init()](YseEngine/system.cpp#L58-L62) creates five default child channels of master — `ambient`, `fx`, `music`, `gui`, `voice`. In any app that doesn't explicitly route sounds through them, they sit permanently empty (no sounds, no sub-children).

In [implementationObject::dsp()](YseEngine/channel/channelImplementation.cpp#L107-L110), every child was unconditionally dispatched to the fast threadpool. The empty child's own `dsp()` would early-return at the top, so the worker had nothing to do — but the matching [join() in buffersToParent](YseEngine/channel/channelImplementation.cpp#L145) spins on `System().sleep(2)` until the worker wakes up and sets `isDone`.

The 2 ms sleep tick dominates the timing:

- **Playing:** audio thread does ~100 us+ of `source.process()` work after `addFastJob` and before `join`. Workers finish; `join()` returns immediately.
- **Post-stop:** sound's `dsp()` returns `false` early, so the audio thread reaches `join()` essentially with no gap → loses the race → sleeps 2 ms per empty child per render.

`STANDARD_BUFFERSIZE` is 128, so a typical ~1100-sample PA callback runs 8–10 renders. 5 idle default channels × 2 ms × 8 renders = the 10–15 ms post-stop callback wall-clock spike that #82 reported (and that the integration regression test caught).

## Fix

One conditional in the dispatch loop ([channelImplementation.cpp:107-122](YseEngine/channel/channelImplementation.cpp#L107-L122)):

```cpp
for (auto i = children.begin(); i != children.end(); ++i)
{
    if ((*i)->children.empty() && (*i)->sounds.empty()) continue;
    INTERNAL::Global().addFastJob(*i);
}
```

The empty child's `dsp()` would have been a no-op anyway. With no dispatch, `inQueue` stays `false`, so `join()` returns immediately on the next pass — the sleep loop never enters.

## Numbers (from the regression test)

| phase   | before fix | after fix |
|---------|-----------:|----------:|
| idle    |     0.03 % |   0.02 %  |
| playing |    ~4 %    |  ~0.5 %   |
| stopped |    ~45 %   |  ~0.2 %   |

Active-playback cpuLoad drops 8× too. The dispatch–join sleep was a quieter but persistent cost during playback as well — it was just masked by source work that kept the EMA from looking bad.

## Test plan

- [x] `python yse.py build --release` — clean
- [x] `python yse.py test` — full default suite passes 14/14
- [x] `python yse.py test --integration` — recovery test from #82 (`engine: cpuLoad recovers after multi-sine playback stops`) now passes the CHECK; CSV trace at `%TEMP%/yse_cpuload_issue82.csv` shows post-stop sitting at idle baseline
- [x] `python yse.py analyze YseEngine/channel/channelImplementation.cpp` — no new findings (171 warnings, all suppressed in non-user code)
- [ ] Cross-verify on the phi client: confirm the WASAPI repro from #82 no longer plateaus post-stop

## Investigation trail

Method that actually worked (after several wrong hypotheses on denormals, EMA normalisation, and PortAudio scheduling): added temporary `fprintf` instrumentation to `paCallback`, then `renderOneBlock`, then `buffersToParent::join()`, each time narrowing where wall-clock disappeared. Once `join` was localised, the three `0000…D40 / D80 / 540` empty child channels in the trace pointed directly at the default-channel layout from `system.cpp`. All instrumentation removed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)