### PR TITLE
yse.py --python flag + *-python presets for embedded-CPython (#139)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ build-android-arm64/
 build-android-x86_64/
 build-tools/
 build-python-tests/
+build-debug-python/
+build-python/
+build-tests-python/
 [Bb]in/
 [Oo]bj/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,9 @@ every preset:
 ```powershell
 python yse.py build              # debug preset
 python yse.py build --release    # release preset
+python yse.py build --python     # debug + embedded-Python live-coding (YSE_ENABLE_PYTHON, desktop only)
 python yse.py test               # tests-debug preset + ctest
+python yse.py test --python      # tests-debug-python preset + ctest (runs the embedded-interpreter suite)
 python yse.py run Demo00         # run a demo from build-debug/bin/
 python yse.py analyze            # clang-tidy
 python yse.py format             # clang-format -i

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -42,6 +42,36 @@
       }
     },
     {
+      "name": "debug-python",
+      "displayName": "Debug + Python",
+      "description": "Debug build with the embedded-CPython live-coding feature enabled (YSE_ENABLE_PYTHON=ON; desktop only)",
+      "inherits": "debug",
+      "binaryDir": "${sourceDir}/build-debug-python",
+      "cacheVariables": {
+        "YSE_ENABLE_PYTHON": "ON"
+      }
+    },
+    {
+      "name": "release-python",
+      "displayName": "Release + Python",
+      "description": "Optimized release build with the embedded-CPython live-coding feature enabled (YSE_ENABLE_PYTHON=ON; desktop only)",
+      "inherits": "release",
+      "binaryDir": "${sourceDir}/build-python",
+      "cacheVariables": {
+        "YSE_ENABLE_PYTHON": "ON"
+      }
+    },
+    {
+      "name": "tests-debug-python",
+      "displayName": "Debug + Tests + Python",
+      "description": "Debug test build with the embedded-CPython live-coding feature enabled, so the #127 hot-reload/runtime suite runs (YSE_ENABLE_PYTHON=ON; desktop only)",
+      "inherits": "tests-debug",
+      "binaryDir": "${sourceDir}/build-tests-python",
+      "cacheVariables": {
+        "YSE_ENABLE_PYTHON": "ON"
+      }
+    },
+    {
       "name": "bench",
       "displayName": "Release + Benchmarks",
       "description": "Release build with the Bench/ suite enabled (fetches google-benchmark on first configure)",
@@ -100,6 +130,21 @@
       "configurePreset": "tests-debug"
     },
     {
+      "name": "debug-python",
+      "displayName": "Debug + Python",
+      "configurePreset": "debug-python"
+    },
+    {
+      "name": "release-python",
+      "displayName": "Release + Python",
+      "configurePreset": "release-python"
+    },
+    {
+      "name": "tests-debug-python",
+      "displayName": "Debug + Tests + Python",
+      "configurePreset": "tests-debug-python"
+    },
+    {
       "name": "bench",
       "displayName": "Release + Benchmarks",
       "configurePreset": "bench"
@@ -130,6 +175,12 @@
       "name": "tests-debug",
       "displayName": "Debug tests",
       "configurePreset": "tests-debug",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "tests-debug-python",
+      "displayName": "Debug tests + Python",
+      "configurePreset": "tests-debug-python",
       "output": { "outputOnFailure": true }
     },
     {

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -67,14 +67,19 @@ The old .NET/Xamarin wrappers, the WPF demo, the UWP build, and the JUCE backend
 | `debug` | `build-debug/` | Library + demos, no tests |
 | `release` | `build/` | Optimized release |
 | `tests-debug` | `build-tests/` | Debug + `YSE_BUILD_TESTS=ON` |
+| `debug-python` | `build-debug-python/` | `debug` + `YSE_ENABLE_PYTHON=ON` (embedded-CPython live-coding; desktop only) |
+| `release-python` | `build-python/` | `release` + `YSE_ENABLE_PYTHON=ON` (desktop only) |
+| `tests-debug-python` | `build-tests-python/` | `tests-debug` + `YSE_ENABLE_PYTHON=ON` — runs the embedded-interpreter suite |
 | `coverage` | `build-coverage/` | Linux only — gcc/clang `--coverage` instrumentation |
 | `coverage-windows` | `build-coverage/` | Windows/Clang only — LLVM source-based coverage |
 
 ```sh
 python yse.py build                # cmake --preset debug + build
 python yse.py build --release      # release variant
+python yse.py build --python       # debug variant with embedded-Python live-coding (YSE_ENABLE_PYTHON=ON, desktop only)
 python yse.py test                 # tests-debug preset + ctest
 python yse.py test --integration   # also run the integration suite (needs a real audio device)
+python yse.py test --python        # tests-debug-python preset — also runs the embedded-interpreter suite
 python yse.py coverage             # coverage preset + report (gcovr → coverage.xml on Linux,
                                    # llvm-profdata+llvm-cov → coverage-llvm.json on Windows)
 python yse.py run [Demo]           # run a demo from build-debug/bin/ (default: Demo00)

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ Flutter-style CLI for the common tasks.  On Windows run it via:
 ```sh
 python yse.py build              # configure + debug build (default)
 python yse.py build --release    # release build
+python yse.py build --python     # debug build with the embedded-Python live-coding feature (desktop only)
 python yse.py test               # build tests-debug preset, run ctest
+python yse.py test --python      # tests-debug-python preset — also runs the embedded-interpreter suite
 python yse.py coverage           # coverage build + gcovr report (Linux only)
 python yse.py run                # run Demo00 from build-debug/bin/
 python yse.py run Demo05         # run a specific demo

--- a/yse.py
+++ b/yse.py
@@ -79,18 +79,22 @@ def _demo_exe(name):
 
 def cmd_build(args):
     preset = "release" if args.release else "debug"
+    if args.python:
+        preset += "-python"
     run(["cmake", "--preset", preset])
     run(["cmake", "--build", "--preset", preset])
 
 
 def cmd_test(args):
-    run(["cmake", "--preset", "tests-debug"])
-    run(["cmake", "--build", "--preset", "tests-debug"])
-    run(["ctest", "--preset", "tests-debug"])
+    preset = "tests-debug-python" if args.python else "tests-debug"
+    build_dir = "build-tests-python" if args.python else "build-tests"
+    run(["cmake", "--preset", preset])
+    run(["cmake", "--build", "--preset", preset])
+    run(["ctest", "--preset", preset])
 
     if args.integration:
         suffix = ".exe" if IS_WINDOWS else ""
-        exe = ROOT / "build-tests" / "bin" / ("yse_tests" + suffix)
+        exe = ROOT / build_dir / "bin" / ("yse_tests" + suffix)
         if not exe.exists():
             print(f"error: {exe} not found after build.")
             sys.exit(1)
@@ -250,6 +254,9 @@ def cmd_clean(args):
         ROOT / "build-coverage",
         ROOT / "build-bench",
         ROOT / "build-tools",
+        ROOT / "build-debug-python",
+        ROOT / "build-python",
+        ROOT / "build-tests-python",
     ]
     files_to_remove = [
         ROOT / "coverage.xml",
@@ -857,8 +864,10 @@ def build_parser():
         epilog="""examples:
   python yse.py build              configure + build (debug)
   python yse.py build --release    configure + build (release)
+  python yse.py build --python     configure + build (debug) with embedded-Python live-coding (YSE_ENABLE_PYTHON=ON)
   python yse.py test               build tests-debug preset, run ctest
   python yse.py test --integration same, plus the integration suite (needs real audio device)
+  python yse.py test --python      build tests-debug-python preset so the embedded-interpreter suite runs
   python yse.py bench              build bench preset, run benchmark binary
   python yse.py bench --filter Buffer  run only benchmarks matching 'Buffer'
   python yse.py coverage           coverage preset + report (Linux: gcovr→coverage.xml; Windows: llvm-cov→coverage-llvm.json)
@@ -892,6 +901,11 @@ def build_parser():
         "--release", action="store_true",
         help="Use the release preset instead of debug",
     )
+    p.add_argument(
+        "--python", action="store_true",
+        help="Enable the embedded-CPython live-coding feature (YSE_ENABLE_PYTHON=ON; "
+             "uses the *-python preset; desktop only)",
+    )
     p.set_defaults(func=cmd_build)
 
     # test
@@ -911,6 +925,12 @@ def build_parser():
     p.add_argument(
         "--integration", action="store_true",
         help="Also run the integration suite (requires a real audio device)",
+    )
+    p.add_argument(
+        "--python", action="store_true",
+        help="Enable the embedded-CPython live-coding feature (YSE_ENABLE_PYTHON=ON; "
+             "uses the tests-debug-python preset so the embedded-interpreter suite "
+             "runs; desktop only)",
     )
     p.set_defaults(func=cmd_test)
 


### PR DESCRIPTION
## Summary

Makes the embedded-CPython live-coding feature (`YSE_ENABLE_PYTHON`, landed in #124/#126/#127) buildable through the project's standard tooling. Until now no preset set the option and `yse.py` only invoked the non-Python presets, leaving a hand-rolled `cmake` invocation as the only path — which CLAUDE.md explicitly steers away from.

## Linked issue
Closes #139

## Changes
- **`CMakePresets.json`** — three new configure presets (`debug-python`, `release-python`, `tests-debug-python`) that **inherit** the base ones and add `YSE_ENABLE_PYTHON: ON`, each with its own `binaryDir`; matching build + test presets. Presets stay the source of truth per CLAUDE.md.
- **`yse.py`** — `--python` flag on `build` and `test` that selects the matching `*-python` preset; the integration-exe path follows the preset's build dir; `clean` removes the new build dirs; help/epilog updated.
- **`.gitignore`** — ignore `build-debug-python/`, `build-python/`, `build-tests-python/`.
- **`README.md` / `PROJECT_OVERVIEW.md` / `CLAUDE.md`** — document the new flag and presets.

## Design decisions
- **New inheriting presets + flag**, not a `-D` passthrough — keeps the presets canonical.
- **Strictly opt-in: CI is untouched.** The #127 hot-reload/runtime suite runs only when a developer builds with `--python`.
- **Desktop-only is preserved.** Only the desktop `yse.py` invokes these presets, and CMake already `FATAL_ERROR`s if `YSE_ENABLE_PYTHON` is combined with Android.

## Test plan
- [x] `python yse.py test --python` — configures `tests-debug-python`, builds, runs ctest: **16/16 pass**, including `yse_tests_python` (test #14), which only registers when `YSE_ENABLE_PYTHON=ON` — confirming the feature is genuinely enabled by the preset.
- [x] `cmake --preset debug-python` — resolves libpython (3.14.4) and configures clean (exit 0).
- [x] `python yse.py build --help` / `test --help` — `--python` flag present and documented.
- [x] JSON validated; new build dirs confirmed gitignored.
- No automated test added: this is infra/tooling with no `yse.py` test harness. The end-to-end verification above (the embedded-Python suite building and running under the new preset) is the meaningful check. No C++ changed, so the `yse.py analyze` commit-gate does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)