### PR TITLE
FIX: Move streaming disk I/O off the audio callback thread (#185)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(YSE_TEST_SOURCES
   channel/test_channel_metering.cpp
   channel/test_channel_bus.cpp
   sound/test_sound_state.cpp
+  sound/test_sound_streaming.cpp
   sound/test_sound_impl.cpp
   sound/test_sound_concurrency.cpp
   sound/test_sound_bufferIO.cpp
@@ -102,6 +103,14 @@ target_link_libraries(yse_tests
   PRIVATE
     yse_objects   # direct object linkage: full symbol access without API export boundary
     doctest
+    yse::sndfile  # test_sound_streaming.cpp needs sndfile.hh (fixture writer + INTERNAL::soundFile)
+)
+
+# test_sound_streaming.cpp drives INTERNAL::soundFile directly, whose header is
+# gated behind LIBSOUNDFILE_BACKEND (defined PRIVATE on yse_objects). Enable the
+# gate for just this one TU so the rest of the suite is unaffected (issue #185).
+set_source_files_properties(sound/test_sound_streaming.cpp PROPERTIES
+  COMPILE_DEFINITIONS LIBSOUNDFILE_BACKEND
 )
 
 target_compile_features(yse_tests PRIVATE cxx_std_17)

--- a/Tests/sound/test_sound_streaming.cpp
+++ b/Tests/sound/test_sound_streaming.cpp
@@ -1,0 +1,255 @@
+// Tests for streaming-sound playback in the interleaved read path
+// (YseEngine/internal/abstractSoundFile.cpp + lsfSoundfile.cpp).
+//
+// Regression coverage for issue #185: streaming refills must happen on the slow
+// thread pool, never as blocking disk I/O on the audio callback. These tests
+// drive INTERNAL::soundFile::read() directly (playing the audio thread's role)
+// while the real slow pool fills the back buffer, and assert the produced audio
+// is correct across buffer boundaries, at end-of-file, when looping, and after a
+// stop/restart. They also exercise destruction while a refill is in flight.
+//
+// White-box access: this TU is compiled with LIBSOUNDFILE_BACKEND (set for just
+// this file in Tests/CMakeLists.txt) so it can see INTERNAL::soundFile and use
+// libsndfile to generate fixtures. The engine is initialised with the audio
+// stream paused (TestHelpers::engineInit), so the test thread is the sole caller
+// of read(); the slow pool still runs on its own worker threads.
+
+#if LIBSOUNDFILE_BACKEND
+
+#include <doctest/doctest.h>
+#include <sndfile.hh>
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "internal/lsfSoundfile.h"
+#include "internal/time.h"
+#include "dsp/buffer.hpp"
+#include "support/null_device.hpp"
+
+using YSE::SOUND_STATUS;
+using YSE::INTERNAL::soundFile;
+// Flt / UInt / Bool are global typedefs (headers/types.hpp).
+
+namespace {
+
+// A distinct, position-sensitive sample value for frame n. Using a hash makes a
+// mis-swap (replaying the wrong buffer) produce clearly wrong values.
+float sampleAt(long n) {
+  uint32_t h = static_cast<uint32_t>(n) * 2654435761u;
+  return static_cast<float>(((h >> 8) & 0xFFFF) / 32768.0 - 1.0);
+}
+
+// Write a mono float WAV of `frames` frames at the engine sample rate and return
+// its path; also fills `src` with the exact samples written (float WAV is stored
+// losslessly, so playback should reproduce these values bit-for-bit).
+std::string writeWav(long frames, std::vector<float>& src) {
+  src.resize(static_cast<size_t>(frames));
+  for (long n = 0; n < frames; ++n) src[static_cast<size_t>(n)] = sampleAt(n);
+
+  namespace fs = std::filesystem;
+  fs::path p = fs::temp_directory_path() / ("yse_stream_" + std::to_string(frames) + ".wav");
+  SndfileHandle h(p.string().c_str(), SFM_WRITE, SF_FORMAT_WAV | SF_FORMAT_FLOAT,
+                  1, static_cast<int>(YSE::SAMPLERATE));
+  h.writef(src.data(), frames);
+  // SndfileHandle flushes and closes on destruction (end of this function).
+  return p.string();
+}
+
+// Wait for the slow-pool load to finish (state == READY) or time out.
+bool waitReady(soundFile& f) {
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (f.getState() == YSE::INTERNAL::READY) return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  return f.getState() == YSE::INTERNAL::READY;
+}
+
+// Read one STANDARD_BUFFERSIZE block, transparently retrying a transient underrun
+// (a fully silent block while still playing) after giving the slow pool time to
+// land the refill. Returns true once the stream has stopped (EOF reached).
+bool readBlock(soundFile& f, Flt& pos, Bool loop, SOUND_STATUS& intent,
+               Flt& vol, std::vector<float>& out) {
+  for (int retry = 0; retry < 500; ++retry) {
+    std::vector<YSE::DSP::buffer> fb(1); // one mono output buffer of length STANDARD_BUFFERSIZE
+    f.read(fb, pos, YSE::STANDARD_BUFFERSIZE, 1.0f, loop, intent, vol);
+    const Flt* p = fb[0].getPtr();
+    out.assign(p, p + YSE::STANDARD_BUFFERSIZE);
+    if (intent == YSE::SS_STOPPED) return true;
+    bool allZero = std::all_of(out.begin(), out.end(), [](float v) { return v == 0.0f; });
+    if (!allZero) return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(3)); // underrun: let the refill land
+  }
+  return false;
+}
+
+// Small periodic pause so the slow pool always fills the next buffer well before
+// the play cursor reaches it — keeps the tests free of (allowed but timing-
+// dependent) underruns so frame accounting stays exact.
+void breathe(int block) {
+  if ((block & 7) == 0) std::this_thread::sleep_for(std::chrono::milliseconds(1));
+}
+
+const long S = static_cast<long>(YSE::STREAM_BUFFERSIZE); // 44100
+
+} // namespace
+
+TEST_SUITE("sound") {
+
+// 1. Audio stays sample-accurate across buffer boundaries (the core swap path).
+TEST_CASE("streaming: audio is continuous across buffer boundaries") {
+  if (!TestHelpers::engineInit()) return;
+
+  std::vector<float> src;
+  std::string path = writeWav(2 * S + 10000, src); // spans two buffer boundaries
+  soundFile f(path);
+  f.create(true);
+  REQUIRE(waitReady(f));
+
+  Flt pos = 0.f, vol = 1.f;
+  SOUND_STATUS intent = YSE::SS_PLAYING_FULL_VOLUME;
+  std::vector<float> out;
+  long frame = 0;
+  const long verifyTo = 2 * S + 4000; // stays before EOF
+  for (int b = 0; frame < verifyTo; ++b) {
+    bool stopped = readBlock(f, pos, false, intent, vol, out);
+    REQUIRE_FALSE(stopped);
+    for (UInt j = 0; j < YSE::STANDARD_BUFFERSIZE && frame < static_cast<long>(src.size()); ++j, ++frame) {
+      CHECK(out[j] == doctest::Approx(src[static_cast<size_t>(frame)]).epsilon(0.0001));
+    }
+    breathe(b);
+  }
+}
+
+// 2. A non-looping stream longer than one buffer plays its full tail, then stops.
+//    (The pre-#185 code dropped the final partial buffer — up to ~1 s of tail.)
+TEST_CASE("streaming: non-looping stream plays its full tail then stops") {
+  if (!TestHelpers::engineInit()) return;
+
+  const long r = 12345; // 0 < r < S and not a multiple of STANDARD_BUFFERSIZE
+  std::vector<float> src;
+  std::string path = writeWav(S + r, src);
+  soundFile f(path);
+  f.create(true);
+  REQUIRE(waitReady(f));
+
+  Flt pos = 0.f, vol = 1.f;
+  SOUND_STATUS intent = YSE::SS_PLAYING_FULL_VOLUME;
+  std::vector<float> out;
+  long frame = 0;
+  bool stopped = false;
+  for (int b = 0; !stopped && b < 4000; ++b) {
+    stopped = readBlock(f, pos, false, intent, vol, out);
+    for (UInt j = 0; j < YSE::STANDARD_BUFFERSIZE; ++j) {
+      if (frame < static_cast<long>(src.size())) {
+        CHECK(out[j] == doctest::Approx(src[static_cast<size_t>(frame)]).epsilon(0.0001));
+        ++frame;
+      } else {
+        CHECK(out[j] == 0.0f); // past true EOF: silence
+      }
+    }
+    breathe(b);
+  }
+
+  CHECK(stopped);
+  CHECK(frame == static_cast<long>(src.size())); // every real frame played — no dropped tail
+}
+
+// 3. A looping stream wraps seamlessly and keeps producing the right samples.
+TEST_CASE("streaming: looping stream wraps seamlessly") {
+  if (!TestHelpers::engineInit()) return;
+
+  const long len = S + 12345; // loop period straddling a buffer boundary
+  std::vector<float> src;
+  std::string path = writeWav(len, src);
+  soundFile f(path);
+  f.create(true);
+  REQUIRE(waitReady(f));
+
+  Flt pos = 0.f, vol = 1.f;
+  SOUND_STATUS intent = YSE::SS_PLAYING_FULL_VOLUME;
+  std::vector<float> out;
+  long frame = 0;
+  const long verifyTo = len + S + 4000; // read well past the first wrap
+  for (int b = 0; frame < verifyTo; ++b) {
+    bool stopped = readBlock(f, pos, true, intent, vol, out);
+    REQUIRE_FALSE(stopped); // a looping stream never stops
+    for (UInt j = 0; j < YSE::STANDARD_BUFFERSIZE && frame < verifyTo; ++j, ++frame) {
+      CHECK(out[j] == doctest::Approx(src[static_cast<size_t>(frame % len)]).epsilon(0.0001));
+    }
+    breathe(b);
+  }
+}
+
+// 4. Stopping a stream re-primes it; the next play starts from frame 0 again.
+TEST_CASE("streaming: stop re-primes so restart plays from the start") {
+  if (!TestHelpers::engineInit()) return;
+
+  std::vector<float> src;
+  std::string path = writeWav(2 * S, src);
+  soundFile f(path);
+  f.create(true);
+  REQUIRE(waitReady(f));
+
+  Flt pos = 0.f, vol = 1.f;
+  SOUND_STATUS intent = YSE::SS_PLAYING_FULL_VOLUME;
+  std::vector<float> out;
+
+  // Play past the first boundary (into buffer 1).
+  for (int b = 0; b < 500; ++b) {
+    readBlock(f, pos, false, intent, vol, out);
+    breathe(b);
+  }
+
+  // Emulate the audio-thread stop action (mirrors dspFunc_parseIntent's
+  // file->reset() on a paused→stopped streaming sound).
+  f.reset();
+
+  // Restart: playback must resume from frame 0.
+  pos = 0.f;
+  vol = 1.f;
+  intent = YSE::SS_PLAYING_FULL_VOLUME;
+  long frame = 0;
+  for (int b = 0; b < 40; ++b) {
+    bool stopped = readBlock(f, pos, false, intent, vol, out);
+    REQUIRE_FALSE(stopped);
+    for (UInt j = 0; j < YSE::STANDARD_BUFFERSIZE; ++j, ++frame) {
+      CHECK(out[j] == doctest::Approx(src[static_cast<size_t>(frame)]).epsilon(0.0001));
+    }
+    breathe(b);
+  }
+}
+
+// 5. Destroying a streaming soundFile while a refill is in flight must not crash
+//    or touch freed memory (the dtor joins the refill job). Run under ASan/TSan
+//    in CI for the real teardown-race coverage.
+TEST_CASE("streaming: destruction with a refill in flight is clean") {
+  if (!TestHelpers::engineInit()) return;
+
+  std::vector<float> src;
+  std::string path = writeWav(3 * S, src);
+
+  for (int iter = 0; iter < 8; ++iter) {
+    soundFile f(path);
+    f.create(true);
+    REQUIRE(waitReady(f)); // load finished; only the back-buffer refill may be in flight
+    Flt pos = 0.f, vol = 1.f;
+    SOUND_STATUS intent = YSE::SS_PLAYING_FULL_VOLUME;
+    std::vector<YSE::DSP::buffer> fb(1);
+    // One read schedules the buffer-1 refill; drop the file immediately so the
+    // refill is very likely still queued/running when ~soundFile joins it.
+    f.read(fb, pos, YSE::STANDARD_BUFFERSIZE, 1.0f, false, intent, vol);
+  } // ~soundFile joins the refill job before freeing the handle/buffers
+
+  CHECK(true); // reaching here without a crash / ASan report is the assertion
+}
+
+} // TEST_SUITE("sound")
+
+#endif // LIBSOUNDFILE_BACKEND

--- a/YseEngine/internal/abstractSoundFile.cpp
+++ b/YseEngine/internal/abstractSoundFile.cpp
@@ -10,17 +10,24 @@
 
 #include "../internalHeaders.h"
 #include <string.h>
+#include <cassert>
 
 YSE::INTERNAL::abstractSoundFile::abstractSoundFile(bool interleaved)
   : useInterleavedBuffer(interleaved)
   , _iBuffer(nullptr)
+  , _iBufferBack(nullptr)
   , _audioBuffer(nullptr)
   , _multiChannelBuffer(nullptr)
   , state(NEW)
   , _sampleRateAdjustment(1.f)
   , _channels(0)
+  , _needsReset(false)
+  , _frontBufferBase(0)
+  , _frontValidFrames(0)
+  , _frontTerminal(false)
   , idleTime(0)
 {
+  _refillJob.owner = this;
 }
 
 YSE::INTERNAL::abstractSoundFile::abstractSoundFile(const std::string & fileName, bool interleaved)
@@ -69,6 +76,19 @@ Bool YSE::INTERNAL::abstractSoundFile::read(std::vector<DSP::buffer> & filebuffe
   else return readNonInterleaved(this, filebuffer, pos, length, speed, loop, intent, volume);
 }
 
+void YSE::INTERNAL::abstractSoundFile::requestRefill(Bool loop) {
+  // Called from the audio thread. Publishes the current loop flag and schedules
+  // at most one back-buffer refill on the slow pool. Never touches the disk.
+  _streamLoop.store(loop, std::memory_order_relaxed);
+  // A filled back buffer is already waiting to be swapped in — nothing to do.
+  if (_backReady.load(std::memory_order_acquire)) return;
+  // Schedule exactly one refill; _refillInFlight is cleared by fillBackBuffer().
+  Bool expected = false;
+  if (_refillInFlight.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+    Global().addSlowJob(&_refillJob);
+  }
+}
+
 
 Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile * file, std::vector<DSP::buffer> & filebuffer, Flt& pos, UInt length, Flt speed, Bool loop, SOUND_STATUS & intent, Flt & volume) {
   /** Yes, this function uses goto...
@@ -81,18 +101,11 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile * fi
   // adjust speed for sample rate
   speed *= file->_sampleRateAdjustment;
 
-  // don't play streaming sounds backwards
-  if (file->_streaming && speed < 0) speed = 0;
+  // Non-interleaved sources (audio-buffer / multichannel) are never streaming;
+  // streaming always uses the interleaved path, so no disk refill happens here
+  // (issue #185). Guard it so a future change can't reintroduce a blocking read.
+  assert(!file->_streaming);
 
-  Flt realPos = 0;
-  if (file->_streaming) {
-    realPos = pos;
-    while (pos >= STREAM_BUFFERSIZE) {
-      pos -= STREAM_BUFFERSIZE;
-    }
-    realPos -= pos;
-  }
-  
   // this is for a smooth fade-in to avoid glitches
   if (intent == SS_WANTSTOPLAY) {
     intent = SS_PLAYING;
@@ -280,26 +293,6 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile * fi
       }
 
 calibrate:
-      if (file->_streaming) {
-        while (pos >= STREAM_BUFFERSIZE) {
-          if(file->fillStream(loop)) {
-            pos -= STREAM_BUFFERSIZE;
-            realPos += STREAM_BUFFERSIZE;
-            if (realPos >= file->_length) {
-              realPos -= file->_length;
-            }
-          }
-          else {
-            pos = 0;
-						realPos = 0;
-            intent = SS_STOPPED;
-            volume = 0.f;
-            file->_streamPos = 0;
-            continue;
-          }
-        }
-      }
-      else 
       {
         // if we get here, pos is past the end or before the beginning
         // recalibrate position now. We can't simply set it to the end
@@ -316,31 +309,61 @@ calibrate:
       }
     }
 
-    // This label creates a safe point to start processing the next channel when the 
+    // This label creates a safe point to start processing the next channel when the
     // current one is done
     nextBuffer: ;
   }
 
-  if (file->_streaming) pos += realPos;
   // make sure position is reset to zero if playing has stopped during this read
   if (intent == SS_STOPPED) {
     pos = 0;
-		realPos = 0;
-    if (file->_streaming) {
-			file->reset();
-      if (file->fillStream(loop)) {
-        //pos -= STREAM_BUFFERSIZE;
-        //realPos += STREAM_BUFFERSIZE;
-        //if (realPos >= file->_length) {
-        //  realPos -= file->_length;
-        //}
-      }
-      pos += realPos;
-    }
   }
   return true;
 }
 
+
+// Try to bring the prefetched back buffer in as the new front buffer. Runs on
+// the audio thread; never touches the disk. See issue #185.
+YSE::INTERNAL::abstractSoundFile::swapResult
+YSE::INTERNAL::abstractSoundFile::streamSwap(abstractSoundFile * file, Flt & pos, Flt & streamEnd, Bool loop) {
+  if (file->_frontTerminal) return SWAP_TERMINAL;
+
+  // Drop a back buffer prefetched before a stop (its stream position is stale)
+  // so it is refilled from the current position instead of played on restart.
+  if (file->_backReady.load(std::memory_order_acquire)
+      && file->_backGen.load(std::memory_order_relaxed) != file->_fillGen.load(std::memory_order_relaxed)) {
+    file->_backReady.store(false, std::memory_order_relaxed);
+  }
+
+  if (!file->_backReady.load(std::memory_order_acquire)) {
+    file->requestRefill(loop); // prefetch not ready yet — caller emits silence
+    return SWAP_UNDERRUN;
+  }
+
+  // Publish-safe: _backValidFrames/_backTerminal were written before the
+  // _backReady release store we just acquired above.
+  Long consumed = file->_frontValidFrames;
+  Flt * tmp = file->_iBuffer;
+  file->_iBuffer = file->_iBufferBack;
+  file->_iBufferBack = tmp;
+  file->_frontValidFrames = file->_backValidFrames.load(std::memory_order_relaxed);
+  file->_frontTerminal = file->_backTerminal.load(std::memory_order_relaxed);
+  file->_frontBufferBase += consumed;
+  file->_backReady.store(false, std::memory_order_relaxed);
+  pos -= (Flt)consumed;
+  streamEnd = (Flt)file->_frontValidFrames;
+  file->requestRefill(loop); // prefetch the next buffer
+  return SWAP_DONE;
+}
+
+// Called on stop (audio thread): reset to frame 0 and arm an async re-prime so
+// the next play starts at the beginning. reset() empties the front state and
+// bumps the fill generation; requestRefill schedules the from-0 refill now so a
+// prompt restart finds it ready.
+void YSE::INTERNAL::abstractSoundFile::streamReprime(abstractSoundFile * file, Bool loop) {
+  file->reset();
+  file->requestRefill(loop);
+}
 
 //////////////////////////////////////////////////////////////////////////////////
 // interleaved read function
@@ -360,13 +383,31 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(abstractSoundFile * file,
   // don't play streaming sounds backwards
   if (file->_streaming && speed < 0) speed = 0;
 
-  Flt realPos = 0;
+  // For streaming, `pos` is buffer-local in [0, streamEnd) where streamEnd is the
+  // count of real frames in the current front buffer (issue #185). For other
+  // sources the per-sample checks below use file->_length directly.
+  Flt streamEnd = (Flt)file->_frontValidFrames;
+
   if (file->_streaming) {
-    realPos = pos;
-    while (pos >= STREAM_BUFFERSIZE) {
-      pos -= STREAM_BUFFERSIZE;
+    // Keep the refill pipeline primed (schedules at most one slow-pool fill).
+    file->requestRefill(loop);
+    // Resolve any buffer boundary reached on a previous block *before* indexing
+    // into the front buffer in the state machine below. Never blocks on disk.
+    while (pos >= streamEnd) {
+      swapResult r = streamSwap(file, pos, streamEnd, loop);
+      if (r == SWAP_DONE) continue;
+      // Terminal (EOF) or underrun: emit a silent block and retry next callback.
+      FOREACH(filebuffer) {
+        Flt * o = filebuffer[i].getPtr();
+        for (UInt k = 0; k < length; ++k) o[k] = 0.f;
+      }
+      if (r == SWAP_TERMINAL) {
+        intent = SS_STOPPED;
+        pos = 0;
+        streamReprime(file, loop);
+      }
+      return true;
     }
-    realPos -= pos;
   }
 
   // this is for a smooth fade-in to avoid glitches
@@ -416,7 +457,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(abstractSoundFile * file,
         pos += speed;
         x++;
 
-				if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length)) { // NOSONAR S134: nesting follows the state-machine structure documented at function level
+				if (pos < 0 || pos >= (file->_streaming ? streamEnd : file->_length)) { // NOSONAR S134: nesting follows the state-machine structure documented at function level
 					goto calibrate;
 				}
       }
@@ -430,7 +471,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(abstractSoundFile * file,
         volume += 0.005f;
         x++;
 
-        if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length)) goto calibrate;
+        if (pos < 0 || pos >= (file->_streaming ? streamEnd : file->_length)) goto calibrate;
 
         if ((volume >= 1.f)) {
           // full volume is reached. Move to the optimized version
@@ -449,7 +490,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(abstractSoundFile * file,
         volume -= 0.005f;
         x++;
 
-        if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length)) goto calibrate;
+        if (pos < 0 || pos >= (file->_streaming ? streamEnd : file->_length)) goto calibrate;
 
         if ((volume <= 0.f)) {
           // fade out complete, switch intent to paused and restart
@@ -469,7 +510,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(abstractSoundFile * file,
         volume -= 0.005f;
         x++;
 
-        if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length)) goto calibrate;
+        if (pos < 0 || pos >= (file->_streaming ? streamEnd : file->_length)) goto calibrate;
 
         if ((volume <= 0.f)) {
           // fade out complete, switch intent to paused and restart
@@ -483,23 +524,30 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(abstractSoundFile * file,
 
 calibrate:
     if (file->_streaming) {
-      while (pos >= STREAM_BUFFERSIZE) {
-        if (file->fillStream(loop)) {
-          pos -= STREAM_BUFFERSIZE;
-          realPos += STREAM_BUFFERSIZE;
-          if (realPos  >= file->_length) {
-						while (realPos >= STREAM_BUFFERSIZE) {
-							realPos -= STREAM_BUFFERSIZE;
-						}
-          }
+      // Boundary reached mid-block. Swap in prefetched buffers (never blocks on
+      // disk — see issue #185). On underrun, zero-fill the rest of this block and
+      // resume next callback. On EOF, stop.
+      Bool silence = false;
+      while (pos >= streamEnd) {
+        swapResult r = streamSwap(file, pos, streamEnd, loop);
+        if (r == SWAP_DONE) {
+          in = file->_iBuffer; // the front buffer pointer changed
+          continue;
         }
-        else {
+        if (r == SWAP_TERMINAL) {
           pos = 0;
-					realPos = 0;
           intent = SS_STOPPED;
           volume = 0.f;
-          file->_streamPos = 0;
-          continue;
+        }
+        else {
+          silence = true; // underrun
+        }
+        break;
+      }
+      if (silence) {
+        while (x < length) {
+          FOREACH(filebuffer) *filebuffer[i].cursor++ = 0;
+          x++;
         }
       }
     }
@@ -525,28 +573,13 @@ calibrate:
 
     goto startAgain;
   }
-  
 
-	if (file->_streaming) {
-		if (realPos < 0) {
-		}
-		pos += realPos;
-	}
   // make sure position is reset to zero if playing has stopped during this read
   if (intent == SS_STOPPED) {
     pos = 0;
-		realPos = 0;
-    if (file->_streaming) {
-			file->reset();
-      if (file->fillStream(loop)) {
-        //pos -= STREAM_BUFFERSIZE;
-        //realPos += STREAM_BUFFERSIZE;
-        //if (realPos >= file->_length) {
-        //  realPos -= file->_length;
-        //}
-      }
-      pos += realPos;
-    }
+    // For a stopped stream, arm an async re-prime from frame 0 so the next play
+    // starts at the beginning. No disk I/O on the audio thread (issue #185).
+    if (file->_streaming) streamReprime(file, loop);
   }
   return true;
 }
@@ -579,7 +612,18 @@ YSE::INTERNAL::FILESTATE YSE::INTERNAL::abstractSoundFile::getState() {
 }
 
 YSE::INTERNAL::abstractSoundFile & YSE::INTERNAL::abstractSoundFile::reset() {
-  _needsReset = true;
+  // Called on stop (audio thread only — from read() and dspFunc_parseIntent).
+  // Resets to frame 0 for the next play: the audio-owned front state is emptied
+  // so the next read() swaps in a freshly-filled buffer, the next disk fill seeks
+  // back to 0, and the generation is bumped so any fill that started before this
+  // stop (stale position) is discarded rather than played on restart. The
+  // prefetched back buffer is dropped for the same reason. (issue #185)
+  _frontValidFrames = 0;
+  _frontTerminal = false;
+  _frontBufferBase = 0;
+  _needsReset.store(true, std::memory_order_relaxed);
+  _fillGen.fetch_add(1, std::memory_order_release);
+  _backReady.store(false, std::memory_order_relaxed);
   return *this;
 }
 

--- a/YseEngine/internal/abstractSoundFile.h
+++ b/YseEngine/internal/abstractSoundFile.h
@@ -17,6 +17,8 @@
 #include "../headers/enums.hpp"
 #include "customFileReader.h"
 #include <forward_list>
+#include <atomic>
+#include <cstdint>
 #include "threadPool.h"
 
 namespace YSE {
@@ -71,12 +73,43 @@ namespace YSE {
       static Bool readNonInterleaved(abstractSoundFile * file, std::vector<DSP::buffer> & filebuffer, Flt& pos, UInt length, Flt speed, Bool loop, SOUND_STATUS & intent, Flt & volume);
       static Bool readInterleaved(abstractSoundFile * file, std::vector<DSP::buffer> & filebuffer, Flt& pos, UInt length, Flt speed, Bool loop, SOUND_STATUS & intent, Flt & volume);
 
+      // Streaming buffer-boundary handling for readInterleaved (issue #185).
+      enum swapResult { SWAP_DONE, SWAP_TERMINAL, SWAP_UNDERRUN };
+      // Try to swap the prefetched back buffer in as the new front buffer. On
+      // SWAP_DONE, pos/streamEnd are advanced into the new buffer. SWAP_TERMINAL
+      // means the current front buffer was the final one (EOF, no loop).
+      // SWAP_UNDERRUN means the prefetch has not landed yet (caller emits silence).
+      static swapResult streamSwap(abstractSoundFile * file, Flt & pos, Flt & streamEnd, Bool loop);
+      // Arm an async re-prime from frame 0 for the next play (called on stop).
+      static void streamReprime(abstractSoundFile * file, Bool loop);
+
+      // Streaming refill is done off the audio callback thread (issue #185). The
+      // audio thread never touches the disk: it plays the front buffer and, at a
+      // buffer boundary, swaps in a back buffer that the slow pool prefilled. This
+      // helper (called from the audio thread's read()) makes sure exactly one
+      // refill of the back buffer is scheduled on the slow pool.
+      void requestRefill(Bool loop);
+      // Fill the back buffer from disk. Runs on the slow pool via _refillJob;
+      // must never be called on the audio thread. Implemented by the backend.
+      virtual void fillBackBuffer() = 0;
+
+      // Slow-pool job that drives fillBackBuffer() for this file. A dedicated job
+      // (rather than reusing the abstractSoundFile load job) is required: the load
+      // job's run() reopens the handle and reallocates the buffers.
+      class streamRefillJob : public threadPoolJob {
+      public:
+        abstractSoundFile * owner = nullptr;
+        void run() override { owner->fillBackBuffer(); }
+      };
+      streamRefillJob _refillJob;
+
       std::string fileName;
 
       // pointer to a (multichannel) soundfile
       Bool useInterleavedBuffer;
       const Flt ** _buffer; // this version is used when a non interleaved buffer is used
-      Flt * _iBuffer; // this version is used when an interleaved buffer is used
+      Flt * _iBuffer; // front buffer (audio thread reads); interleaved-buffer path
+      Flt * _iBufferBack; // back buffer (slow pool fills) for streaming double buffering
 
       // used for passing an audio buffer as a sound source
       YSE::DSP::buffer   * _audioBuffer       ;
@@ -93,10 +126,30 @@ namespace YSE {
       UInt _streamSize;
       Bool _endReached;
       Int  _streamPos ;
-      Bool _needsReset;
-      
+      // Written by the audio thread (reset() on stop), read/cleared by the slow
+      // pool (fillBackBuffer) — must be atomic now that the fill is off-thread.
+      std::atomic<Bool> _needsReset;
 
-      virtual Bool fillStream(Bool loop) = 0;
+      // Double-buffer publication (issue #185). Writer = slow pool, reader = audio.
+      // _backValidFrames/_backTerminal/_backGen are written before the _backReady
+      // release store and read after the audio thread's acquire load of it.
+      std::atomic<Bool> _backReady{ false };        // back buffer filled, ready to swap in
+      std::atomic<Bool> _backTerminal{ false };     // back fill hit non-loop EOF (last buffer)
+      std::atomic<Bool> _refillInFlight{ false };   // a refill is queued/running (dedup)
+      std::atomic<Bool> _streamLoop{ false };       // loop flag published to the slow pool
+      std::atomic<Long> _backValidFrames{ 0 };      // real (non-padded) frames in back buffer
+      // Generation guard for stop/restart: reset() bumps _fillGen; each fill tags
+      // its result with the gen it observed. The audio thread accepts a swap only
+      // when the tag still matches, so a fill that started before a stop (stale
+      // position) is discarded instead of played on restart.
+      std::atomic<uint32_t> _fillGen{ 0 };
+      std::atomic<uint32_t> _backGen{ 0 };
+      // Audio-thread-owned: absolute frame index of the front buffer's first
+      // sample, the real frame count in the front buffer, and whether the front
+      // buffer is the final (EOF) one.
+      Long _frontBufferBase;
+      Long _frontValidFrames;
+      Bool _frontTerminal;
 
       // for keeping track of objects using this file      
       std::forward_list<SOUND::implementationObject*> clientList;

--- a/YseEngine/internal/lsfSoundfile.cpp
+++ b/YseEngine/internal/lsfSoundfile.cpp
@@ -34,7 +34,12 @@ YSE::INTERNAL::soundFile::soundFile(MULTICHANNELBUFFER * buffer)
 }
 
 YSE::INTERNAL::soundFile::~soundFile() {
+  // A back-buffer refill may still be queued or running on the slow pool. Let it
+  // finish before we free the handle and buffers it writes to, or it would touch
+  // freed memory (issue #185). join() returns immediately if nothing is in flight.
+  _refillJob.join();
   if (_iBuffer != nullptr) delete[] _iBuffer;
+  if (_iBufferBack != nullptr) delete[] _iBufferBack;
   if (handle != nullptr) delete handle;
 }
 
@@ -52,9 +57,18 @@ void YSE::INTERNAL::soundFile::loadStreaming() {
       _channels = handle->channels();
 
       Int size = STREAM_BUFFERSIZE * _channels;
-      _iBuffer = new Flt[size];
+      _iBuffer = new Flt[size];       // front buffer (audio thread plays)
+      _iBufferBack = new Flt[size];   // back buffer (slow pool prefills) — issue #185
       _streamPos = 0;
-      fillStream(false);
+
+      // Prime the front buffer (buffer 0). The back-buffer prefetch is scheduled
+      // by the first read() once the real loop flag is known, so we don't guess
+      // it here. Mark the front buffer's real-frame count; it is never treated as
+      // terminal (stop is decided by the back-buffer fills that know `loop`).
+      UInt valid = fillBuffer(_iBuffer, false);
+      _frontValidFrames = (Long)valid;
+      _frontTerminal = false;
+      _frontBufferBase = 0;
       state = READY;
     }
     else {
@@ -119,14 +133,13 @@ void YSE::INTERNAL::soundFile::loadNonStreaming() {
   if (ptr != nullptr) INTERNAL::customFileReader::Close(ptr);
 }
 
-Bool YSE::INTERNAL::soundFile::fillStream(Bool loop) {
-	if (_needsReset) {
-		handle->seek(0, SEEK_SET);
-		_streamPos = 0;
-		_needsReset = false;
-	}
+UInt YSE::INTERNAL::soundFile::fillBuffer(Flt * dest, Bool loop) {
+  if (_needsReset.exchange(false, std::memory_order_relaxed)) {
+    handle->seek(0, SEEK_SET);
+    _streamPos = 0;
+  }
   Int framesToRead = STREAM_BUFFERSIZE;
-  Flt * ptr = _iBuffer;
+  Flt * ptr = dest;
 
   while (framesToRead > 0) {
     U64 read = handle->readf(ptr, framesToRead);
@@ -139,18 +152,35 @@ Bool YSE::INTERNAL::soundFile::fillStream(Bool loop) {
         _streamPos = 0;
       }
       else {
-        framesToRead *= _channels;
-        while (framesToRead--) *ptr++ = 0.0f;
+        // non-loop EOF: zero-pad the remainder and report the real frame count
+        UInt valid = STREAM_BUFFERSIZE - (UInt)framesToRead;
+        Int zeros = framesToRead * _channels;
+        while (zeros-- > 0) *ptr++ = 0.0f;
         _streamPos = 0;
-        return false;
+        return valid;
       }
     }
     else {
-      return true;
+      return STREAM_BUFFERSIZE;
     }
-    
   }
-  return false;
+  return STREAM_BUFFERSIZE;
+}
+
+void YSE::INTERNAL::soundFile::fillBackBuffer() {
+  Bool loop = _streamLoop.load(std::memory_order_relaxed);
+  // Tag this fill with the generation observed at the start. reset() (on stop)
+  // bumps _fillGen, so the audio thread discards a fill that began before the
+  // stop instead of playing its stale position on restart (issue #185).
+  uint32_t gen = _fillGen.load(std::memory_order_acquire);
+  UInt valid = fillBuffer(_iBufferBack, loop);
+  // Publish: these are read by the audio thread after its acquire load of
+  // _backReady, so the release store below makes them visible.
+  _backValidFrames.store((Long)valid, std::memory_order_relaxed);
+  _backTerminal.store(valid < STREAM_BUFFERSIZE, std::memory_order_relaxed);
+  _backGen.store(gen, std::memory_order_relaxed);
+  _backReady.store(true, std::memory_order_release);
+  _refillInFlight.store(false, std::memory_order_relaxed);
 }
 
 

--- a/YseEngine/internal/lsfSoundfile.h
+++ b/YseEngine/internal/lsfSoundfile.h
@@ -41,7 +41,16 @@ namespace YSE {
 
     private:
 
-      Bool fillStream(Bool loop);
+      // Fill `dest` with up to STREAM_BUFFERSIZE frames from the current handle
+      // position, zero-padding the tail at non-loop EOF. Returns the number of
+      // real (non-padded) frames written (== STREAM_BUFFERSIZE unless EOF was hit
+      // without looping). Does blocking disk I/O — slow pool / load only, never
+      // the audio thread (issue #185).
+      UInt fillBuffer(Flt * dest, Bool loop);
+
+      // Slow-pool entry point: refill the back buffer and publish it. Overrides
+      // the base hook driven by _refillJob.
+      void fillBackBuffer() override;
 
       SndfileHandle * handle;
 


### PR DESCRIPTION
## Summary

Streaming sounds refilled their 1-second stream buffer with a **blocking `sf_readf`/`sf_seek` on the audio callback thread** (`readInterleaved`'s `calibrate` path and the stop-path re-prime) — a multi-hundred-KB disk read inside a ~2.9 ms block budget, risking deterministic dropouts on cold cache / slow media / Android flash under load (issue #185, Critical, from the 2026-07-02 lock-free audit).

This moves every stream refill onto the slow thread pool via double buffering. The audio thread only ever swaps a pointer and reads an atomic flag; on a rare prefetch miss it emits silence and retries the next block instead of blocking. `fillStream`-style disk I/O never runs on the audio thread again.

## Linked issue
Closes #185

## Changes
- **`abstractSoundFile.h/.cpp`** — second interleaved back buffer + a dedicated slow-pool refill job (`_refillJob`) and publication atomics (`_backReady`/`_backValidFrames`/`_backTerminal`, plus a `_fillGen` generation guard for stop/restart). Rewrote the streaming path of `readInterleaved` around a **buffer-local `pos` in `[0, streamEnd)`** plus an audio-thread-owned `_frontBufferBase`, replacing the fragile `realPos` reconstruction. `streamEnd` tracks the real (non-padded) frame count so the final EOF buffer plays its **full tail sample-accurately, then stops** (previously up to ~1 s of tail was dropped). Underrun → silence + retry, never block. Stop re-primes from frame 0 asynchronously via `reset()` (empties front state, bumps the fill generation, drops the prefetch). `readNonInterleaved` (buffer sources, never streaming) now asserts `!_streaming` and its dead streaming branches were removed.
- **`lsfSoundfile.h/.cpp`** — split `fillStream` into a buffer-targeted `fillBuffer()` core + a slow-pool `fillBackBuffer()`; allocate/free the back buffer; **`~soundFile` joins the refill job before freeing the handle/buffers** (teardown UAF fix).
- **`Tests/sound/test_sound_streaming.cpp`** (new) + `Tests/CMakeLists.txt` — drives `soundFile::read()` directly against generated fixtures.

## Test plan
- [x] `python yse.py build` — clean (only pre-existing `-Winconsistent-missing-override` warnings)
- [x] `python yse.py analyze` on both changed engine files — no new findings in modified code
- [x] Unit tests: **full ctest 16/16 pass** (`python yse.py test`)
- [x] Streaming suite (new): **5/5 cases, 259,994 assertions** — sample-accurate audio across buffer boundaries, full-tail EOF stop (regression guard for the dropped-tail bug), seamless looping, stop→restart-from-zero, and clean destruction with a refill in flight
- [x] **AddressSanitizer** (Linux Docker, `tools/ci-linux`): streaming suite clean — no UAF/leaks in the refill/teardown path (259,994 assertions). One *pre-existing* harness-level ASan `alloc-dealloc-mismatch` in `test_named_bus.cpp`'s global `operator new/delete` override (libsndfile `new(nothrow)` vs overridden `delete`) surfaced — unrelated to #185, filed as #219. CI's `clang+asan` leg only runs `ctest -L python`, so this does not affect CI.

## Out of scope (filed as follow-ups)
- #217 — streaming `setFilePos` does not seek the file handle
- #218 — per-impl streaming `soundFile` is leaked (never deleted)
- #219 — `test_named_bus.cpp` operator override breaks ASan for soundfile-loading tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)