### PR TITLE
FIX: Move soundFiles GC off the audio callback thread (#186)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -43,6 +43,7 @@ set(YSE_TEST_SOURCES
   sound/test_sound_concurrency.cpp
   sound/test_sound_bufferIO.cpp
   sound/test_sound_manager.cpp
+  sound/test_sound_file_gc.cpp
   sound/test_sound_bus.cpp
   reverb/test_reverb_dsp.cpp
   reverb/test_reverb_concurrency.cpp

--- a/Tests/sound/test_sound_file_gc.cpp
+++ b/Tests/sound/test_sound_file_gc.cpp
@@ -1,0 +1,123 @@
+// Regression tests for issue #186: the soundFiles list was raced between the
+// main thread (addFile) and the audio-thread GC in Manager::update(), and
+// ~soundFile (sf_close + delete[]) ran on the audio callback.
+//
+// The fix moves soundFile garbage collection off the audio thread onto a
+// slow-pool job (mgrFileGC) that owns the list structure together with addFile
+// under soundFilesMutex, and guards the per-file clientList with its own mutex.
+// update() no longer touches soundFiles at all.
+//
+// Like the other lifecycle races in this suite (issue #41), the assertion is
+// crash-freedom under concurrent traffic; the value is realised under the
+// ThreadSanitizer CI build, which flags the unsynchronised soundFiles / clientList
+// crossings on the pre-fix code and stays clean on the fixed code.
+
+#include <doctest/doctest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+#include "yse.hpp"
+#include "sound/soundInterface.hpp"
+#include "sound/soundManager.h"
+#include "dsp/buffer.hpp"
+#include "internal/time.h"
+#include "support/null_device.hpp"
+
+namespace {
+
+// File-scope buffers used as sound sources. addFile() dedups by buffer pointer,
+// so a pool of distinct buffers yields distinct soundFiles for the GC pass to
+// walk while addFile is concurrently emplacing. They must outlive every soundFile
+// that references them.
+std::vector<YSE::DSP::buffer> & sourceBuffers() {
+    static std::vector<YSE::DSP::buffer> bufs = [] {
+        std::vector<YSE::DSP::buffer> v;
+        v.reserve(32);
+        for (int i = 0; i < 32; ++i) v.emplace_back(128);
+        return v;
+    }();
+    return bufs;
+}
+
+// Drive the manager forward: this is the audio-thread surrogate in the paused
+// engine. Post-fix it schedules the slow-pool GC job; pre-fix it ran the GC
+// inline and raced any concurrent addFile.
+void drain(int iterations, int sleepMs = 1) {
+    for (int i = 0; i < iterations; ++i) {
+        YSE::INTERNAL::Time().update();
+        YSE::SOUND::Manager().update();
+        if (sleepMs > 0) std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
+    }
+}
+
+} // namespace
+
+TEST_SUITE("sound") {
+
+// ─── The exact crossing: main-thread addFile vs the file GC ──────────────────
+//
+// A worker thread hammers Manager().addFile() (the operation that raced) while
+// the test thread drives update(). Pre-fix, update()'s inline GC iterated
+// soundFiles unsynchronised against the worker's emplace_front — a data race and
+// potential UAF. Post-fix, addFile and the slow-pool GC serialise on
+// soundFilesMutex and update() never touches the list.
+TEST_CASE("SOUND #186: concurrent addFile and file GC do not race") {
+    if (!TestHelpers::engineInit()) return;
+
+    auto & bufs = sourceBuffers();
+    std::atomic<bool> workerDone{false};
+    constexpr int ROUNDS = 400;
+
+    std::thread worker([&]() {
+        for (int r = 0; r < ROUNDS; ++r) {
+            // Walk the whole pool so addFile both finds existing entries and
+            // emplaces new ones, exercising the list traversal under the lock.
+            YSE::INTERNAL::soundFile * sf =
+                YSE::SOUND::Manager().addFile(&bufs[r % bufs.size()]);
+            (void)sf;
+            std::this_thread::sleep_for(std::chrono::microseconds(20));
+        }
+        workerDone.store(true, std::memory_order_release);
+    });
+
+    // Keep updating (scheduling GC) until the worker is done. The loop runs long
+    // enough that fileGCTimer crosses its ~1s threshold and the slow-pool GC job
+    // actually fires and iterates soundFiles concurrently with the worker.
+    int safety = 20000;
+    while (!workerDone.load(std::memory_order_acquire) && --safety > 0) {
+        drain(2, 0);
+    }
+    worker.join();
+    drain(20); // settle: let any in-flight GC job finish
+
+    CHECK(true); // crash-freedom (and TSan-cleanliness) is the assertion
+}
+
+// ─── End-to-end churn with real clients: attach / release / inUse crossing ───
+//
+// Buffer-backed sounds populate soundFiles AND drive attach() (create, main
+// thread) + release() (~implementationObject, slow pool), while the GC's inUse()
+// reads clientList. Creating/destroying them under the live audio callback puts
+// the real audio thread on update() (scheduling GC) at the same time.
+TEST_CASE("SOUND #186: buffer-backed sound churn under live audio callback"
+          * doctest::test_suite("integration")) {
+    if (!TestHelpers::engineInitWithAudio()) return;
+
+    auto & bufs = sourceBuffers();
+    constexpr int N = 150;
+    for (int i = 0; i < N; ++i) {
+        YSE::sound s;
+        s.create(bufs[i % bufs.size()]);
+        s.play();
+        // Short lifetime: the impl attaches to its soundFile and is released
+        // almost immediately, so attach/release churn overlaps the audio
+        // callback's GC scheduling.
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    } // ~sound() releases each impl; the slow pool runs release() + GC.
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    CHECK(true);
+}
+
+} // TEST_SUITE("sound")

--- a/YseEngine/internal/abstractSoundFile.cpp
+++ b/YseEngine/internal/abstractSoundFile.cpp
@@ -627,9 +627,14 @@ YSE::INTERNAL::abstractSoundFile & YSE::INTERNAL::abstractSoundFile::reset() {
   return *this;
 }
 
-bool YSE::INTERNAL::abstractSoundFile::inUse() {
+bool YSE::INTERNAL::abstractSoundFile::inUse(Flt dt) {
+  // Runs on the slow-pool GC job (issue #186), never the audio thread. The idle
+  // timer is advanced by the elapsed time the caller measured between GC passes
+  // (previously Time().delta() accumulated per audio callback). clientList is
+  // guarded because attach/release run on other threads.
+  std::scoped_lock lk(clientListMutex);
   if (clientList.empty()) {
-    idleTime += Time().delta();
+    idleTime += dt;
   }
   if (idleTime > 30) {
     return false;
@@ -638,6 +643,7 @@ bool YSE::INTERNAL::abstractSoundFile::inUse() {
 }
 
 void YSE::INTERNAL::abstractSoundFile::attach(YSE::SOUND::implementationObject * impl) {
+  std::scoped_lock lk(clientListMutex);
   for (auto i = clientList.begin(); i != clientList.end(); ++i) {
     if (*i == impl) return;
   }
@@ -645,6 +651,7 @@ void YSE::INTERNAL::abstractSoundFile::attach(YSE::SOUND::implementationObject *
 }
 
 void YSE::INTERNAL::abstractSoundFile::release(SOUND::implementationObject *impl) {
+  std::scoped_lock lk(clientListMutex);
   auto previous = clientList.before_begin();
   for (auto i = clientList.begin(); i != clientList.end(); ++i) {
     if(*i == impl) {

--- a/YseEngine/internal/abstractSoundFile.h
+++ b/YseEngine/internal/abstractSoundFile.h
@@ -19,6 +19,7 @@
 #include <forward_list>
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 #include "threadPool.h"
 
 namespace YSE {
@@ -67,7 +68,10 @@ namespace YSE {
       // to keep track of clients
       void attach (SOUND::implementationObject * impl);
       void release(SOUND::implementationObject * impl);
-      bool inUse();
+      // Advance the idle timer by `dt` seconds and report whether this file is
+      // still in use (has clients, or hasn't been idle long enough to GC).
+      // Runs on the slow-pool GC job (issue #186), never the audio thread.
+      bool inUse(Flt dt);
 
     protected:
       static Bool readNonInterleaved(abstractSoundFile * file, std::vector<DSP::buffer> & filebuffer, Flt& pos, UInt length, Flt speed, Bool loop, SOUND_STATUS & intent, Flt & volume);
@@ -151,8 +155,13 @@ namespace YSE {
       Long _frontValidFrames;
       Bool _frontTerminal;
 
-      // for keeping track of objects using this file      
+      // for keeping track of objects using this file
+      // clientList is crossed by three roles: attach (main thread, from
+      // implementationObject::create), release (slow pool, from
+      // ~implementationObject) and the idle check in inUse() (slow-pool GC job,
+      // issue #186). None run on the audio thread, so this mutex is RT-safe.
       std::forward_list<SOUND::implementationObject*> clientList;
+      std::mutex clientListMutex;
       Flt idleTime;
 
     private:

--- a/YseEngine/sound/soundManager.cpp
+++ b/YseEngine/sound/soundManager.cpp
@@ -19,10 +19,11 @@ YSE::SOUND::managerObject & YSE::SOUND::Manager() {
 }
 
 
-YSE::SOUND::managerObject::managerObject() 
+YSE::SOUND::managerObject::managerObject()
   : mgrSetup(this),
     mgrDelete(this) {
   //formatManager.registerBasicFormats();
+  mgrFileGC.owner = this;
 }
 
 YSE::SOUND::managerObject::~managerObject() noexcept {
@@ -30,6 +31,7 @@ YSE::SOUND::managerObject::~managerObject() noexcept {
     // wait for jobs to finish
     mgrSetup.join();
     mgrDelete.join();
+    mgrFileGC.join();
 
     // drain any pointers still queued by the main thread; they reference impls
     // owned by `implementations` and will be freed when that list is cleared.
@@ -42,7 +44,10 @@ YSE::SOUND::managerObject::~managerObject() noexcept {
     implementations.clear();
 
     // remove all sounds that are still in memory
-    soundFiles.clear();
+    {
+      std::scoped_lock lk(soundFilesMutex);
+      soundFiles.clear();
+    }
   } catch (...) {
     INTERNAL::LogImpl().emit(E_ERROR, "SOUND::Manager destructor swallowed exception");
   }
@@ -50,6 +55,8 @@ YSE::SOUND::managerObject::~managerObject() noexcept {
 
 
 YSE::INTERNAL::soundFile * YSE::SOUND::managerObject::addFile(const std::string & fileName) {
+  // Serialise with the slow-pool GC job that erases from soundFiles (issue #186).
+  std::scoped_lock lk(soundFilesMutex);
   // find out if this file already exists
   for (auto i = soundFiles.begin(); i != soundFiles.end(); ++i) {
     if ( i->contains(fileName)) {
@@ -70,6 +77,8 @@ YSE::INTERNAL::soundFile * YSE::SOUND::managerObject::addFile(const std::string 
 
 
 YSE::INTERNAL::soundFile * YSE::SOUND::managerObject::addFile(YSE::DSP::buffer * buffer) {
+  // Serialise with the slow-pool GC job that erases from soundFiles (issue #186).
+  std::scoped_lock lk(soundFilesMutex);
   // find out if this file already exists
   for (auto i = soundFiles.begin(); i != soundFiles.end(); ++i) {
     if ( i->contains(buffer)) {
@@ -89,6 +98,8 @@ YSE::INTERNAL::soundFile * YSE::SOUND::managerObject::addFile(YSE::DSP::buffer *
 }
 
 YSE::INTERNAL::soundFile * YSE::SOUND::managerObject::addFile(MULTICHANNELBUFFER * buffer) {
+  // Serialise with the slow-pool GC job that erases from soundFiles (issue #186).
+  std::scoped_lock lk(soundFilesMutex);
   // find out if this file already exists
   for (auto i = soundFiles.begin(); i != soundFiles.end(); ++i) {
     if ( i->contains(buffer)) {
@@ -207,15 +218,14 @@ void YSE::SOUND::managerObject::update() {
   // drain the main→audio inbox of newly-set-up impls
   drainInbox();
 
-  // garbage-collect finished soundFiles
-  auto iMinus = soundFiles.before_begin();
-  for (auto i = soundFiles.begin(); i != soundFiles.end(); ) {
-    if (i->isQueued() || i->inUse()) {
-      iMinus = i;
-      ++i;
-    } else {
-      i = soundFiles.erase_after(iMinus);
-    }
+  // Hand soundFile garbage collection to the slow pool (issue #186). The audio
+  // thread must not iterate or erase `soundFiles`: erasing runs ~soundFile
+  // (sf_close + delete[]) on the callback and races addFile on the main thread.
+  // Throttle to roughly once a second so the GC job isn't re-queued every tick.
+  fileGCTimer += INTERNAL::Time().delta();
+  if (fileGCTimer >= 1.0f && !mgrFileGC.isQueued()) {
+    fileGCTimer = 0.f;
+    INTERNAL::Global().addSlowJob(&mgrFileGC);
   }
 
   VirtualSoundFinder().reset();
@@ -233,7 +243,30 @@ void YSE::SOUND::managerObject::update() {
   syncAndReleaseInUse();
 
   VirtualSoundFinder().calculate();
-  
+
+}
+
+void YSE::SOUND::managerObject::garbageCollectFiles() {
+  // Runs on the slow pool (mgrFileGC), never the audio thread (issue #186).
+  // Measure the wall time elapsed since the previous pass so the per-file idle
+  // timer advances at the same rate it did when this loop ran every audio
+  // callback (it accumulated Time().delta() there). ~soundFile — with its
+  // sf_close and delete[] — now runs here on the erase, off the callback.
+  std::clock_t now = std::clock();
+  Flt dt = (lastGCClock == 0) ? 0.f
+                              : static_cast<Flt>(now - lastGCClock) / static_cast<Flt>(CLOCKS_PER_SEC);
+  lastGCClock = now;
+
+  std::scoped_lock lk(soundFilesMutex);
+  auto iMinus = soundFiles.before_begin();
+  for (auto i = soundFiles.begin(); i != soundFiles.end(); ) {
+    if (i->isQueued() || i->inUse(dt)) {
+      iMinus = i;
+      ++i;
+    } else {
+      i = soundFiles.erase_after(iMinus);
+    }
+  }
 }
 
 Bool YSE::SOUND::managerObject::empty() {

--- a/YseEngine/sound/soundManager.h
+++ b/YseEngine/sound/soundManager.h
@@ -14,6 +14,7 @@
 #include <forward_list>
 #include <mutex>
 #include <vector>
+#include <ctime>
 #include "sound.hpp"
 #include "soundMessage.h"
 #include "soundInterface.hpp"
@@ -112,14 +113,42 @@ namespace YSE {
       void promoteReadyImpls();
       void syncAndReleaseInUse();
 
+      // Garbage-collect unused soundFiles. Runs on the slow pool via mgrFileGC —
+      // NEVER on the audio thread: erasing a soundFile runs ~soundFile (sf_close +
+      // delete[]) which must stay off the callback, and the erase races addFile
+      // on the main thread. Owns `soundFiles` structure together with addFile
+      // under `soundFilesMutex` (same pattern as the impl managers). (issue #186)
+      void garbageCollectFiles();
+
+      // Slow-pool job wrapper that drives garbageCollectFiles().
+      class fileGCJob : public INTERNAL::threadPoolJob {
+      public:
+        managerObject * owner = nullptr;
+        void run() override { owner->garbageCollectFiles(); }
+      };
+      fileGCJob mgrFileGC;
+
+      // Audio-thread-only: accumulates Time().delta() so update() hands the GC to
+      // the slow pool at most about once a second instead of every callback.
+      Flt fileGCTimer = 0.f;
+      // Slow-pool-only (GC job): previous std::clock() sample, used to measure the
+      // elapsed time fed to soundFile::inUse() for the idle timer.
+      std::clock_t lastGCClock = 0;
+
       /** the lastGain buffer of each sound is needed to provide smooth changes
       in volume for each channel. When the number of output channels is changed
       this buffer has to change accordingly. This is done by this function.
       */
       void adjustLastGainBuffer();
 
-      // a forward list containing all sound files
+      // a forward list containing all sound files. Structure is touched by the
+      // main thread (addFile) and the slow-pool GC job (garbageCollectFiles);
+      // the audio thread never iterates or erases it. Guarded by soundFilesMutex.
       std::forward_list<INTERNAL::soundFile> soundFiles;
+
+      // Guards `soundFiles` between the main thread (addFile) and the slow-pool
+      // GC job. Never taken by the audio thread. (issue #186)
+      std::mutex soundFilesMutex;
 
       // a format Manager to assist in reading audio files
       // It is used by soundFiles, but put here because we only need one for all files.


### PR DESCRIPTION
## Summary

`SOUND::managerObject::soundFiles` was raced between the **main thread** (`addFile()` walks + `emplace_front`) and the **audio-thread GC** in `update()` (`erase_after`). An interleaving where the GC unlinks/frees a node while `addFile` is mid-walk dereferences a freed node → UAF/crash. Two aggravators: `~soundFile` ran on the audio callback (`sf_close` syscall + `delete[]`), and `clientList` was a second unsynchronized crossing (`attach`/`release`/`inUse`).

The fix mirrors the existing `implementations`-manager pattern: the audio thread stops owning `soundFiles` structure; a slow-pool job does the GC and destruction under a mutex shared with `addFile`.

## Linked issue
Closes #186

## Changes
- **`soundManager.h/.cpp`**: new `soundFilesMutex` guards `soundFiles`; new slow-pool `fileGCJob` (`mgrFileGC`) runs `garbageCollectFiles()` under it. All three `addFile()` overloads take the lock. `update()` no longer iterates/erases `soundFiles` — it only throttle-schedules the GC (~1×/sec via `Time().delta()`). `~soundFile` (`sf_close` + `delete[]`) now runs on the slow pool, off the callback.
- **`abstractSoundFile.h/.cpp`**: new `clientListMutex` guards `clientList` across its three roles (`attach`=main, `release`=slow-pool dtor, idle check=slow-pool GC). `inUse()` takes a `dt` measured by the GC between passes instead of `Time().delta()`, preserving the 30 s idle-eviction policy. No lock is ever taken on the audio thread → RT-safe.
- **Tests**: `Tests/sound/test_sound_file_gc.cpp` — deterministic `addFile`-vs-GC crossing test (paused) + live-audio `[integration]` attach/release churn test.

Scope kept tight: no opportunistic refactors; the idle-eviction *policy* is unchanged, only *where* it runs.

## Test plan
- [x] `python yse.py analyze` on both changed `.cpp` files — no new user-code findings
- [x] `python yse.py test` — **16/16 test groups pass** (full unit + concurrency + integration)
- [x] Both new `#186` cases confirmed executing and passing (incl. live-audio variant)
- [ ] **TSan**: this is a data-race/UAF fix; like the existing issue-#41 concurrency suite, crash-freedom is the assertion and the pre-fix race is caught deterministically only under the ThreadSanitizer CI build, not a plain build. Validation deferred to CI's TSan job (no reliable local red/green on a non-TSan build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)