### PR TITLE
docs: strip YSE_C_CALLBACK so Sphinx parses callback typedefs (#110)

### DIFF
--- a/documentation/Doxyfile
+++ b/documentation/Doxyfile
@@ -47,6 +47,7 @@ EXPAND_ONLY_PREDEF     = NO
 SKIP_FUNCTION_MACROS   = NO
 PREDEFINED             = YSE_API= \
                          YSE_BUILD_DLL= \
+                         YSE_C_CALLBACK= \
                          _WIN32
 
 # Only documented symbols are exposed. Undocumented entities disappear from


### PR DESCRIPTION
## Summary
- Add `YSE_C_CALLBACK=` to Doxyfile `PREDEFINED` so the Windows-only `__cdecl` calling-convention marker never reaches Sphinx's C++ domain.
- Callbacks (`YseLogCallback`, `YseMidiInRawCallback`, `YseMidiInParsedCallback`) now render as real C++ typedefs with anchors and cross-references; the three `Invalid C++ declaration` warnings from `sphinx-build` are gone.

## Test plan
- [x] `doxygen Doxyfile` regenerates XML — `typedef void(* YseLogCallback)(...)` (no `__cdecl`).
- [x] `sphinx-build -W --keep-going -b html source build/html` succeeds (warnings-as-errors).
- [x] Rendered `api/c_api.html`: each callback typedef has a `_CPPv4...` anchor and TOC entry; `*_set_callback` signatures include the mangled callback type name (cross-link target).
- [x] No `__cdecl` remains in the rendered c_api page.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)