### PR TITLE
FIX: NamedBus per-render-thread queues; cache gSend bus address (#187)

### DIFF
--- a/Tests/system/test_named_bus.cpp
+++ b/Tests/system/test_named_bus.cpp
@@ -14,10 +14,12 @@
 // TU because no other test needs it; if a future TU also wants it, lift the
 // probe into a shared header.
 
+#include <array>
 #include <atomic>
 #include <cstdlib>
 #include <new>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <doctest/doctest.h>
@@ -184,6 +186,47 @@ TEST_CASE("named bus: T_DSP publish drops string/list payloads silently") {
     CHECK(hits == 1);
 
     bus.unsubscribe(h);
+}
+
+TEST_CASE("named bus: concurrent T_DSP publishers each keep their own queue") {
+    // Regression for issue #187: gSend publishes on T_DSP from whichever thread
+    // renders the owning channel, and child channels render concurrently on
+    // fast-pool workers. A single shared SPSC queue would have two producers
+    // racing in inner_enqueue → torn indices and lost messages. Each producing
+    // thread must own its own queue, so every message survives.
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    constexpr int kThreads   = 4;
+    constexpr int kPerThread = 500;  // < per-queue capacity, so nothing drops
+
+    std::array<int, kThreads> hits{};
+    std::vector<YSE::INTERNAL::SubHandle> handles;
+    handles.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        handles.push_back(bus.subscribe("ch.mt." + std::to_string(t),
+            [t, &hits](const YSE::INTERNAL::BusValue& v) {
+                if (std::get_if<int>(&v)) ++hits[t];
+            }));
+    }
+
+    std::vector<std::thread> workers;
+    workers.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        workers.emplace_back([t, &bus] {
+            const std::string name = "ch.mt." + std::to_string(t);
+            for (int i = 0; i < kPerThread; ++i)
+                bus.publish(name, YSE::INTERNAL::BusValue{i}, YSE::T_DSP);
+        });
+    }
+    for (auto& w : workers) w.join();
+
+    // Nothing is delivered until the consumer drains — on the main thread.
+    bus.drainPending();
+
+    for (int t = 0; t < kThreads; ++t) CHECK(hits[t] == kPerThread);
+
+    for (auto h : handles) bus.unsubscribe(h);
 }
 
 TEST_CASE("named bus: duplicate subscriptions on a name each get called") {

--- a/YseEngine/internal/namedBus.cpp
+++ b/YseEngine/internal/namedBus.cpp
@@ -11,13 +11,65 @@
 #include "namedBus.h"
 
 #include <algorithm>
+#include <thread>
 
 namespace YSE {
   namespace INTERNAL {
 
-    NamedBus::NamedBus() : audioQueue_(kQueueCapacity) {}
+    namespace {
+      // Monotonic across the whole process so every NamedBus instance gets a
+      // distinct stamp even when a new one is allocated at the address a freed
+      // one used (engine restart). Paired with the thread_local slot cache in
+      // producerQueue().
+      std::atomic<std::uint64_t> g_busGeneration { 0 };
+
+      // Per-thread slot into the current bus's queue pool. `generation` marks
+      // which bus instance `index` was claimed against; a mismatch means this
+      // thread has not yet claimed a slot on the live bus.
+      struct ProducerSlot {
+        std::uint64_t generation = 0;
+        std::size_t   index = 0;
+        bool          valid = false;
+      };
+      thread_local ProducerSlot t_slot;
+
+      // Provision a queue per render thread: the audio callback thread plus one
+      // per fast-pool worker (sized to hardware_concurrency), with headroom for
+      // transient producers. Bounded so a machine reporting a huge core count
+      // does not reserve an unreasonable amount of queue memory.
+      std::size_t provisionedQueueCount() {
+        unsigned int hw = std::thread::hardware_concurrency();
+        if (hw == 0) hw = 4;  // hardware_concurrency() may report 0
+        std::size_t count = static_cast<std::size_t>(hw) + 4;
+        constexpr std::size_t kMaxQueues = 128;
+        return count < kMaxQueues ? count : kMaxQueues;
+      }
+    }  // namespace
+
+    NamedBus::NamedBus()
+      : generation_(g_busGeneration.fetch_add(1, std::memory_order_relaxed) + 1) {
+      const std::size_t count = provisionedQueueCount();
+      audioQueues_.reserve(count);
+      for (std::size_t i = 0; i < count; ++i) {
+        audioQueues_.push_back(std::make_unique<lfQueue<PooledMessage>>(kQueueCapacity));
+      }
+    }
 
     NamedBus::~NamedBus() = default;
+
+    lfQueue<NamedBus::PooledMessage>* NamedBus::producerQueue() {
+      // Claim a slot the first time this thread publishes on the live bus. The
+      // fetch_add runs at most once per thread per session — steady-state
+      // publishing hits neither an atomic nor a lock here.
+      if (t_slot.generation != generation_) {
+        const std::size_t slot = nextSlot_.fetch_add(1, std::memory_order_relaxed);
+        t_slot.generation = generation_;
+        t_slot.index = slot;
+        t_slot.valid = slot < audioQueues_.size();
+      }
+      if (!t_slot.valid) return nullptr;  // more producers than provisioned
+      return audioQueues_[t_slot.index].get();
+    }
 
     NamedBus& Bus() {
       return Global().namedBus();
@@ -40,13 +92,19 @@ namespace YSE {
           return;
         }
 
+        // Route to this thread's own SPSC queue. producerQueue() returns null
+        // only if more render threads publish than were provisioned — drop
+        // rather than share a queue and break the single-producer contract.
+        lfQueue<PooledMessage>* queue = producerQueue();
+        if (queue == nullptr) return;
+
         const std::size_t n = name.size() < kNameCapacity ? name.size() : kNameCapacity;
         std::memcpy(msg.nameStorage, name.data(), n);
         msg.nameStorage[n] = '\0';
 
         // try_push never allocates; if the queue is saturated the message is
         // dropped rather than blocking the audio callback.
-        audioQueue_.try_push(msg);
+        queue->try_push(msg);
         return;
       }
 
@@ -81,14 +139,19 @@ namespace YSE {
     }
 
     void NamedBus::drainPending() {
+      // Drain every producer queue. Each is single-consumer (only this call
+      // pops), so touching them all from the update thread is race-free. Empty
+      // queues cost a single try_pop; slots past nextSlot_ are never claimed.
       PooledMessage msg;
-      while (audioQueue_.try_pop(msg)) {
-        BusValue value;
-        switch (msg.kind) {
-          case PooledMessage::Kind::Int:   value = msg.value.i; break;
-          case PooledMessage::Kind::Float: value = msg.value.f; break;
+      for (auto& queue : audioQueues_) {
+        while (queue->try_pop(msg)) {
+          BusValue value;
+          switch (msg.kind) {
+            case PooledMessage::Kind::Int:   value = msg.value.i; break;
+            case PooledMessage::Kind::Float: value = msg.value.f; break;
+          }
+          dispatch(std::string(msg.nameStorage), value);
         }
-        dispatch(std::string(msg.nameStorage), value);
       }
     }
 

--- a/YseEngine/internal/namedBus.h
+++ b/YseEngine/internal/namedBus.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -49,11 +50,18 @@ namespace YSE {
       // Publish a value to `name`.
       //
       //   thread == T_GUI : dispatch synchronously to every subscriber.
-      //   thread == T_DSP : enqueue into the lock-free SPSC queue. The queue
-      //                     entry has a fixed footprint, so only int and float
-      //                     values are accepted on the audio path. String /
-      //                     list / monostate publishes from T_DSP are dropped
-      //                     silently (no allocation, no log) — composers route
+      //   thread == T_DSP : enqueue into this thread's lock-free SPSC queue.
+      //                     Multiple render threads publish concurrently (the
+      //                     audio callback thread plus every fast-pool worker
+      //                     that renders a child channel), so each producing
+      //                     thread owns its own queue — claimed on first use
+      //                     and drained from `drainPending()`. This keeps every
+      //                     queue genuinely single-producer/single-consumer
+      //                     (issue #187). The queue entry has a fixed
+      //                     footprint, so only int and float values are
+      //                     accepted on the audio path. String / list /
+      //                     monostate publishes from T_DSP are dropped silently
+      //                     (no allocation, no log) — composers route
       //                     non-trivial payloads through main-thread bridges.
       //                     Names longer than `kNameCapacity` bytes are
       //                     truncated; producers must keep names short.
@@ -93,7 +101,22 @@ namespace YSE {
 
       void dispatch(const std::string& name, const BusValue& value);
 
-      lfQueue<PooledMessage> audioQueue_;
+      // Route this thread's T_DSP publish to its own SPSC queue, claiming a
+      // slot on first use. Returns nullptr once every provisioned slot is
+      // taken (more render threads than expected) — the caller then drops.
+      lfQueue<PooledMessage>* producerQueue();
+
+      // One SPSC queue per potential render-thread producer. Fixed at
+      // construction (never resized) so `producerQueue()` and `drainPending()`
+      // touch it without synchronisation. unique_ptr because lfQueue is
+      // non-movable and needs a non-default capacity.
+      std::vector<std::unique_ptr<lfQueue<PooledMessage>>> audioQueues_;
+      std::atomic<std::size_t> nextSlot_ { 0 };
+      // Distinguishes this bus instance from any earlier one a surviving
+      // thread may have cached a slot against — engine restart builds a fresh
+      // NamedBus that may reuse the same address (issue #187).
+      const std::uint64_t generation_;
+
       mutable std::shared_mutex subsMutex_;
       std::unordered_map<std::string, std::vector<Subscription>> subs_;
       std::unordered_map<SubHandle, std::string> handleIndex_;

--- a/YseEngine/patcher/genericObjects/gSend.cpp
+++ b/YseEngine/patcher/genericObjects/gSend.cpp
@@ -24,19 +24,13 @@ CONSTRUCT() {
   PARAM_DOC("globalOnly", "0", "When 1, skip in-patcher delivery and publish only to the global bus.", "0 or 1");
 }
 
-// Publish helper. `parent` is a patcherImplementation by construction (the
-// patcher hands itself to every object via SetParent); the cast mirrors the
-// existing PassData calls in this file. RT-safety: on T_DSP the bus
-// publish path is allocation-free and lock-free for int/float; bang and
-// list payloads silently drop on T_DSP per the bus contract.
+// RT-safety: on T_DSP the bus publish path is allocation-free and lock-free
+// for int/float; bang and list payloads silently drop on T_DSP per the bus
+// contract. The address is precomputed off the audio thread (SetParent /
+// RefreshBusAddress) into busAddress_ so no std::string is built here.
 namespace {
   using YSE::INTERNAL::Bus;
   using YSE::INTERNAL::BusValue;
-
-  inline std::string busAddress(YSE::PATCHER::patcherImplementation * p,
-                                const std::string & dataName) {
-    return p->Name() + "." + dataName;
-  }
 
   // The bus is owned by INTERNAL::Global() between init() and close(); skip
   // publishing outside that window so tests instantiating a patcher without
@@ -44,6 +38,23 @@ namespace {
   inline bool busAvailable() {
     return YSE::INTERNAL::Global().isActive();
   }
+}
+
+// `parent` is a patcherImplementation by construction (the patcher hands
+// itself to every object via SetParent); the cast mirrors the existing
+// PassData calls below.
+void gSend::SetParent(pObject * newParent) {
+  pObject::SetParent(newParent);
+  RefreshBusAddress();
+}
+
+void gSend::RefreshBusAddress() {
+  if (parent == nullptr) {
+    busAddress_.clear();
+    return;
+  }
+  auto * p = static_cast<patcherImplementation*>(parent);
+  busAddress_ = p->Name() + "." + dataName;
 }
 
 BANG_IN(SetBangValue) {
@@ -54,7 +65,7 @@ BANG_IN(SetBangValue) {
   }
   if (busAvailable()) {
     // Bang on the bus is a monostate publish — only delivered on T_GUI.
-    Bus().publish(busAddress(p, dataName), BusValue{}, thread);
+    Bus().publish(busAddress_, BusValue{}, thread);
   }
 }
 
@@ -65,7 +76,7 @@ INT_IN(SetIntValue) {
     p->PassData(value, dataName, thread);
   }
   if (busAvailable()) {
-    Bus().publish(busAddress(p, dataName), BusValue{value}, thread);
+    Bus().publish(busAddress_, BusValue{value}, thread);
   }
 }
 
@@ -76,7 +87,7 @@ FLOAT_IN(SetFloatValue) {
     p->PassData(value, dataName, thread);
   }
   if (busAvailable()) {
-    Bus().publish(busAddress(p, dataName), BusValue{value}, thread);
+    Bus().publish(busAddress_, BusValue{value}, thread);
   }
 }
 
@@ -87,6 +98,6 @@ LIST_IN(SetListValue) {
     p->PassData(value, dataName, thread);
   }
   if (busAvailable()) {
-    Bus().publish(busAddress(p, dataName), BusValue{value}, thread);
+    Bus().publish(busAddress_, BusValue{value}, thread);
   }
 }

--- a/YseEngine/patcher/genericObjects/gSend.h
+++ b/YseEngine/patcher/genericObjects/gSend.h
@@ -13,11 +13,26 @@ namespace YSE {
       _BANG_IN(SetBangValue)
       _LIST_IN(SetListValue)
 
+      // Cache the bus address ("<patcherName>.<dataName>") the moment the
+      // parent is known, so the audio-path publishes never concatenate a
+      // std::string on the callback thread (issue #187).
+      void SetParent(pObject * parent) override;
+
+      // Recompute the cached address after a patcher rename. Mirrors
+      // gReceive::Resubscribe(); called from patcherImplementation::SetName so
+      // sends keep matching the re-anchored receivers.
+      void RefreshBusAddress();
+
     private:
       // 0 = also fire the in-patcher PassData/PassBang path (default),
       // 1 = publish only to the global bus. Parsed from the second
       // constructor argument (issue #122).
       int globalOnly = 0;
+
+      // Precomputed "<patcherName>.<dataName>" bus address. Written on the main
+      // thread (SetParent / RefreshBusAddress), read on the audio thread under
+      // the owning patcher's lock; empty until a parent is assigned.
+      std::string busAddress_;
   };
 }
 }

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -5,6 +5,7 @@
 #include "../headers/enums.hpp"
 #include "genericObjects/pDac.h"
 #include "genericObjects/gReceive.h"
+#include "genericObjects/gSend.h"
 #include "pHandle.hpp"
 #include "../utils/json.hpp"
 #include <atomic>
@@ -40,6 +41,10 @@ void patcherImplementation::SetName(const std::string & n) {
   for (auto & x : objects) {
     if (strcmp(x.second->Type(), OBJ::G_RECEIVE) == 0) {
       static_cast<gReceive*>(x.second)->Resubscribe();
+    } else if (strcmp(x.second->Type(), OBJ::G_SEND) == 0) {
+      // Keep gSend's cached bus address in step with the receivers that just
+      // re-anchored, so sends still reach them under the new name (issue #187).
+      static_cast<gSend*>(x.second)->RefreshBusAddress();
     }
   }
   mtx.unlock();


### PR DESCRIPTION
## Summary
`NamedBus::publish(T_DSP)` pushed into a single SPSC queue, but `gSend` fires from `patcher->Calculate(T_DSP)`, which runs on whichever thread renders the owning channel — and child channels render concurrently on fast-pool workers. Two `gSend`s under different channels then entered `lfQueue::inner_enqueue` simultaneously, violating the single-producer contract: torn/lost messages and corrupted queue indices. Additionally, `gSend` concatenated `p->Name() + "." + dataName` into a `std::string` on every send, heap-allocating on the audio path.

## Linked issue
Closes #187

## Changes
- **Per-render-thread SPSC queues** (`namedBus.h/.cpp`): a fixed pool of `lfQueue`s (audio callback thread + one per fast-pool worker, sized to `hardware_concurrency + margin`, capped at 128). Each producing thread lazily claims a slot via a `thread_local` index, guarded by a per-instance generation stamp so a surviving thread cannot reuse a slot against a `NamedBus` rebuilt at the same address on engine restart. `drainPending()` drains them all. No atomics in the steady-state publish path — every queue stays genuinely single-producer/single-consumer.
- **Precomputed gSend address** (`gSend.h/.cpp`): cache `"<patcherName>.<dataName>"` on `SetParent`, refresh from `patcherImplementation::SetName` (mirroring `gReceive`'s re-anchor). The audio path no longer builds a `std::string` per send.
- **Regression test** (`test_named_bus.cpp`): four threads publish 500 int messages each on `T_DSP` concurrently; after `drainPending()` every message must survive.

Note: on a machine reporting a very high core count the pool caps at 128 SPSC queues; render threads beyond that silently drop `T_DSP` publishes rather than share a queue (a non-issue for realistic render-thread counts).

## Test plan
- [x] Full suite passes: **16/16 test binaries** (`python yse.py test`), run twice
- [x] New concurrent-publisher test is a valid regression: forcing producers back onto one shared queue makes it deterministically trip `lfQueue`'s single-producer assertion (`!inSection`); with the fix all messages survive
- [x] Existing rename test (`patcher: renaming the parent patcher re-subscribes existing gReceives`) guards the gSend address-caching parity — breaks if `SetName` fails to refresh the cache
- [x] clang-tidy on changed files: no new findings (only the pre-existing `readability-string-compare` baseline in untouched functions)

No integration test added: this is engine-internal threading/lifecycle code with no user-visible flow to drive end-to-end; it is covered by the unit/concurrency layer per the project's test taxonomy (DSP/threading code gets unit + concurrency tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)