### PR TITLE
FIX: Revive global thread pools on engine re-init (#140)

### DIFF
--- a/Tests/system/test_lifecycle.cpp
+++ b/Tests/system/test_lifecycle.cpp
@@ -12,12 +12,12 @@
 // close() now calls REVERB::Manager().destroy() and CHANNEL::Manager().destroy(),
 // which drop the handles so the next init() re-creates them cleanly.
 //
-// SCOPE: this verifies the *assert* is gone — the documented init/close/init
-// repro no longer aborts and the persistent objects re-validate. It does NOT
-// assert a fully functional re-initialized engine: global::close() shuts the
-// slow/fast thread pools down for good (global::init() has no restart path), so
-// a re-init'd engine cannot yet load sounds or run jobs. That deeper gap is
-// tracked in #140 and is out of scope for #132.
+// SCOPE: the first case here verifies the *assert* is gone — the documented
+// init/close/init repro no longer aborts and the persistent objects re-validate.
+// The functional gap it used to defer (a re-init'd engine could not load sounds
+// or run jobs because global::close() shut the thread pools down for good) is
+// closed by #140 and covered by the second case below, which drives a real
+// sound to OBJECT_READY after an init/close/init cycle.
 //
 // ISOLATION: this lives in its own "lifecycle" TEST_SUITE, run as a dedicated
 // ctest process and excluded from the combined `yse_unit_tests` run. Calling
@@ -32,10 +32,24 @@
 // it as a pass.
 
 #include <doctest/doctest.h>
+#include <chrono>
+#include <thread>
 #include "yse.hpp"
 #include "channel/channelInterface.hpp"
 #include "reverb/reverbInterface.hpp"
 #include "reverb/reverbManager.h"
+#include "sound/soundInterface.hpp"
+#include "sound/soundManager.h"
+#include "internal/time.h"
+
+// Absolute path to the WAV fixture injected by CMake; falls back to a relative
+// path that works when the test binary runs from build-X/bin/ (mirrors the
+// definition in Tests/sound/test_sound_state.cpp).
+#ifndef YSE_TEST_FIXTURES_DIR
+#  define YSE_TEST_FIXTURES_DIR "../../Tests/support/fixtures"
+#endif
+static const char* const WAV_FIXTURE =
+    YSE_TEST_FIXTURES_DIR "/test_mono_44100.wav";
 
 TEST_SUITE("lifecycle") {
 
@@ -67,6 +81,48 @@ TEST_CASE("lifecycle: repeated init/close re-creates global reverb + channels (i
     REQUIRE(YSE::System().initOffline());
     CHECK(YSE::REVERB::Manager().getGlobalReverb().isValid());
     CHECK(YSE::ChannelMaster().isValid());
+    YSE::System().close();
+}
+
+// Regression test for issue #140: after a full init/close cycle, global::init()
+// must revive the slow/fast thread pools so a re-initialized engine is actually
+// *functional* — not just non-aborting. The clearest observable proof is a WAV
+// file reaching OBJECT_READY, which requires the slow pool's file-load worker to
+// be alive again. Before the fix, close() joined the pools for good and init()
+// had no restart path, so the second session's sound stayed at LOADING forever
+// and this CHECK failed.
+//
+// Runs in the isolated "lifecycle" process for the same reason as the case
+// above: it drives System::close(), which the shared unit-test process cannot
+// tolerate mid-run.
+TEST_CASE("lifecycle: re-init'd engine loads a sound to OBJECT_READY (issue #140)") {
+    YSE::System().close(); // normalize to a closed engine
+
+    // Burn one full lifecycle, then re-init — this is the cycle that left the
+    // pools dead before the fix.
+    if (!YSE::System().initOffline()) return; // no offline device on this host
+    YSE::System().close();
+    REQUIRE(YSE::System().initOffline());
+
+    {
+        YSE::sound s;
+        s.create(WAV_FIXTURE);
+        if (s.isValid()) { // skip only if the fixture is missing on this host
+            // Pump the manager directly (test thread drives update; audio is
+            // paused). Budget ~2 s: the 244-byte WAV loads through the single
+            // revived slow-pool worker within a few update ticks.
+            const auto deadline =
+                std::chrono::steady_clock::now() + std::chrono::seconds(2);
+            while (std::chrono::steady_clock::now() < deadline) {
+                YSE::INTERNAL::Time().update();
+                YSE::SOUND::Manager().update();
+                if (s.isReady()) break;
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            }
+            CHECK(s.isReady());
+        }
+    } // ~sound fires here, while the engine is still up
+
     YSE::System().close();
 }
 

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -131,6 +131,12 @@ YSE::INTERNAL::global::global() : slowThreads(1), fastThreads(), bus(), update(f
 YSE::INTERNAL::global::~global() = default;
 
 void YSE::INTERNAL::global::init() {
+  // Revive the worker pools first: close() joins them for good, so a second
+  // session would otherwise start with dead pools — no slow-pool file loading,
+  // no fast-pool DSP fan-out or manager setup/delete jobs (issue #140). No-op
+  // on the very first session, where the pools are still live from the ctor.
+  slowThreads.startup();
+  fastThreads.startup();
   REVERB::Manager().create();
   bus = std::make_unique<NamedBus>();
 }

--- a/YseEngine/internal/threadPool.cpp
+++ b/YseEngine/internal/threadPool.cpp
@@ -50,30 +50,37 @@ void YSE::INTERNAL::threadPoolThread::run() {
   }
 }
 
-YSE::INTERNAL::threadPool::threadPool(Int numThreads) : active(true){
-  if (numThreads == -1) {
-    numThreads = std::thread::hardware_concurrency();
+YSE::INTERNAL::threadPool::threadPool(Int numThreads) : poolSize(numThreads), active(false) {
+  if (poolSize == -1) {
+    poolSize = std::thread::hardware_concurrency();
   }
 
   // this might happen if hardware_concurrency() is not well defined or not computable
   // in which case we need at least one thread to continue
-  if (numThreads == 0) {
-    numThreads = 1;
+  if (poolSize == 0) {
+    poolSize = 1;
   }
 
-  for (Int i = 0; i < numThreads; i++) {
-    threads.emplace_front(this);
-    threads.front().start();
-  }
+  startup();
 }
 
 YSE::INTERNAL::threadPool::~threadPool() {
   shutdown();
 }
 
+void YSE::INTERNAL::threadPool::startup() {
+  if (active) return; // already running — startup() is idempotent
+  active = true;
+  for (Int i = 0; i < poolSize; i++) {
+    threads.emplace_front(this);
+    threads.front().start();
+  }
+}
+
 void YSE::INTERNAL::threadPool::shutdown() {
   {
     std::unique_lock<std::mutex> lock(mutex);
+    if (!active) return; // already shut down — nothing to join or drain
     active = false;
     while (!jobs.empty()) {
       jobs.front()->inQueue = false;
@@ -85,6 +92,10 @@ void YSE::INTERNAL::threadPool::shutdown() {
   for (auto i = threads.begin(); i != threads.end(); ++i) {
     i->stop();
   }
+  // Drop the now-joined worker objects; startup() re-populates the list when
+  // the pool is revived for the next session (issue #140). Clearing also lets
+  // ~threadPoolThread's assert(!isRunning()) pass — every handle is null now.
+  threads.clear();
 }
 
 void YSE::INTERNAL::threadPool::addJob(threadPoolJob * job) {

--- a/YseEngine/internal/threadPool.h
+++ b/YseEngine/internal/threadPool.h
@@ -62,12 +62,21 @@ namespace YSE {
       // only used by threadPoolThread, returns nullptr if there's no job to execute
       threadPoolJob * getJob();
 
-      // shutdown this pool. Call this before deconstructing
+      // (Re)spawn the worker threads and mark the pool active. Called by the
+      // constructor and, after a shutdown(), by global::init() to revive the
+      // pool for a fresh engine session (issue #140). Idempotent: a no-op while
+      // the pool is already active.
+      void startup();
+
+      // shutdown this pool: drain the queue, join every worker, and drop the
+      // (now-joined) thread objects so a later startup() re-spawns cleanly. Call
+      // before deconstructing; safe to call on an already-inactive pool.
       void shutdown();
 
     private:
       std::queue<threadPoolJob*> jobs;
       std::forward_list<threadPoolThread> threads;
+      Int poolSize; // resolved worker count, reused when startup() re-spawns
       aBool active;
       std::mutex mutex;
       std::condition_variable cv;


### PR DESCRIPTION
## Summary

After a `System` init/close/init cycle in one process, the engine came back *structurally* (reverb/channels re-created per #132) but not *functionally*: `global::close()` joins the slow/fast `threadPool`s for good and `global::init()` had no restart path. The dead slow pool never loaded files (sounds never reached `OBJECT_READY`) and the dead fast pool never ran manager setup/delete jobs or child-channel DSP fan-out.

This adds an idempotent `threadPool::startup()` that (re)spawns the workers, and calls it for both pools at the top of `global::init()`.

## Linked issue

Closes #140

## Changes

- **`threadPool` restart path** — the ctor stores the resolved `poolSize` and delegates spawning to a new idempotent `startup()`; `shutdown()` is now idempotent and `threads.clear()`s the joined workers so a later `startup()` re-populates cleanly (and `~threadPoolThread`'s `assert(!isRunning())` holds).
- **`global::init()`** calls `slowThreads.startup()` / `fastThreads.startup()` before reverb/bus creation — a no-op on the first session (pools live from the ctor), a revive on every re-init.
- **Regression test** — a functional case in the isolated `lifecycle` process drives a WAV to `OBJECT_READY` after an init/close/init cycle.

## Subsystem audit (issue's second ask)

The manager setup/delete passes are `threadPoolJob`s dispatched onto the global pools, so reviving the pools revives them. The patcher `TimerThread` survives idle across cycles; `DEVICE`/`MIDI`/scripting already `init`/`close` per cycle. **The global pools were the sole "shut down once" defect — no follow-up issues filed.**

## Test plan

- [x] `clang-tidy` on both changed `.cpp` files — no new findings in modified code
- [x] Unit tests pass — full `ctest` 16/16 green with the fix
- [x] **Regression verified** — with the `startup()` calls disabled, the new case fails exactly at `CHECK(s.isReady())` (`test_lifecycle.cpp:122`) while #132's case still passes; passes with the fix restored
- [x] Integration suite (`yse_tests_integration`) passes
- n/a formatter — repo does not follow its own `.clang-format` (2-space K&R is the real style); edits match the surrounding style

🤖 Generated with [Claude Code](https://claude.com/claude-code)
