### PR TITLE
Python: hot-reload cleanup + scheduling lifecycle (#127)

### DIFF
--- a/Tests/python/test_yse_module.cpp
+++ b/Tests/python/test_yse_module.cpp
@@ -279,6 +279,83 @@ TEST_CASE("yse module: cancel_all keeps same-generation registrations") {
   CHECK(std::get<int>(echo.last()) == 3);
 }
 
+TEST_CASE("yse module: a schedule from an older generation still fires after a "
+          "reload without cancel_all") {
+  if (!TestHelpers::engineInit()) return;
+
+  BusCapture ready, fired;
+  ScopedSub readySub("ysemod.schedreload.ready", ready);
+  ScopedSub firedSub("ysemod.schedreload.fired", fired);
+
+  // Evaluation A (generation G): arm a schedule far enough out that it cannot
+  // mature before evaluation B runs.
+  run("yse.schedule(8, lambda: yse.send('ysemod.schedreload.fired', 1))\n");
+  // Evaluation B (generation G+1): a plain marker, NO cancel_all.
+  run("yse.send('ysemod.schedreload.ready', 1)\n");
+  REQUIRE(pumpCount(ready, 1));
+
+  // Pump past the 8-tick horizon: the gen-G schedule survived the reload.
+  REQUIRE(pumpCount(fired, 1));
+  CHECK(std::get<int>(fired.last()) == 1);
+}
+
+TEST_CASE("yse module: cancel_all on reload tears down an older-generation "
+          "schedule before it fires") {
+  if (!TestHelpers::engineInit()) return;
+
+  BusCapture ready, fired;
+  ScopedSub readySub("ysemod.schedcancel.ready", ready);
+  ScopedSub firedSub("ysemod.schedcancel.fired", fired);
+
+  // Evaluation A (generation G): same schedule as above.
+  run("yse.schedule(8, lambda: yse.send('ysemod.schedcancel.fired', 1))\n");
+  // Evaluation B (generation G+1): the editor prefix wipes generation G.
+  run("yse.cancel_all()\n"
+      "yse.send('ysemod.schedcancel.ready', 1)\n");
+  REQUIRE(pumpCount(ready, 1));
+
+  // Pump well past the horizon; the gen-G schedule must never fire.
+  for (int i = 0; i < 20; ++i) {
+    YSE::System().update();
+    YSE::System().sleep(10);
+  }
+  CHECK(fired.count() == 0);
+}
+
+TEST_CASE("yse module: fresh_scope wipes earlier generations but keeps its own "
+          "block's registrations") {
+  if (!TestHelpers::engineInit()) return;
+
+  BusCapture ready, oldEcho, newEcho;
+  ScopedSub readySub("ysemod.fresh.ready", ready);
+  ScopedSub oldEchoSub("ysemod.fresh.old.echo", oldEcho);
+  ScopedSub newEchoSub("ysemod.fresh.new.echo", newEcho);
+
+  // Evaluation A (generation G): an older-generation subscriber.
+  run("yse.on('ysemod.fresh.old.in', "
+      "lambda v: yse.send('ysemod.fresh.old.echo', v))\n");
+
+  // Evaluation B (generation G+1): fresh_scope() cancels generation G on entry,
+  // then registers a new subscriber inside the block — which must survive.
+  run("with yse.fresh_scope():\n"
+      "    yse.on('ysemod.fresh.new.in', "
+      "lambda v: yse.send('ysemod.fresh.new.echo', v))\n"
+      "yse.send('ysemod.fresh.ready', 1)\n");
+  REQUIRE(pumpCount(ready, 1));
+
+  // The new (in-block) subscriber fires; the old one was torn down.
+  bus().publish("ysemod.fresh.new.in", BusValue{7}, YSE::T_GUI);
+  REQUIRE(pumpCount(newEcho, 1));
+  CHECK(std::get<int>(newEcho.last()) == 7);
+
+  bus().publish("ysemod.fresh.old.in", BusValue{9}, YSE::T_GUI);
+  for (int i = 0; i < 10; ++i) {
+    YSE::System().update();
+    YSE::System().sleep(10);
+  }
+  CHECK(oldEcho.count() == 0);
+}
+
 TEST_CASE("yse module: send rejects non-bus types via the error callback") {
   if (!TestHelpers::engineInit()) return;
   ErrSink sink;

--- a/YseEngine/python/yse_module.cpp
+++ b/YseEngine/python/yse_module.cpp
@@ -274,6 +274,32 @@ class Latch:
 
 def latch(name):
     return Latch(name)
+
+
+class _FreshScope:
+    """Context manager returned by ``fresh_scope()``.
+
+    Calls ``cancel_all()`` on entry, so every subscription and schedule from
+    a strictly older generation is torn down before the block's body runs.
+    Registrations made *inside* the block belong to the current generation
+    and therefore survive — exactly as if the script had opened with a bare
+    ``cancel_all()``. The exit is a no-op; exceptions propagate unchanged.
+    """
+    __slots__ = ()
+
+    def __enter__(self):
+        cancel_all()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def fresh_scope():
+    """Wipe earlier generations before running this block. Sugar for a
+    ``cancel_all()`` at the top of the body — see the hot-reload section of
+    docs/design/live_coding_dsl.md."""
+    return _FreshScope()
 )PY";
 
       } // namespace

--- a/documentation/source/live_coding/index.rst
+++ b/documentation/source/live_coding/index.rst
@@ -108,6 +108,40 @@ The primitives
       yse.cancel_all()   # wipe the previous evaluation
       # ... the rest of the script ...
 
+``yse.fresh_scope()``
+   A context manager that calls :func:`yse.cancel_all` on entry — sugar for
+   composers who prefer to scope a fresh start to a block rather than prefix the
+   whole script. Registrations made *inside* the ``with`` block belong to the
+   current evaluation and survive; everything from older evaluations is torn
+   down before the body runs.
+
+   .. code-block:: python
+
+      with yse.fresh_scope():
+          yse.on("trigger", on_trigger)
+          yse.schedule(4, kick)
+
+   This is exactly equivalent to opening the block's body with a bare
+   ``yse.cancel_all()``.
+
+Hot-reload pattern
+------------------
+
+Because libYSE never auto-clears state between evaluations, layering is the
+default: re-evaluating a script *adds* its subscriptions and schedules on top of
+what earlier evaluations installed. To get *replacement* behaviour instead — the
+usual expectation when iterating on a patch — start each evaluation from a clean
+slate. Either prefix the script:
+
+.. code-block:: python
+
+   yse.cancel_all()
+   # ... the patch ...
+
+or wrap it in :func:`yse.fresh_scope`. The Phi editor's "Evaluate" button can be
+configured to inject the ``yse.cancel_all()`` prefix automatically; composers who
+want to layer can omit it per evaluation.
+
 Addressing
 ----------
 


### PR DESCRIPTION
## Summary

Completes the hot-reload lifecycle work for the embedded-Python live-coding
DSL. Most of #127's listed acceptance items — the generation counter,
generation-tagging on `yse.on` / `yse.schedule`, and `yse.cancel_all`
(strictly-older-generations only) — already landed when the `yse` module was
implemented in #126. This PR delivers the genuinely missing pieces:

- **`yse.fresh_scope()`** — a pure-Python context manager that calls
  `cancel_all()` on entry. Sugar for composers who prefer to scope a fresh
  start to a `with` block instead of prefixing the whole script. Registrations
  made inside the block belong to the current evaluation and survive.
  Implemented in `kBootstrap` alongside `Latch` (class-based, no stdlib import).
- **Scheduling-lifecycle doctests** the acceptance list calls for.
- **Docs** — the Sphinx live-coding guide now covers `fresh_scope` and the
  layering-vs-replacement hot-reload pattern.

## Linked issue

Closes #127

## Changes

- `YseEngine/python/yse_module.cpp` — add `_FreshScope` / `fresh_scope()` to the
  module bootstrap.
- `Tests/python/test_yse_module.cpp` — three new cases:
  - a schedule from an older generation still fires after a reload that omits
    `cancel_all`;
  - the same schedule is torn down when the reload is prefixed with
    `cancel_all()`;
  - `fresh_scope()` wipes the older generation but keeps its own block's
    registrations.
- `documentation/source/live_coding/index.rst` — document `fresh_scope` and the
  hot-reload pattern.

The design spec (`docs/design/live_coding_dsl.md`) already locks this surface and
needs no change — the implementation matches it.

## Test plan

- [x] `analyze` on the changed engine file clean (26 warnings, all in non-user
  pybind headers; zero in changed code)
- [x] Python doctest suite passes (`yse_tests --test-suite=python`): 21/21 cases,
  171 assertions
- [x] The 3 new cases confirmed running real assertions against a live engine
  (not early-returned on a missing audio device)

No C API surface change, so no integration test beyond the engine-driven
doctests — which already exercise the real `yse_run_script` path on the script
thread (source submitted through the C API, observed via C++ bus subscribers and
the error callback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)