### PR TITLE
engine: global named bus primitive (#121)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,6 +1,6 @@
 <!-- META
-last_updated_commit: 115fa3d0e8671a8365098cd3f4bfc3292bc12042
-last_updated_at: 2026-05-21
+last_updated_commit: dc8fb40
+last_updated_at: 2026-05-22
 -->
 
 # YSE Sound Engine — Project Overview
@@ -355,6 +355,7 @@ Callback bridge conventions (atomic-swap callback pointer, no mutex, no malloc o
 - **Communication** — cross-thread state changes use a lock-free SPSC inbox (`utils/lfQueue.hpp`) between the main and audio threads. The audio thread never takes a mutex on the hot path.
 - **Lifecycle fences** — `OBJECT_DELETE_PENDING` handshake prevents the slow-pool deleter from freeing an impl while the audio thread still has it in `toLoad`; `connectedToParent` atomic flag coordinates parent-channel disconnect.
 - **Atomic wrappers:** `aBool`, `aInt`, `aUInt`, `aFlt` (thin `std::atomic<T>` aliases in `utils/atomicOps.hpp`).
+- **Global named bus** ([internal/namedBus.h](YseEngine/internal/namedBus.h)) — `INTERNAL::Bus()` is the by-name addressing substrate underneath the live-coding DSL (epic [#119](https://github.com/yvanvds/yse-soundengine/issues/119)). Subscribers register against UTF-8 names; publishes from the main thread dispatch synchronously, publishes from the audio thread (`T_DSP`) enqueue into a pre-sized SPSC `lfQueue` and are drained from `system::update()`. The audio-thread path is allocation-free and lock-free — only `int` and `float` payloads fit the pooled-message footprint (strings and lists from `T_DSP` are dropped silently). Subscription registration takes a `std::shared_mutex` and never runs on the audio thread. Lifetime is tied to `System::init` / `System::close`: state does not persist across sessions.
 
 ---
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(YSE_TEST_SOURCES
   music/test_motif.cpp
   listener/test_listener.cpp
   io/test_bufferIO.cpp
+  system/test_named_bus.cpp
   system/test_system_active_state.cpp
   integration/test_device.cpp
 )

--- a/Tests/system/test_named_bus.cpp
+++ b/Tests/system/test_named_bus.cpp
@@ -1,0 +1,205 @@
+// Tests for INTERNAL::NamedBus (issue #121).
+//
+// Covers:
+//   - subscribe → publish(T_GUI) → callback fires synchronously
+//   - subscribe → publish(T_DSP) → callback fires after drainPending
+//   - unsubscribe stops delivery
+//   - 1000 subscribers + 1000 audio-path publishes: no heap allocations
+//   - publish() to a name with no subscribers is a no-op (no allocation)
+//
+// Allocation probe: the operator-new replacement below is a "replaceable
+// allocation function" per [basic.stc.dynamic.allocation]. It counts calls
+// only while `g_alloc_probe_active` is true so the rest of the test binary
+// (doctest, STL, std::function, ...) is unaffected. The probe lives in this
+// TU because no other test needs it; if a future TU also wants it, lift the
+// probe into a shared header.
+
+#include <atomic>
+#include <cstdlib>
+#include <new>
+#include <string>
+#include <vector>
+
+#include <doctest/doctest.h>
+
+#include "yse.hpp"
+#include "internal/namedBus.h"
+#include "support/null_device.hpp"
+
+namespace {
+
+std::atomic<int>  g_alloc_count{0};
+std::atomic<bool> g_alloc_probe_active{false};
+
+struct ProbeScope {
+    ProbeScope()  { g_alloc_count = 0; g_alloc_probe_active = true; }
+    ~ProbeScope() { g_alloc_probe_active = false; }
+};
+
+} // namespace
+
+void* operator new(std::size_t n) {
+    if (g_alloc_probe_active.load(std::memory_order_relaxed))
+        g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+    if (void* p = std::malloc(n == 0 ? 1 : n)) return p;
+    throw std::bad_alloc{};
+}
+
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+
+TEST_SUITE("system") {
+
+TEST_CASE("named bus: subscribe then publish on T_GUI fires the callback synchronously") {
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    int received = 0;
+    auto h = bus.subscribe("ch.test.gui", [&](const YSE::INTERNAL::BusValue& v) {
+        if (auto* i = std::get_if<int>(&v)) received = *i;
+    });
+
+    bus.publish("ch.test.gui", YSE::INTERNAL::BusValue{42}, YSE::T_GUI);
+    CHECK(received == 42);
+
+    bus.unsubscribe(h);
+}
+
+TEST_CASE("named bus: T_DSP publish is queued and dispatched on drainPending") {
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    float received = 0.0f;
+    int   hits = 0;
+    auto h = bus.subscribe("ch.test.dsp", [&](const YSE::INTERNAL::BusValue& v) {
+        if (auto* f = std::get_if<float>(&v)) { received = *f; ++hits; }
+    });
+
+    bus.publish("ch.test.dsp", YSE::INTERNAL::BusValue{1.25f}, YSE::T_DSP);
+    // Not delivered synchronously — still 0.
+    CHECK(hits == 0);
+
+    bus.drainPending();
+    CHECK(hits == 1);
+    CHECK(received == doctest::Approx(1.25f));
+
+    bus.unsubscribe(h);
+}
+
+TEST_CASE("named bus: unsubscribe stops delivery on both paths") {
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    int count = 0;
+    auto h = bus.subscribe("ch.test.unsub", [&](const YSE::INTERNAL::BusValue&) { ++count; });
+
+    bus.publish("ch.test.unsub", YSE::INTERNAL::BusValue{1}, YSE::T_GUI);
+    CHECK(count == 1);
+
+    bus.unsubscribe(h);
+
+    bus.publish("ch.test.unsub", YSE::INTERNAL::BusValue{2}, YSE::T_GUI);
+    bus.publish("ch.test.unsub", YSE::INTERNAL::BusValue{3}, YSE::T_DSP);
+    bus.drainPending();
+    CHECK(count == 1);
+}
+
+TEST_CASE("named bus: publish to a name with no subscribers does not allocate") {
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    // Pre-construct the name so the probe scope only measures publish().
+    const std::string name = "ch.test.empty";
+
+    {
+        ProbeScope probe;
+        bus.publish(name, YSE::INTERNAL::BusValue{7}, YSE::T_GUI);
+        bus.publish(name, YSE::INTERNAL::BusValue{0.5f}, YSE::T_DSP);
+    }
+
+    CHECK(g_alloc_count.load() == 0);
+}
+
+TEST_CASE("named bus: audio-thread publish path does not allocate at scale") {
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    constexpr int kSubs     = 1000;
+    constexpr int kPublishes = 1000;
+
+    // Register 1000 subscribers spread across a few names. Pre-allocate the
+    // handles vector outside the probe so the probe only sees publish().
+    std::vector<YSE::INTERNAL::SubHandle> handles;
+    handles.reserve(kSubs);
+
+    int hits = 0;
+    auto cb = [&](const YSE::INTERNAL::BusValue&) { ++hits; };
+
+    const std::string nameA = "ch.scale.a";
+    const std::string nameB = "ch.scale.b";
+
+    for (int i = 0; i < kSubs; ++i) {
+        handles.push_back(bus.subscribe((i & 1) ? nameA : nameB, cb));
+    }
+
+    YSE::INTERNAL::BusValue intVal{99};
+    YSE::INTERNAL::BusValue fltVal{0.25f};
+
+    {
+        ProbeScope probe;
+        for (int i = 0; i < kPublishes; ++i) {
+            bus.publish((i & 1) ? nameA : nameB,
+                        (i & 1) ? intVal : fltVal,
+                        YSE::T_DSP);
+        }
+    }
+
+    CHECK(g_alloc_count.load() == 0);
+
+    bus.drainPending();
+    // Sanity check that the messages actually made it through. Half of the
+    // 1000 publishes go to nameA (500 subscribers each), the other half to
+    // nameB (500 subscribers each) — so 1000 * 500 == 500'000 dispatches.
+    CHECK(hits == kPublishes * (kSubs / 2));
+
+    for (auto h : handles) bus.unsubscribe(h);
+}
+
+TEST_CASE("named bus: T_DSP publish drops string/list payloads silently") {
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    int hits = 0;
+    auto h = bus.subscribe("ch.test.dsp.drop", [&](const YSE::INTERNAL::BusValue&) { ++hits; });
+
+    // String and list payloads on T_DSP exceed the pooled-message footprint
+    // and must be dropped silently rather than queued.
+    bus.publish("ch.test.dsp.drop", YSE::INTERNAL::BusValue{std::string("nope")}, YSE::T_DSP);
+    bus.publish("ch.test.dsp.drop", YSE::INTERNAL::BusValue{std::vector<float>{1.0f, 2.0f}}, YSE::T_DSP);
+    bus.drainPending();
+    CHECK(hits == 0);
+
+    // Sanity: the same payload still delivers on T_GUI.
+    bus.publish("ch.test.dsp.drop", YSE::INTERNAL::BusValue{std::string("ok")}, YSE::T_GUI);
+    CHECK(hits == 1);
+
+    bus.unsubscribe(h);
+}
+
+TEST_CASE("named bus: duplicate subscriptions on a name each get called") {
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    int a = 0, b = 0;
+    auto h1 = bus.subscribe("ch.test.dup", [&](const YSE::INTERNAL::BusValue&) { ++a; });
+    auto h2 = bus.subscribe("ch.test.dup", [&](const YSE::INTERNAL::BusValue&) { ++b; });
+
+    bus.publish("ch.test.dup", YSE::INTERNAL::BusValue{1}, YSE::T_GUI);
+    CHECK(a == 1);
+    CHECK(b == 1);
+
+    bus.unsubscribe(h1);
+    bus.unsubscribe(h2);
+}
+
+} // TEST_SUITE("system")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -52,6 +52,7 @@ set(YSE_SRCS
   internal/customFileReader.cpp
   internal/global.cpp
   internal/lsfSoundfile.cpp
+  internal/namedBus.cpp
   internal/reverbDSP.cpp
   internal/settings.cpp
   internal/thread.cpp

--- a/YseEngine/YseEngine.vcxitems
+++ b/YseEngine/YseEngine.vcxitems
@@ -72,6 +72,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)internal\customFileReader.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)internal\global.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)internal\lsfSoundfile.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)internal\namedBus.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)internal\reverbDSP.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)internal\settings.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)internal\thread.h" />
@@ -241,6 +242,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)internal\customFileReader.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)internal\global.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)internal\lsfSoundfile.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)internal\namedBus.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)internal\reverbDSP.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)internal\settings.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)internal\thread.cpp" />

--- a/YseEngine/YseEngine.vcxitems.filters
+++ b/YseEngine/YseEngine.vcxitems.filters
@@ -253,6 +253,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)internal\lsfSoundfile.h">
       <Filter>internal</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)internal\namedBus.h">
+      <Filter>internal</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)internal\reverbDSP.h">
       <Filter>internal</Filter>
     </ClInclude>
@@ -735,6 +738,9 @@
       <Filter>internal</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)internal\lsfSoundfile.cpp">
+      <Filter>internal</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)internal\namedBus.cpp">
       <Filter>internal</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)internal\reverbDSP.cpp">

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -9,6 +9,7 @@
 */
 
 #include "../internalHeaders.h"
+#include "namedBus.h"
 
 
 YSE::INTERNAL::global & YSE::INTERNAL::Global() {
@@ -24,14 +25,29 @@ void YSE::INTERNAL::global::addFastJob(threadPoolJob * job) {
   fastThreads.addJob(job);
 }
 
-YSE::INTERNAL::global::global() : slowThreads(1), fastThreads(), update(false), active(false), sampleRateLocked(false) {}
+YSE::INTERNAL::NamedBus& YSE::INTERNAL::global::namedBus() {
+  // Tied to System::init / System::close lifecycle — callers must respect
+  // that contract. Asserting (rather than lazy-creating) keeps the
+  // "no persistence across init/close" guarantee from issue #121 honest.
+  assert(bus && "INTERNAL::Global().namedBus() accessed outside of an active engine session");
+  return *bus;
+}
+
+YSE::INTERNAL::global::global() : slowThreads(1), fastThreads(), bus(), update(false), active(false), sampleRateLocked(false) {}
+
+YSE::INTERNAL::global::~global() = default;
 
 void YSE::INTERNAL::global::init() {
   REVERB::Manager().create();
+  bus = std::make_unique<NamedBus>();
 }
 
 void YSE::INTERNAL::global::close() {
   // first wait for all threads to exit
   slowThreads.shutdown();
   fastThreads.shutdown();
+  // Tear down the bus last — by this point the audio device is already
+  // closed (system::close() ran DEVICE::Manager().close() before us), so
+  // no audio-thread producer can still be enqueuing publish() messages.
+  bus.reset();
 }

--- a/YseEngine/internal/global.h
+++ b/YseEngine/internal/global.h
@@ -11,14 +11,18 @@
 #ifndef GLOBAL_H_INCLUDED
 #define GLOBAL_H_INCLUDED
 
+#include <memory>
+
 #include "../headers/types.hpp"
 #include "../classes.hpp"
 #include "threadPool.h"
 
-namespace YSE {  
-    
+namespace YSE {
+
   namespace INTERNAL {
-    
+
+    class NamedBus;
+
     class global {
     public:
       bool isActive() { return active; }
@@ -40,7 +44,14 @@ namespace YSE {
       bool needsUpdate() { return update > 0;  }
       void updateDone() { update--; }
 
+      // Global named bus (issue #121). Constructed lazily in init() and
+      // destroyed in close() so subscribers, the SPSC queue, and the next
+      // handle counter do not persist across an init/close cycle. Calling
+      // namedBus() before init() or after close() is a programming error.
+      NamedBus& namedBus();
+
       global();
+      ~global();
 
 
     private:
@@ -49,6 +60,8 @@ namespace YSE {
 
       threadPool slowThreads;
       threadPool fastThreads;
+
+      std::unique_ptr<NamedBus> bus;
 
       aInt update;
       aBool active; // set true after System().init(), false at System().close()

--- a/YseEngine/internal/namedBus.cpp
+++ b/YseEngine/internal/namedBus.cpp
@@ -1,0 +1,115 @@
+/*
+  ==============================================================================
+
+    namedBus.cpp
+    Created: 2026-05-22
+
+  ==============================================================================
+*/
+
+#include "../internalHeaders.h"
+#include "namedBus.h"
+
+#include <algorithm>
+
+namespace YSE {
+  namespace INTERNAL {
+
+    NamedBus::NamedBus() : audioQueue_(kQueueCapacity) {}
+
+    NamedBus::~NamedBus() = default;
+
+    NamedBus& Bus() {
+      return Global().namedBus();
+    }
+
+    void NamedBus::publish(const std::string& name, const BusValue& value, YSE::THREAD thread) {
+      if (thread == T_DSP) {
+        // Audio-thread path: must not allocate, must not lock. The queue entry
+        // has a fixed footprint, so we accept only int and float.
+        PooledMessage msg;
+        if (const int* ip = std::get_if<int>(&value)) {
+          msg.kind = PooledMessage::Kind::Int;
+          msg.value.i = *ip;
+        } else if (const float* fp = std::get_if<float>(&value)) {
+          msg.kind = PooledMessage::Kind::Float;
+          msg.value.f = *fp;
+        } else {
+          // Unsupported payload on the audio path. Drop silently — callers
+          // route strings and lists through the main-thread publish path.
+          return;
+        }
+
+        const std::size_t n = name.size() < kNameCapacity ? name.size() : kNameCapacity;
+        std::memcpy(msg.nameStorage, name.data(), n);
+        msg.nameStorage[n] = '\0';
+
+        // try_push never allocates; if the queue is saturated the message is
+        // dropped rather than blocking the audio callback.
+        audioQueue_.try_push(msg);
+        return;
+      }
+
+      // Main-thread / GUI path: synchronous dispatch.
+      dispatch(name, value);
+    }
+
+    SubHandle NamedBus::subscribe(const std::string& name, Subscriber callback) {
+      const SubHandle handle = nextHandle_.fetch_add(1, std::memory_order_relaxed);
+      std::unique_lock lock(subsMutex_);
+      subs_[name].push_back(Subscription{ handle, std::move(callback) });
+      handleIndex_.emplace(handle, name);
+      return handle;
+    }
+
+    void NamedBus::unsubscribe(SubHandle handle) {
+      std::unique_lock lock(subsMutex_);
+      auto idxIt = handleIndex_.find(handle);
+      if (idxIt == handleIndex_.end()) return;
+      auto subsIt = subs_.find(idxIt->second);
+      if (subsIt != subs_.end()) {
+        auto& list = subsIt->second;
+        list.erase(
+          std::remove_if(list.begin(), list.end(),
+            [handle](const Subscription& s) { return s.handle == handle; }),
+          list.end());
+        if (list.empty()) {
+          subs_.erase(subsIt);
+        }
+      }
+      handleIndex_.erase(idxIt);
+    }
+
+    void NamedBus::drainPending() {
+      PooledMessage msg;
+      while (audioQueue_.try_pop(msg)) {
+        BusValue value;
+        switch (msg.kind) {
+          case PooledMessage::Kind::Int:   value = msg.value.i; break;
+          case PooledMessage::Kind::Float: value = msg.value.f; break;
+        }
+        dispatch(std::string(msg.nameStorage), value);
+      }
+    }
+
+    void NamedBus::dispatch(const std::string& name, const BusValue& value) {
+      // Copy out the matching callbacks under the shared lock, then invoke
+      // them with the lock released. This lets a subscriber call back into
+      // subscribe()/unsubscribe() without self-deadlock.
+      std::vector<Subscriber> callbacks;
+      {
+        std::shared_lock lock(subsMutex_);
+        auto it = subs_.find(name);
+        if (it == subs_.end()) return;
+        callbacks.reserve(it->second.size());
+        for (const auto& sub : it->second) {
+          callbacks.push_back(sub.callback);
+        }
+      }
+      for (auto& cb : callbacks) {
+        cb(value);
+      }
+    }
+
+  } // namespace INTERNAL
+} // namespace YSE

--- a/YseEngine/internal/namedBus.h
+++ b/YseEngine/internal/namedBus.h
@@ -1,0 +1,108 @@
+/*
+  ==============================================================================
+
+    namedBus.h
+    Created: 2026-05-22
+
+    Global named-bus addressing primitive (issue #121, epic #119).
+
+    Engine-internal only. Subscribers register against a UTF-8 string name and
+    receive callbacks when any producer publishes a matching value. Producers
+    on the main thread dispatch synchronously; producers on the audio thread
+    enqueue into a lock-free SPSC queue that is drained from `system::update()`.
+
+  ==============================================================================
+*/
+
+#ifndef NAMED_BUS_H_INCLUDED
+#define NAMED_BUS_H_INCLUDED
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "../headers/enums.hpp"
+#include "../utils/lfQueue.hpp"
+
+namespace YSE {
+  namespace INTERNAL {
+
+    using BusValue = std::variant<std::monostate, int, float, std::string, std::vector<float>>;
+    using SubHandle = std::uint64_t;
+    using Subscriber = std::function<void(const BusValue&)>;
+
+    class NamedBus {
+    public:
+      NamedBus();
+      ~NamedBus();
+
+      NamedBus(const NamedBus&) = delete;
+      NamedBus& operator=(const NamedBus&) = delete;
+
+      // Publish a value to `name`.
+      //
+      //   thread == T_GUI : dispatch synchronously to every subscriber.
+      //   thread == T_DSP : enqueue into the lock-free SPSC queue. The queue
+      //                     entry has a fixed footprint, so only int and float
+      //                     values are accepted on the audio path. String /
+      //                     list / monostate publishes from T_DSP are dropped
+      //                     silently (no allocation, no log) — composers route
+      //                     non-trivial payloads through main-thread bridges.
+      //                     Names longer than `kNameCapacity` bytes are
+      //                     truncated; producers must keep names short.
+      void publish(const std::string& name, const BusValue& value, YSE::THREAD thread);
+
+      // Register a subscriber for `name`. The returned handle is unique for
+      // the lifetime of the bus and can be passed to `unsubscribe()`.
+      SubHandle subscribe(const std::string& name, Subscriber callback);
+
+      // Drop the subscription that owns `handle`. No-op if the handle is
+      // unknown (e.g. already unsubscribed, or never issued).
+      void unsubscribe(SubHandle handle);
+
+      // Drain the audio-thread queue and dispatch each message. Must run on
+      // the same thread that registers subscribers (main / update thread).
+      // Called once per `system::update()` tick.
+      void drainPending();
+
+      static constexpr std::size_t kNameCapacity = 63;  // null terminator follows
+      static constexpr std::size_t kQueueCapacity = 1024;
+
+    private:
+      struct PooledMessage {
+        enum class Kind : std::uint8_t { Int = 1, Float = 2 };
+        Kind kind { Kind::Int };
+        char nameStorage[kNameCapacity + 1] {};
+        union {
+          int i;
+          float f;
+        } value {};
+      };
+
+      struct Subscription {
+        SubHandle handle;
+        Subscriber callback;
+      };
+
+      void dispatch(const std::string& name, const BusValue& value);
+
+      lfQueue<PooledMessage> audioQueue_;
+      mutable std::shared_mutex subsMutex_;
+      std::unordered_map<std::string, std::vector<Subscription>> subs_;
+      std::unordered_map<SubHandle, std::string> handleIndex_;
+      std::atomic<SubHandle> nextHandle_ { 1 };
+    };
+
+    NamedBus& Bus();
+
+  } // namespace INTERNAL
+} // namespace YSE
+
+#endif  // NAMED_BUS_H_INCLUDED

--- a/YseEngine/internalHeaders.h
+++ b/YseEngine/internalHeaders.h
@@ -58,6 +58,7 @@
 #include "implementations/logImplementation.h"
 
 #include "internal/global.h"
+#include "internal/namedBus.h"
 #include "internal/reverbDSP.h"
 #include "internal/settings.h"
 

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -86,6 +86,10 @@ Bool YSE::system::initShared(bool openDevice) {
 
 void YSE::system::update() {
   INTERNAL::Global().flagForUpdate();
+  // Drain any publishes the audio thread queued since the last update tick
+  // and dispatch them synchronously to their subscribers. Cheap when empty:
+  // a single SPSC peek + early exit.
+  INTERNAL::Global().namedBus().drainPending();
 	unsigned int callbacks = DEVICE::Manager().GetCallbacksSinceLastUpdate();
 	if (callbacks == 0) {
 		currentlyMissedCallbacks++;


### PR DESCRIPTION
Closes #121. Part of epic #119.

## Summary

- New `INTERNAL::NamedBus` ([YseEngine/internal/namedBus.h](YseEngine/internal/namedBus.h), [.cpp](YseEngine/internal/namedBus.cpp)) — the by-name addressing substrate the live-coding DSL needs before any patcher / sound-property / Python integration can land.
- Owned by `INTERNAL::Global()`, created in `init()`, destroyed in `close()` — no state persists across `System::init / System::close` cycles.
- `system::update()` calls `drainPending()` once per tick to deliver audio-thread publishes synchronously to their subscribers.

## Design

- `publish(name, value, T_GUI)` dispatches synchronously to every matching subscriber (with the subscribers vector copied under a `std::shared_mutex` shared lock so callbacks can safely re-enter `subscribe`/`unsubscribe`).
- `publish(name, value, T_DSP)` enqueues into a pre-sized SPSC `lfQueue<PooledMessage>` (capacity 1024). The pooled message has a fixed footprint — name truncated to 63 bytes + a tagged int/float union — so the queue entry has no heap-owned members. `try_push` is used, so a saturated queue drops the message rather than allocating or blocking.
- String / list payloads from `T_DSP` exceed the pooled footprint and are dropped silently (callers route those through the main-thread publish path).
- `subscribe` / `unsubscribe` take an exclusive `std::shared_mutex` lock and are never called from the audio thread. Handles are unique 64-bit integers; duplicate subscriptions on the same name are permitted (each fires).

## Acceptance — issue checklist

| Item | Status |
|------|--------|
| `INTERNAL::NamedBus` integrated into `INTERNAL::Global()` lifecycle | ✅ |
| `system::update()` calls `drainPending()` | ✅ |
| subscribe → publish (T_GUI) → callback fires synchronously | ✅ test |
| subscribe → publish (T_DSP) → callback fires after `drainPending` | ✅ test |
| Unsubscribe stops delivery on both paths | ✅ test |
| 1000 subscribers + 1000 audio publishes: zero heap allocations | ✅ test (operator-new replacement probe) |
| Publish to a name with no subscribers is a no-op (no allocation) | ✅ test |
| `PROJECT_OVERVIEW.md` updated under "Threading & Concurrency Model" | ✅ |
| clang-tidy clean on new files (no new findings vs. baseline) | ✅ `yse.py analyze` ran clean |

## Test plan

- [x] `python yse.py build` — debug build clean
- [x] `python yse.py test` — full doctest suite green (`yse_tests_system` includes 7 new test cases / 20 assertions)
- [x] `python yse.py analyze YseEngine/internal/namedBus.cpp` (and the other touched TUs) — no new findings
- [ ] CI: Linux build + SonarCloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)