### PR TITLE
FIX: Make the thread pool wait-free on the audio callback path (#188)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -13,7 +13,9 @@ set(YSE_TEST_SOURCES
   utils/test_atomic.cpp
   utils/test_vector.cpp
   utils/test_lfqueue.cpp
+  utils/test_mpmcqueue.cpp
   utils/test_interpolators.cpp
+  internal/test_threadpool.cpp
   dsp/test_filters.cpp
   dsp/test_delay.cpp
   dsp/test_envelope.cpp

--- a/Tests/internal/test_threadpool.cpp
+++ b/Tests/internal/test_threadpool.cpp
@@ -1,0 +1,154 @@
+// Tests for YSE::INTERNAL::threadPool — the wait-free job pool the audio
+// callback dispatches DSP fan-out and manager jobs through (issue #188).
+//
+// These drive the pool directly (no engine session): they verify that jobs
+// dispatched via addJob() actually run, that join() returns without the old
+// 2 ms sleep, that a full render ring falls back to inline execution instead
+// of dropping work, and that a pool survives shutdown()/startup() cycling.
+
+#include <doctest/doctest.h>
+#include "internal/threadPool.h"
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+#include <memory>
+
+using YSE::INTERNAL::threadPool;
+using YSE::INTERNAL::threadPoolJob;
+using YSE::INTERNAL::poolClass;
+
+namespace {
+  // A job that records the thread it ran on and bumps a shared counter.
+  struct CountJob : threadPoolJob {
+    std::atomic<int>* counter;
+    std::atomic<std::thread::id>* ranOn;
+    explicit CountJob(std::atomic<int>* c, std::atomic<std::thread::id>* r = nullptr)
+      : counter(c), ranOn(r) {}
+    void run() override {
+      if (ranOn) ranOn->store(std::this_thread::get_id());
+      counter->fetch_add(1, std::memory_order_relaxed);
+    }
+  };
+}
+
+TEST_SUITE("internal") {
+
+TEST_CASE("threadPool: every dispatched render job runs and joins") {
+    threadPool pool(4, poolClass::render);
+    std::atomic<int> counter{0};
+
+    constexpr int N = 500;
+    std::vector<std::unique_ptr<CountJob>> jobs;
+    jobs.reserve(N);
+    for (int i = 0; i < N; ++i) jobs.emplace_back(std::make_unique<CountJob>(&counter));
+
+    for (auto& j : jobs) pool.addJob(j.get());
+    for (auto& j : jobs) j->join();
+
+    CHECK(counter.load() == N);
+    for (auto& j : jobs) CHECK(j->isQueued() == false);
+}
+
+TEST_CASE("threadPool: background pool runs fire-and-forget jobs") {
+    threadPool pool(1, poolClass::background);
+    std::atomic<int> counter{0};
+
+    constexpr int N = 100;
+    std::vector<std::unique_ptr<CountJob>> jobs;
+    jobs.reserve(N);
+    for (int i = 0; i < N; ++i) jobs.emplace_back(std::make_unique<CountJob>(&counter));
+
+    for (auto& j : jobs) pool.addJob(j.get());
+    for (auto& j : jobs) j->join();
+
+    CHECK(counter.load() == N);
+}
+
+TEST_CASE("threadPool: join() returns promptly (no 2 ms sleep quantum)") {
+    threadPool pool(4, poolClass::render);
+    std::atomic<int> counter{0};
+
+    // Dispatch a batch and time the round-trip. The old join() slept in 2 ms
+    // steps, so N joins on completed-but-not-yet-observed jobs cost O(N * 2ms).
+    // The spin join should clear this in well under that.
+    constexpr int N = 50;
+    std::vector<std::unique_ptr<CountJob>> jobs;
+    jobs.reserve(N);
+    for (int i = 0; i < N; ++i) jobs.emplace_back(std::make_unique<CountJob>(&counter));
+
+    auto t0 = std::chrono::steady_clock::now();
+    for (auto& j : jobs) pool.addJob(j.get());
+    for (auto& j : jobs) j->join();
+    auto elapsed = std::chrono::steady_clock::now() - t0;
+
+    CHECK(counter.load() == N);
+    CHECK(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() < 50);
+}
+
+TEST_CASE("threadPool: render ring overflow falls back to inline execution") {
+    // RENDER_CAPACITY is 4096. Stalling all workers and then dispatching more
+    // than the ring holds forces the inline fallback path: no job is dropped.
+    threadPool pool(2, poolClass::render);
+    std::atomic<int> counter{0};
+
+    // A blocking job pins a worker until released, so the ring can actually
+    // fill instead of being drained as fast as we push.
+    struct BlockJob : threadPoolJob {
+      std::atomic<bool>* release;
+      explicit BlockJob(std::atomic<bool>* r) : release(r) {}
+      void run() override {
+        while (!release->load(std::memory_order_acquire)) std::this_thread::yield();
+      }
+    };
+
+    std::atomic<bool> release{false};
+    std::vector<std::unique_ptr<BlockJob>> blockers;
+    for (int i = 0; i < 2; ++i) { // one per worker
+      blockers.emplace_back(std::make_unique<BlockJob>(&release));
+      pool.addJob(blockers.back().get());
+    }
+
+    // Now flood past capacity. With both workers stuck, ~4096 land in the ring
+    // and the remainder run inline on this (calling) thread.
+    constexpr int N = 5000;
+    std::vector<std::unique_ptr<CountJob>> jobs;
+    jobs.reserve(N);
+    for (int i = 0; i < N; ++i) {
+      jobs.emplace_back(std::make_unique<CountJob>(&counter));
+      pool.addJob(jobs.back().get());
+    }
+
+    release.store(true, std::memory_order_release);
+    for (auto& b : blockers) b->join();
+    for (auto& j : jobs) j->join();
+
+    CHECK(counter.load() == N); // nothing dropped
+}
+
+TEST_CASE("threadPool: survives shutdown()/startup() cycling") {
+    threadPool pool(2, poolClass::render);
+    std::atomic<int> counter{0};
+
+    auto runBatch = [&](int n) {
+      std::vector<std::unique_ptr<CountJob>> jobs;
+      jobs.reserve(n);
+      for (int i = 0; i < n; ++i) jobs.emplace_back(std::make_unique<CountJob>(&counter));
+      for (auto& j : jobs) pool.addJob(j.get());
+      for (auto& j : jobs) j->join();
+    };
+
+    runBatch(50);
+    pool.shutdown();
+    // addJob on an inactive pool is a no-op; the job stays un-queued.
+    CountJob ignored(&counter);
+    pool.addJob(&ignored);
+    CHECK(ignored.isQueued() == false);
+
+    pool.startup();
+    runBatch(50);
+
+    CHECK(counter.load() == 100);
+}
+
+} // TEST_SUITE

--- a/Tests/utils/test_mpmcqueue.cpp
+++ b/Tests/utils/test_mpmcqueue.cpp
@@ -1,0 +1,126 @@
+// Tests for YSE::mpmcQueue — a bounded lock-free MPMC queue (utils/mpmcQueue.hpp).
+// Added with issue #188 (wait-free threadPool hand-off).
+
+#include <doctest/doctest.h>
+#include "utils/mpmcQueue.hpp"
+#include <atomic>
+#include <thread>
+#include <vector>
+#include <set>
+
+TEST_SUITE("utils") {
+
+TEST_CASE("mpmcQueue: single element push/pop round-trip") {
+    YSE::mpmcQueue<int> q(16);
+    CHECK(q.try_push(42) == true);
+    int result = 0;
+    CHECK(q.try_pop(result) == true);
+    CHECK(result == 42);
+}
+
+TEST_CASE("mpmcQueue: try_pop on empty queue returns false") {
+    YSE::mpmcQueue<int> q(16);
+    int result = -1;
+    CHECK(q.try_pop(result) == false);
+    CHECK(result == -1); // left untouched
+}
+
+TEST_CASE("mpmcQueue: FIFO ordering with a single thread") {
+    YSE::mpmcQueue<int> q(16);
+    for (int i = 0; i < 8; ++i) CHECK(q.try_push(i));
+    for (int i = 0; i < 8; ++i) {
+        int v = -1;
+        CHECK(q.try_pop(v));
+        CHECK(v == i);
+    }
+}
+
+TEST_CASE("mpmcQueue: capacity is rounded up to a power of two") {
+    YSE::mpmcQueue<int> q(10);
+    CHECK(q.capacity() == 16);
+    YSE::mpmcQueue<int> q2(16);
+    CHECK(q2.capacity() == 16);
+    YSE::mpmcQueue<int> q3(1);
+    CHECK(q3.capacity() == 2);
+}
+
+TEST_CASE("mpmcQueue: try_push returns false when full, no overwrite") {
+    YSE::mpmcQueue<int> q(4); // holds exactly 4
+    CHECK(q.capacity() == 4);
+    CHECK(q.try_push(1));
+    CHECK(q.try_push(2));
+    CHECK(q.try_push(3));
+    CHECK(q.try_push(4));
+    CHECK(q.try_push(5) == false); // full — rejected
+    // Draining still yields the first four in order.
+    int v = 0;
+    for (int expected = 1; expected <= 4; ++expected) {
+        CHECK(q.try_pop(v));
+        CHECK(v == expected);
+    }
+    CHECK(q.try_pop(v) == false);
+}
+
+TEST_CASE("mpmcQueue: wraps around the ring across many push/pop cycles") {
+    YSE::mpmcQueue<int> q(4);
+    for (int round = 0; round < 1000; ++round) {
+        CHECK(q.try_push(round));
+        int v = -1;
+        CHECK(q.try_pop(v));
+        CHECK(v == round);
+    }
+}
+
+TEST_CASE("mpmcQueue: concurrent producers and consumers conserve every item") {
+    constexpr int PRODUCERS = 4;
+    constexpr int CONSUMERS = 4;
+    constexpr int PER_PRODUCER = 20000;
+    constexpr int TOTAL = PRODUCERS * PER_PRODUCER;
+
+    YSE::mpmcQueue<int> q(1024);
+    std::atomic<int> produced{0};
+    std::atomic<long long> sumConsumed{0};
+    std::atomic<int> consumedCount{0};
+    std::atomic<bool> producersDone{false};
+
+    std::vector<std::thread> threads;
+    for (int p = 0; p < PRODUCERS; ++p) {
+        threads.emplace_back([&, p] {
+            for (int i = 0; i < PER_PRODUCER; ++i) {
+                int value = p * PER_PRODUCER + i; // globally unique
+                while (!q.try_push(value)) std::this_thread::yield();
+                produced.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    for (int c = 0; c < CONSUMERS; ++c) {
+        threads.emplace_back([&] {
+            int value = 0;
+            for (;;) {
+                if (q.try_pop(value)) {
+                    sumConsumed.fetch_add(value, std::memory_order_relaxed);
+                    consumedCount.fetch_add(1, std::memory_order_relaxed);
+                } else if (producersDone.load(std::memory_order_acquire)) {
+                    // One last drain attempt after producers stop.
+                    if (!q.try_pop(value)) break;
+                    sumConsumed.fetch_add(value, std::memory_order_relaxed);
+                    consumedCount.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    std::this_thread::yield();
+                }
+            }
+        });
+    }
+
+    for (int p = 0; p < PRODUCERS; ++p) threads[p].join();
+    producersDone.store(true, std::memory_order_release);
+    for (int c = PRODUCERS; c < PRODUCERS + CONSUMERS; ++c) threads[c].join();
+
+    CHECK(produced.load() == TOTAL);
+    CHECK(consumedCount.load() == TOTAL);
+    // Sum of all globally-unique values 0..TOTAL-1 — catches duplicates/drops.
+    long long expectedSum = (long long)TOTAL * (TOTAL - 1) / 2;
+    CHECK(sumConsumed.load() == expectedSum);
+}
+
+} // TEST_SUITE

--- a/YseEngine/YseEngine.vcxitems
+++ b/YseEngine/YseEngine.vcxitems
@@ -179,6 +179,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\interpolators.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\json.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\lfQueue.hpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)utils\mpmcQueue.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\misc.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\vector.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)yse.hpp" />

--- a/YseEngine/YseEngine.vcxitems.filters
+++ b/YseEngine/YseEngine.vcxitems.filters
@@ -382,6 +382,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\lfQueue.hpp">
       <Filter>utils</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)utils\mpmcQueue.hpp">
+      <Filter>utils</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)utils\misc.hpp">
       <Filter>utils</Filter>
     </ClInclude>

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -126,7 +126,9 @@ void YSE::INTERNAL::global::drainScriptResults() {
 #endif
 }
 
-YSE::INTERNAL::global::global() : slowThreads(1), fastThreads(), bus(), update(false), active(false), sampleRateLocked(false) {}
+YSE::INTERNAL::global::global()
+  : slowThreads(1, poolClass::background), fastThreads(-1, poolClass::render),
+    bus(), update(false), active(false), sampleRateLocked(false) {}
 
 YSE::INTERNAL::global::~global() = default;
 

--- a/YseEngine/internal/thread.cpp
+++ b/YseEngine/internal/thread.cpp
@@ -12,6 +12,13 @@
 #include <assert.h>
 #include "time.h"
 
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <pthread.h>
+#include <sched.h>
+#endif
+
 YSE::INTERNAL::thread::thread()
 : shouldExit(false) {
 }
@@ -46,6 +53,27 @@ void YSE::INTERNAL::thread::stop() {
       handle.reset();
     }
   }
+}
+
+void YSE::INTERNAL::thread::setPriority(bool high) {
+  if (!handle) return;
+#if defined(_WIN32)
+  ::SetThreadPriority(static_cast<HANDLE>(handle->native_handle()),
+                      high ? THREAD_PRIORITY_HIGHEST : THREAD_PRIORITY_NORMAL);
+#else
+  // Best-effort: raising to SCHED_FIFO needs privileges (CAP_SYS_NICE / RT
+  // limits). If pthread_setschedparam fails we leave the thread at its default
+  // policy — the spin-based join() still bounds the callback stall, priority is
+  // only an optimisation against preemption.
+  int policy = high ? SCHED_FIFO : SCHED_OTHER;
+  sched_param param{};
+  if (high) {
+    int lo = ::sched_get_priority_min(SCHED_FIFO);
+    int hi = ::sched_get_priority_max(SCHED_FIFO);
+    param.sched_priority = (lo >= 0 && hi >= 0) ? lo + (hi - lo) / 2 : 0;
+  }
+  ::pthread_setschedparam(handle->native_handle(), policy, &param);
+#endif
 }
 
 bool YSE::INTERNAL::thread::threadShouldExit() const {

--- a/YseEngine/internal/thread.h
+++ b/YseEngine/internal/thread.h
@@ -32,6 +32,16 @@ namespace YSE {
       void start();
       void stop();
 
+      // Best-effort thread priority. `high` raises this thread toward the
+      // audio-callback priority band (SCHED_FIFO on POSIX / THREAD_PRIORITY_-
+      // HIGHEST on Windows) so a render worker can't be preempted by ordinary
+      // work while the callback spins in threadPoolJob::join() waiting for it
+      // (issue #188). Must be called after start(); a no-op if the underlying
+      // handle isn't running yet. Failure (e.g. POSIX RT scheduling denied to
+      // an unprivileged process) is silently ignored — correctness never
+      // depends on the priority actually taking effect.
+      void setPriority(bool high);
+
       bool isRunning() const;
       bool threadShouldExit() const;
 

--- a/YseEngine/internal/threadPool.cpp
+++ b/YseEngine/internal/threadPool.cpp
@@ -10,8 +10,32 @@
 
 #include "threadPool.h"
 #include <assert.h>
+#include <chrono>
+#include <thread>
 #include "../system.hpp"
 #include "denormalGuard.h"
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
+namespace {
+  // Relax the CPU inside a spin loop: on x86 this is the PAUSE instruction
+  // (frees the pipeline / hyperthread sibling and cuts power), on ARM the YIELD
+  // hint, and a portable no-op elsewhere. Not a scheduling yield — the caller
+  // decides when to escalate to std::this_thread::yield().
+  inline void cpuRelax() {
+#if defined(_MSC_VER)
+    _mm_pause();
+#elif defined(__i386__) || defined(__x86_64__)
+    __builtin_ia32_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+    __asm__ __volatile__("yield");
+#else
+    std::this_thread::yield();
+#endif
+  }
+}
 
 YSE::INTERNAL::threadPoolJob::threadPoolJob() : shouldStop(false), inQueue(false), isDone(false) {}
 
@@ -20,9 +44,22 @@ YSE::INTERNAL::threadPoolJob::~threadPoolJob() {
 }
 
 void YSE::INTERNAL::threadPoolJob::join() {
+  // Bounded-spin wait, called from the audio callback (buffersToParent) — it
+  // must never sleep or lock. The old implementation slept in 2 ms quanta,
+  // burning ~70% of a 2.9 ms render block waiting on a worker (issue #188).
+  // Instead spin on the done flag, relaxing the CPU for a while and then
+  // yielding so a not-yet-scheduled worker can run. Render workers run at
+  // raised priority, so the yield path is rarely reached.
+  constexpr int YIELD_AFTER = 8192;
+  int spins = 0;
   while (!isDone) {
-    if (!inQueue) return;
-    System().sleep(2);
+    if (!inQueue) return; // never queued, or already drained by shutdown()
+    if (spins < YIELD_AFTER) {
+      cpuRelax();
+      ++spins;
+    } else {
+      std::this_thread::yield();
+    }
   }
 }
 
@@ -50,7 +87,9 @@ void YSE::INTERNAL::threadPoolThread::run() {
   }
 }
 
-YSE::INTERNAL::threadPool::threadPool(Int numThreads) : poolSize(numThreads), active(false) {
+YSE::INTERNAL::threadPool::threadPool(Int numThreads, poolClass cls)
+  : jobs(cls == poolClass::render ? RENDER_CAPACITY : BACKGROUND_CAPACITY),
+    poolSize(numThreads), classOf(cls), active(false) {
   if (poolSize == -1) {
     poolSize = std::thread::hardware_concurrency();
   }
@@ -74,21 +113,30 @@ void YSE::INTERNAL::threadPool::startup() {
   for (Int i = 0; i < poolSize; i++) {
     threads.emplace_front(this);
     threads.front().start();
+    // Render workers race the audio-callback deadline: raise them so ordinary
+    // threads can't preempt one while the callback spins in join() (issue
+    // #188). Best-effort — a denied request just leaves the worker at default
+    // priority. Background workers stay at normal priority.
+    if (classOf == poolClass::render) {
+      threads.front().setPriority(true);
+    }
   }
 }
 
 void YSE::INTERNAL::threadPool::shutdown() {
-  {
-    std::unique_lock<std::mutex> lock(mutex);
-    if (!active) return; // already shut down — nothing to join or drain
-    active = false;
-    while (!jobs.empty()) {
-      jobs.front()->inQueue = false;
-      jobs.front()->isDone = true;
-      jobs.pop();
-    }
+  if (!active) return; // already shut down — nothing to join or drain
+  active = false;
+
+  // Release any queued jobs so a pending join() returns instead of spinning
+  // forever. Marking inQueue=false is enough (join() exits on !inQueue); we do
+  // not run them. No lock: getJob() stops popping once active is false, so this
+  // thread is the only consumer of the ring now.
+  threadPoolJob * job = nullptr;
+  while (jobs.try_pop(job)) {
+    job->inQueue = false;
+    job->isDone = true;
   }
-  cv.notify_all();
+
   for (auto i = threads.begin(); i != threads.end(); ++i) {
     i->stop();
   }
@@ -102,18 +150,42 @@ void YSE::INTERNAL::threadPool::addJob(threadPoolJob * job) {
   if (!active) return;
 
   job->start();
-  {
-    std::unique_lock<std::mutex> lock(mutex);
-    jobs.push(job);
+  if (jobs.try_push(job)) return;
+
+  // Ring full. For a render pool the caller (audio thread or a worker) runs the
+  // job inline so no DSP work is lost — correct, just serial for this one job.
+  // A background pool must not run inline (the caller may be the audio thread
+  // and the work touches disk), so we clear the queued flag and drop it; the
+  // manager/refill schedulers are self-healing and re-enqueue next tick. Both
+  // paths are effectively unreachable at the chosen capacities.
+  if (classOf == poolClass::render) {
+    job->activate();
+  } else {
+    assert(false && "background threadPool ring overflow");
+    job->inQueue = false;
   }
-  cv.notify_one();
 }
 
 YSE::INTERNAL::threadPoolJob * YSE::INTERNAL::threadPool::getJob() {
-  std::unique_lock<std::mutex> lock(mutex);
-  cv.wait(lock, [this] { return !jobs.empty() || !active; });
-  if (jobs.empty()) return nullptr;
-  threadPoolJob * result = jobs.front();
-  jobs.pop();
-  return result;
+  // Adaptive backoff: pick up work within nanoseconds while the pool is hot
+  // (busy render), fall to a cooperative yield, and only start sleeping once
+  // the pool has been idle for a while so an idle engine doesn't peg a core.
+  // No producer-side wakeup is needed, so addJob() never has to lock or notify.
+  using clock = std::chrono::steady_clock;
+  auto idleStart = clock::now();
+  threadPoolJob * job = nullptr;
+
+  while (active) {
+    if (jobs.try_pop(job)) return job;
+
+    auto idle = clock::now() - idleStart;
+    if (idle < std::chrono::microseconds(50)) {
+      cpuRelax();
+    } else if (idle < std::chrono::milliseconds(5)) {
+      std::this_thread::yield();
+    } else {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+  return nullptr;
 }

--- a/YseEngine/internal/threadPool.h
+++ b/YseEngine/internal/threadPool.h
@@ -12,15 +12,25 @@
 #define THREADPOOL_H_INCLUDED
 
 #include "../headers/types.hpp"
+#include "../utils/mpmcQueue.hpp"
 #include <forward_list>
-#include <queue>
-#include <mutex>
-#include <condition_variable>
 #include "thread.h"
 
 namespace YSE {
   namespace INTERNAL {
     class threadPool;
+
+    // How a pool behaves on the audio-callback path (issue #188).
+    enum class poolClass {
+      // Render fan-out: workers run at raised priority and, if the job ring is
+      // ever full, the producer runs the job inline rather than dropping it.
+      render,
+      // Background work (manager setup/delete, file loading, stream refill):
+      // default-priority workers; a fire-and-forget queue that must never run
+      // inline on the caller (the caller may be the audio thread and the work
+      // touches disk).
+      background,
+    };
 
     class threadPoolJob {
     public:
@@ -53,13 +63,18 @@ namespace YSE {
 
     class threadPool {
     public:
-      // numThreads: -1 means hardware_concurrency
-      explicit threadPool(Int numThreads = -1);
+      // numThreads: -1 means hardware_concurrency. cls selects the RT behaviour
+      // (see poolClass).
+      explicit threadPool(Int numThreads = -1, poolClass cls = poolClass::render);
       ~threadPool();
 
+      // Wait-free on the producer side: pushes the job into the lock-free ring
+      // and lets a worker pick it up. Never locks, allocates, or blocks — safe
+      // to call from the audio callback. For a render pool, a full ring falls
+      // back to running the job inline on the caller so no DSP work is dropped.
       void addJob(threadPoolJob * job);
 
-      // only used by threadPoolThread, returns nullptr if there's no job to execute
+      // only used by threadPoolThread, returns nullptr when the pool shuts down
       threadPoolJob * getJob();
 
       // (Re)spawn the worker threads and mark the pool active. Called by the
@@ -68,23 +83,28 @@ namespace YSE {
       // the pool is already active.
       void startup();
 
-      // shutdown this pool: drain the queue, join every worker, and drop the
-      // (now-joined) thread objects so a later startup() re-spawns cleanly. Call
-      // before deconstructing; safe to call on an already-inactive pool.
+      // shutdown this pool: mark inactive, drain the ring, join every worker,
+      // and drop the (now-joined) thread objects so a later startup() re-spawns
+      // cleanly. Call before deconstructing; safe on an already-inactive pool.
       void shutdown();
 
     private:
-      std::queue<threadPoolJob*> jobs;
+      // Ring capacity. Render must hold one job per channel dispatched in a
+      // render pass; background holds the handful of manager/setup/refill jobs.
+      // Both are far above any realistic live count, and a full render ring
+      // degrades gracefully to inline execution rather than dropping work.
+      static constexpr std::size_t RENDER_CAPACITY = 4096;
+      static constexpr std::size_t BACKGROUND_CAPACITY = 1024;
+
+      mpmcQueue<threadPoolJob*> jobs;
       std::forward_list<threadPoolThread> threads;
-      Int poolSize; // resolved worker count, reused when startup() re-spawns
+      Int poolSize;        // resolved worker count, reused when startup() re-spawns
+      poolClass classOf;   // render vs background behaviour
       aBool active;
-      std::mutex mutex;
-      std::condition_variable cv;
     };
 
   }
 }
-
 
 
 

--- a/YseEngine/utils/mpmcQueue.hpp
+++ b/YseEngine/utils/mpmcQueue.hpp
@@ -1,0 +1,131 @@
+/*
+  ==============================================================================
+
+    mpmcQueue.hpp
+    Created: 3 Jul 2026
+
+    Bounded lock-free multi-producer / multi-consumer queue.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_UTILS_MPMCQUEUE_HPP_INCLUDED
+#define YSE_UTILS_MPMCQUEUE_HPP_INCLUDED
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace YSE {
+
+  // Bounded lock-free multi-producer / multi-consumer queue — Dmitry Vyukov's
+  // array-of-cells algorithm. Fixed capacity, allocated once at construction;
+  // try_push / try_pop never lock, never allocate, and are wait-free bar the
+  // bounded CAS retry loop under producer/consumer contention.
+  //
+  // Introduced for INTERNAL::threadPool (issue #188): the audio callback hands
+  // DSP fan-out jobs (render pool) and manager/setup jobs (background pool) to
+  // the worker threads without ever touching a mutex, allocating, or issuing a
+  // wakeup syscall. Both pools push from the callback; the render pool also has
+  // multiple worker producers (nested child dispatch) and multiple consumers,
+  // so a full MPMC queue — not the SPSC lfQueue — is required.
+  //
+  // T must be trivially copyable (this queue stores pointers). Capacity is
+  // rounded up to the next power of two so the index wrap is a single mask.
+  template <typename T>
+  class mpmcQueue {
+  public:
+    explicit mpmcQueue(std::size_t capacity)
+      : buffer_(new cell[roundUpPow2(capacity)]),
+        capacityMask_(roundUpPow2(capacity) - 1) {
+      for (std::size_t i = 0; i <= capacityMask_; ++i) {
+        buffer_[i].sequence.store(i, std::memory_order_relaxed);
+      }
+      enqueuePos_.store(0, std::memory_order_relaxed);
+      dequeuePos_.store(0, std::memory_order_relaxed);
+    }
+
+    // Enqueue a value. Returns false (without blocking or allocating) when the
+    // queue is full.
+    bool try_push(T const& value) {
+      cell* c;
+      std::size_t pos = enqueuePos_.load(std::memory_order_relaxed);
+      for (;;) {
+        c = &buffer_[pos & capacityMask_];
+        std::size_t seq = c->sequence.load(std::memory_order_acquire);
+        std::intptr_t diff = (std::intptr_t)seq - (std::intptr_t)pos;
+        if (diff == 0) {
+          if (enqueuePos_.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed)) {
+            break;
+          }
+        } else if (diff < 0) {
+          return false; // full
+        } else {
+          pos = enqueuePos_.load(std::memory_order_relaxed);
+        }
+      }
+      c->data = value;
+      c->sequence.store(pos + 1, std::memory_order_release);
+      return true;
+    }
+
+    // Dequeue into value. Returns false when the queue is empty.
+    bool try_pop(T& value) {
+      cell* c;
+      std::size_t pos = dequeuePos_.load(std::memory_order_relaxed);
+      for (;;) {
+        c = &buffer_[pos & capacityMask_];
+        std::size_t seq = c->sequence.load(std::memory_order_acquire);
+        std::intptr_t diff = (std::intptr_t)seq - (std::intptr_t)(pos + 1);
+        if (diff == 0) {
+          if (dequeuePos_.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed)) {
+            break;
+          }
+        } else if (diff < 0) {
+          return false; // empty
+        } else {
+          pos = dequeuePos_.load(std::memory_order_relaxed);
+        }
+      }
+      value = c->data;
+      c->sequence.store(pos + capacityMask_ + 1, std::memory_order_release);
+      return true;
+    }
+
+    std::size_t capacity() const { return capacityMask_ + 1; }
+
+  private:
+    struct cell {
+      std::atomic<std::size_t> sequence;
+      T data;
+    };
+
+    static std::size_t roundUpPow2(std::size_t x) {
+      if (x < 2) return 2;
+      --x;
+      x |= x >> 1;
+      x |= x >> 2;
+      x |= x >> 4;
+      x |= x >> 8;
+      x |= x >> 16;
+      if (sizeof(std::size_t) > 4) x |= x >> 32;
+      return x + 1;
+    }
+
+    // Producer and consumer cursors live on separate cache lines so the two
+    // sides don't ping-pong a shared line under contention.
+    static constexpr std::size_t CACHE_LINE = 64;
+
+    std::unique_ptr<cell[]> buffer_;
+    const std::size_t capacityMask_;
+    alignas(CACHE_LINE) std::atomic<std::size_t> enqueuePos_;
+    alignas(CACHE_LINE) std::atomic<std::size_t> dequeuePos_;
+
+    mpmcQueue(mpmcQueue const&) = delete;
+    mpmcQueue& operator=(mpmcQueue const&) = delete;
+  };
+
+} // namespace YSE
+
+#endif // YSE_UTILS_MPMCQUEUE_HPP_INCLUDED


### PR DESCRIPTION
## Summary

The PortAudio callback dispatched DSP fan-out (`addFastJob`) and manager/setup jobs (`addSlowJob`) through a `std::mutex` + `std::queue` + `condition_variable` pool, and `buffersToParent()` → `join()` slept in 2 ms quanta waiting for workers — ~70% of a 2.9 ms render block. Under load a not-yet-scheduled worker blew the block deadline and dropped audio.

Both pools are reached from the audio callback (`deviceManager.cpp:35 doOnCallback`): the three managers' `update()` call `addSlowJob` (mutex + alloc + `notify_one`), and `renderOneBlock` calls `addFastJob` + `join()`. A path the issue omitted — the streaming refill (`abstractSoundFile::requestRefill`, explicitly "Called from the audio thread") — also enqueues on the slow pool.

## Linked issue
Closes #188

## Changes
Replace the pool's mutex/cv/queue with a bounded lock-free MPMC ring (Vyukov) shared by both pools:

- **`utils/mpmcQueue.hpp`** — new bounded lock-free MPMC queue; allocated once, `try_push`/`try_pop` never lock or allocate.
- **`addJob()` is wait-free** — a single lock-free push, no allocation, no wakeup syscall. A full **render** ring runs the job inline on the caller rather than dropping it; the **background** ring never runs inline (its caller may be the audio thread and the work touches disk).
- **`join()` spins** on the done flag (`cpuRelax` + `yield`) instead of sleeping, so it no longer burns the render-block budget.
- **Workers use adaptive backoff** (pause → yield → short sleep) so an idle engine doesn't peg a core, while a hot pool dispatches within nanoseconds — no producer-side lock or notify needed.
- **Render workers raised** toward the callback priority band (`thread::setPriority`, best-effort `SCHED_FIFO` / `THREAD_PRIORITY_HIGHEST`) so they can't be preempted while the callback spins in `join()`.
- Pools are tagged `render` / `background` via a `poolClass` enum wired in `global`.

This covers every audio-thread producer at one point: the channel render fan-out, the sound/channel/reverb manager setup/delete jobs, and the streaming refill path.

## Test plan
- [x] Formatter: intentionally **not** run — the repo does not follow its own `.clang-format` (house style is 2-space K&R); new files match it by hand. `yse.py format` would reformat existing code and cause drift.
- [x] `yse.py analyze` (clang-tidy) clean on every changed file — 21 warnings, all in system headers, 0 in changed code or `mpmcQueue.hpp`.
- [x] Unit tests pass — all 16 ctest groups green. New `utils/test_mpmcqueue.cpp` (3050 assertions: FIFO, full/empty, ring wrap, 4×4 concurrent producer/consumer item conservation) and `internal/test_threadpool.cpp` (507 assertions: jobs run + join, join returns <50 ms for 50 jobs vs old ~100 ms, render-ring-overflow inline fallback drops nothing, shutdown/startup cycling).
- [x] Integration/e2e: the device integration test (16.2 s) drives the **real** audio device through the rewritten pools end-to-end and passes — the user-visible coverage for this RT change. A deterministic dropout-repro test is intentionally omitted (it would be timing-dependent/flaky); the join-timing unit test and the real-device integration run stand in for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)