### PR TITLE
Sync Release v2.1.1 bump back to dev

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -18,7 +18,7 @@
 #include <string>
 
 namespace YSE {
-  const std::string VERSION = "2.1.0";
+  const std::string VERSION = "2.1.1";
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *


### PR DESCRIPTION
Brings the v2.1.1 version-bump commit (\`0383c96\`) and its merge commit (\`e643221\`) back to \`dev\` so the two branches stay in sync after the release. Standard post-release housekeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)