### PR TITLE
Release v2.2.0

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -18,7 +18,7 @@
 #include <string>
 
 namespace YSE {
-  const std::string VERSION = "2.1.1";
+  const std::string VERSION = "2.2.0";
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *


### PR DESCRIPTION
Version bump for the v2.2.0 release. Routed through a PR because branch protection on master requires it (same path as release-v2.1.1 -> PR #99).