### PR TITLE
sound: drop stale __WINDOWS__ guards on lsfSoundfile load paths (fixes #46)

### DIFF
--- a/Tests/sound/test_sound_state.cpp
+++ b/Tests/sound/test_sound_state.cpp
@@ -14,9 +14,13 @@
 // removeInterface() (setting head = nullptr) before going out of scope.
 
 #include <doctest/doctest.h>
+#include <chrono>
+#include <thread>
 #include "sound/soundInterface.hpp"
+#include "sound/soundManager.h"
 #include "sound/soundMessage.h"
 #include "dsp/dspObject.hpp"
+#include "internal/time.h"
 #include "support/null_device.hpp"
 
 // Minimal no-op DSP source used to create sounds without file I/O.
@@ -433,6 +437,32 @@ TEST_CASE("sound: WAV file sound destructs cleanly") {
         YSE::sound s;
         s.create(WAV_FIXTURE);
     } // ~sound() fires here
+}
+
+// Regression: issue #46. The slow-pool's soundFile load runs on every desktop
+// build, but a stale __WINDOWS__ guard around lsfSoundfile.cpp's loadStreaming
+// / loadNonStreaming bodies meant the function did nothing on Linux/macOS —
+// `state` stayed at LOADING forever, the impl never reached OBJECT_SETUP, and
+// isReady() never became true. This test guarantees a WAV-loaded sound
+// actually transitions to READY after the manager pumps the inbox and the
+// slow-pool finishes the load.
+TEST_CASE("sound: WAV file reaches OBJECT_READY after manager updates") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::sound s;
+    s.create(WAV_FIXTURE);
+    if (!s.isValid()) return; // fixture missing in this environment
+
+    // Pump the manager directly (test thread drives update; audio is paused).
+    // Budget: ~1 s wall-clock — loading a 244-byte WAV through the single
+    // slow-pool worker normally completes within a couple of update ticks.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        YSE::INTERNAL::Time().update();
+        YSE::SOUND::Manager().update();
+        if (s.isReady()) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    CHECK(s.isReady());
 }
 
 } // TEST_SUITE("sound")

--- a/YseEngine/internal/lsfSoundfile.cpp
+++ b/YseEngine/internal/lsfSoundfile.cpp
@@ -39,10 +39,10 @@ YSE::INTERNAL::soundFile::~soundFile() {
 }
 
 void YSE::INTERNAL::soundFile::loadStreaming() {
-#ifdef __WINDOWS__
   assert(handle == nullptr);
   if (IO().getActive()) {
-
+    // Custom-IO streaming has never been implemented; the empty body leaves
+    // state at LOADING. The path is unused in the supported builds.
   }
   else {
     handle = new SndfileHandle(fileName);
@@ -50,7 +50,7 @@ void YSE::INTERNAL::soundFile::loadStreaming() {
       _sampleRateAdjustment = static_cast<Flt>(handle->samplerate()) / static_cast<Flt>(SAMPLERATE);
       _length = (Int)handle->frames();
       _channels = handle->channels();
-      
+
       Int size = STREAM_BUFFERSIZE * _channels;
       _iBuffer = new Flt[size];
       _streamPos = 0;
@@ -62,13 +62,11 @@ void YSE::INTERNAL::soundFile::loadStreaming() {
       state = INVALID;
     }
   }
-#endif
 }
 
 void YSE::INTERNAL::soundFile::loadNonStreaming() {
   assert(handle == nullptr);
   void * ptr = nullptr;
-#ifdef __WINDOWS__
 
   if (IO().getActive()) {
     long long size;
@@ -78,7 +76,7 @@ void YSE::INTERNAL::soundFile::loadNonStreaming() {
       state = INVALID;
       return;
     }
-    
+
     std::ostringstream message;
     message << "SoundFile: loading buffer ";
     message << fileName << " with size " << size;
@@ -89,12 +87,12 @@ void YSE::INTERNAL::soundFile::loadNonStreaming() {
   else {
     handle = new SndfileHandle(fileName);
   }
-    
+
   if (*handle) {
     _sampleRateAdjustment = static_cast<Flt>(handle->samplerate()) / static_cast<Flt>(SAMPLERATE);
     _length = (Int)handle->frames();
     _channels = handle->channels();
-      
+
     Int size = _length * _channels;
     _iBuffer = new Flt[size];
     Long read = handle->readf(_iBuffer, _length);
@@ -118,9 +116,7 @@ void YSE::INTERNAL::soundFile::loadNonStreaming() {
     state = INVALID;
   }
 
-
   if (ptr != nullptr) INTERNAL::customFileReader::Close(ptr);
- #endif
 }
 
 Bool YSE::INTERNAL::soundFile::fillStream(Bool loop) {


### PR DESCRIPTION
## Summary

- `YseEngine/internal/lsfSoundfile.cpp` wraps both `loadStreaming()` and `loadNonStreaming()` in `#ifdef __WINDOWS__ ... #endif`. `__WINDOWS__` is only defined on Windows ([defines.hpp:19](https://github.com/yvanvds/yse-soundengine/blob/dev/YseEngine/headers/defines.hpp#L19)), so on Linux / macOS / Android both functions are empty stubs. `state` never transitions out of `LOADING`, the impl cycles through `OBJECT_SETTING_UP → OBJECT_SETUP → readyCheck() lastGain.size()==0 → OBJECT_CREATED →` forever, and `isReady()` never becomes true.
- The guards date to the 2018 CMake-build-system commit, when libsndfile wasn't yet a dep on non-Windows platforms. It has been one for a long time now (system pkg on Linux/macOS, FetchContent on Android).
- Add a regression test that waits up to 1 s for `isReady()` after `s.create(WAV_FIXTURE)`. No existing test exercised the load-to-ready transition — the prior WAV tests stop at `isValid()`, which only depends on `FileExists()` and was already passing despite the load never completing.

## Investigation trail

- Built the engine with a one-off `YSE_DIAG_46` flag and ran the JACK-dummy Docker recipe. Diagnostic log:
  `abstractSoundFile::run EXIT state=1 channels=0 length=<garbage>` — confirming the function entered with LOADING and exited still in LOADING, with the channel/length fields never written.
- After lifting the guards, same diagnostic shows `state=2 channels=1 length=100` for the 100-frame mono fixture.

## Test plan

- [x] Linux JACK dummy via `tools/ci-linux/Dockerfile.audio`: new regression test passes; sound suite 86/86; integration suite 14/14.
- [x] Windows (MSYS2 Clang64) via `python yse.py test`: 14/14 ctest groups pass.
- [x] Android arm64 build via `cmake --build build-android-arm64 --target yse_tests`: clean.
- [x] Android x86_64 build via `cmake --build build-android-x86_64 --target yse_tests`: clean.
- [x] clang-tidy on changed files: no new findings.

Android note: The fix is a strict improvement on Android. Existing on-device WAV tests pass today only because they stop at `isValid()` (which only needs `FileExists()` to succeed) — they never wait for the load. With the fix, the load actually runs to completion; libsndfile is already FetchContent'd into the APK and `android_asset_bridge.cpp` extracts fixtures to the path `WAV_FIXTURE` resolves to.

Fixes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)