### PR TITLE
Clear persistent reverb/channel handles on close so re-init doesn't assert (#132)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(YSE_TEST_SOURCES
   io/test_bufferIO.cpp
   system/test_named_bus.cpp
   system/test_system_active_state.cpp
+  system/test_lifecycle.cpp
   integration/test_device.cpp
   python/test_c_api_python.cpp
 )
@@ -125,10 +126,24 @@ set_target_properties(yse_tests PROPERTIES
 if(NOT ANDROID)
 add_test(
   NAME    yse_unit_tests
-  COMMAND yse_tests --test-suite-exclude=integration --duration=true
+  # `lifecycle` is excluded alongside `integration`: it drives System::close(),
+  # which permanently stops the global thread pools and would break every later
+  # suite sharing this process. It runs in its own process via yse_tests_lifecycle.
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
+
+# Engine init/close lifecycle (issue #132). Isolated in its own process because
+# System::close() tears down process-global state (thread pools, named bus) that
+# the rest of the suite assumes stays up. Uses initOffline(), so no audio
+# hardware is needed and it runs in CI.
+add_test(
+  NAME    yse_tests_lifecycle
+  COMMAND yse_tests --test-suite=lifecycle
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_lifecycle PROPERTIES LABELS lifecycle)
 
 add_test(
   NAME    yse_tests_dsp

--- a/Tests/system/test_lifecycle.cpp
+++ b/Tests/system/test_lifecycle.cpp
@@ -1,0 +1,73 @@
+// Regression test for issue #132: a second engine lifecycle in the same
+// process must not trip assert(pimpl == nullptr) on re-init.
+//
+// System::init() re-creates two sets of *persistent* interface objects every
+// cycle, each guarded by assert(pimpl == nullptr):
+//   - the reverb manager's global / calculated reverbs (reverb::create), and
+//   - the channel manager's master + named channels (channel::create /
+//     createGlobal).
+// Before the fix, close() tore down the thread pools and the bus but never
+// cleared those handles, so the second init() re-entered create() with a stale
+// pimpl and aborted (release builds would double-register / leak instead).
+// close() now calls REVERB::Manager().destroy() and CHANNEL::Manager().destroy(),
+// which drop the handles so the next init() re-creates them cleanly.
+//
+// SCOPE: this verifies the *assert* is gone — the documented init/close/init
+// repro no longer aborts and the persistent objects re-validate. It does NOT
+// assert a fully functional re-initialized engine: global::close() shuts the
+// slow/fast thread pools down for good (global::init() has no restart path), so
+// a re-init'd engine cannot yet load sounds or run jobs. That deeper gap is
+// tracked in #140 and is out of scope for #132.
+//
+// ISOLATION: this lives in its own "lifecycle" TEST_SUITE, run as a dedicated
+// ctest process and excluded from the combined `yse_unit_tests` run. Calling
+// System::close() permanently stops the global thread pools, so a lifecycle
+// test sharing a process with the other suites would break every later test
+// that relies on a live engine (the harness keeps one engine up for the whole
+// process — see Tests/support/null_device.hpp). A separate process sidesteps
+// that entirely.
+//
+// initOffline() needs no audio hardware, so this runs in CI. If it ever returns
+// false (no offline device on some host), the case bails out and doctest counts
+// it as a pass.
+
+#include <doctest/doctest.h>
+#include "yse.hpp"
+#include "channel/channelInterface.hpp"
+#include "reverb/reverbInterface.hpp"
+#include "reverb/reverbManager.h"
+
+TEST_SUITE("lifecycle") {
+
+TEST_CASE("lifecycle: repeated init/close re-creates global reverb + channels (issue #132)") {
+    // Normalize to a closed engine regardless of starting state (close() is a
+    // no-op when the engine is inactive).
+    YSE::System().close();
+
+    // First lifecycle: brings the global reverb and master channel up.
+    if (!YSE::System().initOffline()) return; // no offline device on this host
+    CHECK(YSE::REVERB::Manager().getGlobalReverb().isValid());
+    CHECK(YSE::ChannelMaster().isValid());
+
+    YSE::System().close();
+    // After close() the persistent handles are cleared, so a re-init can run
+    // create()/createGlobal() again without tripping their asserts.
+    CHECK_FALSE(YSE::REVERB::Manager().getGlobalReverb().isValid());
+    CHECK_FALSE(YSE::ChannelMaster().isValid());
+
+    // Second lifecycle in the same process — this is where init aborted before
+    // the fix (reverb::create first, then channel::createGlobal once reverb was
+    // patched).
+    REQUIRE(YSE::System().initOffline());
+    CHECK(YSE::REVERB::Manager().getGlobalReverb().isValid());
+    CHECK(YSE::ChannelMaster().isValid());
+
+    // A third cycle for good measure, then leave the engine closed.
+    YSE::System().close();
+    REQUIRE(YSE::System().initOffline());
+    CHECK(YSE::REVERB::Manager().getGlobalReverb().isValid());
+    CHECK(YSE::ChannelMaster().isValid());
+    YSE::System().close();
+}
+
+} // TEST_SUITE("lifecycle")

--- a/YseEngine/channel/channelManager.cpp
+++ b/YseEngine/channel/channelManager.cpp
@@ -142,6 +142,33 @@ Bool YSE::CHANNEL::managerObject::empty() {
   return implementations.empty();
 }
 
+void YSE::CHANNEL::managerObject::destroy() {
+  // Runs from system::close() after both thread pools have been joined and the
+  // audio device is closed, with Global().active already false, so nothing
+  // else can touch these lists and the impl destructors take their inactive
+  // path (no audio-thread parent disconnect). Mirrors
+  // REVERB::Manager().destroy() (issue #132).
+
+  // These are no-ops once the pools are down, but mirror the destructor's
+  // contract that no setup/delete job is mid-flight before the lists are torn.
+  mgrSetup.join();
+  mgrDelete.join();
+
+  // Drain the main->audio inbox; the pointers it holds reference impls owned
+  // by `implementations` and would dangle once that list is cleared below.
+  implementationObject * drained;
+  while (toLoadInbox.try_pop(drained)) { (void)drained; }
+  toLoad.clear();
+  inUse.clear();
+  {
+    std::scoped_lock lk(implementationsMutex);
+    // Each impl destructor nulls its interface's pimpl, clearing the persistent
+    // master/named channels so the next System::init() re-creates them cleanly.
+    implementations.clear();
+  }
+  runDelete = false;
+}
+
 YSE::channel & YSE::CHANNEL::managerObject::master() {
   return _master;
 }

--- a/YseEngine/channel/channelManager.h
+++ b/YseEngine/channel/channelManager.h
@@ -34,6 +34,17 @@ namespace YSE {
 
       void update();
 
+      /** Tear down all per-session channel state so the manager can be
+          re-created by a subsequent System::init(). Called from system::close()
+          after both thread pools are joined and the audio device is closed,
+          with Global().active already false. Clearing `implementations` runs
+          each impl's destructor, which nulls its interface's pimpl — including
+          the persistent master/ambient/fx/music/gui/voice channels — so
+          channel::create()/createGlobal() do not trip their
+          assert(pimpl == nullptr) on the next init (issue #132).
+      */
+      void destroy();
+
       implementationObject * addImplementation(channel * head);
       void setup(implementationObject * impl);
       Bool empty();

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -139,6 +139,11 @@ void YSE::INTERNAL::global::close() {
   // first wait for all threads to exit
   slowThreads.shutdown();
   fastThreads.shutdown();
+  // Threads are joined now, so the reverb manager's session state can be torn
+  // down synchronously. This clears the global reverb's implementation handle
+  // so a subsequent System::init() can re-create it instead of asserting
+  // (issue #132).
+  REVERB::Manager().destroy();
   // Tear down the bus last — by this point the audio device is already
   // closed (system::close() ran DEVICE::Manager().close() before us), so
   // no audio-thread producer can still be enqueuing publish() messages.

--- a/YseEngine/reverb/reverbManager.cpp
+++ b/YseEngine/reverb/reverbManager.cpp
@@ -44,6 +44,31 @@ void YSE::REVERB::managerObject::create() {
   calculatedValues.create();
 }
 
+void YSE::REVERB::managerObject::destroy() {
+  // Runs from INTERNAL::global::close() after both thread pools have been
+  // joined and the audio device is closed, so nothing else can touch these
+  // lists while we clear them.
+
+  // Drain the main->audio inbox; the pointers it holds reference impls owned
+  // by `implementations` and would dangle once that list is cleared below.
+  implementationObject * drained;
+  while (toLoadInbox.try_pop(drained)) { (void)drained; }
+  toLoad.clear();
+  inUse.clear();
+  {
+    std::scoped_lock lk(implementationsMutex);
+    implementations.clear();
+  }
+  runDelete = false;
+
+  // The global and calculated reverbs are persistent members that outlive the
+  // session; their implementations were just destroyed above. Clear the now
+  // dangling handles so the next System::init() re-runs reverb::create()
+  // cleanly instead of tripping assert(pimpl == nullptr) (issue #132).
+  globalReverb.pimpl = nullptr;
+  calculatedValues.pimpl = nullptr;
+}
+
 YSE::REVERB::implementationObject * YSE::REVERB::managerObject::addImplementation(YSE::reverb * head) {
   std::scoped_lock lk(implementationsMutex);
   implementations.emplace_front(head);

--- a/YseEngine/reverb/reverbManager.h
+++ b/YseEngine/reverb/reverbManager.h
@@ -37,6 +37,16 @@ namespace YSE {
       */
       void create();
 
+      /** Tear down all per-session reverb state so the manager can be
+          re-created by a subsequent System::init(). Called from
+          INTERNAL::global::close() after the slow-pool and audio threads have
+          been shut down, so the implementation lists are cleared synchronously
+          without racing either thread. Clears the persistent global/calculated
+          reverbs' implementation handles so reverb::create() does not trip its
+          assert(pimpl == nullptr) on the next init (issue #132).
+      */
+      void destroy();
+
       /** Request a new implementationObject. This should be called from the interfaceObject.
       It creates an implementationObject that will be linked to the interfaceObject.
 

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -129,6 +129,12 @@ void YSE::system::close() {
     INTERNAL::Global().active = false;
     DEVICE::Manager().close();
     INTERNAL::Global().close();
+    // Tear down the channel manager last: Global().close() has joined both
+    // thread pools and the device is already closed, so the persistent
+    // master/named channels can be cleared synchronously. This drops their
+    // implementation handles so the next System::init() can re-create them
+    // instead of asserting (issue #132).
+    CHANNEL::Manager().destroy();
   }
 
 #ifdef YSE_WINDOWS


### PR DESCRIPTION
## Summary

Calling `System::init() → close() → init()` a second time in one process aborted on a debug assertion (`assert(pimpl == nullptr)`), first in `reverb::create()` (the bug as filed) and then in `channel::createGlobal()` once reverb was patched.

`System::init()` re-creates two sets of **persistent** interface objects every cycle — the reverb manager's `global`/`calculated` reverbs and the channel manager's `master`/named channels — each guarded by `assert(pimpl == nullptr)`. `close()` shut down the thread pools and the named bus but never cleared those handles, so the second `init()` re-entered `create()`/`createGlobal()` with a stale `pimpl` and aborted (release builds would double-register / leak instead).

## Linked issue

Closes #132

## Changes

- `REVERB::managerObject::destroy()` and `CHANNEL::managerObject::destroy()` — drain the main→audio inbox, clear the impl lists, and drop the persistent interfaces' `pimpl` handles. For channels, clearing `implementations` runs each impl destructor (which nulls its interface's `pimpl`); since `Global().active` is already `false`, those destructors take their inactive path (no audio-thread parent disconnect).
- Wired into the existing close path once the thread pools are joined and the device is closed: `REVERB::Manager().destroy()` from `global::close()`, `CHANNEL::Manager().destroy()` from `system::close()` after it.
- New `lifecycle` test suite (`Tests/system/test_lifecycle.cpp`) driving the real `initOffline → close → init` repro. It runs in its **own ctest process** (`yse_tests_lifecycle`) and is excluded from the combined `yse_unit_tests` run, because `System::close()` permanently stops the global thread pools — a lifecycle test sharing the process would break every later suite that relies on a live engine.

## Scope

This fixes the **asserts** so the documented repro no longer aborts and the persistent objects re-validate on re-init. The deeper functional gap — `close()` permanently stops the global thread pools and `init()` has no restart path, so a re-initialized engine can't yet load sounds or run jobs — is filed as #140 and is out of scope here.

## Test plan

- [x] `python yse.py analyze` on all four changed engine files — no new findings (all warnings suppressed in non-user/header code).
- [x] `python yse.py test` — 16/16 ctest entries pass, including the combined `yse_unit_tests` and the isolated `yse_tests_lifecycle`.
- [x] Regression confirmed: on unpatched code the repro aborts at the reverb assert (and, with only reverb patched, at the channel assert), as observed during development.
- [ ] No integration/e2e test added: the change is startup/teardown only (not user-visible rendering/flow), and the functional re-init path it would exercise is blocked by #140 (dead thread pools). The lifecycle test covers the no-abort + re-validation behavior that is in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)