### PR TITLE
Release v2.1.1

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,8 @@
       "Read(//tmp/**)",
       "Read(//d/tmp/**)",
       "Edit(/.claude/skills/c-api-extend/**)",
-      "Edit(/.claude/skills/fix-issues/**)"
+      "Edit(/.claude/skills/fix-issues/**)",
+      "Edit(/.claude/skills/release/**)"
     ],
     "additionalDirectories": [
       "\\tmp\\gh-issues",

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: release
+description: Use when the user asks to cut a new release of libYSE — phrases like "release a new version", "cut a patch/minor/major release", "publish a new release", "ship X.Y.Z". Orchestrates version bump, doc refresh, C API drift audit, dev→master promotion, and tag-driven publication via the existing release.yml workflow. Do NOT use for branch-management tasks unrelated to a release, or for republishing an already-tagged version (that's a workflow_dispatch on release.yml, not this skill).
+---
+
+# Cutting a new libYSE release
+
+A release is irreversible (the tag, the GitHub release artefact, and the
+downstream binding regenerations all assume the version went out the door
+and stayed there). This skill drives the workflow end-to-end with a single
+confirmation gate at the start.
+
+Authoritative version source: [`YseEngine/system.hpp`](YseEngine/system.hpp)
+line `const std::string VERSION = "X.Y.Z";`. Everything else — Sphinx
+`conf.py`, `dist/` archive names, the GitHub release title — derives from
+that string.
+
+## Tools the skill drives
+
+- `python yse.py release patch|minor|major` — bumps `VERSION` in
+  `system.hpp`, commits `Release vX.Y.Z`, tags `vX.Y.Z`, pushes both.
+  Requires clean tree and current branch in `{master, dev}`. **Only runs
+  the bump on `master`** — see step 5.
+- `.github/workflows/release.yml` — fires on `v*` tag push. Builds Linux
+  x64, Windows x64, and Android multi-ABI archives; publishes them as
+  GitHub release assets.
+- `.github/workflows/build.yml`, `benchmark.yml`, `documentation.yml` —
+  the dev→master PR triggers these; we wait for green before merging.
+
+## Procedure
+
+### 1. Ask the user which bump kind
+
+The trigger phrase rarely specifies. Prompt:
+
+> Patch (`X.Y.Z+1`) / Minor (`X.Y+1.0`) / Major (`X+1.0.0`) — which?
+
+Use `AskUserQuestion` with the three options and one "Other" for raw
+input (e.g. they want to skip a number, which `yse.py release` does not
+support and would have to be done manually).
+
+### 2. Pre-flight on `dev`
+
+```sh
+git checkout dev
+git pull --ff-only origin dev
+git status --porcelain   # must be empty
+```
+
+Read `YseEngine/system.hpp` to get the current version. Compute the new
+version. Confirm the tag does not already exist (`git tag -l vX.Y.Z` and
+`gh api repos/:owner/:repo/releases/tags/vX.Y.Z` — the second catches
+remote-only tags).
+
+### 3. C API drift audit
+
+The Dart bindings (and any other FFI consumer) are generated from
+`YseEngine/c_api/include/yse_c/*.h` in a separate repository. If new
+public C++ surface landed since the last release but wasn't mirrored
+into the C bridge, downstream bindings will silently miss it. To catch
+this:
+
+1. Find the last release commit: `git log v$LAST..HEAD -- YseEngine/ ':!YseEngine/c_api'`
+   — public headers (`*.hpp` not in `internal/` / `implementations/` /
+   `synth/`) and `yse.hpp` that changed.
+2. Inspect each changed header. Look for:
+   - New public methods on classes already exposed via `yse_c/yse_*.h`
+   - New public free functions / accessors
+   - New enum values in `YseEngine/headers/enums.hpp` (compile-time
+     `yse_enums_check.cpp` will catch missing mirrors, but only if a
+     build runs — see step 4)
+3. For each suspected drift, hand off to the `c-api-extend` skill
+   (`/c-api-extend`) — it knows the conventions. Do NOT inline a wrapper
+   yourself unless it is a single trivial accessor.
+4. If drift exists and the user wants to ship the release before fixing
+   it, document the gap in the release notes ("known to be missing from
+   C API in this version").
+
+### 4. Build sanity + enum mirror check
+
+```sh
+python yse.py build --release
+```
+
+A successful release-config build with `YSE_BUILD_C_API=ON` (the default)
+implies `yse_enums_check.cpp` passed at compile time — enum mirrors in
+`yse_c/yse_enums.h` are consistent with `YseEngine/headers/enums.hpp`. If
+the build fails on `yse_enums_check.cpp`, the enums drifted; fix them
+before continuing.
+
+### 5. Refresh README and PROJECT_OVERVIEW.md (on dev, in a release-prep PR)
+
+Branch: `release/vX.Y.Z-prep` from `dev`.
+
+- `README.md` — only update the `# libYSE X.Y` header if the major or
+  minor bumped (patch releases don't touch the README header). Skip on
+  patch.
+- `PROJECT_OVERVIEW.md` — delegate to the `project-overview-update`
+  skill workflow (read meta header SHA, diff against HEAD, decide
+  partial vs full). On a patch release this is usually a no-op or a
+  small section touch; on a minor/major it is more often a partial
+  rewrite of a few sections.
+- Sphinx `conf.py` reads VERSION from `system.hpp` automatically (per
+  PR #89) — **do not** edit `documentation/` for the version. Only
+  touch `documentation/source/` if a code change in this release also
+  changed user-facing behaviour that the intro/tutorials describe.
+
+Commit the prep PR with message:
+
+```
+release-prep vX.Y.Z: refresh README and overview
+```
+
+Push and open the PR with `gh pr create --base dev`.
+
+### 6. Wait for prep-PR CI, merge to dev
+
+Use `gh pr checks --watch` on the prep PR. When green, merge:
+
+```sh
+gh pr merge --merge --auto <pr-number>
+```
+
+(Or `--squash` if the project convention is squash; check existing
+release-prep PRs for the pattern. Looking at recent history,
+`--merge` matches the existing style.)
+
+### 7. Promote dev → master
+
+```sh
+gh pr create --base master --head dev \
+  --title "Release vX.Y.Z" \
+  --body "<short summary of what's in this release>"
+```
+
+Wait for CI on this PR too (`gh pr checks --watch`). When green, merge
+with `--merge` (release commits should stay individually identifiable on
+master — do **not** squash).
+
+### 8. Run the bump on master
+
+```sh
+git checkout master
+git pull --ff-only origin master
+python yse.py release patch|minor|major
+```
+
+`yse.py release` will:
+- bump VERSION in system.hpp,
+- commit `Release vX.Y.Z`,
+- tag `vX.Y.Z`,
+- push both the commit and the tag to `origin/master`.
+
+The `release.yml` workflow fires on the `v*` tag push and builds +
+publishes the GitHub release.
+
+### 9. Sync the release commit back to dev
+
+```sh
+git checkout dev
+git pull --ff-only origin dev
+gh pr create --base dev --head master \
+  --title "Sync Release vX.Y.Z bump back to dev" \
+  --body "Brings the version bump commit and tag back to dev so the two branches stay in sync."
+```
+
+Merge with `--merge`. Confirm dev is now at the same tip as master.
+
+### 10. Report status to the user
+
+```
+Released vX.Y.Z.
+- Tag pushed:           https://github.com/yvanvds/yse-soundengine/releases/tag/vX.Y.Z
+- Release workflow:     https://github.com/yvanvds/yse-soundengine/actions
+- Wait ~5–10 minutes for the multi-ABI build matrix to finish; artefacts
+  are uploaded as release assets automatically.
+```
+
+Optionally poll `gh run watch` on the release-workflow run if the user
+wants confirmation that the artefacts uploaded.
+
+## Confirmation gate
+
+Before doing anything destructive, show the plan and stop **once**:
+
+```
+About to release vX.Y.Z:
+
+  Current:  v<cur>
+  New:      v<new>  (<bump-kind>)
+
+  Branch:   dev → master (via two PRs)
+  Tag:      vX.Y.Z on master
+  Workflow: release.yml will publish Linux x64, Windows x64, Android multi-ABI archives
+
+  C API drift check: <none | <list of headers worth reviewing>>
+
+  Steps that will run unattended after you confirm:
+    1. release-prep PR on dev (README + PROJECT_OVERVIEW.md refresh)
+    2. wait for CI, merge to dev
+    3. dev → master PR
+    4. wait for CI, merge to master
+    5. yse.py release <kind> on master (commits, tags, pushes)
+    6. release.yml fires on the tag
+    7. master → dev sync PR
+```
+
+After "yes", run end-to-end without further pauses. Surface CI failures
+immediately if they happen; do not retry destructive steps on your own.
+
+## Don't
+
+- Don't run `yse.py release` on `dev`. Even though the script allows
+  it, the project convention is that release tags live on `master`.
+- Don't squash-merge the release PR — release commits should be
+  individually identifiable in `master`'s history.
+- Don't bump the version yourself in `system.hpp` — `yse.py release`
+  is the only sanctioned mutator. Direct edits skip the tag push, the
+  branch-name check, and the clean-tree check.
+- Don't edit `documentation/source/conf.py` for the version. It reads
+  from `system.hpp` (PR #89).
+- Don't run the skill if there's an open PR that should land before the
+  release. Check `gh pr list --base dev --state open` first; flag any
+  outstanding ones and let the user decide whether to wait.
+- Don't run on a dirty working tree. `yse.py release` enforces this
+  but step 5's prep work would already have failed earlier.
+- Don't publish a release for a downgrade or skip-version. `yse.py
+  release` doesn't support it; if the user asks for a custom version,
+  bail out and tell them they need to do it manually.
+
+## Example interaction
+
+User: "Cut a patch release"
+
+You:
+1. Ask: "Patch / Minor / Major?" → user says Patch.
+2. Read `YseEngine/system.hpp`: current is `2.1.0`. New is `2.1.1`.
+3. `gh api repos/yvanvds/yse-soundengine/releases/tags/v2.1.1` → 404, OK.
+4. `git log v2.1.0..HEAD -- YseEngine ':!YseEngine/c_api'`: 8 commits, no public-header touches.
+5. `python yse.py build --release` → success, enum check passes.
+6. Show the plan + confirmation gate. User confirms.
+7. Branch `release/v2.1.1-prep` from dev, refresh PROJECT_OVERVIEW.md (incremental update). README header stays at "libYSE 2.1". Commit + push + PR + wait CI + merge.
+8. dev → master PR, wait CI, merge.
+9. `git checkout master && python yse.py release patch`. release.yml fires.
+10. master → dev sync PR, merge.
+11. Report URLs.
+
+## File / branch invariants this skill assumes
+
+- `YseEngine/system.hpp` is the single source of truth for VERSION.
+- `dev` is the integration branch; `master` is the release branch.
+- The `release.yml` workflow triggers on `v*` tag push on any branch but
+  the project convention puts release tags on `master`.
+- `release.yml` already builds Linux + Windows + Android multi-ABI and
+  uploads to the GitHub release — we don't need to invoke `yse.py
+  package` ourselves.
+- `documentation.yml` rebuilds Sphinx + Doxygen and deploys to GitHub
+  Pages on every push to `master`, so the docs site updates
+  automatically when the release PR merges.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,83 @@ jobs:
           path: dist/libyse-*-windows-x64.zip
           if-no-files-found: error
 
+  build-android:
+    # Cross-compile libyse.so for each Android ABI we ship. Mirrors the
+    # build.yml Android matrix, but with CMAKE_BUILD_TYPE=Release and
+    # without the tests target — release packages don't ship libyse_tests.so.
+    name: Build (Android ${{ matrix.abi }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [arm64-v8a, x86_64]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Install host build tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y cmake ninja-build
+
+      - name: Setup Android NDK
+        id: ndk
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # v1.5.0
+        with:
+          ndk-version: r27
+          local-cache: true
+
+      - name: Configure & build (release)
+        run: >
+          cmake -B build-android -G Ninja
+          -DCMAKE_TOOLCHAIN_FILE=${{ steps.ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake
+          -DANDROID_ABI=${{ matrix.abi }}
+          -DANDROID_PLATFORM=android-26
+          -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build libyse.so
+        run: cmake --build build-android --target yse
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-libs-${{ matrix.abi }}
+          path: build-android/bin/libyse.so
+          if-no-files-found: error
+          retention-days: 1
+
+  package-android:
+    # Merge the per-ABI matrix outputs into a single multi-ABI bundle
+    # (lib/<abi>/libyse.so + headers + LICENSE + README) for upload.
+    name: Package (Android multi-ABI)
+    needs: build-android
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: android-libs
+          pattern: 'android-libs-*'
+
+      - name: Package
+        run: python3 yse.py package --platform android --android-libs android-libs
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: libyse-android
+          path: dist/libyse-*-android.tar.gz
+          if-no-files-found: error
+
   publish:
     name: Publish GitHub Release
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-windows, package-android]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -121,4 +195,5 @@ jobs:
             --title "libYSE $TAG" \
             --generate-notes \
             artifacts/libyse-*-linux-x64.tar.gz \
-            artifacts/libyse-*-windows-x64.zip
+            artifacts/libyse-*-windows-x64.zip \
+            artifacts/libyse-*-android.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ documentation/source/_doxygen/
 [Rr]elease/
 [Rr]elease32/
 [Rr]elease64/
+# Exempt skill directories — `[Rr]elease/` above would otherwise hide the
+# .claude/skills/release/ tooling skill that ships with the repo.
+!.claude/skills/**
 x64/
 build/
 build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ build-asan/
 build-linux/
 build-linux-asan/
 build-linux-tsan/
+build-linux-audio-clean/
+build-linux-audio-diag/
 build-linux-audio/
 build-android-arm64/
 build-android-x86_64/

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,56 +1,63 @@
 <!-- META
-last_updated_commit: cf77d87df92c012437bdadd2c7e006fd5b1a4498
-last_updated_at: 2026-05-06
+last_updated_commit: 9397b10dba6734f0e85518fd0911a6bc2f457d00
+last_updated_at: 2026-05-19
 -->
 
 # YSE Sound Engine — Project Overview
 
-**Version:** 2.0.1
+**Version:** 2.1.0 (single source of truth: [`YseEngine/system.hpp`](YseEngine/system.hpp))
 **Language:** C++17
-**Platforms:** Windows (MSYS2/Clang64, MSVC), Linux, Android
-**Build:** CMake 3.20+ (primary, with `CMakePresets.json`), Visual Studio solution (Windows legacy)
-**Key Dependencies:** PortAudio (audio I/O), libsndfile (file loading), RtMidi (MIDI device I/O — required on every desktop platform), pthreads
+**Platforms:** Windows (MSYS2/Clang64, MSVC), Linux (gcc/clang), Android (NDK r27+, API 26+, arm64-v8a + x86_64)
+**Build:** CMake 3.20+ via `CMakePresets.json`; Android wraps the same CMake invocation through Gradle in `Tests/Android/`
+**Key Dependencies:** PortAudio (desktop audio I/O), Oboe (Android audio I/O), libsndfile (file loading), RtMidi (MIDI device I/O — desktop only, gated by `YSE_ENABLE_MIDI_DEVICE`), pthreads, doctest + google-benchmark (vendored / fetched for tests + benches)
 
 ---
 
 ## Repository Layout
 
 ```
-YseEngine/                  # Core C++ sound engine — built as shared library (libyse)
-Tests/                      # doctest unit-test suite (gated behind YSE_BUILD_TESTS)
-  support/                  # Shared test helpers (audio_helpers, null_device, fixtures)
-  TEST_PLAN.md              # 13-phase test plan (utils → DSP → patcher → … → device)
-Demo.Windows.Native/        # 18 C++ console demos (Demo00–Demo17 + Test01_Pitch + combined Demo)
-Tests/Android/              # Gradle wrapper that packages libyse_tests.so into a NativeActivity APK
-Yse.Windows.Native/         # Windows static/shared lib build (VS)
-dist/                       # Release archives written by `python yse.py package` (gitignored)
-TestResources/              # Audio test files (drone.ogg, kick.ogg, demo.mid, …)
-dependencies/               # Vendored headers: portaudio/, rtmidi/, libsndfile/, libsndfile64/, doctest/
-cmake/                      # CMake helper scripts (demo_main.cpp.in template)
-build/                      # Out-of-tree Release build (gitignored)
-build-debug/                # Out-of-tree Debug build (gitignored)
-build-tests/                # tests-debug preset output (gitignored)
-build-coverage/             # coverage / coverage-windows preset output (gitignored)
-CMakeLists.txt              # Root CMake build (adds YseEngine + Demo.Windows.Native + Tests)
-CMakePresets.json           # Named build presets (debug, release, tests-debug, coverage, coverage-windows)
-yse.py                      # Python CLI wrapper over cmake --preset / ctest --preset
-.clang-format               # clang-format style config (used by `yse.py format`)
-sonar-project.properties    # SonarCloud analysis configuration
-.github/workflows/build.yml     # GitHub Actions: Linux Debug + coverage + SonarQube scan
-.github/workflows/release.yml   # GitHub Actions: tag-driven release — Windows/Linux x64 archives
-documentation/              # Doxygen + Sphinx (Breathe, sphinx-book-theme) docs
-(known issues tracked in GitHub Issues, not in-repo)
+YseEngine/                       # Core C++ sound engine — compiled to libyse (SHARED)
+  c_api/                         # extern "C" ABI bridge (yse_*) folded into libyse for FFI bindings
+    include/yse_c/               # Public C headers (yse_all.h aggregates all subsystems)
+Tests/                           # doctest suite (~863 TEST_CASEs across 46 TUs) — gated by YSE_BUILD_TESTS
+  Android/                       # Gradle wrapper that packages libyse_tests.so into a NativeActivity APK
+  support/                       # audio_helpers, null_device, android_asset_bridge, fixtures
+  TEST_PLAN.md                   # Phased roadmap (utils → DSP → patcher → … → device)
+Bench/                           # google-benchmark suite — gated by YSE_BUILD_BENCHMARKS
+  dsp/ patcher/ integration/     # bench_* TUs; results pushed to the `bench-history` orphan branch by CI
+Demo.Windows.Native/             # 18 C++ console demos (Demo00–Demo17 + Test01_Pitch + combined Demo)
+Yse.Windows.Native/              # Legacy Windows static/shared lib build (Visual Studio project)
+documentation/                   # Doxygen + Sphinx + Breathe (sphinx-book-theme); published to GitHub Pages
+  source/intro/                  # Install + hello-sound + mental-model
+  source/tutorials/              # 5 tutorial pages (play, properties, 3D, channels, reverb)
+  source/api/                    # Breathe-driven API reference (12 grouped pages)
+tools/ci-linux/                  # Docker images for local Linux CI reproduction (Dockerfile, Dockerfile.audio)
+TestResources/                   # Audio files used by demos (drone.ogg, kick.ogg, demo.mid, …)
+dependencies/                    # Vendored headers: portaudio/, rtmidi/, doctest/, etc.
+cmake/                           # CMake helper templates (demo_main.cpp.in)
+logo/                            # SVG/PNG artwork (yse-logo.svg, yse-icon.svg)
+dist/                            # Release archives written by `yse.py package` (gitignored)
+CMakeLists.txt                   # Root build
+CMakePresets.json                # Named build presets (debug, release, tests-debug, coverage[-windows])
+yse.py                           # Python CLI wrapper over cmake --preset / ctest --preset
+.clang-tidy                      # Opt-in baseline; analyze-before-commit workflow via `yse.py analyze`
+.clang-format                    # clang-format config (used by `yse.py format`)
+sonar-project.properties         # SonarCloud analysis configuration
+.github/workflows/build.yml          # SonarQube Linux Debug + coverage on push/PR
+.github/workflows/release.yml        # Tag-driven release: Windows/Linux x64 + Android multi-ABI archives
+.github/workflows/benchmark.yml      # google-benchmark runs; writes the bench-history orphan branch
+.github/workflows/documentation.yml  # Doxygen + Sphinx → GitHub Pages on push to master
 ```
 
-The old .NET/Xamarin wrappers (`NetYse/`, `YSE.NET.PCL/`, `Yse.NET.Standard/`, `Yse.NET.Android/`), WPF demo, and UWP build have been removed.
+The old .NET/Xamarin wrappers, the WPF demo, the UWP build, and the JUCE backend have all been removed.
 
 ---
 
 ## Build System
 
-### Recommended entry point: CMakePresets.json + yse.py
+### Recommended entry point: `CMakePresets.json` + `yse.py`
 
-`CMakePresets.json` at the repo root defines every named build configuration:
+`CMakePresets.json` at the repo root defines every named build configuration. IDEs with CMake Tools support (VS Code, CLion, Visual Studio) auto-discover the presets. `yse.py` wraps them for terminal use:
 
 | Preset | Binary dir | Purpose |
 |--------|-----------|---------|
@@ -58,118 +65,81 @@ The old .NET/Xamarin wrappers (`NetYse/`, `YSE.NET.PCL/`, `Yse.NET.Standard/`, `
 | `release` | `build/` | Optimized release |
 | `tests-debug` | `build-tests/` | Debug + `YSE_BUILD_TESTS=ON` |
 | `coverage` | `build-coverage/` | Linux only — gcc/clang `--coverage` instrumentation |
-| `coverage-windows` | `build-coverage/` | Windows/Clang only — LLVM source-based coverage (`-fprofile-instr-generate`) |
-
-IDEs with CMake Tools support (VS Code, CLion, Visual Studio) auto-discover the presets. The Python script `yse.py` wraps them for terminal use:
+| `coverage-windows` | `build-coverage/` | Windows/Clang only — LLVM source-based coverage |
 
 ```sh
-python yse.py build              # cmake --preset debug + cmake --build --preset debug
-python yse.py build --release    # release variant
-python yse.py test               # tests-debug preset, then ctest --preset tests-debug
-python yse.py test --integration # same, plus integration suite (needs real audio device)
-python yse.py coverage           # coverage preset + report
-                                 #   Linux:   gcovr --sonarqube → coverage.xml
-                                 #   Windows: llvm-profdata + llvm-cov → coverage-llvm.json
-python yse.py run [Demo]         # runs a demo from build-debug/bin/ (default: Demo00)
-python yse.py debug Demo00       # launches the demo under lldb
-python yse.py clean [--yes]      # removes all build dirs + coverage artifacts
-python yse.py analyze            # clang-tidy via compile_commands.json (sonar-scanner fallback)
-python yse.py format             # clang-format -i over YseEngine/ and Tests/
-python yse.py package            # build a release archive in dist/ (used by CI)
-python yse.py release patch      # bump VERSION (patch/minor/major), commit, tag, push
+python yse.py build                # cmake --preset debug + build
+python yse.py build --release      # release variant
+python yse.py test                 # tests-debug preset + ctest
+python yse.py test --integration   # also run the integration suite (needs a real audio device)
+python yse.py coverage             # coverage preset + report (gcovr → coverage.xml on Linux,
+                                   # llvm-profdata+llvm-cov → coverage-llvm.json on Windows)
+python yse.py run [Demo]           # run a demo from build-debug/bin/ (default: Demo00)
+python yse.py debug Demo00         # launch a demo under lldb
+python yse.py clean [--yes]        # remove all build dirs + coverage artefacts
+python yse.py analyze [path]       # clang-tidy via compile_commands.json (sonar-scanner fallback)
+python yse.py format               # clang-format -i over YseEngine/ and Tests/
+python yse.py package              # release archive in dist/ (consumed by CI)
+python yse.py release patch        # bump VERSION (patch/minor/major), commit, tag, push
 ```
 
-Direct `cmake -B build ...` invocations remain fully valid; the presets are additive.
+Direct `cmake -B build ...` invocations remain fully valid — the presets are additive.
 
-### CMake (direct invocation)
-
-```bash
-# Release
-cmake -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build
-
-# Debug
-cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug
-cmake --build build-debug
-```
-
-All binaries land in `<build-dir>/bin/`. Demos must be run from that directory (`cd build/bin && ./Demo00.exe`) because audio file paths are hardcoded as `../../TestResources/...`.
-
-**CMake options:**
+### CMake options
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `YSE_BUILD_TESTS` | OFF | Build the `Tests/` doctest suite; adds `yse_tests` target and enables CTest |
+| `YSE_BUILD_BENCHMARKS` | OFF | Build the `Bench/` google-benchmark suite (fetched via FetchContent, pinned tag) |
+| `YSE_BUILD_C_API` | **ON** | Fold the `extern "C"` ABI bridge (yse_*) into `libyse` so language bindings (Dart FFI, Python ctypes, …) can consume the DLL without C++ ABI compatibility |
+| `YSE_ENABLE_MIDI_DEVICE` | ON on desktop, OFF on Android | RtMidi-backed MIDI device backend. OFF compiles MIDI device source files out and skips the RtMidi configure-time dependency |
 | `YSE_ENABLE_LTO` | OFF | Link-time optimization for Release builds |
 | `YSE_NATIVE_ARCH` | OFF | `-march=native` (local dev only — not distributable) |
-| `YSE_BUILD_TESTS` | OFF | Build the `Tests/` doctest suite; adds `yse_tests` target and enables CTest |
 | `YSE_ENABLE_COVERAGE` | OFF | gcov/gcovr coverage; forces `YSE_BUILD_TESTS=ON`; Linux only (GCC/Clang) |
 | `YSE_LLVM_COVERAGE` | OFF | LLVM source-based coverage (`-fprofile-instr-generate`); Clang only — mutually exclusive with `YSE_ENABLE_COVERAGE` |
 
 `CMAKE_EXPORT_COMPILE_COMMANDS=ON` is set unconditionally so `compile_commands.json` is always generated for clangd and SonarCloud.
 
-**Compiler flags (GCC/Clang):** `-Wall -Wextra -Wpedantic`, plus `-O3 -fno-math-errno` (Release). `-ffast-math` is **deliberately not used** — it breaks IEEE 754 semantics in ways that produce subtle DSP bugs (NaN propagation, denormal flushing).
+**Compiler flags (GCC/Clang):** `-Wall -Wextra -Wpedantic`, plus `-O3 -fno-math-errno` (Release). `-ffast-math` is **deliberately not used** — it breaks IEEE 754 semantics in ways that produce subtle DSP bugs (NaN propagation, denormal flushing). Linux/macOS builds use `CXX_VISIBILITY_PRESET hidden` + per-symbol `API` annotations — issue [#34](https://github.com/yvanvds/yse-soundengine/issues/34) was closed in commit `e080c16`.
 
-**Test build commands:**
+### Platform dependencies
 
-```bash
-# Build and run tests (no coverage)
-cmake --preset tests-debug
-cmake --build --preset tests-debug
-ctest --preset tests-debug
-# Optionally also run the integration suite (real audio device required):
-build-tests/bin/yse_tests --test-suite=integration   # or: python yse.py test --integration
-
-# Coverage (Linux): writes coverage.xml for SonarQube
-cmake --preset coverage
-cmake --build --preset coverage
-ctest --preset coverage
-gcovr --root . --filter ./YseEngine/ --filter ./Tests/ --sonarqube --output coverage.xml
-
-# Coverage (Windows/Clang64): writes coverage-llvm.json
-python yse.py coverage   # easiest path — handles LLVM_PROFILE_FILE plumbing
-```
-
-**Platform dependencies (MSYS2/Clang64):**
+**MSYS2/Clang64 (Windows):**
 
 ```
-pacman -S mingw-w64-clang-x86_64-portaudio
-pacman -S mingw-w64-clang-x86_64-libsndfile
-pacman -S mingw-w64-clang-x86_64-rtmidi
+pacman -S mingw-w64-clang-x86_64-portaudio \
+          mingw-w64-clang-x86_64-libsndfile \
+          mingw-w64-clang-x86_64-rtmidi
 ```
 
-**Platform dependencies (Debian/Ubuntu):**
+**Debian/Ubuntu (Linux):**
 
 ```
 sudo apt install cmake ninja-build clang \
                  libportaudio-dev libsndfile1-dev librtmidi-dev
 ```
 
-RtMidi is a **mandatory dependency on every desktop platform** the CMake build targets (Windows and Linux). The MIDI device source files are guarded by `#if YSE_WINDOWS || YSE_LINUX` and link against RtMidi symbols; CMake configuration fails with a clear error if the package is missing. Android compiles the MIDI device files out and does not need RtMidi.
-
-See [GitHub Issues](https://github.com/yvanvds/yse-soundengine/issues) for documented build quirks (ELF visibility follow-up [#34](https://github.com/yvanvds/yse-soundengine/issues/34), ASIO fallback [#38](https://github.com/yvanvds/yse-soundengine/issues/38), demo run-directory [#36](https://github.com/yvanvds/yse-soundengine/issues/36), etc.).
+**Android (NDK):** No pkg-config in the sysroot. libsndfile is fetched from source (1.2.2, WAV-only, no external codec libs), Oboe is fetched at tag 1.9.3, RtMidi is not used. Link options include `-Wl,-z,max-page-size=16384` for Android 15+ 16 KB page-size compatibility (Play Store requirement, Nov 2025+).
 
 ---
 
-## CI / SonarQube
+## CI / Distribution
 
-The single GitHub Actions workflow at [.github/workflows/build.yml](.github/workflows/build.yml) runs on push to `master` and on pull requests:
+Four GitHub Actions workflows under `.github/workflows/`:
 
-| Step | What it does |
-|------|--------------|
-| Install Build Wrapper | SonarSource `install-build-wrapper@v6.0.0` |
-| Install dependencies | `cmake ninja-build pkg-config portaudio19-dev libsndfile1-dev librtmidi-dev gcovr` |
-| Configure CMake | `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DYSE_ENABLE_COVERAGE=ON` |
-| Run Build Wrapper | `build-wrapper-linux-x86-64 --out-dir … cmake --build build` |
-| Run tests | `ctest --test-dir build --output-on-failure` |
-| Generate coverage | `gcovr --root . --filter YseEngine/ --filter Tests/ --gcov-ignore-parse-errors --sonarqube --output coverage.xml build` |
-| SonarQube Scan | `sonarqube-scan-action@v6.0.0` with `sonar.cfamily.compile-commands` from the build wrapper |
+| Workflow | Triggers | What it does |
+|----------|----------|--------------|
+| `build.yml` | push (master/dev), PR | Linux Debug + `YSE_ENABLE_COVERAGE=ON` build, ctest, gcovr SonarQube report, SonarCloud scan (`yvanvds_yse-soundengine`) |
+| `release.yml` | tag `v*`, manual | Builds Linux x64, Windows x64, and Android multi-ABI release archives → `dist/` → uploaded as GH release assets |
+| `benchmark.yml` | push (master/dev), PR to master | Runs google-benchmark; results pushed to the `bench-history` orphan branch; PR comments on regressions |
+| `documentation.yml` | push to master | Doxygen + Sphinx HTML → GitHub Pages |
 
-The runner is `ubuntu-latest`. There is currently **no Windows CI job**; Windows is built and tested locally via `yse.py`. A Windows job using `coverage-windows` is a natural follow-up (the preset and `yse.py coverage` already work end-to-end there).
+Headless audio coverage on GHA is **not** feasible — `snd-aloop`, `PulseAudio null sink`, and JACK-dummy all fail for kernel-module / capability reasons on the Azure-hosted runner kernel. The Linux Docker image at `tools/ci-linux/Dockerfile.audio` reproduces the headless JACK-dummy environment locally (requires `--cap-add IPC_LOCK --ulimit memlock=-1 --shm-size=512m`).
 
 `sonar-project.properties` declares:
 - `sonar.projectKey=yvanvds_yse-soundengine`, `sonar.organization=yvanvds`
 - `sonar.sources=YseEngine`, `sonar.tests=Tests`
-- Exclusions: `dependencies/**`, vendored `YseEngine/json/**`, all `build*/`, legacy native projects, packaging helpers
+- Exclusions: `dependencies/**`, vendored `YseEngine/json/**`, all `build*/`, legacy native projects
 - `sonar.cfamily.compile-commands=build/compile_commands.json`
 - `sonar.coverageReportPaths=coverage.xml`
 
@@ -177,18 +147,17 @@ The runner is `ubuntu-latest`. There is currently **no Windows CI job**; Windows
 
 ## Sound Engine Architecture (`YseEngine/`)
 
-The engine is compiled as a **shared library** (`libyse.dll` / `libyse.so`). The single include entry point is `yse.hpp`.
+The engine is compiled as a **shared library** (`libyse.dll` / `libyse.so`). Two public entry points:
+
+- `yse.hpp` — full C++ API, single header.
+- `yse_c/yse_all.h` — flat `extern "C"` ABI for language bindings (Dart FFI, Python ctypes, …).
 
 ### Build target structure
 
-The engine is split into two CMake targets:
+- **`yse_objects`** — `OBJECT` library containing every engine source file plus (if `YSE_BUILD_C_API=ON`) the `yse_*` C bridge. Compiled with `YSE_DLL_BUILD` and `POSITION_INDEPENDENT_CODE ON` so the same objects can link into either a SHARED library or a static test binary. Hidden default ELF visibility; public symbols marked with the `API` macro from `headers/defines.hpp`.
+- **`yse`** — `SHARED` library that consumes `yse_objects` via `PRIVATE` linkage. Propagates `YSE_DLL` to consumers via `INTERFACE`, which switches `API` to `__declspec(dllimport)` on Windows.
 
-- **`yse_objects`** — `OBJECT` library containing every engine source file. Compiled with `YSE_DLL_BUILD` defined (activates `__declspec(dllexport)` via the `API` macro in `headers/defines.hpp`). `POSITION_INDEPENDENT_CODE ON` so the same objects can be linked into either a SHARED library or a static test binary.
-- **`yse`** — `SHARED` library that consumes `yse_objects` via `target_link_libraries(... PRIVATE yse_objects)`. Propagates `YSE_DLL` to consumers via `INTERFACE`, which switches the `API` macro to `__declspec(dllimport)`.
-
-The test executable links `yse_objects` directly (bypassing the DLL export boundary), so white-box tests can reach internal symbols without API annotations on them. Both build paths produce an identical `libyse.dll` export table.
-
-Linux/macOS currently use `CXX_VISIBILITY_PRESET default` (export-all); switching ELF builds to `-fvisibility=hidden` + per-symbol `visibility("default")` is tracked in [issue #34](https://github.com/yvanvds/yse-soundengine/issues/34).
+The test executable / shared-lib (on Android, a `.so` loaded by NativeActivity) links `yse_objects` directly, bypassing the DLL export boundary so white-box tests can reach internal symbols.
 
 ### Subsystem Map
 
@@ -202,8 +171,8 @@ Application
     ├── reverb                 positional room effects
     ├── player                 polyphonic note sequencer
     ├── patcher                modular DSP graph (Max/MSP-style)
-    ├── MIDI                   file + device I/O
-    └── (synth)                polyphonic sampler/DSP synth — API defined, currently commented out in yse.hpp
+    ├── MIDI                   file + (optionally) device I/O
+    └── (synth)                polyphonic sampler/DSP synth — implemented but not exposed (commented out in yse.hpp)
 ```
 
 ---
@@ -212,7 +181,7 @@ Application
 
 **Files:** [sound/soundInterface.hpp](YseEngine/sound/soundInterface.hpp), [sound/soundImplementation.cpp](YseEngine/sound/soundImplementation.cpp), [sound/soundManager.cpp](YseEngine/sound/soundManager.cpp)
 
-Each public `YSE::sound` wraps a private `SOUND::implementationObject`. State changes are posted as messages to the audio thread; they are never applied directly.
+Each public `YSE::sound` wraps a private `SOUND::implementationObject`. State changes are posted as messages to the audio thread — they are never applied directly.
 
 **Creation variants:**
 
@@ -224,21 +193,11 @@ sound.create(dspSourceObject, channel, volume);   // procedural source
 sound.create(patcher, channel, volume);           // modular synthesis
 ```
 
-**Key per-sound properties:**
+**Implementation state machine:** `OBJECT_CONSTRUCTED → OBJECT_CREATED → OBJECT_SETTING_UP → OBJECT_SETUP → OBJECT_READY → OBJECT_RELEASE → OBJECT_DELETE_PENDING → OBJECT_DELETE` with a documented use-after-free fence around the `OBJECT_DELETE_PENDING` handshake (see soundManager.cpp comments).
 
-| Property | Description |
-|----------|-------------|
-| position (Pos) | 3D world position |
-| size (float) | rolloff distance |
-| speed (float) | playback speed / pitch (negative → reverse playback for buffered sounds) |
-| volume | with optional fade time |
-| spread | multichannel stereo spread |
-| relative | move with listener (2D mode) |
-| doppler | enable doppler pitch shift |
-| occlusion | 0–1 low-pass filter amount |
-
-**Implementation state machine:** `CONSTRUCTED → CREATED → LOADED → READY → DONE`
 **Play intent states:** `SI_NONE / SI_PLAY / SI_STOP / SI_PAUSE / SI_TOGGLE / SI_RESTART`
+
+**Per-sound properties:** position (Pos), size (rolloff distance), speed (negative → reverse playback), volume (with fade time), spread, relative, doppler, occlusion (0–1 LPF amount).
 
 ---
 
@@ -246,15 +205,7 @@ sound.create(patcher, channel, volume);           // modular synthesis
 
 **Files:** [listener.hpp](YseEngine/listener.hpp), [implementations/listenerImplementation.cpp](YseEngine/implementations/listenerImplementation.cpp)
 
-`YSE::Listener()` is a singleton representing the listener's point of view. Its velocity is derived automatically from position deltas each update tick.
-
-**Per-frame pipeline for each active sound:**
-
-1. Compute distance from sound position to listener position.
-2. Apply inverse-distance volume attenuation (governed by `size`).
-3. Compute angle → map to stereo/surround pan coefficients.
-4. If `doppler` is set, shift pitch based on relative radial velocity.
-5. If an occlusion callback is registered, query it for a 0–1 occlusion value and apply a corresponding low-pass filter.
+`YSE::Listener()` is a singleton representing the listener's point of view. Per-frame pipeline for each active sound: inverse-distance attenuation, angle → stereo/surround pan, doppler shift from radial velocity, optional user-supplied occlusion callback → LPF.
 
 **Occlusion hook:**
 
@@ -262,8 +213,7 @@ sound.create(patcher, channel, volume);           // modular synthesis
 system& occlusionCallback(float(*func)(const Pos& source, const Pos& listener));
 ```
 
-**Output channel configurations:**
-`CT_MONO CT_STEREO CT_QUAD CT_51 CT_51SIDE CT_61 CT_71 CT_CUSTOM`
+**Output channel configurations:** `CT_MONO CT_STEREO CT_QUAD CT_51 CT_51SIDE CT_61 CT_71 CT_CUSTOM`
 
 ---
 
@@ -271,19 +221,9 @@ system& occlusionCallback(float(*func)(const Pos& source, const Pos& listener));
 
 **Files:** [channel/channelInterface.hpp](YseEngine/channel/channelInterface.hpp), [channel/channelImplementation.cpp](YseEngine/channel/channelImplementation.cpp), [channel/channelManager.cpp](YseEngine/channel/channelManager.cpp)
 
-Channels form a **tree** whose root is `MainMix`. Five pre-made leaf channels: `FX`, `Music`, `Ambient`, `Voice`, `GUI`. Custom channels can be inserted anywhere. Volume and effects cascade from leaves to root.
+Channels form a **tree** rooted at `MainMix`, with five pre-made leaves (`FX`, `Music`, `Ambient`, `Voice`, `GUI`) and arbitrary user-created children. Sounds can be reparented via `moveTo` at runtime. Sounds beyond a distance threshold are virtualized to save CPU.
 
-```
-MainMix
-├── FX
-├── Music
-├── Ambient
-├── Voice
-└── GUI
-    └── (custom children …)
-```
-
-Sounds can be reparented (`moveTo`) at runtime. Channels support virtual sound culling (sounds beyond a distance threshold are suspended to save CPU).
+Issue [#82](https://github.com/yvanvds/yse-soundengine/issues/82) added measured-callback-timing-based `cpuLoad` and fixed a fast-pool dispatch overhead for empty child channels.
 
 ---
 
@@ -291,20 +231,18 @@ Sounds can be reparented (`moveTo`) at runtime. Channels support virtual sound c
 
 **Files:** [reverb/reverbInterface.hpp](YseEngine/reverb/reverbInterface.hpp), [reverb/reverbImplementation.cpp](YseEngine/reverb/reverbImplementation.cpp), [reverb/reverbManager.cpp](YseEngine/reverb/reverbManager.cpp), [internal/reverbDSP.cpp](YseEngine/internal/reverbDSP.cpp), [internal/underWaterEffect.cpp](YseEngine/internal/underWaterEffect.cpp)
 
-One actual Freeverb-derived reverb processor; multiple `YSE::reverb` objects each represent a positioned zone. The engine blends them by proximity to the listener. A global reverb can be set via `System().getGlobalReverb()`.
+One Freeverb-derived reverb processor; multiple `YSE::reverb` objects each represent a positioned zone. The engine blends them by proximity to the listener. A global reverb is available via `System().getGlobalReverb()`.
 
 **Reverb properties:** position, size, rollOff, roomSize, damping, dryWetBalance, modulation.
 **Built-in presets:** `REVERB_OFF, GENERIC, PADDED, ROOM, BATHROOM, STONEROOM, LARGEROOM, HALL, CAVE, SEWERPIPE, UNDERWATER`
 
-A separate `underWaterEffect` filter is attached per channel via `system::underWaterFX(channel)` and `setUnderWaterDepth(...)`.
+A separate `underWaterEffect` filter attaches per channel via `system::underWaterFX(channel)` + `setUnderWaterDepth(...)`.
 
 ---
 
 ### 5. DSP System
 
-**Files:** [dsp/dspObject.hpp](YseEngine/dsp/dspObject.hpp), [dsp/buffer.hpp](YseEngine/dsp/buffer.hpp), [dsp/fileBuffer.hpp](YseEngine/dsp/fileBuffer.hpp), `dsp/` modules
-
-#### Base abstractions
+**Files:** [dsp/dspObject.hpp](YseEngine/dsp/dspObject.hpp), [dsp/buffer.hpp](YseEngine/dsp/buffer.hpp), [dsp/fileBuffer.hpp](YseEngine/dsp/fileBuffer.hpp), `dsp/modules/`
 
 ```cpp
 class dspObject {          // filter / effect in a chain
@@ -320,10 +258,8 @@ class dspSourceObject {    // audio generator (replaces file)
 };
 ```
 
-`DSP::buffer` — single-channel float buffer with thread-safe length query and arithmetic operators.
+`DSP::buffer` — single-channel float buffer with arithmetic operators.
 `MULTICHANNELBUFFER` — `std::vector<DSP::buffer>`; supports mono-to-surround spreading.
-
-#### Available DSP modules
 
 | Category | Modules |
 |----------|---------|
@@ -343,16 +279,12 @@ class dspSourceObject {    // audio generator (replaces file)
 
 **Files:** [device/deviceInterface.hpp](YseEngine/device/deviceInterface.hpp), [device/portaudioDeviceManager.cpp](YseEngine/device/portaudioDeviceManager.cpp), [device/oboeImplementation.cpp](YseEngine/device/oboeImplementation.cpp), [device/androidDeviceManager.cpp](YseEngine/device/androidDeviceManager.cpp)
 
-Abstracts the OS audio API behind a single interface. PortAudio handles Windows (WASAPI/DirectSound/WDM — ASIO is not available with the MSYS2 package; see [issue #38](https://github.com/yvanvds/yse-soundengine/issues/38)) and Linux; Oboe (AAudio on API 26+, OpenSL ES fallback) is used on Android.
+Abstracts the OS audio API behind a single interface.
 
-```cpp
-const std::vector<device>& getDevices();
-unsigned int getNumDevices();
-const device& getDevice(unsigned int n);
-void openDevice(const deviceSetup&, CHANNEL_TYPE = CT_AUTO);
-```
+- **Desktop:** PortAudio handles Windows (WASAPI/DirectSound/WDM — ASIO is not available with the MSYS2 package; see [issue #38](https://github.com/yvanvds/yse-soundengine/issues/38)) and Linux (ALSA/JACK).
+- **Android:** Oboe 1.9.3 negotiates AAudio on API 26+ (our minSdk) and falls back to OpenSL ES on rare devices where AAudio is unavailable. `androidDeviceManager.cpp` is the platform-specific entry point.
 
-The engine monitors for missed callbacks and can auto-reconnect on device dropout (`system::autoReconnect(bool, int delay)`).
+The engine monitors for missed callbacks and can auto-reconnect on device dropout (`system::autoReconnect(bool, int delay)`). `cpuLoad()` is now measured from the audio callback itself rather than relying on PortAudio's `Pa_GetStreamCpuLoad` (issue #82).
 
 ---
 
@@ -360,11 +292,13 @@ The engine monitors for missed callbacks and can auto-reconnect on device dropou
 
 **Files:** [dsp/fileBuffer.hpp](YseEngine/dsp/fileBuffer.hpp), [internal/abstractSoundFile.cpp](YseEngine/internal/abstractSoundFile.cpp), [internal/lsfSoundfile.cpp](YseEngine/internal/lsfSoundfile.cpp)
 
-- **Buffered (default):** file loaded fully into memory; shared across all sounds using the same path; auto-released when unused.
+- **Buffered (default):** file loaded fully into memory by a slow-pool worker; shared across all sounds using the same path; auto-released when unused.
 - **Streaming:** per-sound disk read; for large files where memory is the constraint.
-- Custom file-reader callbacks are supported (e.g., network streams) via [internal/customFileReader.cpp](YseEngine/internal/customFileReader.cpp).
+- Custom file-reader callbacks (e.g., network streams) via [internal/customFileReader.cpp](YseEngine/internal/customFileReader.cpp).
 
-libsndfile is the underlying decoder (`LIBSOUNDFILE_BACKEND` is the only file backend defined for the CMake build).
+libsndfile is the only file backend (`LIBSOUNDFILE_BACKEND` is defined on every platform). On Android, libsndfile is FetchContent-built (WAV only, no external codec libs).
+
+Until issue [#46](https://github.com/yvanvds/yse-soundengine/issues/46) (closed in PR #95) the `loadStreaming` / `loadNonStreaming` bodies were guarded by `__WINDOWS__` and therefore empty stubs on Linux/macOS/Android — files never transitioned to `READY` outside of Windows.
 
 ---
 
@@ -372,7 +306,7 @@ libsndfile is the underlying decoder (`LIBSOUNDFILE_BACKEND` is the only file ba
 
 **Files:** [patcher/patcher.hpp](YseEngine/patcher/patcher.hpp), [patcher/patcherImplementation.cpp](YseEngine/patcher/patcherImplementation.cpp), [patcher/pRegistry.cpp](YseEngine/patcher/pRegistry.cpp)
 
-A Max/MSP-style node graph for building synthesis and effect networks in code or JSON.
+A Max/MSP-style node graph for building synthesis and effect networks in code or via JSON serialisation.
 
 ```cpp
 pHandle* obj = patcher.CreateObject("pSine", "440");
@@ -381,54 +315,65 @@ patcher.DumpJSON();          // serialize
 patcher.ParseJSON(content);  // restore
 ```
 
-**Node categories:**
-- generators: `pSine`, `dSaw`, `dNoise`
-- filters: `pLowpass`, `pHighpass`, `pBandpass`, `dVcf`
-- math: `dAdd`, `dSubstract`, `dMultiply`, `dDivide`, `dClip`, `gAdd`, `gSubstract`, `gMultiply`, `gDivide`, `gRandom`, `gCounter`, `pMidiToFrequency`, `pFrequencyToMidi`
-- generic: `pDac`, `pLine`, `gGate`, `gSwitch`, `gSend`, `gReceive`, `gRoute`
-- GUI controls: `gButton`, `gSlider`, `gToggle`, `gFloat`, `gInt`, `gList`, `gMessage`, `gText`
-- time: `gMetro` (with `TimerThread`)
-- MIDI: `mMidiNoteOn`, `mMidiNoteOff`, `mMidiControl`, `mMidiProgramChange`, `mMidiChannelPressure`, `mMidiPolyPressure`, `mMidiOut`
+Node categories: generators (`pSine`, `dSaw`, `dNoise`), filters (`pLowpass`, `pHighpass`, `pBandpass`, `dVcf`), math (`dAdd`, `dSubstract`, `dMultiply`, `dDivide`, `dClip`, `g*` integer variants, `gRandom`, `gCounter`, `pMidiToFrequency`, `pFrequencyToMidi`), generic (`pDac`, `pLine`, `gGate`, `gSwitch`, `gSend`, `gReceive`, `gRoute`), GUI controls (`gButton`, `gSlider`, `gToggle`, `gFloat`, `gInt`, `gList`, `gMessage`, `gText`), time (`gMetro` driven by `TimerThread`), MIDI (`mMidi*` family).
 
-Patcher TUs share a set of warning suppressions (`-Wno-unused-parameter`, plus Clang-specific `-Wno-deprecated-literal-operator -Wno-tautological-overlap-compare` from the vendored `json.hpp`) applied per-source-file in `YseEngine/CMakeLists.txt` and mirrored in `Tests/CMakeLists.txt` for patcher tests.
+Patcher TUs share warning suppressions for `-Wno-unused-parameter` plus Clang-specific noise from the vendored `json.hpp`.
 
 ---
 
-### 9. Threading & Concurrency Model
+### 9. C ABI Bridge (`YseEngine/c_api/`)
+
+A flat `extern "C"` surface compiled into `libyse` so language bindings (Dart FFI, Python ctypes, …) can consume the DLL without C++ ABI compatibility. Source files are folded into `yse_objects` via `include(c_api/CMakeLists.txt)` — never `add_subdirectory()`'d, the goal is to extend the existing target.
+
+```
+c_api/include/yse_c/         # Public C headers — Dart's ffigen entry point
+  yse_all.h                  # Aggregate header (includes the rest)
+  yse_system.h yse_listener.h yse_channel.h yse_sound.h yse_reverb.h
+  yse_device.h yse_dsp.h yse_dsp_modules.h yse_patcher.h yse_midi.h
+  yse_music.h yse_log.h yse_buffer_io.h yse_common.h yse_enums.h
+c_api/                       # Wrappers (yse_*.cpp) and the internal helper header yse_c_internal.hpp
+```
+
+Callback bridge conventions (atomic-swap callback pointer, no mutex, no malloc on audio-callback-reachable paths, `YSE_C_CALLBACK` on the typedef) are documented in `yse_c_internal.hpp` and enforced by the `c-api-extend` skill.
+
+---
+
+### 10. Threading & Concurrency Model
 
 **Files:** [internal/threadPool.cpp](YseEngine/internal/threadPool.cpp), [internal/thread.cpp](YseEngine/internal/thread.cpp), [utils/lfQueue.hpp](YseEngine/utils/lfQueue.hpp), [utils/atomicOps.hpp](YseEngine/utils/atomicOps.hpp)
 
-- **Audio callback thread** — managed by PortAudio/Oboe; runs DSP chain at buffer rate.
-- **Application thread** — drives `system::update()` each frame.
-- **Thread pool** — `threadPool` manages a set of `threadPoolThread` workers using a condition-variable-guarded job queue. Pool size defaults to `std::hardware_concurrency`.
-- **Communication** — all cross-thread state changes use a lock-free SPSC message queue (`utils/lfQueue.hpp`); no mutexes in the hot path.
-- **Thread-safe atomic wrappers:** `aBool`, `aInt`, `aUInt`, `aFlt` (thin `std::atomic<T>` aliases in `utils/atomicOps.hpp`).
+- **Audio callback thread** — managed by PortAudio/Oboe; runs DSP chain at buffer rate. FTZ/DAZ enabled per thread (issue [#81](https://github.com/yvanvds/yse-soundengine/issues/81)).
+- **Application thread** — drives `system::update()` each frame; only flags for update, the audio thread drains.
+- **Thread pool** — `threadPool` manages a set of `threadPoolThread` workers on a CV-guarded job queue. The "slow pool" is single-threaded by construction (`slowThreads(1)`) so file loads + the manager setup/delete jobs are serialised.
+- **Communication** — cross-thread state changes use a lock-free SPSC inbox (`utils/lfQueue.hpp`) between the main and audio threads. The audio thread never takes a mutex on the hot path.
+- **Lifecycle fences** — `OBJECT_DELETE_PENDING` handshake prevents the slow-pool deleter from freeing an impl while the audio thread still has it in `toLoad`; `connectedToParent` atomic flag coordinates parent-channel disconnect.
+- **Atomic wrappers:** `aBool`, `aInt`, `aUInt`, `aFlt` (thin `std::atomic<T>` aliases in `utils/atomicOps.hpp`).
 
 ---
 
-### 10. MIDI
+### 11. MIDI
 
 **Files:** `midi/` directory
 
-- **File playback** (`midifile.hpp`, `midifileImplementation.cpp`, `midifileManager.cpp`) — load and play standard MIDI files.
-- **Device I/O** (`device.cpp`, `midiDeviceManager.cpp`, `midiNote.cpp`) — wraps RtMidi; required on Windows and Linux desktop builds. Enumerate via `System().getNumMidiInDevices()` / `getNumMidiOutDevices()`. The Linux backend uses RtMidi's ALSA driver and is lightly tested in practice (see [issue #35](https://github.com/yvanvds/yse-soundengine/issues/35) for the proposed `YSE_ENABLE_MIDI_DEVICE` gate).
-- **Patcher integration** — `patcher/midi/` registers MIDI objects (NoteOn, NoteOff, Control, ProgramChange, PolyPressure, ChannelPressure, MidiOut) in the patcher node registry; registered unconditionally in `pRegistry.cpp`.
+- **File playback** — load and play standard MIDI files; always available.
+- **Device I/O** — RtMidi-backed; gated by `YSE_ENABLE_MIDI_DEVICE` (ON by default on Windows/Linux desktop, OFF on Android/Mac). Issue [#35](https://github.com/yvanvds/yse-soundengine/issues/35) was closed in commit `899260b`.
+- **Patcher integration** — `patcher/midi/` registers MIDI objects (NoteOn, NoteOff, Control, ProgramChange, PolyPressure, ChannelPressure, MidiOut) in the patcher node registry.
 
 ---
 
-### 11. Music / Composition
+### 12. Music / Composition
 
 **Files:** `music/`, `player/`
 
-Polyphonic note player with scale constraints, motif sequencing, and randomized pitch/velocity/gap ranges. Exposes `YSE::scale`, `YSE::motif`, `YSE::player`, `YSE::note`, `YSE::pNote`, `YSE::chord` as public objects.
+Polyphonic note player with scale constraints, motif sequencing, and randomised pitch/velocity/gap ranges. Exposes `YSE::scale`, `YSE::motif`, `YSE::player`, `YSE::note`, `YSE::pNote`, `YSE::chord` as public objects.
 
 ---
 
-### 12. Synth (In Progress)
+### 13. Synth (Implemented but unexposed)
 
-**Files:** `synth/` — `synthInterface.hpp/.cpp`, `samplerSound.cpp`, `dspSound.cpp`, `dspVoice.hpp/.cpp`, `dspVoiceInternal.cpp`
+**Files:** `synth/` — `synthInterface.hpp/.cpp`, `synthManager.h/.cpp`, `synthImplementation.h/.cpp`, `samplerSound.cpp`, `dspSound.cpp`, `dspVoice.hpp/.cpp`, `dspVoiceInternal.cpp`
 
-A polyphonic sampler/DSP synth system. The implementation files are compiled into the library; the public interface (`synth.hpp`, `synthInterface.hpp`, `dspVoice.hpp`) is commented out in `yse.hpp` and not yet part of the public API.
+Polyphonic sampler/DSP synth. The source files compile into the library; the public interface (`synth.hpp`, `synthInterface.hpp`, `dspVoice.hpp`) is commented out in [yse.hpp](YseEngine/yse.hpp) and not yet part of the public API.
 
 ---
 
@@ -454,118 +399,125 @@ sound.play()
 | Pattern | Where used |
 |---------|-----------|
 | Interface + Implementation (pimpl) | `sound`, `channel`, `reverb`, `synth` — public API decoupled from audio-thread objects |
-| Message queue | All sound/channel/reverb/player/motif/scale state changes; keeps audio callback lock-free |
-| Manager singletons | `soundManager`, `channelManager`, `reverbManager`, `motifManager`, `scaleManager`, `playerManager` |
+| Lock-free SPSC inbox | Main → audio handoff for new impls (no mutex on the audio path) |
+| Manager singletons | `soundManager`, `channelManager`, `reverbManager`, `motifManager`, `scaleManager`, `playerManager`, `midifileManager` |
+| Manager job templates | `managerSetupJob`/`managerDeleteJob` factor the common setup/delete-tick body across sound/channel/reverb |
 | Singleton globals | `YSE::System()`, `YSE::Listener()`, `INTERNAL::Global()` |
-| Thread pool | Parallel DSP work dispatched via `threadPool` / `threadPoolJob` |
+| Single-threaded "slow pool" | Serialises file loads + manager setup/delete jobs |
 | Chain of Responsibility | DSP `link()` — each processor hands buffer to next |
 | Proximity blending | Reverb zones blended by listener distance |
 | OBJECT-library + SHARED-library split | `yse_objects` consumed by both `yse` (DLL export) and `yse_tests` (direct linkage, full symbol visibility) |
+| Atomic-swap callback bridge | C API wraps C++ callbacks with `YSE_C_CALLBACK` typedefs; no mutex on the audio path |
 
 ---
 
 ## Demo Applications
 
-**Location:** [Demo.Windows.Native/](Demo.Windows.Native/)
-**18 demos** (Demo00–Demo17) plus `Test01_Pitch` and a combined `Demo` executable that wires every page through `MenuTop.cpp`.
+**Location:** [Demo.Windows.Native/](Demo.Windows.Native/) — Windows-only (uses Windows console APIs and relies on RtMidi for MIDI demos).
+18 demos (Demo00–Demo17) plus `Test01_Pitch` and a combined `Demo` executable that wires every page through `MenuTop.cpp`.
 
-| Demo | Topic |
-|------|-------|
-| Demo00 | Basic playback (`drone.ogg`) |
-| Demo01 | Sound properties |
-| Demo02 | 3D positioning |
-| Demo03 | Virtual sounds |
-| Demo04 | Channel mixer |
-| Demo05 | Reverb zones |
-| Demo06 | Device enumeration |
-| Demo07 | DSP source |
-| Demo08 | Occlusion |
-| Demo09 | Streaming |
-| Demo10 | File position |
-| Demo11 | Virtual I/O |
-| Demo12 | AudioTest |
-| Demo13 | Patcher synthesis |
-| Demo14 | Load patcher from JSON |
-| Demo15 | Audio device restart |
-| Demo16 | MIDI device output (requires RtMidi) |
-| Demo17 | MIDI patcher |
-| Test01_Pitch | Pitch test |
+| Demo | Topic | Demo | Topic |
+|------|-------|------|-------|
+| Demo00 | Basic playback (`drone.ogg`) | Demo09 | Streaming |
+| Demo01 | Sound properties | Demo10 | File position |
+| Demo02 | 3D positioning | Demo11 | Virtual I/O |
+| Demo03 | Virtual sounds | Demo12 | AudioTest |
+| Demo04 | Channel mixer | Demo13 | Patcher synthesis |
+| Demo05 | Reverb zones | Demo14 | Load patcher from JSON |
+| Demo06 | Device enumeration | Demo15 | Audio device restart |
+| Demo07 | DSP source | Demo16 | MIDI device output |
+| Demo08 | Occlusion | Demo17 | MIDI patcher |
+| Test01_Pitch | Pitch test | | |
 
 Each standalone executable is generated from a per-target `main_<Demo>.cpp` produced by `configure_file()` against `cmake/demo_main.cpp.in`. Shared menu/page infrastructure lives in the `yse_demo_common` static library.
 
 ---
 
-## Unit Tests (`Tests/`)
+## Tests (`Tests/`)
 
-**Location:** [Tests/](Tests/)
-**Framework:** [doctest](https://github.com/doctest/doctest) v2.4.11, vendored at `dependencies/doctest/doctest.h`.
-**Build gate:** `YSE_BUILD_TESTS=ON` (default OFF — demos and Android builds are unaffected).
-**Roadmap:** [Tests/TEST_PLAN.md](Tests/TEST_PLAN.md) — 13 phased subsystems (utils → DSP buffers → DSP math → DSP filters → DSP modules → patcher → channel → sound → reverb → MIDI → music → device integration). Phases 1–13 are all scaffolded and most have committed tests.
+**Framework:** [doctest](https://github.com/doctest/doctest) v2.4.11 vendored at `dependencies/doctest/doctest.h`.
+**Scale:** ~863 TEST_CASEs across 46 translation units.
+**Build gate:** `YSE_BUILD_TESTS=ON` (default OFF — demos and Android library builds are unaffected).
+**Roadmap:** [Tests/TEST_PLAN.md](Tests/TEST_PLAN.md).
 
-All test files compile into a single executable (`yse_tests`) which links `yse_objects` directly (bypassing the DLL boundary) so internal symbols are reachable without API annotations. The doctest runner is defined in [Tests/main.cpp](Tests/main.cpp) via `DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN`. Tests are organized into doctest `TEST_SUITE` tags so subsets can be run via `--test-suite=<name>`.
-
-### Layout
+All test files compile into a single executable (`yse_tests`) — except on Android where it's built as `libyse_tests.so` loaded by a NativeActivity APK (`Tests/Android/`). Both variants link `yse_objects` directly, bypassing the DLL boundary so internal symbols are reachable without `API` annotations.
 
 ```
 Tests/
-  main.cpp                          # doctest entry point
-  test_sanity.cpp                   # smoke test
+  main.cpp                            # doctest entry point
+  test_sanity.cpp                     # smoke test
+  Android/                            # Gradle wrapper → NativeActivity APK
   support/
-    audio_helpers.hpp               # makeBuffer, makeRamp, makeImpulse, measureRms,
-                                    # buffersNearlyEqual, peakBinIndex, decaysToSilence, …
-    null_device.hpp                 # TestHelpers::engineInit() — calls System().init()
-                                    # safe to skip stream open if no output device
+    audio_helpers.hpp                 # makeBuffer, measureRms, peakBinIndex, …
+    null_device.hpp                   # engineInit / engineInitWithAudio helpers
+    android_asset_bridge.cpp          # Extracts assets/fixtures/ to internal data path
     fixtures/
-      test_mono_44100.wav           # 244 B mono PCM fixture
-      test_type0.mid                # 41 B Type-0 MIDI fixture
-  utils/      (test_atomic, test_vector, test_lfqueue)
-  dsp/        (test_buffer, test_ramp, test_math_scalars, test_math_converters,
-               test_oscillators, test_filters, test_delay, test_envelope,
-               test_fourier, test_modules)
-  patcher/    (test_graph, test_nodes, test_patcher_math)
-  channel/    (test_channel)
-  sound/      (test_sound_state)
-  reverb/     (test_reverb_dsp)
-  midi/       (test_midifile)
-  music/      (test_scale, test_note, test_motif)
-  integration/ (test_device — DISABLED in CTest by default)
+      test_mono_44100.wav             # 244 B mono PCM
+      test_type0.mid                  # 41 B Type-0 MIDI
+  utils/    dsp/    patcher/    channel/    sound/    reverb/
+  midi/     music/  listener/  system/      io/       integration/
 ```
 
 ### Per-suite CTest entries
 
-`Tests/CMakeLists.txt` registers a catchall `yse_unit_tests` plus per-suite entries with CTest labels:
+`Tests/CMakeLists.txt` registers a catchall `yse_unit_tests` plus per-suite entries with CTest labels (`dsp`, `utils`, `patcher`, `channel`, `sound`, `reverb`, `midi`, `music`). The `integration` suite is `DISABLED TRUE` by default — opt in via `ctest -L integration` or `python yse.py test --integration` (needs a real audio device).
 
-| CTest name | Label | Notes |
-|-----------|-------|-------|
-| `yse_unit_tests` | — | Full suite |
-| `yse_tests_dsp` | `dsp` | |
-| `yse_tests_utils` | `utils` | |
-| `yse_tests_patcher` | `patcher` | |
-| `yse_tests_channel` | `channel` | Requires `null_device` |
-| `yse_tests_sound` | `sound` | Requires `null_device` and the WAV fixture |
-| `yse_tests_reverb` | `reverb` | |
-| `yse_tests_midi` | `midi` | Uses MIDI fixture; no device opened |
-| `yse_tests_music` | `music` | |
-| `yse_tests_integration` | `integration` | `DISABLED TRUE` — opt-in via `ctest -L integration` |
+### Test fixture path
 
-The fixture directory is exposed to test code via `YSE_TEST_FIXTURES_DIR` (compile definition pointing at `Tests/support/fixtures`).
-
-### Known regressions sentinelled by tests
-
-`Tests/dsp/test_buffer.cpp` covers two known DSP buffer bugs (file separate GitHub issues for each before fixing):
-- Uninitialised `cursor` and `sampleRateAdjustment` in fresh `DSP::buffer` instances.
-- `buffer::maxValue()` SIMD unroll bug for buffers of length ≥ 8 with the maximum at a non-leading position.
-
-These tests stand as regression sentinels and may be marked `[!shouldfail]` until the underlying fixes land.
+Exposed via `YSE_TEST_FIXTURES_DIR` compile definition:
+- Desktop: `${CMAKE_CURRENT_SOURCE_DIR}/support/fixtures`
+- Android: `/data/user/0/net.attrx.yse.tests/files/fixtures` (populated by `android_asset_bridge.cpp` extracting from APK assets at startup)
 
 ---
 
-## Vendored Dependencies
+## Benchmarks (`Bench/`)
 
-| Library | Location | Used for |
-|---------|----------|---------|
-| PortAudio headers | `dependencies/portaudio/include/` | Windows-specific extension headers (`pa_asio.h`, WASAPI) not shipped by the MSYS2 package; library itself comes from the system |
-| RtMidi headers | `dependencies/rtmidi/include/` | Header search path that resolves both `"RtMidi.h"` and `"../dependencies/rtmidi/include/RtMidi.h"`; library comes from the system |
-| libsndfile / libsndfile64 | `dependencies/libsndfile*/` | Vendored copies retained but unused by the CMake build (system library is used) |
-| doctest | `dependencies/doctest/doctest.h` | Single-header C++ test framework (v2.4.11, MIT licence). Exposed as the `doctest` INTERFACE library in `Tests/CMakeLists.txt`. |
-| cJSON | `YseEngine/json/cJSON.cpp` | Vendored C JSON parser used by patcher serialisation; warnings suppressed file-wide (`-w`) and excluded from SonarQube analysis. |
+**Framework:** google-benchmark, fetched at tag `v1.9.0`.
+**Build gate:** `YSE_BUILD_BENCHMARKS=ON`.
+**CI:** `.github/workflows/benchmark.yml` runs on push to master/dev and PRs to master; results are pushed to the orphan `bench-history` branch (never merged into mainline) so historical bench data accumulates without polluting `dev`/`master`.
+
+Layout:
+```
+Bench/
+  dsp/         (bench_buffer, bench_delay, bench_filters, bench_math, bench_oscillators, bench_reverb)
+  patcher/     (bench_patcher)
+  integration/ (bench_mixing)
+  support/     (bench_helpers.hpp)
+```
+
+---
+
+## Documentation (`documentation/`)
+
+**Tooling:** Doxygen 1.9+ → XML → Sphinx + Breathe + sphinx-book-theme → HTML.
+**Output:** [github.io/yse-soundengine/](https://yvanvds.github.io/yse-soundengine/) (deployed by `documentation.yml` on push to master).
+
+```
+documentation/
+  Doxyfile                         # Doxygen config (XML output → source/_doxygen/xml/)
+  requirements.txt                 # Sphinx + Breathe + sphinx-book-theme
+  Makefile / make.bat              # `make html`, `make sphinx`, `make doxygen`, `make serve`
+  source/
+    conf.py                        # Reads VERSION from YseEngine/system.hpp (PR #89)
+    index.rst                      # Landing page
+    intro/                         # install, hello_sound, mental_model
+    tutorials/                     # 5 pages: play, properties, 3D, channels, reverb
+    api/                           # 12 grouped pages: core, sounds, channels, dsp, dsp_modules,
+                                   # devices, midi, music, patcher, player, utils, index
+```
+
+The version string in `conf.py` is auto-synced from `YseEngine/system.hpp` so the published docs always match the released library.
+
+---
+
+## Vendored / Fetched Dependencies
+
+| Library | Source | Used for |
+|---------|--------|---------|
+| PortAudio headers | `dependencies/portaudio/include/` | Windows-specific extension headers not shipped by the MSYS2 package; the library itself comes from the system |
+| RtMidi headers | `dependencies/rtmidi/include/` | Header search path that resolves both `"RtMidi.h"` and the vendored copy; library comes from the system |
+| libsndfile 1.2.2 | FetchContent (Android only) | WAV-only static build, no external codec libs |
+| Oboe 1.9.3 | FetchContent (Android only) | Audio I/O — AAudio with OpenSL ES fallback |
+| doctest 2.4.11 | `dependencies/doctest/doctest.h` | Single-header C++ test framework (MIT) |
+| google-benchmark 1.9.0 | FetchContent (when `YSE_BUILD_BENCHMARKS=ON`) | Benchmarks |
+| cJSON | `YseEngine/json/cJSON.cpp` | Patcher JSON serialisation; warnings suppressed file-wide and excluded from SonarQube |

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,5 +1,5 @@
 <!-- META
-last_updated_commit: 9397b10dba6734f0e85518fd0911a6bc2f457d00
+last_updated_commit: 51a4a94622379dd291d432b762c3d92bd6d0b505
 last_updated_at: 2026-05-19
 -->
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
   <img src="logo/yse-logo.svg" alt="libYSE" width="520">
 </p>
 
-# libYSE 2.0
+# libYSE 2.1
 
-libYSE is a cross-platform sound engine written in C++. Version 2.0 removes the
-JUCE dependency; PortAudio and libsndfile are the only audio backends. Windows,
-Linux, and Android are supported. The CMake build described here covers Windows
-(MSYS2 Clang) and Linux (system Clang or GCC). Android is out of scope for this
-build system step.
+libYSE is a cross-platform sound engine written in C++. PortAudio handles audio
+I/O on desktop, Oboe (AAudio + OpenSL ES fallback) on Android, and libsndfile
+decodes sample files everywhere. Windows, Linux, and Android are all supported
+by the CMake build:
+
+- **Windows** — MSYS2 Clang64 (primary) or MSVC
+- **Linux** — system Clang or GCC (Ubuntu/Debian, Fedora/RHEL)
+- **Android** — NDK r27+, API 26+, arm64-v8a and x86_64 (built via Gradle in `Tests/Android/`)
+
+A flat `extern "C"` ABI (`yse_c/yse_*.h`) is folded into the same shared library
+so language bindings (Dart FFI, Python ctypes, …) can call it without C++ ABI
+compatibility — enabled by default via the `YSE_BUILD_C_API` option.
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=yvanvds_yse-soundengine&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=yvanvds_yse-soundengine)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=yvanvds_yse-soundengine&metric=bugs)](https://sonarcloud.io/summary/new_code?id=yvanvds_yse-soundengine)
@@ -36,10 +43,10 @@ pacman -S --needed \
   mingw-w64-clang-x86_64-rtmidi
 ```
 
-`rtmidi` is required on Windows because the MIDI device source files link
-against it. If you skip it, `cmake` will fail with a clear error. See
-[issue #35](https://github.com/yvanvds/yse-soundengine/issues/35) for the
-proposal to gate this behind a `YSE_ENABLE_MIDI_DEVICE` CMake option.
+`rtmidi` is required when the MIDI device backend is enabled (the default on
+desktop). To build without it, configure with `-DYSE_ENABLE_MIDI_DEVICE=OFF` —
+the rest of the engine (MIDI file playback, music primitives, patcher) is
+unaffected and still builds.
 
 ### Configure and build
 
@@ -76,6 +83,10 @@ cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 |---|---|---|
 | `YSE_ENABLE_LTO` | `OFF` | Link-time optimisation for Release builds |
 | `YSE_NATIVE_ARCH` | `OFF` | Add `-march=native` (local builds only — not for distributable binaries) |
+| `YSE_BUILD_TESTS` | `OFF` | Build the `Tests/` doctest suite and enable CTest |
+| `YSE_BUILD_BENCHMARKS` | `OFF` | Build the `Bench/` google-benchmark suite (fetched on demand) |
+| `YSE_BUILD_C_API` | `ON` | Fold the `extern "C"` ABI bridge into `libyse` |
+| `YSE_ENABLE_MIDI_DEVICE` | `ON` (desktop) | RtMidi-backed MIDI device backend |
 
 ---
 
@@ -97,9 +108,9 @@ sudo dnf install \
   portaudio-devel libsndfile-devel rtmidi-devel
 ```
 
-`librtmidi` (the ALSA-backed MIDI device library) is required on Linux just
-like it is on Windows: the MIDI device source files link against it. If you
-skip it, `cmake` will fail with a clear error.
+`librtmidi` (the ALSA-backed MIDI device library) is required when the MIDI
+device backend is enabled (the default on Linux). Configure with
+`-DYSE_ENABLE_MIDI_DEVICE=OFF` to build without it.
 
 ### Configure and build
 
@@ -117,6 +128,35 @@ cd build/bin
 
 The `$ORIGIN` rpath is embedded in each demo binary so that `libyse.so` is
 found automatically from the same directory.
+
+---
+
+## Building on Android
+
+The Android build is wired through Gradle in `Tests/Android/`. It produces a
+NativeActivity APK that ships `libyse_tests.so` (the full test suite) for two
+ABIs — `arm64-v8a` and `x86_64`. The release workflow at
+`.github/workflows/release.yml` builds production multi-ABI archives the same
+way and publishes them as release assets.
+
+### Prerequisites
+
+- NDK r27+ installed (Android Studio's SDK Manager → NDK (Side by side))
+- Gradle 8+ (the wrapper in `Tests/Android/gradlew` will use it automatically)
+- An attached device or emulator at API 26+
+
+### Build and run on-device
+
+```sh
+cd Tests/Android
+./gradlew installDebug
+adb shell am start -n net.attrx.yse.tests/.MainActivity
+adb logcat -s yse_tests
+```
+
+The engine fetches libsndfile 1.2.2 and Oboe 1.9.3 from source via
+`FetchContent` on the first configure — no system packages are required. RtMidi
+is unused on Android (the MIDI device source files compile to empty TUs).
 
 ---
 
@@ -212,11 +252,16 @@ Pages is configured for the repo with **Source: GitHub Actions**
 
 | Directory | Contents |
 |---|---|
-| `YseEngine/` | Engine source (compiled into `libyse`) |
-| `Demo.Windows.Native/` | Native C++ demos (one executable each) |
+| `YseEngine/` | Engine source (compiled into `libyse`); `c_api/` holds the flat C ABI bridge |
+| `Tests/` | doctest unit suite (`YSE_BUILD_TESTS=ON`); `Tests/Android/` packages it as a NativeActivity APK |
+| `Bench/` | google-benchmark suite (`YSE_BUILD_BENCHMARKS=ON`); CI pushes results to the `bench-history` orphan branch |
+| `Demo.Windows.Native/` | Native C++ demos (one executable each) — Windows only |
 | `TestResources/` | Audio files referenced by demos |
 | `documentation/` | Doxygen + Sphinx + Breathe documentation sources |
-| `dependencies/` | Vendored headers (rtmidi headers used by build; PortAudio/libsndfile vendored copies unused) |
+| `tools/ci-linux/` | Docker images for local Linux CI reproduction (`Dockerfile`, `Dockerfile.audio`) |
+| `dependencies/` | Vendored headers (rtmidi, doctest); PortAudio/libsndfile system packages on desktop |
+
+A deeper architectural reference lives in [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md).
 
 ---
 

--- a/Tests/integration/test_device.cpp
+++ b/Tests/integration/test_device.cpp
@@ -23,8 +23,12 @@
 // null_device.hpp and is not tested here; shutdown is exercised by process exit.
 
 #include <doctest/doctest.h>
+#include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <vector>
 #include "yse.hpp"
 #include "support/null_device.hpp"
 #include "headers/defines.hpp"
@@ -45,6 +49,40 @@ struct ConstantSource : YSE::DSP::dspSourceObject {
         UInt len = samples[0].getLength();
         for (UInt i = 0; i < len; i++) p[i] = 0.5f;
         intent = YSE::SS_PLAYING;
+    }
+    void frequency(float) override {}
+};
+
+// Multi-sine DSP source — 11 sine generators feeding a low-pass, modelled
+// on AudioTest's shepard tone (YseEngine/internal/AudioTest.cpp) and on
+// Demo07_DspSource. This is the canonical "several sines + IIR feedback"
+// shape that triggered the original #53 / #82 reports; using it in the
+// recovery test keeps the cpuLoad measurement honest against exactly the
+// graph topology the bug appeared with. File-scope for the same lifetime
+// reason as ConstantSource.
+struct MultiSineSource : YSE::DSP::dspSourceObject {
+    static constexpr int kNumGens = 11;
+    YSE::DSP::sine    generators[kNumGens];
+    YSE::DSP::lowPass lp;
+    YSE::DSP::buffer  out;
+    float             freq[kNumGens];
+
+    MultiSineSource() {
+        // Spread sines across the audible band — keeps every generator
+        // contributing real signal rather than collapsing into beating.
+        for (int i = 0; i < kNumGens; ++i) {
+            freq[i] = 110.f + (float)i * 87.f;
+        }
+        lp.setFrequency(1500.f);
+    }
+
+    void process(YSE::SOUND_STATUS& intent) override {
+        out = 0.0f;
+        for (int i = 0; i < kNumGens; ++i) out += generators[i](freq[i]);
+        out *= (1.f / (float)kNumGens);
+        YSE::DSP::buffer& result = lp(out);
+        for (UInt i = 0; i < samples.size(); ++i) samples[i] = result;
+        if (intent == YSE::SS_WANTSTOSTOP) intent = YSE::SS_STOPPED;
     }
     void frequency(float) override {}
 };
@@ -70,8 +108,9 @@ struct ProbeEffect : YSE::DSP::dspObject {
     }
 };
 
-static ConstantSource g_source;
-static ProbeEffect    g_probe;
+static ConstantSource  g_source;
+static MultiSineSource g_multi_sine;
+static ProbeEffect     g_probe;
 
 // Sleep briefly, pump one update tick, then report whether the audio callback
 // fired during that interval (missedCallbacks resets to 0 when callbacks arrive).
@@ -169,6 +208,100 @@ TEST_CASE("engine: cpuLoad stays bounded with no graph activity") {
     const float load = YSE::System().cpuLoad();
     CHECK(load >= 0.0f);
     CHECK(load < 0.5f);
+}
+
+// Issue #82 (reopened): the original report observed Pa_GetStreamCpuLoad
+// staying elevated after stopping AudioTest, and the phi client still sees
+// elevated cpuLoad after stopping its sine playback even after the timing
+// rewrite landed. Diagnose by sampling cpuLoad once per second through a
+// full idle → playing → stopped cycle and writing the trace to a CSV the
+// user can post-hoc correlate against an external probe (GetProcessTimes,
+// perf, etc.). The graph here mirrors AudioTest (11 sines + low-pass),
+// the same DSP shape that triggered both #53 and #82.
+//
+// Total runtime: ~13 s on a Release build. Run explicitly with:
+//
+//   python yse.py test --integration
+//   yse_tests --test-suite=integration --test-case='*cpuLoad recovers*'
+TEST_CASE("engine: cpuLoad recovers after multi-sine playback stops [issue #82]") {
+    if (!TestHelpers::engineInitWithAudio()) return;
+    if (YSE::System().getNumDevices() == 0) return;
+
+    auto sample_cpu = []() { return YSE::System().cpuLoad(); };
+
+    // Let the EMA settle (~1 s time constant) before the trace begins so
+    // we have a clean idle baseline to compare the post-stop reading to.
+    for (int i = 0; i < 4; i++) {
+        YSE::System().sleep(500);
+        YSE::System().update();
+    }
+    const float idle_baseline = sample_cpu();
+
+    struct Sample {
+        int         t_secs;
+        const char* phase;
+        float       cpu;
+    };
+    std::vector<Sample> trace;
+    trace.push_back({0, "idle", idle_baseline});
+
+    YSE::sound s;
+    s.create(g_multi_sine);
+    s.relative(true);
+    s.play();
+
+    // 5 seconds of active playback.
+    for (int i = 1; i <= 5; i++) {
+        YSE::System().sleep(1000);
+        YSE::System().update();
+        trace.push_back({i, "playing", sample_cpu()});
+    }
+
+    s.stop();
+
+    // 5 seconds after stop. By the end of this window the ~1 s EMA should
+    // have decayed any "playing" contribution to under 1 %, so the final
+    // reading should sit very close to the idle baseline.
+    for (int i = 1; i <= 5; i++) {
+        YSE::System().sleep(1000);
+        YSE::System().update();
+        trace.push_back({5 + i, "stopped", sample_cpu()});
+    }
+
+    // Drop the trace to a deterministic temp path. Whoever runs the test
+    // can diff this against an external CPU probe to confirm whether the
+    // engine reading still drifts up under their setup.
+    const auto log_path = std::filesystem::temp_directory_path() / "yse_cpuload_issue82.csv";
+    {
+        std::ofstream csv(log_path);
+        csv << "t_secs,phase,cpu_load\n";
+        for (const auto& smp : trace) {
+            csv << smp.t_secs << "," << smp.phase << "," << smp.cpu << "\n";
+        }
+    }
+    MESSAGE("cpuLoad trace written to " << log_path.string());
+
+    float max_playing = 0.f;
+    for (int i = 1; i <= 5; i++) max_playing = std::max(max_playing, trace[i].cpu);
+    const float final_stopped = trace.back().cpu;
+
+    INFO("idle_baseline = " << idle_baseline);
+    INFO("max_playing   = " << max_playing);
+    INFO("final_stopped = " << final_stopped);
+
+    // Sanity bounds: nothing negative, no impossible (>1.0) values.
+    for (const auto& smp : trace) {
+        CHECK(smp.cpu >= 0.0f);
+        CHECK(smp.cpu < 1.5f);
+    }
+
+    // The recovery assertion. 5 s after stop with a ~1 s tau, the playing
+    // component has decayed by e^-5 ≈ 0.7 %, so the final reading must
+    // sit very close to the idle baseline. Allow a generous 25 % of
+    // max_playing as slack for slow machines and EMA noise; if the
+    // engine still reports half its playing value at this point, the
+    // bug from the original report is back.
+    CHECK(final_stopped <= max_playing * 0.25f + idle_baseline + 0.01f);
 }
 
 // ─── Audio callback ───────────────────────────────────────────────────────────

--- a/Tests/integration/test_device.cpp
+++ b/Tests/integration/test_device.cpp
@@ -210,14 +210,23 @@ TEST_CASE("engine: cpuLoad stays bounded with no graph activity") {
     CHECK(load < 0.5f);
 }
 
-// Issue #82 (reopened): the original report observed Pa_GetStreamCpuLoad
-// staying elevated after stopping AudioTest, and the phi client still sees
-// elevated cpuLoad after stopping its sine playback even after the timing
-// rewrite landed. Diagnose by sampling cpuLoad once per second through a
-// full idle → playing → stopped cycle and writing the trace to a CSV the
-// user can post-hoc correlate against an external probe (GetProcessTimes,
-// perf, etc.). The graph here mirrors AudioTest (11 sines + low-pass),
-// the same DSP shape that triggered both #53 and #82.
+// Issue #82 regression guard. Original report: cpuLoad stayed elevated for
+// seconds after sound.stop(), then was eventually root-caused to YSE's
+// default empty child channels (ambient/fx/music/gui/voice — see
+// system.cpp's initShared) being dispatched to the fast threadpool every
+// render. The audio thread's join() on those workers spin-slept in 2 ms
+// increments, adding ~10 ms of fake wall-clock per callback once the
+// source was silent (during playback the source work hid the wait).
+//
+// Fixed by skipping addFastJob for children with no work in
+// channelImplementation::dsp(); this test samples cpuLoad once per
+// second through idle → playing → stopped phases and asserts the
+// stopped reading decays back to the idle baseline. CSV trace written
+// to a deterministic temp path for offline correlation.
+//
+// The graph mirrors AudioTest (11 sines + low-pass), the same DSP
+// shape from the original repro, so the test also exercises the
+// FTZ/DAZ path on the audio thread (issue #53 / PR #70).
 //
 // Total runtime: ~13 s on a Release build. Run explicitly with:
 //

--- a/Tests/sound/test_sound_state.cpp
+++ b/Tests/sound/test_sound_state.cpp
@@ -14,9 +14,13 @@
 // removeInterface() (setting head = nullptr) before going out of scope.
 
 #include <doctest/doctest.h>
+#include <chrono>
+#include <thread>
 #include "sound/soundInterface.hpp"
+#include "sound/soundManager.h"
 #include "sound/soundMessage.h"
 #include "dsp/dspObject.hpp"
+#include "internal/time.h"
 #include "support/null_device.hpp"
 
 // Minimal no-op DSP source used to create sounds without file I/O.
@@ -433,6 +437,32 @@ TEST_CASE("sound: WAV file sound destructs cleanly") {
         YSE::sound s;
         s.create(WAV_FIXTURE);
     } // ~sound() fires here
+}
+
+// Regression: issue #46. The slow-pool's soundFile load runs on every desktop
+// build, but a stale __WINDOWS__ guard around lsfSoundfile.cpp's loadStreaming
+// / loadNonStreaming bodies meant the function did nothing on Linux/macOS —
+// `state` stayed at LOADING forever, the impl never reached OBJECT_SETUP, and
+// isReady() never became true. This test guarantees a WAV-loaded sound
+// actually transitions to READY after the manager pumps the inbox and the
+// slow-pool finishes the load.
+TEST_CASE("sound: WAV file reaches OBJECT_READY after manager updates") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::sound s;
+    s.create(WAV_FIXTURE);
+    if (!s.isValid()) return; // fixture missing in this environment
+
+    // Pump the manager directly (test thread drives update; audio is paused).
+    // Budget: ~1 s wall-clock — loading a 244-byte WAV through the single
+    // slow-pool worker normally completes within a couple of update ticks.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        YSE::INTERNAL::Time().update();
+        YSE::SOUND::Manager().update();
+        if (s.isReady()) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    CHECK(s.isReady());
 }
 
 } // TEST_SUITE("sound")

--- a/YseEngine/channel/channelImplementation.cpp
+++ b/YseEngine/channel/channelImplementation.cpp
@@ -104,6 +104,19 @@ void YSE::CHANNEL::implementationObject::dsp()
 	// calculate child channels if there are any
 	for (auto i = children.begin(); i != children.end(); ++i)
 	{
+		// Skip the fast-pool dispatch for children that have no work this
+		// render. Their dsp() would early-return at the top of this same
+		// function anyway, but the dispatch + matching join() in
+		// buffersToParent() would otherwise spin-sleep in 2 ms increments
+		// waiting for the worker to wake up and signal isDone. YSE's
+		// System().init() creates five default child channels of master
+		// (ambient/fx/music/gui/voice — see system.cpp); apps that don't
+		// use them — and especially silent / post-stop graphs where the
+		// audio thread has no source work to fill the dispatch→join gap —
+		// were losing ~10 ms of fake wall-clock per callback waiting for
+		// those no-op workers. Observed as the cpuLoad post-stop spike in
+		// issue #82.
+		if ((*i)->children.empty() && (*i)->sounds.empty()) continue;
 		INTERNAL::Global().addFastJob(*i);
 	}
 

--- a/YseEngine/device/portaudioDeviceManager.cpp
+++ b/YseEngine/device/portaudioDeviceManager.cpp
@@ -54,9 +54,10 @@ int YSE::DEVICE::managerObject::paCallback(
   , PaStreamCallbackFlags /*statusFlags*/
   , void * userData) {
   YSE::INTERNAL::enableFlushToZero();
-  // Issue #82: Pa_GetStreamCpuLoad was unreliable under WASAPI shared mode
-  // (plateaued at ~50% after silence). Time the callback ourselves with
-  // steady_clock; cpuLoad() returns the EMA of (elapsed / buffer-period).
+  // cpuLoad() reports a wall-clock ratio (time in callback / buffer period),
+  // EMA-smoothed. We time it ourselves with steady_clock rather than reading
+  // Pa_GetStreamCpuLoad so the Oboe path can report a comparable number
+  // (PortAudio's number doesn't exist on the Android backend).
   const auto cbStart = std::chrono::steady_clock::now();
   YSE::DEVICE::managerObject * manager = (YSE::DEVICE::managerObject *)userData;
 	manager->callbacksSinceLastUpdate++;

--- a/YseEngine/internal/lsfSoundfile.cpp
+++ b/YseEngine/internal/lsfSoundfile.cpp
@@ -39,10 +39,10 @@ YSE::INTERNAL::soundFile::~soundFile() {
 }
 
 void YSE::INTERNAL::soundFile::loadStreaming() {
-#ifdef __WINDOWS__
   assert(handle == nullptr);
   if (IO().getActive()) {
-
+    // Custom-IO streaming has never been implemented; the empty body leaves
+    // state at LOADING. The path is unused in the supported builds.
   }
   else {
     handle = new SndfileHandle(fileName);
@@ -50,7 +50,7 @@ void YSE::INTERNAL::soundFile::loadStreaming() {
       _sampleRateAdjustment = static_cast<Flt>(handle->samplerate()) / static_cast<Flt>(SAMPLERATE);
       _length = (Int)handle->frames();
       _channels = handle->channels();
-      
+
       Int size = STREAM_BUFFERSIZE * _channels;
       _iBuffer = new Flt[size];
       _streamPos = 0;
@@ -62,13 +62,11 @@ void YSE::INTERNAL::soundFile::loadStreaming() {
       state = INVALID;
     }
   }
-#endif
 }
 
 void YSE::INTERNAL::soundFile::loadNonStreaming() {
   assert(handle == nullptr);
   void * ptr = nullptr;
-#ifdef __WINDOWS__
 
   if (IO().getActive()) {
     long long size;
@@ -78,7 +76,7 @@ void YSE::INTERNAL::soundFile::loadNonStreaming() {
       state = INVALID;
       return;
     }
-    
+
     std::ostringstream message;
     message << "SoundFile: loading buffer ";
     message << fileName << " with size " << size;
@@ -89,12 +87,12 @@ void YSE::INTERNAL::soundFile::loadNonStreaming() {
   else {
     handle = new SndfileHandle(fileName);
   }
-    
+
   if (*handle) {
     _sampleRateAdjustment = static_cast<Flt>(handle->samplerate()) / static_cast<Flt>(SAMPLERATE);
     _length = (Int)handle->frames();
     _channels = handle->channels();
-      
+
     Int size = _length * _channels;
     _iBuffer = new Flt[size];
     Long read = handle->readf(_iBuffer, _length);
@@ -118,9 +116,7 @@ void YSE::INTERNAL::soundFile::loadNonStreaming() {
     state = INVALID;
   }
 
-
   if (ptr != nullptr) INTERNAL::customFileReader::Close(ptr);
- #endif
 }
 
 Bool YSE::INTERNAL::soundFile::fillStream(Bool loop) {

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -218,12 +218,12 @@ namespace YSE {
      *
      *  This is a **dropout-risk** indicator: 1.0 means the callback is taking
      *  as long as the buffer it produces, i.e. the next buffer will arrive
-     *  late. It does NOT reflect total engine CPU across the threadpool
-     *  workers — for that, see issue #84.
+     *  late.
      *
-     *  Distinct from the cost of ``update()`` on the main thread. Replaces
-     *  the previous pass-through of ``Pa_GetStreamCpuLoad``, which read as
-     *  inflated under WASAPI shared mode after periods of silence (see #82).
+     *  Distinct from the cost of ``update()`` on the main thread. Timed
+     *  ourselves (rather than reading ``Pa_GetStreamCpuLoad``) so the Oboe /
+     *  Android backend can report a comparable number — that API doesn't
+     *  exist there.
      */
     float cpuLoad();
 

--- a/documentation/source/api/c_api.rst
+++ b/documentation/source/api/c_api.rst
@@ -1,0 +1,102 @@
+C ABI (language bindings)
+=========================
+
+libYSE ships a flat ``extern "C"`` API alongside the C++ one, folded into the
+same shared library by the ``YSE_BUILD_C_API=ON`` CMake option (default on).
+It exists so language bindings — Dart FFI, Python ctypes, etc. — can consume
+``libyse.dll`` / ``libyse.so`` without C++ ABI compatibility.
+
+Single entry point:
+
+.. code-block:: c
+
+   #include "yse_c/yse_all.h"
+
+This umbrella header pulls in every subsystem header below.
+
+Conventions
+-----------
+
+- Borrowed singletons (system, listener) are obtained via getters and **must
+  not** be destroyed by the caller.
+- Owned objects (sound, channel, reverb, patcher, device-setup, …) are
+  created with ``yse_<type>_create*`` and released with
+  ``yse_<type>_destroy``. ``destroy`` is always safe to call with ``NULL``.
+- Callback typedefs are marked ``YSE_C_CALLBACK`` and run on engine-managed
+  threads (often the audio thread). They must not block, allocate, or call
+  back into the engine.
+- All functions return either ``void``, an ``int`` (0 = success, non-zero =
+  error code), or an owned/borrowed handle. Pointer parameters are
+  documented as ``IN`` / ``OUT`` in the header.
+
+Umbrella header
+---------------
+
+.. doxygenfile:: c_api/include/yse_c/yse_all.h
+   :project: libYSE
+
+System and listener
+-------------------
+
+.. doxygenfile:: c_api/include/yse_c/yse_system.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_listener.h
+   :project: libYSE
+
+Sound objects, channels, and reverb
+-----------------------------------
+
+.. doxygenfile:: c_api/include/yse_c/yse_sound.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_channel.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_reverb.h
+   :project: libYSE
+
+Audio device
+------------
+
+.. doxygenfile:: c_api/include/yse_c/yse_device.h
+   :project: libYSE
+
+DSP and patcher
+---------------
+
+.. doxygenfile:: c_api/include/yse_c/yse_dsp.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_dsp_modules.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_patcher.h
+   :project: libYSE
+
+MIDI and music
+--------------
+
+.. doxygenfile:: c_api/include/yse_c/yse_midi.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_music.h
+   :project: libYSE
+
+Logging and buffer I/O
+----------------------
+
+.. doxygenfile:: c_api/include/yse_c/yse_log.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_buffer_io.h
+   :project: libYSE
+
+Common types and enums
+----------------------
+
+.. doxygenfile:: c_api/include/yse_c/yse_common.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_enums.h
+   :project: libYSE

--- a/documentation/source/api/index.rst
+++ b/documentation/source/api/index.rst
@@ -45,3 +45,9 @@ The pages below are generated from the source code by Doxygen + Breathe.
    :caption: Utilities
 
    utils
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Language bindings
+
+   c_api

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -11,6 +11,7 @@ If the XML directory is missing, Sphinx will emit empty API pages — run
 Doxygen first.
 """
 
+import re
 from pathlib import Path
 
 # -- Project information -----------------------------------------------------
@@ -18,7 +19,34 @@ from pathlib import Path
 project = "libYSE"
 author = "Yvan Vander Sanden"
 copyright = "2014-2026, Yvan Vander Sanden"
-release = "2.1"
+
+
+def _read_engine_version():
+    """Parse the canonical VERSION literal out of YseEngine/system.hpp.
+
+    Single source of truth for the docs banner. ``yse.py release`` writes
+    to ``system.hpp`` only; this picks it up at Sphinx-build time so the
+    docs never lag a release. See issue #89.
+    """
+    engine_hpp = (
+        Path(__file__).resolve().parent.parent.parent / "YseEngine" / "system.hpp"
+    )
+    m = re.search(
+        r'VERSION\s*=\s*"(\d+)\.(\d+)\.(\d+)"',
+        engine_hpp.read_text(encoding="utf-8"),
+    )
+    if not m:
+        raise RuntimeError(
+            f"VERSION literal not found in {engine_hpp}; docs build cannot "
+            f"determine the release banner."
+        )
+    return m.group(1), m.group(2), m.group(3)
+
+
+_major, _minor, _patch = _read_engine_version()
+# Sphinx convention: ``version`` is short (X.Y), ``release`` is full (X.Y.Z).
+version = f"{_major}.{_minor}"
+release = f"{_major}.{_minor}.{_patch}"
 
 # -- General configuration ---------------------------------------------------
 
@@ -58,7 +86,7 @@ breathe_show_include = False
 # -- HTML output -------------------------------------------------------------
 
 html_theme = "sphinx_book_theme"
-html_title = "libYSE 2.1"
+html_title = f"libYSE {version}"
 html_static_path = ["_static"]
 
 # Logo and favicon are sourced from the repo-root `logo/` directory so the

--- a/documentation/source/intro/hello_sound.rst
+++ b/documentation/source/intro/hello_sound.rst
@@ -41,7 +41,10 @@ What just happened
 - ``YSE::sound s; s.create("drone.ogg");`` allocates a sound object and
   loads an audio file. The file path is relative to the working directory.
 - ``s.isValid()`` is the safety check after ``create``. False means the
-  file could not be opened or decoded — log and exit.
+  file could not be found at the given path — log and exit. (Decoding
+  happens asynchronously on a background worker; ``isReady()`` reports when
+  the sound is fully loaded, but ``play()`` is safe to call even while
+  loading — it queues the start.)
 - ``s.play()`` starts playback. The call returns immediately; the sound
   plays on the audio thread.
 - ``std::cin.get()`` is there to keep the program alive long enough to

--- a/documentation/source/intro/index.rst
+++ b/documentation/source/intro/index.rst
@@ -37,11 +37,18 @@ Supported platforms
 -------------------
 
 - **Windows** (MSYS2 / Clang64, MSVC)
-- **Linux** (Clang or GCC)
-- **Android** (out of scope of the CMake build but supported as a target)
+- **Linux** (Clang or GCC, x64)
+- **Android** (NDK r27+, API 26+, ``arm64-v8a`` and ``x86_64`` — built via
+  Gradle in ``Tests/Android/``; release archives published by CI)
 
-The audio backends are PortAudio and libsndfile; MIDI device I/O uses
-RtMidi.
+The audio backends are PortAudio on desktop and Oboe (AAudio with OpenSL ES
+fallback) on Android. libsndfile decodes sample files everywhere. MIDI device
+I/O uses RtMidi on desktop and is gated behind the ``YSE_ENABLE_MIDI_DEVICE``
+CMake option (on by default on Windows/Linux, off on Android).
+
+A flat ``extern "C"`` ABI (``yse_c/yse_*.h``) is folded into the same shared
+library so language bindings (Dart FFI, Python ctypes, …) can call the engine
+without C++ ABI compatibility — enabled by default via ``YSE_BUILD_C_API=ON``.
 
 Licence
 -------

--- a/documentation/source/intro/install.rst
+++ b/documentation/source/intro/install.rst
@@ -2,8 +2,11 @@ Install
 =======
 
 libYSE builds with CMake 3.20+ on Windows (MSYS2 Clang64, MSVC), Linux, and
-Android. The audio backends are PortAudio and libsndfile; MIDI device I/O
-uses RtMidi.
+Android. The audio backends are PortAudio (desktop) and Oboe (Android);
+libsndfile decodes sample files. MIDI device I/O uses RtMidi on desktop and
+is gated by the ``YSE_ENABLE_MIDI_DEVICE`` CMake option — on by default on
+Windows/Linux, off on Android. Configure with ``-DYSE_ENABLE_MIDI_DEVICE=OFF``
+to build without RtMidi.
 
 Linux (Debian / Ubuntu)
 -----------------------
@@ -48,6 +51,31 @@ Open an **MSYS2 CLANG64** shell:
    cmake --build build
 
 The shared library and demo executables land in ``build/bin/``.
+
+Android
+-------
+
+The Android build is wired through Gradle in ``Tests/Android/`` and produces
+a NativeActivity APK that ships the test suite for two ABIs
+(``arm64-v8a`` and ``x86_64``). libsndfile 1.2.2 and Oboe 1.9.3 are fetched
+from source on first configure — no system packages required.
+
+Prerequisites:
+
+- NDK r27+ (installed via Android Studio's SDK Manager → NDK (Side by side))
+- Gradle 8+ (the wrapper at ``Tests/Android/gradlew`` will use it
+  automatically)
+- An attached device or emulator at API 26+
+
+.. code-block:: sh
+
+   cd Tests/Android
+   ./gradlew installDebug
+   adb shell am start -n net.attrx.yse.tests/.MainActivity
+   adb logcat -s yse_tests
+
+The release workflow at ``.github/workflows/release.yml`` builds production
+multi-ABI archives the same way and publishes them as release assets.
 
 Adding libYSE to your CMake project
 -----------------------------------

--- a/documentation/source/intro/mental_model.rst
+++ b/documentation/source/intro/mental_model.rst
@@ -46,8 +46,9 @@ Channel
 
 :cpp:class:`YSE::channel` is a node in a mixing tree. Every sound is attached
 to a channel; channels can themselves be attached to a parent channel,
-forming a tree rooted at ``MainMix``. Each channel renders on its own DSP
-thread, so spreading sounds across channels also spreads them across cores.
+forming a tree rooted at ``MainMix``. Child channels dispatch their DSP work
+to a thread pool, so spreading sounds across channels lets the engine
+parallelise mixing across cores.
 
 A small set of pre-built channels (``ChannelMaster``, ``ChannelMusic``,
 ``ChannelAmbient``, ``ChannelVoice``, ``ChannelGui``, ``ChannelFX``) is

--- a/yse.py
+++ b/yse.py
@@ -546,6 +546,23 @@ def _make_release_readme(version, platform_name, dlls):
             "Link:    `-L<archive>/lib -lyse`\n"
             "Run:     ensure `<archive>/bin/` is on `PATH` or copy its contents next to your `.exe`."
         )
+    elif platform_name == "android":
+        layout = (
+            "    include/                Public C++ headers (use `#include \"yse.hpp\"`)\n"
+            "    lib/<abi>/libyse.so     One libyse.so per Android ABI shipped"
+        )
+        deps_section = (
+            "libYSE on Android uses Oboe for audio I/O — it is statically linked\n"
+            "into `libyse.so`, so the only system requirement is `android-26` (API 26\n"
+            "/ Android 8.0 Oreo) or newer."
+        )
+        link_hint = (
+            "Gradle:   copy the `lib/` directory into your module's\n"
+            "          `src/main/jniLibs/` source set (e.g. `app/src/main/jniLibs/`).\n"
+            "          Reference from JNI / Kotlin code with `System.loadLibrary(\"yse\")`.\n"
+            "CMake:    point your toolchain at `include/` for headers and link the\n"
+            "          ABI-matching `lib/<abi>/libyse.so`."
+        )
     else:  # linux
         layout = (
             "    include/        Public C++ headers (use `#include \"yse.hpp\"`)\n"
@@ -566,15 +583,21 @@ def _make_release_readme(version, platform_name, dlls):
             "Run:     ensure `<archive>/lib/` is on `LD_LIBRARY_PATH` (or install libyse.so system-wide)."
         )
 
-    return f"""# libYSE {version} — {platform_name} x64
+    arch_label = "multi-ABI" if platform_name == "android" else "x86_64"
+    platform_blurb = (
+        "**Android** with one `libyse.so` per ABI (see `lib/<abi>/`)"
+        if platform_name == "android"
+        else f"**{platform_name} x86_64**"
+    )
+    return f"""# libYSE {version} — {platform_name} ({arch_label})
 
 A cross-platform sound engine written in C++. This archive contains the
-prebuilt shared library and public headers for **{platform_name} x86_64**.
+prebuilt shared library and public headers for {platform_blurb}.
 
 - Repository:   <{REPO_URL}>
 - Version:      {version}
 - Built:        {today}
-- Architecture: x86_64
+- Architecture: {arch_label}
 
 ## Contents
 
@@ -614,19 +637,24 @@ def cmd_package(args):
     else:
         platform_name = requested
 
-    # Resolve source build directory.
-    build_dir = Path(args.build_dir)
-    if not build_dir.is_absolute():
-        build_dir = (ROOT / build_dir).resolve()
-    bin_dir = build_dir / "bin"
-    lib_dir_src = build_dir / "lib"
+    # Resolve source layout differently per platform:
+    #   - windows/linux: read from a single CMake build dir's bin/.
+    #   - android: per-ABI .so files arrive separately (from CI matrix
+    #     artefacts), grouped under --android-libs. No host build dir.
+    dll = None
+    import_lib = None
+    shared = None
+    abi_libs = {}  # only populated for android: { abi_name -> Path(libyse.so) }
 
-    if not bin_dir.is_dir():
-        print(f"error: {bin_dir} not found. Run 'python yse.py build --release' first.")
-        sys.exit(1)
-
-    # Locate the built library.
     if platform_name == "windows":
+        build_dir = Path(args.build_dir)
+        if not build_dir.is_absolute():
+            build_dir = (ROOT / build_dir).resolve()
+        bin_dir = build_dir / "bin"
+        lib_dir_src = build_dir / "lib"
+        if not bin_dir.is_dir():
+            print(f"error: {bin_dir} not found. Run 'python yse.py build --release' first.")
+            sys.exit(1)
         dll = bin_dir / "libyse.dll"
         import_lib = lib_dir_src / "libyse.dll.a"
         if not dll.exists():
@@ -636,17 +664,52 @@ def cmd_package(args):
             # MSVC fallback path: yse.lib in lib/, yse.dll in bin/. Not the
             # configuration we ship, but warn rather than miss it silently.
             print(f"warning: {import_lib} not found; archive will lack an import library.")
-    else:
+    elif platform_name == "linux":
+        build_dir = Path(args.build_dir)
+        if not build_dir.is_absolute():
+            build_dir = (ROOT / build_dir).resolve()
+        bin_dir = build_dir / "bin"
+        if not bin_dir.is_dir():
+            print(f"error: {bin_dir} not found. Run 'python yse.py build --release' first.")
+            sys.exit(1)
         shared = bin_dir / "libyse.so"
         if not shared.exists():
             print(f"error: {shared} not found.")
             sys.exit(1)
+    elif platform_name == "android":
+        # Android packaging consumes per-ABI build outputs from CI
+        # download-artifact: each subdir under --android-libs holds one
+        # libyse.so. The subdir name (with an optional "android-libs-"
+        # prefix stripped) becomes the ABI in the bundle's lib/<abi>/ tree.
+        libs_root = Path(args.android_libs)
+        if not libs_root.is_absolute():
+            libs_root = (ROOT / libs_root).resolve()
+        if not libs_root.is_dir():
+            print(f"error: --android-libs {libs_root} not found.")
+            sys.exit(1)
+        prefix = "android-libs-"
+        for sub in sorted(libs_root.iterdir()):
+            if not sub.is_dir():
+                continue
+            so = sub / "libyse.so"
+            if not so.exists():
+                continue
+            abi = sub.name[len(prefix):] if sub.name.startswith(prefix) else sub.name
+            abi_libs[abi] = so
+        if not abi_libs:
+            print(f"error: no per-ABI libyse.so found under {libs_root}.")
+            sys.exit(1)
+        print(f"Including ABIs: {', '.join(sorted(abi_libs))}")
+    else:
+        print(f"error: unknown platform {platform_name!r}.")
+        sys.exit(1)
 
     # Prepare staging directory.
     out_root = Path(args.out_dir)
     if not out_root.is_absolute():
         out_root = (ROOT / out_root).resolve()
-    pkg_name = f"libyse-v{version}-{platform_name}-x64"
+    arch_suffix = "android" if platform_name == "android" else f"{platform_name}-x64"
+    pkg_name = f"libyse-v{version}-{arch_suffix}"
     stage = out_root / pkg_name
     if stage.exists():
         shutil.rmtree(stage)
@@ -698,7 +761,17 @@ def cmd_package(args):
         for d in bundled:
             shutil.copy2(d, out_bin / d.name)
         print(f"Bundled {len(bundled)} runtime DLL(s) into bin/.")
-    else:
+    elif platform_name == "android":
+        # JNI-convention lib/<abi>/libyse.so layout. Apps can drop the lib
+        # tree straight into src/main/jniLibs/.
+        out_lib = stage / "lib"
+        out_lib.mkdir()
+        for abi, so in abi_libs.items():
+            abi_dir = out_lib / abi
+            abi_dir.mkdir()
+            shutil.copy2(so, abi_dir / "libyse.so")
+            print(f"Copied lib/{abi}/libyse.so.")
+    else:  # linux
         out_lib = stage / "lib"
         out_lib.mkdir()
         shutil.copy2(shared, out_lib / shared.name)
@@ -763,6 +836,7 @@ def build_parser():
   python yse.py format             run clang-format on YseEngine/ and Tests/
   python yse.py package            build a release archive in dist/ (used by CI)
   python yse.py package --platform linux    explicit target platform
+  python yse.py package --platform android --android-libs <dir>   multi-ABI bundle from CI per-ABI artefacts
   python yse.py release patch      bump VERSION, commit, tag vX.Y.Z, push
   python yse.py release minor --dry-run     preview without writing
 """,
@@ -951,7 +1025,7 @@ def build_parser():
         ),
     )
     p.add_argument(
-        "--platform", choices=("auto", "linux", "windows"), default="auto",
+        "--platform", choices=("auto", "linux", "windows", "android"), default="auto",
         help="Target platform (default: derived from the host OS)",
     )
     p.add_argument(
@@ -961,6 +1035,15 @@ def build_parser():
     p.add_argument(
         "--out-dir", default="dist",
         help="Where to stage the package and write the archive (default: dist)",
+    )
+    # Android is special: each ABI is cross-compiled in its own CI job, then
+    # the package step consumes the downloaded artifacts. Each subdir under
+    # this directory is treated as one ABI (its name, stripped of an optional
+    # `android-libs-` prefix, becomes the ABI name in the bundle's lib/<abi>/
+    # layout). Ignored for non-android platforms.
+    p.add_argument(
+        "--android-libs", default="android-libs",
+        help="Directory of per-ABI libyse.so subdirs (android only; default: android-libs)",
     )
     p.set_defaults(func=cmd_package)
 


### PR DESCRIPTION
Patch release shipping three internal fixes since v2.1.0. No public C++ or C API surface changes.

## What's in this release

- **#46** — \`sound: drop stale __WINDOWS__ guards on lsfSoundfile load paths\` (\`5f5ca9d\`, PR #95). WAV / OGG / FLAC loading now works on Linux, macOS, and Android. Regression test in \`Tests/sound/test_sound_state.cpp\` waits up to 1 s for \`isReady()\` after creating a sound from the WAV fixture.
- **#82** (post-stop CPU cost investigation) — two follow-ups:
  - \`69cb391\` \`channel: skip fast-pool dispatch for empty child channels\` (PR #93). Eliminates the per-empty-child fast-pool dispatch overhead that the \`cpuLoad\` recovery test surfaced.
  - \`d4644df\` \`docs: retire the debunked WASAPI-artifact framing on cpuLoad\` (PR #94). Comment-only correction.

## Release tooling additions (PR #97 \u2014 already on dev)

- New \`.claude/skills/release\` skill orchestrating the libYSE release workflow.
- \`.gitignore\` exemption so \`.claude/skills/release/\` is not silently swallowed by the generic \`[Rr]elease/\` pattern.
- \`PROJECT_OVERVIEW.md\` meta-SHA bumped to the current HEAD.

## Test plan

- [x] C API drift audit since v2.1.0: clean — no public-header diff, enums unchanged.
- [x] \`python yse.py build --release\` clean.
- [ ] \`build.yml\` CI passes on this PR.
- [ ] \`release.yml\` fires on the v2.1.1 tag (after merge + bump) and uploads Linux x64, Windows x64, and Android multi-ABI archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)