### PR TITLE
infra: embed CPython interpreter behind YSE_ENABLE_PYTHON (#124)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ build-linux-audio/
 build-android-arm64/
 build-android-x86_64/
 build-tools/
+build-python-tests/
 [Bb]in/
 [Oo]bj/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,18 @@ option(YSE_BUILD_C_API
 option(YSE_BUILD_TOOLS
   "Build developer tools (e.g. dump_patcher_meta — regenerates documentation/source/_data/patcher_objects.json). OFF in CI/release builds; turned on automatically by `python yse.py dump-patcher-meta`."
   OFF)
+# YSE_ENABLE_PYTHON: embed a CPython interpreter for the live-coding DSL
+# (epic #119, infra issue #124). Desktop only — Android is explicitly
+# unsupported and fails fast below. OFF by default: when OFF, no Python
+# headers, symbols, or runtime cost enter the build (byte-for-byte equivalent
+# to a build without this option). Sourcing/isolation details live in
+# cmake/YsePython.cmake; the interpreter lifecycle lives in YseEngine/python/.
+option(YSE_ENABLE_PYTHON
+  "Embed CPython interpreter for the live-coding DSL (desktop only)"
+  OFF)
+if(YSE_ENABLE_PYTHON AND ANDROID)
+  message(FATAL_ERROR "YSE_ENABLE_PYTHON is not supported on Android.")
+endif()
 # YSE_ENABLE_MIDI_DEVICE: gate the RtMidi-backed MIDI device backend. Default
 # ON on Windows/Linux desktop (preserves the prior unconditional behavior),
 # OFF on Android (RtMidi isn't built there anyway) and Mac (already excluded
@@ -62,6 +74,13 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ── Dependencies ──────────────────────────────────────────────────────────────
 find_package(Threads REQUIRED)
+
+# Embedded CPython (issue #124). Resolved here so the imported target and
+# YSE_PYTHON_HOME are visible to the YseEngine/ and Tests/ subdirectories. The
+# Android case has already been rejected with a FATAL_ERROR above.
+if(YSE_ENABLE_PYTHON)
+  include(${CMAKE_SOURCE_DIR}/cmake/YsePython.cmake)
+endif()
 
 if(ANDROID)
   # 16 KB page size compatibility — Pixel 8/9 and Android 15 QPR1+ devices may

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -102,8 +102,18 @@ Direct `cmake -B build ...` invocations remain fully valid — the presets are a
 | `YSE_NATIVE_ARCH` | OFF | `-march=native` (local dev only — not distributable) |
 | `YSE_ENABLE_COVERAGE` | OFF | gcov/gcovr coverage; forces `YSE_BUILD_TESTS=ON`; Linux only (GCC/Clang) |
 | `YSE_LLVM_COVERAGE` | OFF | LLVM source-based coverage (`-fprofile-instr-generate`); Clang only — mutually exclusive with `YSE_ENABLE_COVERAGE` |
+| `YSE_ENABLE_PYTHON` | OFF | Embed a CPython interpreter for the live-coding DSL (desktop only; fatal error on Android). OFF is byte-for-byte equivalent to a build without the option. See **Python embedding** below |
 
 `CMAKE_EXPORT_COMPILE_COMMANDS=ON` is set unconditionally so `compile_commands.json` is always generated for clangd and SonarCloud.
+
+### Python embedding (`YSE_ENABLE_PYTHON`)
+
+Optional embedded CPython for the live-coding DSL (epic [#119](https://github.com/yvanvds/yse-soundengine/issues/119); this infrastructure is issue [#124](https://github.com/yvanvds/yse-soundengine/issues/124)). **Desktop only** — enabling it on Android is a configure-time `FATAL_ERROR`. **OFF by default**, and when OFF no Python headers, symbols, or runtime cost enter the build.
+
+- **Sourcing (Option C).** `cmake/YsePython.cmake` locates a system / prebuilt libpython via `find_package(Python3 ≥ 3.10 COMPONENTS Development.Embed)` and links it into `yse_objects`. On MSYS2 Clang64 discovery is anchored to the toolchain's own Python (the `clang++` prefix) so the ABI-matched `libpython3.x.dll.a` is used rather than a registry MSVC install. This **deviates** from the issue's "FetchContent + static + build-time-frozen stdlib" wording: CPython ships no CMake build and does not build under Clang64. Practical consequences: linkage is whatever the platform provides (typically **shared** libpython — deployments must ship/locate it at runtime); the interpreter **version follows the host** (not a pinned 3.12.x).
+- **Runtime isolation instead of a build-time freeze.** `INTERNAL::ScriptRuntime` (`YseEngine/python/`) boots the interpreter with an *isolated* `PyConfig` — no environment, no user site, signal handlers off (the `Py_InitializeEx(0)` intent), and `site_import = 0` so site-packages (and therefore any third-party package) is never importable. `PyConfig.home` is anchored to the located install (`YSE_PYTHON_HOME`) so the standard library still resolves. Net: the epic's "no third-party packages" tenet holds; "curated frozen subset / empty `sys.path`" becomes "full stdlib of the located interpreter, isolated from site-packages".
+- **Lifecycle & threading.** The runtime is a process-global owned in `global.cpp` (kept out of `global.h` so the header carries no Python type and no macro-dependent layout). `system::init` boots it after the audio device opens (`startScripting`), `system::update` wakes it once per tick (`wakeScripting`), `system::close` finalizes it before the device closes (`stopScripting`). A dedicated script thread (subclassing `INTERNAL::thread`) holds the GIL on wake and services two lock-free SPSC queues — inbound `EvalRequest` (source `exec`'d in `__main__`) and outbound `EvalResult` (status + `traceback.format_exception` text). The user-facing `yse_run_script` C API and the `yse` Python module are **not** part of this layer (issues #125 / #126).
+- **No CI by default.** No preset enables `YSE_ENABLE_PYTHON`; existing builds are unaffected. Local enable, e.g. `cmake -S . -B build-python -DYSE_BUILD_TESTS=ON -DYSE_ENABLE_PYTHON=ON` then run `yse_tests --test-suite=python` (the `yse_tests_python` CTest entry). The 50× init/finalize leak case is meaningful when run in that isolated process (the suite owns the interpreter); inside the full binary it attaches to an already-booted interpreter instead.
 
 **Compiler flags (GCC/Clang):** `-Wall -Wextra -Wpedantic`, plus `-O3 -fno-math-errno` (Release). `-ffast-math` is **deliberately not used** — it breaks IEEE 754 semantics in ways that produce subtle DSP bugs (NaN propagation, denormal flushing). Linux/macOS builds use `CXX_VISIBILITY_PRESET hidden` + per-symbol `API` annotations — issue [#34](https://github.com/yvanvds/yse-soundengine/issues/34) was closed in commit `e080c16`.
 
@@ -123,6 +133,9 @@ pacman -S mingw-w64-clang-x86_64-portaudio \
 sudo apt install cmake ninja-build clang \
                  libportaudio-dev libsndfile1-dev librtmidi-dev
 ```
+
+For `YSE_ENABLE_PYTHON=ON` add the Python embedding headers + libpython:
+`mingw-w64-clang-x86_64-python` (MSYS2 Clang64) or `python3-dev` (Debian/Ubuntu).
 
 **Android (NDK):** No pkg-config in the sysroot. libsndfile is fetched from source (1.2.2, WAV-only, no external codec libs), Oboe is fetched at tag 1.9.3, RtMidi is not used. Link options include `-Wl,-z,max-page-size=16384` for Android 15+ 16 KB page-size compatibility (Play Store requirement, Nov 2025+).
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -58,6 +58,13 @@ set(YSE_TEST_SOURCES
   integration/test_device.cpp
 )
 
+# Embedded-CPython runtime tests (issue #124) — only when the option is ON.
+# The TU is guarded by YSE_ENABLE_PYTHON, which propagates from yse_objects
+# (defined PUBLIC there) to this target via the yse_objects link below.
+if(YSE_ENABLE_PYTHON)
+  list(APPEND YSE_TEST_SOURCES python/test_script_runtime.cpp)
+endif()
+
 if(ANDROID)
   # NativeActivity dynamically loads the test runner as libyse_tests.so. The
   # NDK ships android_native_app_glue (translates ANativeActivity callbacks
@@ -197,6 +204,17 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_system PROPERTIES LABELS system)
+
+# Embedded-CPython runtime suite (issue #124). Only present when the option is
+# ON; otherwise the suite has no test cases and registering it would fail.
+if(YSE_ENABLE_PYTHON)
+  add_test(
+    NAME    yse_tests_python
+    COMMAND yse_tests --test-suite=python
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+  )
+  set_tests_properties(yse_tests_python PROPERTIES LABELS python)
+endif()
 
 # Concurrency stress tests for the SOUND/CHANNEL/REVERB managers.  These live
 # in the sound/channel/reverb test suites but each test case name starts with

--- a/Tests/python/test_script_runtime.cpp
+++ b/Tests/python/test_script_runtime.cpp
@@ -1,0 +1,120 @@
+// Tests for the embedded-CPython script runtime (issue #124, epic #119).
+//
+// These only build when YSE_ENABLE_PYTHON is ON (the source is added to the
+// suite conditionally in Tests/CMakeLists.txt); the macro guard is
+// belt-and-suspenders.
+//
+// The runtime is driven directly through its public surface rather than via
+// the engine, so the cases need no audio device and run on CI. They also never
+// init or close the engine, so they coexist safely inside the shared test
+// binary alongside suites that do.
+//
+// Interpreter ownership adapts to context (see ScriptRuntime::start): run in
+// isolation — e.g. the `yse_tests_python` ctest entry's
+// `yse_tests --test-suite=python`, which is the process the ASan job drives —
+// no engine is up, so each locally-constructed runtime owns the interpreter and
+// the 50-cycle case genuinely exercises Py_Initialize/Py_Finalize re-entry. Run
+// inside the full binary after another suite has booted the engine (and, on a
+// YSE_ENABLE_PYTHON build, Python), the runtimes attach to the live interpreter
+// instead; the evals still execute and the cases still pass.
+
+#if YSE_ENABLE_PYTHON
+
+#include <doctest/doctest.h>
+
+#include "yse.hpp"
+#include "python/scriptRuntime.h"
+
+namespace {
+
+using YSE::INTERNAL::EvalResult;
+using YSE::INTERNAL::EvalStatus;
+using YSE::INTERNAL::ScriptRuntime;
+
+// The worker processes a pushed request as soon as it is notified; poll the
+// outbound queue with a bounded wait rather than guessing a fixed delay.
+bool waitForResult(ScriptRuntime& rt, EvalResult& out,
+                   int tries = 300, unsigned int sleepMs = 10) {
+    for (int i = 0; i < tries; ++i) {
+        if (rt.tryPopResult(out)) return true;
+        YSE::System().sleep(sleepMs);
+    }
+    return false;
+}
+
+} // namespace
+
+TEST_SUITE("python") {
+
+TEST_CASE("python: a successful eval reports Ok") {
+    ScriptRuntime rt;
+    rt.start();
+
+    rt.pushEval("result = 1 + 1");
+
+    EvalResult out;
+    REQUIRE(waitForResult(rt, out));
+    CHECK(out.status == EvalStatus::Ok);
+    CHECK(out.traceback.empty());
+
+    rt.stop();
+}
+
+TEST_CASE("python: a raised exception reports Error with a traceback") {
+    ScriptRuntime rt;
+    rt.start();
+
+    rt.pushEval("raise ValueError('boom')");
+
+    EvalResult out;
+    REQUIRE(waitForResult(rt, out));
+    CHECK(out.status == EvalStatus::Error);
+    // The DSL spec mandates traceback.format_exception output; the final line
+    // carries the type and message regardless of formatting details.
+    CHECK(out.traceback.find("ValueError: boom") != std::string::npos);
+
+    rt.stop();
+}
+
+TEST_CASE("python: requests queued before stop() are still drained") {
+    ScriptRuntime rt;
+    rt.start();
+
+    rt.pushEval("a = 41");
+    rt.pushEval("b = a + 1");
+
+    EvalResult first;
+    REQUIRE(waitForResult(rt, first));
+    CHECK(first.status == EvalStatus::Ok);
+    EvalResult second;
+    REQUIRE(waitForResult(rt, second));
+    CHECK(second.status == EvalStatus::Ok);
+
+    rt.stop();
+}
+
+TEST_CASE("python: 50 init->close cycles boot and finalize cleanly") {
+    // Exercises Py_Initialize/Py_Finalize re-entry in one process. Under ASan
+    // this is the leak check from the issue's acceptance criteria.
+    for (int i = 0; i < 50; ++i) {
+        ScriptRuntime rt;
+        rt.start();
+        rt.pushEval("cycle = 1 + 1");
+        EvalResult out;
+        REQUIRE(waitForResult(rt, out));
+        CHECK(out.status == EvalStatus::Ok);
+        rt.stop();
+    }
+}
+
+// NOTE: the real engine wiring (System::initOffline -> startScripting,
+// update -> wakeScripting, close -> stopScripting) is intentionally NOT
+// exercised here. Driving System init/close from a shared-process test trips a
+// pre-existing reverb teardown assertion on re-init (issue #132), unrelated to
+// Python. The wiring is a thin pass-through to ScriptRuntime, which these
+// cases cover directly; the engine-level boot is validated manually until #132
+// makes repeated init/close safe.
+
+} // TEST_SUITE("python")
+
+#endif  // YSE_ENABLE_PYTHON

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -164,6 +164,15 @@ if(YSE_ENABLE_MIDI_DEVICE)
   )
 endif()
 
+# Embedded-CPython script runtime (issue #124). Only compiled when the option
+# is ON; the TU also carries an internal `#if YSE_ENABLE_PYTHON` guard so an
+# accidental inclusion produces an empty object file.
+if(YSE_ENABLE_PYTHON)
+  list(APPEND YSE_SRCS
+    python/scriptRuntime.cpp
+  )
+endif()
+
 # ── Source-file-scoped warning suppressions ───────────────────────────────────
 # cJSON is a vendored C file; suppress all its warnings rather than patching it.
 set_source_files_properties(json/cJSON.cpp
@@ -328,6 +337,18 @@ endif()
 # of every layer (engine, C API, public headers, tests).
 if(YSE_ENABLE_MIDI_DEVICE)
   target_compile_definitions(yse_objects PUBLIC YSE_ENABLE_MIDI_DEVICE=1)
+endif()
+
+# Embedded CPython (issue #124). Python3::Python is linked PUBLIC so the
+# consuming targets (the `yse` shared library and the `yse_tests` executable,
+# which both pull in yse_objects) inherit libpython at link time. The
+# YSE_ENABLE_PYTHON macro is PUBLIC so yse_tests — which links yse_objects
+# directly — sees it too. YSE_PYTHON_HOME is engine-private: only
+# scriptRuntime.cpp consumes it.
+if(YSE_ENABLE_PYTHON)
+  target_link_libraries(yse_objects PUBLIC Python3::Python)
+  target_compile_definitions(yse_objects PUBLIC YSE_ENABLE_PYTHON=1)
+  target_compile_definitions(yse_objects PRIVATE "YSE_PYTHON_HOME=\"${YSE_PYTHON_HOME}\"")
 endif()
 
 # External deps are PUBLIC so both yse (SHARED) and yse_tests inherit them.

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -11,6 +11,18 @@
 #include "../internalHeaders.h"
 #include "namedBus.h"
 
+#if YSE_ENABLE_PYTHON
+#include "../python/scriptRuntime.h"
+#include <memory>
+namespace {
+  // Process-global script runtime, owned here rather than as a global:: member
+  // so global.h stays free of any Python type and its layout never depends on
+  // YSE_ENABLE_PYTHON (which would otherwise be an ODR hazard between engine
+  // and test translation units).
+  std::unique_ptr<YSE::INTERNAL::ScriptRuntime> g_scriptRuntime;
+}
+#endif
+
 
 YSE::INTERNAL::global & YSE::INTERNAL::Global() {
     static global s;
@@ -31,6 +43,30 @@ YSE::INTERNAL::NamedBus& YSE::INTERNAL::global::namedBus() {
   // "no persistence across init/close" guarantee from issue #121 honest.
   assert(bus && "INTERNAL::Global().namedBus() accessed outside of an active engine session");
   return *bus;
+}
+
+void YSE::INTERNAL::global::startScripting() {
+#if YSE_ENABLE_PYTHON
+  if (!g_scriptRuntime) {
+    g_scriptRuntime = std::make_unique<ScriptRuntime>();
+  }
+  g_scriptRuntime->start();
+#endif
+}
+
+void YSE::INTERNAL::global::wakeScripting() {
+#if YSE_ENABLE_PYTHON
+  if (g_scriptRuntime) g_scriptRuntime->wake();
+#endif
+}
+
+void YSE::INTERNAL::global::stopScripting() {
+#if YSE_ENABLE_PYTHON
+  if (g_scriptRuntime) {
+    g_scriptRuntime->stop();
+    g_scriptRuntime.reset();
+  }
+#endif
 }
 
 YSE::INTERNAL::global::global() : slowThreads(1), fastThreads(), bus(), update(false), active(false), sampleRateLocked(false) {}

--- a/YseEngine/internal/global.h
+++ b/YseEngine/internal/global.h
@@ -50,6 +50,16 @@ namespace YSE {
       // namedBus() before init() or after close() is a programming error.
       NamedBus& namedBus();
 
+      // Embedded-CPython lifecycle (issue #124). These are no-ops unless the
+      // engine was built with YSE_ENABLE_PYTHON; the interpreter and the
+      // script thread it owns are file-static in global.cpp so this header
+      // carries no Python dependency and no macro-dependent layout. Called by
+      // system::init / update / close around the audio-device boundary —
+      // start after the device opens, stop before it closes.
+      void startScripting();
+      void wakeScripting();
+      void stopScripting();
+
       global();
       ~global();
 

--- a/YseEngine/internalHeaders.h
+++ b/YseEngine/internalHeaders.h
@@ -59,6 +59,10 @@
 
 #include "internal/global.h"
 #include "internal/namedBus.h"
+
+#if YSE_ENABLE_PYTHON
+#include "python/scriptRuntime.h"
+#endif
 #include "internal/reverbDSP.h"
 #include "internal/settings.h"
 

--- a/YseEngine/python/scriptRuntime.cpp
+++ b/YseEngine/python/scriptRuntime.cpp
@@ -1,0 +1,244 @@
+/*
+  ==============================================================================
+
+    scriptRuntime.cpp
+    Created: 2026-06-21
+
+    Embedded-CPython script runtime (issue #124, epic #119).
+
+    Sourcing is Option C (see cmake/YsePython.cmake): a system / prebuilt
+    libpython located via find_package, isolated at runtime with PyConfig
+    rather than frozen at build time. Concretely the interpreter is booted
+    with an *isolated* config (no environment, no user site), with signal
+    handlers disabled (the Py_InitializeEx(0) intent) and site_import turned
+    off so site-packages — and therefore any third-party package — is never
+    importable. PyConfig.home is anchored to the located install (YSE_PYTHON_HOME)
+    so the standard library still resolves. This honours the epic's "no
+    third-party packages" tenet while deviating from its "build-time frozen
+    subset / empty sys.path" wording, which Option C cannot provide.
+
+  ==============================================================================
+*/
+
+#if YSE_ENABLE_PYTHON
+
+// Python.h must precede standard headers per the C-API documentation.
+#include <Python.h>
+
+#include <cstdio>
+#include <utility>
+
+#include "scriptRuntime.h"
+
+namespace YSE {
+  namespace INTERNAL {
+
+    namespace {
+
+      // Format the *current* Python exception the way the DSL spec mandates:
+      // exactly what traceback.format_exception produces. Falls back to
+      // "<TypeName>: <message>" if the traceback module cannot be imported, so
+      // the type name and message survive even in a degraded interpreter.
+      // The GIL must be held; clears the error indicator before returning.
+      std::string formatCurrentException() {
+        PyObject *type = nullptr, *value = nullptr, *tb = nullptr;
+        PyErr_Fetch(&type, &value, &tb);
+        PyErr_NormalizeException(&type, &value, &tb);
+        if (tb != nullptr && value != nullptr) {
+          PyException_SetTraceback(value, tb);
+        }
+
+        std::string out;
+
+        // Preferred path: traceback.format_exception(value) -> list[str].
+        // Single-argument form (3.10+) reads the traceback off the exception.
+        if (value != nullptr) {
+          PyObject* tbmod = PyImport_ImportModule("traceback");
+          if (tbmod != nullptr) {
+            PyObject* lines =
+                PyObject_CallMethod(tbmod, "format_exception", "O", value);
+            if (lines != nullptr) {
+              PyObject* sep = PyUnicode_FromString("");
+              PyObject* joined = sep ? PyUnicode_Join(sep, lines) : nullptr;
+              if (joined != nullptr) {
+                const char* utf8 = PyUnicode_AsUTF8(joined);
+                if (utf8 != nullptr) out = utf8;
+                Py_DECREF(joined);
+              }
+              Py_XDECREF(sep);
+              Py_DECREF(lines);
+            }
+            Py_DECREF(tbmod);
+          }
+        }
+
+        // Fallback: reconstruct "<TypeName>: <message>" directly.
+        if (out.empty() && value != nullptr) {
+          const char* tname = Py_TYPE(value)->tp_name;
+          PyObject* str = PyObject_Str(value);
+          const char* msg = str ? PyUnicode_AsUTF8(str) : nullptr;
+          out = std::string(tname ? tname : "Exception");
+          if (msg != nullptr && msg[0] != '\0') {
+            out += ": ";
+            out += msg;
+          }
+          Py_XDECREF(str);
+        }
+
+        Py_XDECREF(type);
+        Py_XDECREF(value);
+        Py_XDECREF(tb);
+        PyErr_Clear();
+        return out;
+      }
+
+    } // namespace
+
+    ScriptRuntime::ScriptRuntime() = default;
+
+    ScriptRuntime::~ScriptRuntime() {
+      // Ensure the worker is joined and the interpreter finalized before the
+      // base thread destructor asserts !isRunning().
+      if (started_) stop();
+    }
+
+    void ScriptRuntime::start() {
+      if (started_) return;
+
+      if (Py_IsInitialized() == 0) {
+        PyConfig config;
+        PyConfig_InitIsolatedConfig(&config);   // isolated: no env, no user site
+        config.install_signal_handlers = 0;     // == Py_InitializeEx(0)
+        config.site_import = 0;                  // exclude site-packages
+
+#ifdef YSE_PYTHON_HOME
+        PyStatus hst =
+            PyConfig_SetBytesString(&config, &config.home, YSE_PYTHON_HOME);
+        if (PyStatus_Exception(hst)) {
+          std::fprintf(stderr, "[yse] Python home config failed: %s\n",
+                       hst.err_msg ? hst.err_msg : "unknown");
+          PyConfig_Clear(&config);
+          return;
+        }
+#endif
+
+        PyStatus st = Py_InitializeFromConfig(&config);
+        PyConfig_Clear(&config);
+        if (PyStatus_Exception(st)) {
+          std::fprintf(stderr, "[yse] Python init failed: %s\n",
+                       st.err_msg ? st.err_msg : "unknown");
+          return;
+        }
+
+        ownsInterpreter_ = true;
+        // Release the GIL the initializing thread now holds. The worker
+        // acquires it via PyGILState_Ensure() on each wake.
+        mainThreadState_ = PyEval_SaveThread();
+      } else {
+        // Another ScriptRuntime already booted the process interpreter; attach
+        // without re-initializing or claiming finalization ownership.
+        ownsInterpreter_ = false;
+      }
+
+      stopRequested_ = false;
+      started_ = true;
+      thread::start();  // launches run() on the script thread
+    }
+
+    void ScriptRuntime::stop() {
+      if (!started_) return;
+
+      // Ask the worker to drain remaining requests, then exit.
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stopRequested_ = true;
+        pendingWake_ = true;
+      }
+      cv_.notify_one();
+      thread::stop();  // sets the base exit flag and joins the worker
+
+      if (ownsInterpreter_) {
+        // Re-acquire the GIL on this (the initializing) thread, then finalize.
+        PyEval_RestoreThread(static_cast<PyThreadState*>(mainThreadState_));
+        Py_FinalizeEx();
+        mainThreadState_ = nullptr;
+        ownsInterpreter_ = false;
+      }
+
+      started_ = false;
+    }
+
+    void ScriptRuntime::pushEval(std::string source) {
+      inbound_.push(EvalRequest{std::move(source)});
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        pendingWake_ = true;
+      }
+      cv_.notify_one();
+    }
+
+    void ScriptRuntime::wake() {
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        pendingWake_ = true;
+      }
+      cv_.notify_one();
+    }
+
+    bool ScriptRuntime::tryPopResult(EvalResult& out) {
+      return outbound_.try_pop(out);
+    }
+
+    EvalResult ScriptRuntime::evaluate(const std::string& source) {
+      EvalResult result;
+
+      PyObject* mainModule = PyImport_AddModule("__main__");  // borrowed
+      if (mainModule == nullptr) {
+        result.status = EvalStatus::Error;
+        result.traceback = formatCurrentException();
+        if (result.traceback.empty()) result.traceback = "internal: no __main__";
+        return result;
+      }
+      PyObject* globals = PyModule_GetDict(mainModule);  // borrowed
+
+      // Py_file_input accepts multi-statement source (e.g. "result = 1 + 1").
+      PyObject* ret =
+          PyRun_String(source.c_str(), Py_file_input, globals, globals);
+      if (ret != nullptr) {
+        Py_DECREF(ret);
+        result.status = EvalStatus::Ok;
+        return result;
+      }
+
+      result.status = EvalStatus::Error;
+      result.traceback = formatCurrentException();
+      return result;
+    }
+
+    void ScriptRuntime::run() {
+      for (;;) {
+        {
+          std::unique_lock<std::mutex> lock(mutex_);
+          cv_.wait(lock, [this] {
+            return pendingWake_ || stopRequested_ || threadShouldExit();
+          });
+          pendingWake_ = false;
+        }
+
+        // Drain inbound under the GIL — also on the shutdown wake, so requests
+        // queued just before stop() are not silently dropped.
+        PyGILState_STATE gil = PyGILState_Ensure();
+        EvalRequest request;
+        while (inbound_.try_pop(request)) {
+          outbound_.push(evaluate(request.source));
+        }
+        PyGILState_Release(gil);
+
+        if (stopRequested_ || threadShouldExit()) break;
+      }
+    }
+
+  } // namespace INTERNAL
+} // namespace YSE
+
+#endif  // YSE_ENABLE_PYTHON

--- a/YseEngine/python/scriptRuntime.h
+++ b/YseEngine/python/scriptRuntime.h
@@ -1,0 +1,109 @@
+/*
+  ==============================================================================
+
+    scriptRuntime.h
+    Created: 2026-06-21
+
+    Embedded-CPython script runtime (issue #124, epic #119).
+
+    Owns the interpreter lifecycle and the dedicated script thread that holds
+    the GIL on wake. Two lock-free SPSC queues carry work across threads:
+
+      inbound  (main  -> script) : EvalRequest  { source to exec in __main__ }
+      outbound (script -> main)  : EvalResult   { status + traceback }
+
+    This is infrastructure only — no user-facing API and no `yse` module yet
+    (those are issues #125 and #126). The public surface here exists so the
+    C API (#125) and the doctest suite can drive evaluation without reaching
+    into the worker.
+
+    The header carries no <Python.h> dependency: the interpreter is opaque
+    here (mainThreadState_ is a void* PyThreadState) so consumers and tests
+    can include it without the Python include path.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_PYTHON_SCRIPTRUNTIME_H
+#define YSE_PYTHON_SCRIPTRUNTIME_H
+
+#include <condition_variable>
+#include <mutex>
+#include <string>
+
+#include "../internal/thread.h"
+#include "../utils/lfQueue.hpp"
+
+namespace YSE {
+  namespace INTERNAL {
+
+    // Result of evaluating one EvalRequest. `Error` deliberately avoids the
+    // identifier `ERROR`, which <Windows.h> defines as a macro.
+    enum class EvalStatus { Ok, Error };
+
+    struct EvalRequest {
+      std::string source;
+    };
+
+    struct EvalResult {
+      EvalStatus status = EvalStatus::Ok;
+      // For Error: the string produced by traceback.format_exception (or a
+      // "<TypeName>: <message>" fallback if the traceback module is
+      // unavailable). Empty for Ok.
+      std::string traceback;
+    };
+
+    class ScriptRuntime : public thread {
+    public:
+      ScriptRuntime();
+      ~ScriptRuntime() override;
+
+      ScriptRuntime(const ScriptRuntime&) = delete;
+      ScriptRuntime& operator=(const ScriptRuntime&) = delete;
+
+      // Boot the interpreter (if this is the first runtime in the process)
+      // and launch the worker thread. Safe to call once; a second call while
+      // already started is a no-op.
+      void start();
+
+      // Join the worker (after a final drain of pending requests) and, if this
+      // runtime booted the interpreter, finalize it. Idempotent.
+      void stop();
+
+      // Producer = main thread. Enqueue `source` to be exec'd in the __main__
+      // namespace on the script thread. Wakes the worker.
+      void pushEval(std::string source);
+
+      // One wake per system::update() tick so future scheduled work (the
+      // yse.schedule countdowns landing in #126/#127) can advance. The wake
+      // mechanism exists from here even though nothing schedules yet.
+      void wake();
+
+      // Consumer = main thread. Move the next completed result into `out`.
+      // Returns false if none is ready.
+      bool tryPopResult(EvalResult& out);
+
+      // Worker body — invoked on the script thread by thread::start(). Public
+      // only because the base class dispatches to it; do not call directly.
+      void run() override;
+
+    private:
+      EvalResult evaluate(const std::string& source);  // GIL must be held
+
+      lfQueue<EvalRequest> inbound_;
+      lfQueue<EvalResult>  outbound_;
+
+      std::mutex              mutex_;
+      std::condition_variable cv_;
+      bool pendingWake_   = false;
+      bool stopRequested_ = false;
+
+      bool  started_         = false;
+      bool  ownsInterpreter_ = false;
+      void* mainThreadState_ = nullptr;  // PyThreadState* saved after init
+    };
+
+  } // namespace INTERNAL
+} // namespace YSE
+
+#endif  // YSE_PYTHON_SCRIPTRUNTIME_H

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -78,6 +78,10 @@ Bool YSE::system::initShared(bool openDevice) {
     timeBeginPeriod(1);
 #endif
 
+		// Boot the embedded interpreter (issue #124) after the audio device is
+		// open. No-op unless built with YSE_ENABLE_PYTHON.
+		INTERNAL::Global().startScripting();
+
 		return true;
 	}
 	INTERNAL::LogImpl().emit(E_ERROR, "YSE System object failed to initialize");
@@ -90,6 +94,10 @@ void YSE::system::update() {
   // and dispatch them synchronously to their subscribers. Cheap when empty:
   // a single SPSC peek + early exit.
   INTERNAL::Global().namedBus().drainPending();
+  // Wake the script thread once per tick so future scheduled work can advance
+  // (issue #124 establishes the wake; #126/#127 add the scheduling). No-op
+  // unless built with YSE_ENABLE_PYTHON.
+  INTERNAL::Global().wakeScripting();
 	unsigned int callbacks = DEVICE::Manager().GetCallbacksSinceLastUpdate();
 	if (callbacks == 0) {
 		currentlyMissedCallbacks++;
@@ -107,6 +115,10 @@ void YSE::system::close() {
   YSE::PATCHER::TimerThread().Clear();
 
   if (INTERNAL::Global().active) {
+    // Finalize the embedded interpreter (issue #124) before the audio device
+    // closes, mirroring the start ordering in initShared(). No-op unless built
+    // with YSE_ENABLE_PYTHON.
+    INTERNAL::Global().stopScripting();
     // Release the SAMPLERATE lock first so the next init() pass can rewrite
     // SAMPLERATE if the host opens a device with a different negotiated rate.
     INTERNAL::Global().sampleRateLocked = false;

--- a/cmake/YsePython.cmake
+++ b/cmake/YsePython.cmake
@@ -1,0 +1,66 @@
+# YsePython.cmake — resolve the embedded CPython for YSE_ENABLE_PYTHON.
+#
+# Sourcing strategy (issue #124, epic #119): the issue text calls for
+# "FetchContent fetches CPython at a pinned tag and builds it as a static
+# library" with a build-time *frozen* stdlib subset. CPython ships no CMake
+# build and does not support being built under the project's primary Windows
+# toolchain (MSYS2 Clang64), so that path is impractical here. We instead use
+# **Option C**: locate a system / prebuilt libpython via find_package and
+# isolate it at *runtime* with PyConfig. The deviations this implies are:
+#
+#   * Linkage follows whatever the platform provides — typically the shared
+#     libpython (on MSYS2 Clang64 only the import library
+#     `libpython3.x.dll.a` exists), not a static archive. Deployments must
+#     ship / locate the matching libpython at runtime.
+#   * The interpreter version is whatever the host provides (>= 3.10 for the
+#     PyConfig API), not a pinned 3.12.x.
+#   * There is no build-time freeze. The runtime sees the full standard
+#     library of the located interpreter, anchored via PyConfig.home and with
+#     site-packages disabled (site_import = 0) so no third-party packages are
+#     importable. "Curated frozen subset" therefore becomes "full stdlib,
+#     isolated from site-packages".
+#
+# See docs/design/live_coding_dsl.md (§ value types / cross-references) and
+# PROJECT_OVERVIEW.md "Python embedding" for the user-facing note. The
+# embedding-time isolation lives in YseEngine/python/scriptRuntime.cpp.
+#
+# On success this module sets, in the including scope:
+#   Python3::Python   — imported target with the embed include dirs + libpython
+#   YSE_PYTHON_HOME   — native install prefix (forward-slashed) used as
+#                       PyConfig.home so the interpreter resolves its stdlib.
+
+# Anchor discovery to the active toolchain's own Python so we get an
+# ABI-matched libpython. On MSYS2 Clang64 the compiler lives at
+# <prefix>/bin/clang++.exe and ships <prefix>/bin/python3.exe with a mingw
+# import library (libpython3.x.dll.a); without this hint FindPython3 would
+# prefer a registry MSVC install (C:/PythonXX, python3xx.lib) whose COFF
+# import lib the mingw linker cannot consume. Harmless on Linux (no registry).
+if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  get_filename_component(_yse_clang_bin "${CMAKE_CXX_COMPILER}" DIRECTORY)
+  get_filename_component(_yse_clang_root "${_yse_clang_bin}" DIRECTORY)
+  set(Python3_ROOT_DIR "${_yse_clang_root}")
+  set(Python3_FIND_REGISTRY NEVER)
+endif()
+
+# Development.Embed pulls the libpython suitable for embedding (not the
+# extension-module-only Development.Module component). 3.10 is the floor for
+# the stable PyConfig / Py_InitializeFromConfig API we rely on.
+find_package(Python3 3.10 REQUIRED COMPONENTS Development.Embed Interpreter)
+
+# Anchor the embedded interpreter to the located install. sys.prefix is a
+# native path (e.g. C:\msys64\clang64); TO_CMAKE_PATH forward-slashes it so it
+# survives being baked into a C string literal on Windows.
+execute_process(
+  COMMAND "${Python3_EXECUTABLE}" -c "import sys; print(sys.prefix)"
+  OUTPUT_VARIABLE _yse_python_prefix
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE _yse_python_prefix_rc
+)
+if(NOT _yse_python_prefix_rc EQUAL 0)
+  message(FATAL_ERROR "YSE_ENABLE_PYTHON: failed to query sys.prefix from ${Python3_EXECUTABLE}")
+endif()
+file(TO_CMAKE_PATH "${_yse_python_prefix}" YSE_PYTHON_HOME)
+
+message(STATUS
+  "YSE_ENABLE_PYTHON: embedding Python ${Python3_VERSION} "
+  "(home: ${YSE_PYTHON_HOME}; lib: ${Python3_LIBRARIES})")

--- a/docs/design/live_coding_dsl.md
+++ b/docs/design/live_coding_dsl.md
@@ -66,8 +66,19 @@ later under the same primitive names without a new design pass:
 - **No persistent script state across `System::close`/`init`.** The
   interpreter is finalized on close. Re-init starts from a blank
   `__main__`.
-- **No third-party packages.** Frozen stdlib subset only — see
-  [#124][gh-124] for the curated module list.
+- **No third-party packages.** See [#124][gh-124]. *Implementation note:*
+  #124 sources CPython via `find_package` (a system / prebuilt libpython)
+  and isolates it at **runtime** with `PyConfig` — isolated mode, no
+  environment, and `site_import = 0` so site-packages (hence any
+  third-party package) is never importable — rather than baking a
+  **build-time** frozen module subset as originally envisaged. The
+  "no third-party packages" guarantee holds; the practical difference is
+  that the interpreter sees the *full* standard library of the located
+  install (anchored via `PyConfig.home`), not a curated subset, and its
+  version follows the host rather than a pinned 3.12.x. The CPython static
+  build + freeze tooling proved impractical (no CMake build; unsupported
+  under the project's MSYS2 Clang64 toolchain). See PROJECT_OVERVIEW.md
+  "Python embedding" for the full rationale.
 
 ---
 


### PR DESCRIPTION
## Summary

Desktop-only embedding infrastructure for the live-coding DSL (epic #119): a CPython interpreter that boots inside libyse, runs script source on a dedicated GIL-owning thread, and finalizes cleanly across `init`/`close` cycles. **Infrastructure only** — no user-facing C API and no `yse` module (those are #125 / #126). `YSE_ENABLE_PYTHON` is **OFF by default**; when OFF the build is byte-for-byte equivalent.

## Linked issue

Closes #124

## Sourcing — Option C, with a documented deviation

The issue called for "FetchContent + static libpython + build-time frozen stdlib". That proved impractical: CPython ships no CMake build and does not build under the project's primary Windows toolchain (MSYS2 Clang64). This PR instead uses **Option C** (chosen with the maintainer): locate a system / prebuilt libpython via `find_package(Python3 ≥ 3.10 COMPONENTS Development.Embed)` and isolate it **at runtime** with `PyConfig` — isolated mode, no environment, signal handlers off (the `Py_InitializeEx(0)` intent), and `site_import = 0` so site-packages (hence any third-party package) is never importable; `PyConfig.home` anchored to the located install so the stdlib resolves.

What holds: desktop-only (Android = configure-time `FATAL_ERROR`), and the **no-third-party-packages** tenet. What changes: linkage is whatever the platform provides (typically **shared** libpython — MSYS2 Clang64 ships only the `libpython3.x.dll.a` import lib); the interpreter **version follows the host** (some drift); the runtime sees the **full stdlib** of that install (isolated from site-packages), not a curated frozen subset. Recorded in `PROJECT_OVERVIEW.md` ("Python embedding"), `docs/design/live_coding_dsl.md`, and a comment on epic #119.

## Changes

- **`cmake/YsePython.cmake`** — locate the ABI-matched libpython (anchored to the `clang++` prefix on Clang64 so a registry MSVC install isn't picked); `YSE_ENABLE_PYTHON` option + Android guard in the root `CMakeLists.txt`.
- **`YseEngine/python/scriptRuntime.{h,cpp}`** — `INTERNAL::ScriptRuntime`: interpreter lifecycle + a script thread (subclassing `INTERNAL::thread`) holding the GIL on wake, plus two lock-free SPSC queues — inbound `EvalRequest` (source `exec`'d in `__main__`), outbound `EvalResult` (status + `traceback.format_exception` text). Header carries no `<Python.h>` dependency.
- **Lifecycle wiring** — `global.{h,cpp}` keeps the runtime as a file-static owner so `global.h` gains no Python type and no macro-dependent layout (avoids an ODR hazard); `system.cpp` boots after the device opens, wakes once per `update()` tick, finalizes before the device closes.
- **Tests** — `Tests/python/test_script_runtime.cpp` (eval-ok; eval-error with `ValueError: boom` in the traceback; drain-before-stop; 50× init/finalize re-entry) + `yse_tests_python` CTest entry. Hermetic: it never inits/closes the engine, so it coexists in the shared binary.
- **Docs** — PROJECT_OVERVIEW "Python embedding" section + platform-dep note; design-doc deviation note.

## Out of scope (filed)

- **#132** — pre-existing `assert(pimpl == nullptr)` in `reverb::create()` on repeated `System` init/close (surfaced while testing; independent of Python).
- **#133** — CI coverage for the ON build (Linux/clang + ASan with LSan suppressions). Deferred per review.

## Test plan

All run locally on Windows/Clang64:

- [x] **OFF** (default) configure + full unit suite — 883 cases / 45 984 assertions pass; unchanged
- [x] **ON** configure (finds ABI-matched Clang64 Python 3.14) + full build (`yse.dll` + demos + tests) link clean
- [x] **Python suite** isolated via `ctest -L python` — 4 cases / 110 assertions (incl. the 50× init/finalize case)
- [x] **ON full binary** coexistence — 887 cases / 46 094 assertions, 0 failed
- [x] `clang-tidy` on changed code — clean (only non-user-code warnings inside Python headers)
- [x] **Android + Python** configure fails fast: *"YSE_ENABLE_PYTHON is not supported on Android"*
- [ ] **Linux/clang ON build** and **ASan** leak run — not run in this session (no Linux host); CI-shaped and tracked in #133. CPython needs LSan suppressions for interpreter internals that live until `Py_Finalize`.

This is not user-visible (an opt-in, OFF-by-default build feature with no runtime API yet), so no integration/e2e test applies; the doctest suite drives the runtime directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)