### PR TITLE
Release v2.1.1

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -18,7 +18,7 @@
 #include <string>
 
 namespace YSE {
-  const std::string VERSION = "2.1.0";
+  const std::string VERSION = "2.1.1";
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *


### PR DESCRIPTION
Version bump for the v2.1.1 patch release.

Bumps \`VERSION\` in [YseEngine/system.hpp](YseEngine/system.hpp) from \`2.1.0\` to \`2.1.1\`. Released by \`python yse.py release patch\` — but routed through this PR because branch protection on \`master\` requires PR-based changes (and the previous release \`v2.1.0\` followed the same pattern via the \`release-v2.1.0\` branch \u2192 PR #87 path).

Substantive engine + release-prep changes came via PR #98 (dev \u2192 master, already merged). This PR carries only the bump commit so the \`v2.1.1\` tag can be pinned on a properly-PR'd master commit.

After merge, the tag \`v2.1.1\` will be pushed against the resulting master commit, which fires \`release.yml\` to build and publish the Linux x64, Windows x64, and Android multi-ABI archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)