### PR TITLE
c-api: scripting surface (yse_run_script, error callback) (#125)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(YSE_TEST_SOURCES
   system/test_named_bus.cpp
   system/test_system_active_state.cpp
   integration/test_device.cpp
+  python/test_c_api_python.cpp
 )
 
 # Embedded-CPython runtime tests (issue #124) — only when the option is ON.

--- a/Tests/python/test_c_api_python.cpp
+++ b/Tests/python/test_c_api_python.cpp
@@ -1,0 +1,156 @@
+// C ABI scripting surface tests (issue #125, epic #119).
+//
+// Unlike test_script_runtime.cpp (compiled only when YSE_ENABLE_PYTHON is ON),
+// this TU is always built: the C API ships the same three symbols in both
+// configurations, and the acceptance criteria cover the OFF build too. The
+// cases branch on the macro internally.
+//
+// OFF cases need no engine — the OFF stub answers entirely at the C boundary.
+// ON cases need the interpreter booted and update() draining results, so they
+// drive the engine through TestHelpers::engineInit() and skip gracefully when
+// no audio device is available (CI), like the other engine-dependent suites.
+// engineInit() boots the engine exactly once per process and never closes it
+// (main.cpp does, at exit), so these cases never trip the re-init assertion
+// tracked in issue #132.
+
+#include <doctest/doctest.h>
+
+#include <string>
+
+#include "yse_c/yse_python.h"
+
+#if YSE_ENABLE_PYTHON
+#include "yse.hpp"
+#include "support/null_device.hpp"
+#endif
+
+namespace {
+
+// Userdata for the error callback: counts deliveries and keeps the last
+// traceback so assertions can inspect it.
+struct ErrSink {
+  int         count = 0;
+  std::string last;
+};
+
+void YSE_C_CALLBACK captureCb(const char* traceback, void* userdata) {
+  auto* sink = static_cast<ErrSink*>(userdata);
+  sink->count++;
+  sink->last = traceback != nullptr ? traceback : "";
+}
+
+} // namespace
+
+TEST_SUITE("python") {
+
+TEST_CASE("c-api python: yse_python_enabled reflects the build configuration") {
+#if YSE_ENABLE_PYTHON
+  CHECK(yse_python_enabled() == 1);
+#else
+  CHECK(yse_python_enabled() == 0);
+#endif
+}
+
+#if !YSE_ENABLE_PYTHON
+
+TEST_CASE("c-api python (OFF): run_script reports the missing feature synchronously") {
+  ErrSink sink;
+  yse_set_script_error_callback(&captureCb, &sink);
+
+  // No interpreter to defer to: the callback must fire before run_script
+  // returns, with the documented string.
+  yse_run_script("result = 1 + 1");
+  CHECK(sink.count == 1);
+  CHECK(sink.last == "YSE compiled without YSE_ENABLE_PYTHON");
+
+  yse_set_script_error_callback(nullptr, nullptr);
+}
+
+TEST_CASE("c-api python (OFF): run_script with no callback registered is a safe no-op") {
+  yse_set_script_error_callback(nullptr, nullptr);
+  yse_run_script("anything");  // must not crash with no callback installed
+  CHECK(yse_python_enabled() == 0);
+}
+
+#else  // YSE_ENABLE_PYTHON
+
+namespace {
+
+// Pump update() until the sink has observed at least `expected` callbacks, or
+// the budget is exhausted. The script thread is asynchronous, so the engine
+// delivers "within one tick" only after the worker has run; poll rather than
+// assume a single update() suffices.
+bool pumpUntil(ErrSink& sink, int expected, int tries = 300, unsigned ms = 10) {
+  for (int i = 0; i < tries; ++i) {
+    YSE::System().update();
+    if (sink.count >= expected) return true;
+    YSE::System().sleep(ms);
+  }
+  return false;
+}
+
+} // namespace
+
+TEST_CASE("c-api python (ON): a clean script fires no error callback") {
+  if (!TestHelpers::engineInit()) return;
+  ErrSink sink;
+  yse_set_script_error_callback(&captureCb, &sink);
+
+  yse_run_script("result = 1 + 1");
+  // Give the worker ample ticks; a successful eval must stay silent.
+  for (int i = 0; i < 20; ++i) {
+    YSE::System().update();
+    YSE::System().sleep(10);
+  }
+  CHECK(sink.count == 0);
+
+  yse_set_script_error_callback(nullptr, nullptr);
+}
+
+TEST_CASE("c-api python (ON): a raised exception delivers a traceback") {
+  if (!TestHelpers::engineInit()) return;
+  ErrSink sink;
+  yse_set_script_error_callback(&captureCb, &sink);
+
+  yse_run_script("raise ValueError('boom')");
+  REQUIRE(pumpUntil(sink, 1));
+  CHECK(sink.count == 1);
+  CHECK(sink.last.find("ValueError: boom") != std::string::npos);
+  // The DSL spec / issue #125 mandate the "<script>" source filename.
+  CHECK(sink.last.find("\"<script>\"") != std::string::npos);
+
+  yse_set_script_error_callback(nullptr, nullptr);
+}
+
+TEST_CASE("c-api python (ON): a syntax error delivers a SyntaxError traceback") {
+  if (!TestHelpers::engineInit()) return;
+  ErrSink sink;
+  yse_set_script_error_callback(&captureCb, &sink);
+
+  yse_run_script("def f(:\n  pass\n");
+  REQUIRE(pumpUntil(sink, 1));
+  CHECK(sink.last.find("SyntaxError") != std::string::npos);
+  // SyntaxError formatting names the source file too; must read "<script>".
+  CHECK(sink.last.find("\"<script>\"") != std::string::npos);
+
+  yse_set_script_error_callback(nullptr, nullptr);
+}
+
+TEST_CASE("c-api python (ON): replacing the callback retires the previous one") {
+  if (!TestHelpers::engineInit()) return;
+  ErrSink first, second;
+  yse_set_script_error_callback(&captureCb, &first);
+  // Swap before any error is produced; the error must reach only `second`.
+  yse_set_script_error_callback(&captureCb, &second);
+
+  yse_run_script("raise RuntimeError('after swap')");
+  REQUIRE(pumpUntil(second, 1));
+  CHECK(second.count == 1);
+  CHECK(first.count == 0);
+
+  yse_set_script_error_callback(nullptr, nullptr);
+}
+
+#endif  // YSE_ENABLE_PYTHON
+
+} // TEST_SUITE("python")

--- a/YseEngine/c_api/CMakeLists.txt
+++ b/YseEngine/c_api/CMakeLists.txt
@@ -28,6 +28,7 @@ set(YSE_C_API_SRCS
   yse_music.cpp
   yse_log.cpp
   yse_buffer_io.cpp
+  yse_python.cpp
   yse_enums_check.cpp
 )
 list(TRANSFORM YSE_C_API_SRCS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")

--- a/YseEngine/c_api/include/yse_c/yse_all.h
+++ b/YseEngine/c_api/include/yse_c/yse_all.h
@@ -21,5 +21,6 @@
 #include "yse_music.h"
 #include "yse_log.h"
 #include "yse_buffer_io.h"
+#include "yse_python.h"
 
 #endif

--- a/YseEngine/c_api/include/yse_c/yse_python.h
+++ b/YseEngine/c_api/include/yse_c/yse_python.h
@@ -1,0 +1,57 @@
+/*
+  yse_python.h — C ABI scripting surface (issue #125, epic #119).
+
+  Lets a host (Phi via dart-yse, Python ctypes, …) submit scripts to the
+  embedded CPython interpreter and receive errors asynchronously. The three
+  symbols ship in every build with identical signatures; only their behaviour
+  differs between a YSE_ENABLE_PYTHON=ON and =OFF library, so a binding can be
+  written once and link against either.
+
+  Self-contained C header: depends only on yse_common.h.
+*/
+
+#ifndef YSE_C_PYTHON_H_INCLUDED
+#define YSE_C_PYTHON_H_INCLUDED
+
+#include "yse_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Compile-time feature query. Returns 1 if the library was built with
+   YSE_ENABLE_PYTHON=ON, else 0. Safe to call regardless of build
+   configuration or engine state. */
+YSE_C_API int yse_python_enabled(void);
+
+/* Submit a UTF-8 script for asynchronous evaluation on the script thread.
+   Returns immediately. The engine takes a copy; the caller may free `src`
+   on return. A NULL `src` is a no-op.
+
+   On a YSE_ENABLE_PYTHON=OFF build, the registered error callback (if any) is
+   invoked synchronously, before this returns, with the literal string
+   "YSE compiled without YSE_ENABLE_PYTHON". */
+YSE_C_API void yse_run_script(const char* src);
+
+/* Callback that receives formatted tracebacks from uncaught Python exceptions
+   and syntax errors. `traceback_utf8` is owned by the engine and valid only
+   for the duration of the call — copy it if you need to retain it. */
+typedef void (YSE_C_CALLBACK *yse_script_error_cb)(
+    const char* traceback_utf8, void* userdata);
+
+/* Register the error callback. Pass NULL to clear. Thread-safe via atomic
+   swap (the project's callback-bridge convention): installing or replacing
+   the callback while the engine is dispatching a traceback is safe, and the
+   previous callback never receives a later traceback.
+
+   On an ON build the callback fires on the host thread that drives
+   yse_system_update(), once per failed script. Works identically on an OFF
+   build (it just stores the pointer), so a host may register unconditionally. */
+YSE_C_API void yse_set_script_error_callback(
+    yse_script_error_cb cb, void* userdata);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* YSE_C_PYTHON_H_INCLUDED */

--- a/YseEngine/c_api/yse_python.cpp
+++ b/YseEngine/c_api/yse_python.cpp
@@ -1,0 +1,81 @@
+/*
+  yse_python.cpp — C ABI scripting surface (issue #125, epic #119).
+
+  The host-facing callback (cb + user_data) lives here as atomics, following
+  the callback-bridge convention in yse_c_internal.hpp: the host installs with
+  release ordering, and the engine reads with acquire ordering when it drains a
+  traceback. A single fixed bridge function (c_script_error_bridge) is handed to
+  the engine as the error sink; it reads these atomics on each call, so swapping
+  the callback never leaves the bridge observing a half-installed pair and the
+  previous callback never receives a later traceback.
+
+  Unlike scriptRuntime.cpp (compiled only when YSE_ENABLE_PYTHON=ON), this TU is
+  always built so the C ABI surface is uniform: the three symbols exist with
+  identical signatures in both configurations, and only the yse_run_script /
+  yse_python_enabled bodies branch on the macro.
+*/
+
+#include "yse_c/yse_python.h"
+
+#include "../internal/global.h"
+
+#include <atomic>
+#include <string>
+
+namespace {
+
+  // Host-facing callback + user_data. user_data is published before the
+  // function pointer (release) and read after it (acquire); see the bridge.
+  std::atomic<yse_script_error_cb> g_userCb{nullptr};
+  std::atomic<void*>               g_userData{nullptr};
+
+  // Fixed sink handed to the engine. The `userdata` slot from the engine side
+  // is unused — the host callback and its user_data are read from the atomics
+  // above so a mid-dispatch swap takes effect on the next traceback.
+  void c_script_error_bridge(const char* traceback, void* /*engine_userdata*/) {
+    auto cb = g_userCb.load(std::memory_order_acquire);
+    if (cb == nullptr) return;
+    auto user = g_userData.load(std::memory_order_acquire);
+    cb(traceback, user);
+  }
+
+} // namespace
+
+extern "C" {
+
+YSE_C_API int yse_python_enabled(void) {
+#if YSE_ENABLE_PYTHON
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+YSE_C_API void yse_run_script(const char* src) {
+#if YSE_ENABLE_PYTHON
+  if (src == nullptr) return;
+  YSE::INTERNAL::Global().pushScript(std::string(src));
+#else
+  // No interpreter to run on: report the misconfiguration synchronously through
+  // the same callback path the ON build delivers tracebacks on.
+  (void)src;
+  auto cb = g_userCb.load(std::memory_order_acquire);
+  if (cb == nullptr) return;
+  auto user = g_userData.load(std::memory_order_acquire);
+  cb("YSE compiled without YSE_ENABLE_PYTHON", user);
+#endif
+}
+
+YSE_C_API void yse_set_script_error_callback(yse_script_error_cb cb, void* userdata) {
+  // Publish user_data before the function pointer, both release — pairs with the
+  // acquire loads in the bridge.
+  g_userData.store(userdata, std::memory_order_release);
+  g_userCb.store(cb, std::memory_order_release);
+  // Keep the engine sink wired to our bridge. Re-registering is a cheap atomic
+  // store; the bridge reads the host callback fresh each time, so this stays
+  // correct whether cb is being set or cleared. On an OFF build this is a no-op
+  // store (the engine never drains results) but keeps the code path uniform.
+  YSE::INTERNAL::Global().setScriptErrorSink(&c_script_error_bridge, nullptr);
+}
+
+} // extern "C"

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -13,6 +13,7 @@
 
 #if YSE_ENABLE_PYTHON
 #include "../python/scriptRuntime.h"
+#include <atomic>
 #include <memory>
 namespace {
   // Process-global script runtime, owned here rather than as a global:: member
@@ -20,6 +21,15 @@ namespace {
   // YSE_ENABLE_PYTHON (which would otherwise be an ODR hazard between engine
   // and test translation units).
   std::unique_ptr<YSE::INTERNAL::ScriptRuntime> g_scriptRuntime;
+
+  // Error sink the C API (issue #125) installs. Stored as atomics so the host
+  // thread can swap it while the main thread is mid-dispatch in
+  // drainScriptResults() — the project's lock-free callback-bridge convention
+  // (see yse_c_internal.hpp). user_data is published before the function
+  // pointer (release) and read after it (acquire) so a dispatch never sees a
+  // half-installed pair.
+  std::atomic<YSE::INTERNAL::global::ScriptErrorSink> g_scriptErrorSink{nullptr};
+  std::atomic<void*>                                  g_scriptErrorUser{nullptr};
 }
 #endif
 
@@ -65,6 +75,46 @@ void YSE::INTERNAL::global::stopScripting() {
   if (g_scriptRuntime) {
     g_scriptRuntime->stop();
     g_scriptRuntime.reset();
+  }
+#endif
+}
+
+void YSE::INTERNAL::global::setScriptErrorSink(ScriptErrorSink sink, void* userdata) {
+#if YSE_ENABLE_PYTHON
+  // Publish user_data first, then the function pointer, both with release
+  // ordering — mirrors the acquire loads in drainScriptResults().
+  g_scriptErrorUser.store(userdata, std::memory_order_release);
+  g_scriptErrorSink.store(sink, std::memory_order_release);
+#else
+  (void)sink;
+  (void)userdata;
+#endif
+}
+
+void YSE::INTERNAL::global::pushScript(std::string source) {
+#if YSE_ENABLE_PYTHON
+  if (g_scriptRuntime) g_scriptRuntime->pushEval(std::move(source));
+#else
+  (void)source;
+#endif
+}
+
+void YSE::INTERNAL::global::drainScriptResults() {
+#if YSE_ENABLE_PYTHON
+  if (!g_scriptRuntime) return;
+  EvalResult result;
+  while (g_scriptRuntime->tryPopResult(result)) {
+    if (result.status != EvalStatus::Error) continue;
+    // Load the function pointer first, bail if cleared, then its user_data —
+    // acquire ordering pairs with the releases in setScriptErrorSink(). Re-read
+    // per result so a swap between two drained errors takes effect immediately
+    // and the previous sink never receives a later traceback.
+    ScriptErrorSink sink = g_scriptErrorSink.load(std::memory_order_acquire);
+    if (sink == nullptr) continue;
+    void* user = g_scriptErrorUser.load(std::memory_order_acquire);
+    // result.traceback outlives the call; the pointer is valid only for its
+    // duration (documented contract in yse_python.h).
+    sink(result.traceback.c_str(), user);
   }
 #endif
 }

--- a/YseEngine/internal/global.h
+++ b/YseEngine/internal/global.h
@@ -60,6 +60,29 @@ namespace YSE {
       void wakeScripting();
       void stopScripting();
 
+      // Scripting C-API bridge (issue #125). The C API (yse_python.cpp) is the
+      // only consumer; these stay in INTERNAL so the C ABI surface never leaks
+      // a C++ type. All are no-ops (or trivial stores) unless the engine was
+      // built with YSE_ENABLE_PYTHON, and they carry no Python dependency.
+
+      // Sink invoked on the main thread, once per Error result drained from the
+      // script runtime's outbound queue in drainScriptResults(). The string is
+      // the formatted traceback and is valid only for the duration of the call.
+      using ScriptErrorSink = void (*)(const char* traceback, void* userdata);
+
+      // Install (or clear, with nullptr) the error sink. Stored with the
+      // project's atomic-swap callback convention so the C API can install or
+      // replace it concurrently with a dispatch already in flight.
+      void setScriptErrorSink(ScriptErrorSink sink, void* userdata);
+
+      // Enqueue UTF-8 source for asynchronous evaluation on the script thread.
+      // The runtime takes a copy; the caller may free its buffer on return.
+      void pushScript(std::string source);
+
+      // Drain every completed result; for each Error, invoke the installed sink
+      // with its traceback. Called from system::update() on the main thread.
+      void drainScriptResults();
+
       global();
       ~global();
 

--- a/YseEngine/python/scriptRuntime.cpp
+++ b/YseEngine/python/scriptRuntime.cpp
@@ -201,9 +201,22 @@ namespace YSE {
       }
       PyObject* globals = PyModule_GetDict(mainModule);  // borrowed
 
-      // Py_file_input accepts multi-statement source (e.g. "result = 1 + 1").
-      PyObject* ret =
-          PyRun_String(source.c_str(), Py_file_input, globals, globals);
+      // Compile explicitly so the source carries the filename "<script>": the
+      // DSL spec (docs/design/live_coding_dsl.md) and issue #125 require
+      // tracebacks — and SyntaxError caret lines — to read File "<script>".
+      // PyRun_String would default that name to "<string>". Py_file_input
+      // accepts multi-statement source (e.g. "result = 1 + 1").
+      PyObject* code =
+          Py_CompileString(source.c_str(), "<script>", Py_file_input);
+      if (code == nullptr) {
+        // Compilation failure (SyntaxError): the error indicator is set.
+        result.status = EvalStatus::Error;
+        result.traceback = formatCurrentException();
+        return result;
+      }
+
+      PyObject* ret = PyEval_EvalCode(code, globals, globals);
+      Py_DECREF(code);
       if (ret != nullptr) {
         Py_DECREF(ret);
         result.status = EvalStatus::Ok;

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -98,6 +98,10 @@ void YSE::system::update() {
   // (issue #124 establishes the wake; #126/#127 add the scheduling). No-op
   // unless built with YSE_ENABLE_PYTHON.
   INTERNAL::Global().wakeScripting();
+  // Deliver any completed script results to the C API error callback (issue
+  // #125). Drains on the main thread, so the callback fires here — never on
+  // the script thread. No-op unless built with YSE_ENABLE_PYTHON.
+  INTERNAL::Global().drainScriptResults();
 	unsigned int callbacks = DEVICE::Manager().GetCallbacksSinceLastUpdate();
 	if (callbacks == 0) {
 		currentlyMissedCallbacks++;


### PR DESCRIPTION
## Summary

Adds the C ABI entry point for the embedded CPython interpreter (epic #119, on top of the merged #124), so hosts (Phi via dart-yse, Python ctypes, …) can submit scripts and receive tracebacks without a C++ ABI dependency.

New `c_api/yse_python.{h,cpp}` expose three symbols, present with identical signatures in both `YSE_ENABLE_PYTHON=ON` and `=OFF` builds:

- `yse_python_enabled()` — compile-time feature query (1/0)
- `yse_run_script(src)` — async submit on the script thread; the OFF stub fires the registered error callback synchronously with `"YSE compiled without YSE_ENABLE_PYTHON"`
- `yse_set_script_error_callback(cb, userdata)` — atomic-swap callback bridge (`YSE_C_CALLBACK`-tagged typedef)

## Linked issue

Closes #125

## Changes

- **C API surface:** `yse_python.{h,cpp}`; registered in `yse_all.h` and `c_api/CMakeLists.txt`.
- **Engine wiring:** `global` gains `pushScript` / `drainScriptResults` / `setScriptErrorSink`. The sink uses the project's lock-free release/acquire callback convention. `system::update()` drains the script runtime's outbound queue on the main thread and forwards each `Error` traceback to the C callback — so the callback never fires on the script thread.
- **Spec conformance:** `scriptRuntime::evaluate()` now compiles via `Py_CompileString(..., "<script>", ...)` instead of `PyRun_String`, so tracebacks and `SyntaxError` caret lines read `File "<script>"` as `docs/design/live_coding_dsl.md` and the issue mandate (`PyRun_String` defaulted the name to `"<string>"`). This is the only change touching #124's code, required to meet #125's traceback contract.
- **Tests:** `Tests/python/test_c_api_python.cpp`, always compiled, branches on the macro.

## Test plan

- [x] clang-tidy (`yse.py analyze`) clean on every changed `.cpp`, in **both** OFF and ON configurations (ON paths checked against the `YSE_ENABLE_PYTHON=ON` compile DB).
- [x] **OFF build** — full ctest **14/14 pass** (`yse.py test`). The 3 OFF C-API cases (`enabled()==0`, synchronous "not compiled in" delivery, no-callback no-op) run inside the combined unit run.
- [x] **ON build** (`YSE_ENABLE_PYTHON=ON`) — full ctest **15/15 pass**, incl. `yse_tests_python`. The ON cases drive the real engine end-to-end (`yse_run_script` → script thread → `update()` drain → callback) and assert: clean script stays silent, raised exception delivers a `ValueError: boom` traceback with the `"<script>"` filename, syntax error delivers a `SyntaxError` `"<script>"` traceback, and replacing the callback retires the previous one.

The ON cases are effectively integration tests (real interpreter, real update loop). They skip gracefully on a deviceless CI host via the established `TestHelpers::engineInit()` guard, and reuse the once-per-process init so they never trip the re-init assertion tracked in #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)