### PR TITLE
FIX: wait-free patcher structural edits via swappable GraphState (#226)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(YSE_TEST_SOURCES
   patcher/test_doc_coverage.cpp
   patcher/test_c_api_metadata.cpp
   patcher/test_patcher_bus.cpp
+  patcher/test_patcher_graphstate.cpp
   patcher/test_timerthread.cpp
   channel/test_channel.cpp
   channel/test_channel_concurrency.cpp
@@ -300,6 +301,7 @@ set_source_files_properties(
   patcher/test_doc_coverage.cpp
   patcher/test_c_api_metadata.cpp
   patcher/test_patcher_bus.cpp
+  patcher/test_patcher_graphstate.cpp
   patcher/test_timerthread.cpp
   PROPERTIES COMPILE_FLAGS "${_patcher_test_suppress}"
 )

--- a/Tests/patcher/test_patcher_graphstate.cpp
+++ b/Tests/patcher/test_patcher_graphstate.cpp
@@ -1,0 +1,111 @@
+// Regression tests for the swappable GraphState + atomic publish rework of the
+// patcher (issue #226). These drive patcherImplementation::Calculate directly
+// (the audio-thread entry point) and read the rendered `output`, so they
+// exercise the snapshot path — the topology the audio thread walks comes from
+// the published GraphState, not the live object wiring.
+//
+// A ~noise -> ~dac graph is the simplest DSP flow: ~noise is a start point with
+// no inlets and emits a non-silent buffer every block; ~dac sums its buffer
+// input into the patcher output. Connecting/disconnecting/deleting between
+// Calculate calls must change what the next block renders, proving the
+// build-and-swap actually reaches the audio thread.
+//
+// No audio device required.
+
+#include <doctest/doctest.h>
+#include "patcher/patcherImplementation.h"
+#include "patcher/pHandle.hpp"
+#include "patcher/pObjectList.hpp"
+#include "dsp/buffer.hpp"
+
+using YSE::PATCHER::patcherImplementation;
+
+TEST_SUITE("patcher") {
+
+  TEST_CASE("graphstate: Calculate takes no lock and renders silence when empty") {
+    patcherImplementation p(1, nullptr);
+    p.Calculate(YSE::T_DSP); // no active snapshot yet — must be safe
+    CHECK(p.output[0].isSilent());
+  }
+
+  TEST_CASE("graphstate: Connect through the swap changes what the block renders") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    REQUIRE(noise != nullptr);
+    REQUIRE(dac != nullptr);
+
+    // Unconnected: the DAC has no buffer input, so the output stays silent.
+    p.Calculate(YSE::T_DSP);
+    CHECK(p.output[0].isSilent());
+
+    // Connect noise -> dac and render: the swap must take effect immediately.
+    p.Connect(noise, 0, dac, 0);
+    p.Calculate(YSE::T_DSP);
+    CHECK_FALSE(p.output[0].isSilent());
+  }
+
+  TEST_CASE("graphstate: Disconnect through the swap silences the next block") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    p.Connect(noise, 0, dac, 0);
+
+    p.Calculate(YSE::T_DSP);
+    REQUIRE_FALSE(p.output[0].isSilent());
+
+    p.Disconnect(noise, 0, dac, 0);
+    p.Calculate(YSE::T_DSP);
+    CHECK(p.output[0].isSilent());
+  }
+
+  TEST_CASE("graphstate: deleting a connected source is safe and silences output") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    p.Connect(noise, 0, dac, 0);
+
+    p.Calculate(YSE::T_DSP);
+    REQUIRE_FALSE(p.output[0].isSilent());
+
+    // The deleted object must not be freed while a block could still walk the
+    // retired snapshot; the next Calculate must not touch it.
+    p.DeleteObject(noise);
+    p.Calculate(YSE::T_DSP);
+    CHECK(p.output[0].isSilent());
+  }
+
+  TEST_CASE("graphstate: repeated live edits interleaved with rendering stay stable") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+
+    // Toggle the connection many times, rendering blocks in between, so the
+    // retire/reclaim path runs repeatedly. Output must track the current wiring
+    // every time, and nothing may be freed early (an ASan build would trip).
+    for (int i = 0; i < 64; ++i) {
+      p.Connect(noise, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      CHECK_FALSE(p.output[0].isSilent());
+
+      p.Disconnect(noise, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      p.Calculate(YSE::T_DSP);
+      CHECK(p.output[0].isSilent());
+    }
+  }
+
+  TEST_CASE("graphstate: ParseJSON publishes a renderable graph in one swap") {
+    patcherImplementation src(1, nullptr);
+    YSE::pHandle* noise = src.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = src.CreateObject(YSE::OBJ::D_DAC, "");
+    src.Connect(noise, 0, dac, 0);
+    std::string dump = src.DumpJSON();
+
+    patcherImplementation dst(1, nullptr);
+    dst.ParseJSON(dump);
+    dst.Calculate(YSE::T_DSP);
+    CHECK_FALSE(dst.output[0].isSilent());
+  }
+
+} // TEST_SUITE("patcher")

--- a/YseEngine/patcher/graphState.h
+++ b/YseEngine/patcher/graphState.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <vector>
+
+namespace YSE {
+  namespace PATCHER {
+
+    class pObject;
+    struct inlet;
+
+    // Immutable, compiled snapshot of a patcher's topology (issue #226).
+    //
+    // Built off the audio thread from the objects' control-thread wiring and
+    // published to the audio thread through a single
+    // ``std::atomic<const GraphState*>`` pointer swap. Once published a
+    // GraphState is never mutated; ``Calculate`` pins one snapshot for the
+    // duration of a block and resolves every send/readiness query against it,
+    // so the audio thread never touches the live (mutable) object wiring and
+    // needs no lock.
+    //
+    // Objects are stable (allocated once, never rebuilt), so the ``inlet*``
+    // and ``pObject*`` pointers stored here stay valid across edits; only the
+    // adjacency is swapped. Indices into ``outletTargets`` / ``inletHasDsp``
+    // are the dense, construction-time ``graphId`` stamped on each
+    // outlet / inlet — stable for the object's lifetime, so a swap never
+    // rewrites them.
+    struct GraphState {
+      // Every object in the snapshot — walked to invalidate DSP buffers at the
+      // top of a block.
+      std::vector<pObject*> objects;
+
+      // DSP objects with no active DSP input: the roots the push traversal
+      // starts from. Precomputed so ``Calculate`` never scans for them.
+      std::vector<pObject*> startPoints;
+
+      // DAC sinks whose channel buffers are summed into the patcher output.
+      std::vector<pObject*> dacs;
+
+      // outletTargets[outlet.graphId] = the inlets that outlet feeds. Empty for
+      // ids that belong to deleted objects or outlets with no connections.
+      std::vector<std::vector<inlet*>> outletTargets;
+
+      // inletHasDsp[inlet.graphId] != 0 when the inlet has an active buffer
+      // input in this snapshot. Replaces the audio-thread reads of
+      // ``inlet::dspConnection`` used by start-point selection / WaitingForDSP.
+      std::vector<char> inletHasDsp;
+    };
+
+  } // namespace PATCHER
+} // namespace YSE

--- a/YseEngine/patcher/inlet.cpp
+++ b/YseEngine/patcher/inlet.cpp
@@ -1,6 +1,7 @@
 #include "inlet.h"
 #include "outlet.h"
 #include "pObject.h"
+#include "graphState.h"
 
 using namespace YSE::PATCHER;
 
@@ -103,8 +104,32 @@ void inlet::SetMessage(const std::string& message, YSE::THREAD thread, float val
 }
 
 bool inlet::WaitingForDSP() const {
-  if (dspConnection == nullptr) return false;
+  // Whether this inlet has an active buffer input comes from the pinned
+  // snapshot when the patcher is mid-block (audio-thread path), else from the
+  // live ``dspConnection`` (control-thread / standalone path). See #226.
+  const GraphState* graph = obj ? obj->CurrentBlockGraph() : nullptr;
+  bool hasDsp;
+  if (graph != nullptr && graphId >= 0 &&
+      static_cast<size_t>(graphId) < graph->inletHasDsp.size()) {
+    hasDsp = graph->inletHasDsp[graphId] != 0;
+  } else {
+    hasDsp = (dspConnection != nullptr);
+  }
+  if (!hasDsp) return false;
   return !dspReady;
+}
+
+void inlet::UnwireFromPeers() {
+  // Detach from the buffer input and every control-edge source. Clear our own
+  // lists first so the peers' Disconnect(this) calls stay consistent.
+  outlet* dsp = dspConnection;
+  dspConnection = nullptr;
+  std::vector<outlet*> conns;
+  conns.swap(connections);
+  if (dsp != nullptr) dsp->Disconnect(this);
+  for (unsigned int i = 0; i < conns.size(); i++) {
+    conns[i]->Disconnect(this);
+  }
 }
 
 bool inlet::Connect(outlet* out) {

--- a/YseEngine/patcher/inlet.h
+++ b/YseEngine/patcher/inlet.h
@@ -46,6 +46,21 @@ namespace YSE {
       bool Connect(outlet* out);
       void Disconnect(outlet* out);
 
+      // Drop this inlet's incoming edges and remove it from the outlets that
+      // fed it, so a deleted object leaves no dangling reference in the next
+      // GraphState (issue #226). Mirrors the destructor's peer cleanup but
+      // leaves the inlet allocated.
+      void UnwireFromPeers();
+
+      // Dense, lifetime-stable id assigned when the owning object is added to a
+      // patcher; indexes GraphState::inletHasDsp. -1 until assigned.
+      inline int GraphId() const {
+        return graphId;
+      }
+      inline void SetGraphId(int id) {
+        graphId = id;
+      }
+
       int GetObjectID();
       int GetPosition();
 
@@ -74,6 +89,8 @@ namespace YSE {
       bool dspReady;
       bool active;
       int position;
+      // See GraphId(). -1 = unassigned (standalone object, no patcher).
+      int graphId = -1;
 
       intFunc onInt;
       voidFunc onBang;

--- a/YseEngine/patcher/outlet.cpp
+++ b/YseEngine/patcher/outlet.cpp
@@ -2,11 +2,12 @@
 #include "outlet.h"
 #include "inlet.h"
 #include "pObject.h"
+#include "graphState.h"
 #include "../dsp/buffer.hpp"
 
 using namespace YSE::PATCHER;
 
-outlet::outlet(YSE::OUT_TYPE type) : type(type) {}
+outlet::outlet(pObject* owner, YSE::OUT_TYPE type) : type(type), owner(owner) {}
 
 outlet::~outlet() {
   for (unsigned int i = 0; i < connections.size(); i++) {
@@ -14,39 +15,69 @@ outlet::~outlet() {
   }
 }
 
+// Resolve this outlet's fan-out. When the owning patcher is mid-block it hands
+// back a pinned, immutable GraphState and we read the snapshot's adjacency (the
+// audio-thread path — never touches the live ``connections`` vector). Outside a
+// block, or for a standalone object with no patcher, ``graph`` is null and we
+// fall back to the live wiring (control-thread / unit-test path). See #226.
+const std::vector<YSE::PATCHER::inlet*>& outlet::resolveTargets() const {
+  const GraphState* graph = owner ? owner->CurrentBlockGraph() : nullptr;
+  if (graph != nullptr && graphId >= 0 &&
+      static_cast<size_t>(graphId) < graph->outletTargets.size()) {
+    return graph->outletTargets[graphId];
+  }
+  return connections;
+}
+
 void outlet::SendBang(YSE::THREAD thread) {
-  for (unsigned int i = 0; i < connections.size(); i++) {
-    connections[i]->SetBang(thread);
+  const auto& targets = resolveTargets();
+  for (unsigned int i = 0; i < targets.size(); i++) {
+    targets[i]->SetBang(thread);
   }
 }
 
 void outlet::SendFloat(float value, YSE::THREAD thread) {
-  for (unsigned int i = 0; i < connections.size(); i++) {
-    connections[i]->SetFloat(value, thread);
+  const auto& targets = resolveTargets();
+  for (unsigned int i = 0; i < targets.size(); i++) {
+    targets[i]->SetFloat(value, thread);
   }
 }
 
 void outlet::SendInt(int value, YSE::THREAD thread) {
-  for (unsigned int i = 0; i < connections.size(); i++) {
-    connections[i]->SetInt(value, thread);
+  const auto& targets = resolveTargets();
+  for (unsigned int i = 0; i < targets.size(); i++) {
+    targets[i]->SetInt(value, thread);
   }
 }
 
 void outlet::SendList(const std::string& value, YSE::THREAD thread) {
-  for (unsigned int i = 0; i < connections.size(); i++) {
-    connections[i]->SetList(value, thread);
+  const auto& targets = resolveTargets();
+  for (unsigned int i = 0; i < targets.size(); i++) {
+    targets[i]->SetList(value, thread);
   }
 }
 
 void outlet::SendMessage(const std::string& value, YSE::THREAD thread) {
-  for (unsigned int i = 0; i < connections.size(); i++) {
-    connections[i]->SetMessage(value, thread);
+  const auto& targets = resolveTargets();
+  for (unsigned int i = 0; i < targets.size(); i++) {
+    targets[i]->SetMessage(value, thread);
   }
 }
 
 void outlet::SendBuffer(YSE::DSP::buffer* value, YSE::THREAD thread) {
-  for (unsigned int i = 0; i < connections.size(); i++) {
-    connections[i]->SetBuffer(value, thread);
+  const auto& targets = resolveTargets();
+  for (unsigned int i = 0; i < targets.size(); i++) {
+    targets[i]->SetBuffer(value, thread);
+  }
+}
+
+void outlet::UnwireFromPeers() {
+  // Clear first so any reentrant inlet->Disconnect(this) (the buffer/dsp
+  // branch calls back into this outlet) finds nothing to erase mid-iteration.
+  std::vector<inlet*> conns;
+  conns.swap(connections);
+  for (unsigned int i = 0; i < conns.size(); i++) {
+    conns[i]->Disconnect(this);
   }
 }
 

--- a/YseEngine/patcher/outlet.h
+++ b/YseEngine/patcher/outlet.h
@@ -12,7 +12,9 @@ namespace YSE {
     struct inlet;
 
     struct outlet {
-      outlet(OUT_TYPE type);
+      // ``owner`` is the pObject this outlet belongs to; it is the route from a
+      // send back to the owning patcher's pinned GraphState (issue #226).
+      outlet(pObject* owner, OUT_TYPE type);
       ~outlet();
 
       inline OUT_TYPE Type() const {
@@ -28,6 +30,27 @@ namespace YSE {
 
       void Connect(inlet* in);
       void Disconnect(inlet* in);
+
+      // Drop every connection and remove this outlet from the inlets it fed.
+      // Used when an object is deleted so the next GraphState holds no
+      // reference to it (issue #226). Mirrors the destructor's peer cleanup
+      // but leaves the outlet allocated.
+      void UnwireFromPeers();
+
+      // Dense, lifetime-stable id assigned when the owning object is added to a
+      // patcher; indexes GraphState::outletTargets. -1 until assigned (e.g. a
+      // standalone object outside any patcher).
+      inline int GraphId() const {
+        return graphId;
+      }
+      inline void SetGraphId(int id) {
+        graphId = id;
+      }
+      // The live (control-thread) fan-out list, copied into a GraphState at
+      // build time.
+      inline const std::vector<inlet*>& Targets() const {
+        return connections;
+      }
 
       void DumpJSON(nlohmann::json::value_type& json);
 
@@ -48,7 +71,17 @@ namespace YSE {
       }
 
     private:
+      // Pinned-snapshot adjacency when the patcher is mid-block, else the live
+      // wiring. See the definition for the full contract (issue #226).
+      const std::vector<inlet*>& resolveTargets() const;
+
       OUT_TYPE type;
+
+      // Owning object; the hop to the patcher's pinned GraphState. Never null
+      // for outlets created through the ADD_OUT_* macros.
+      pObject* owner;
+      // See GraphId(). -1 = unassigned (standalone object, no patcher).
+      int graphId = -1;
 
       std::vector<inlet*> connections;
 

--- a/YseEngine/patcher/pObject.cpp
+++ b/YseEngine/patcher/pObject.cpp
@@ -1,6 +1,7 @@
 
 #include "pObject.h"
 #include "pHandle.hpp"
+#include "patcherImplementation.h"
 #include "../headers/enums.hpp"
 #include "../implementations/logImplementation.h"
 
@@ -9,6 +10,23 @@ using namespace YSE::PATCHER;
 unsigned int LastPatcherObjectID = 0;
 unsigned int pObject::CreateID() {
   return LastPatcherObjectID++;
+}
+
+// ``parent`` is the owning patcherImplementation by construction (set via
+// SetParent when the object is added). null for a standalone object or the
+// patcher itself, in which case there is no snapshot to consult.
+const YSE::PATCHER::GraphState* pObject::CurrentBlockGraph() const {
+  if (parent == nullptr) return nullptr;
+  return static_cast<patcherImplementation*>(parent)->CurrentBlockGraph();
+}
+
+void pObject::UnwireFromPeers() {
+  for (unsigned int i = 0; i < inputs.size(); i++) {
+    inputs[i].UnwireFromPeers();
+  }
+  for (unsigned int i = 0; i < outputs.size(); i++) {
+    outputs[i].UnwireFromPeers();
+  }
 }
 
 pObject::pObject(bool isDSPObject, pObject* parent)

--- a/YseEngine/patcher/pObject.h
+++ b/YseEngine/patcher/pObject.h
@@ -25,6 +25,9 @@
 namespace YSE {
   namespace PATCHER {
 
+    struct GraphState;
+    class patcherImplementation;
+
     typedef std::function<void(int, int)> intCallbackFunc;
     typedef std::function<void(int, float)> floatCallbackFunc;
 
@@ -32,6 +35,16 @@ namespace YSE {
     public:
       pObject(bool isDSPObject, pObject* parent = nullptr);
       virtual ~pObject() {}
+
+      // The GraphState the owning patcher has pinned for the current audio
+      // block, or null when the patcher is between blocks or this object has no
+      // patcher (standalone / unit-test use). Outlets and inlets consult it to
+      // resolve topology on the audio thread without a lock (issue #226).
+      const GraphState* CurrentBlockGraph() const;
+
+      // Detach this object from every peer it is wired to, without freeing it,
+      // so the next GraphState holds no reference to it (issue #226).
+      void UnwireFromPeers();
 
       virtual const char* Type() const = 0;
       virtual void Calculate(THREAD thread) = 0;
@@ -185,12 +198,12 @@ namespace YSE {
   inputs.back().RegisterBang(                                                                      \
       std::bind(&className::funcName, this, std::placeholders::_1, std::placeholders::_2))
 
-#define ADD_OUT_BUFFER outputs.emplace_back(OUT_TYPE::BUFFER)
-#define ADD_OUT_FLOAT outputs.emplace_back(OUT_TYPE::FLOAT)
-#define ADD_OUT_INT outputs.emplace_back(OUT_TYPE::INT)
-#define ADD_OUT_BANG outputs.emplace_back(OUT_TYPE::BANG)
-#define ADD_OUT_LIST outputs.emplace_back(OUT_TYPE::LIST)
-#define ADD_OUT_ANY outputs.emplace_back(OUT_TYPE::ANY)
+#define ADD_OUT_BUFFER outputs.emplace_back(this, OUT_TYPE::BUFFER)
+#define ADD_OUT_FLOAT outputs.emplace_back(this, OUT_TYPE::FLOAT)
+#define ADD_OUT_INT outputs.emplace_back(this, OUT_TYPE::INT)
+#define ADD_OUT_BANG outputs.emplace_back(this, OUT_TYPE::BANG)
+#define ADD_OUT_LIST outputs.emplace_back(this, OUT_TYPE::LIST)
+#define ADD_OUT_ANY outputs.emplace_back(this, OUT_TYPE::ANY)
 
 #define ADD_PARAM(var) parms.Register(var)
 

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -53,6 +53,10 @@ void patcherImplementation::SetName(const std::string& n) {
 patcherImplementation::~patcherImplementation() {
   // memory cleanup
   Clear();
+  // The audio thread is stopped at destruction, so reclaim unconditionally:
+  // the deferred retire lists (and the final published snapshot) are freed
+  // here rather than waiting on the block counter.
+  FreeAllRetired();
 }
 
 const char* patcherImplementation::Type() const {
@@ -61,16 +65,24 @@ const char* patcherImplementation::Type() const {
 
 void patcherImplementation::Calculate(YSE::THREAD thread) {
   // works a bit different in case of patchers!
-  // only called by the main patcher to generate output
-  mtx.lock();
+  // only called by the main patcher to generate output.
+  //
+  // No mutex here (issue #226): the topology is read through one atomic load
+  // of the published GraphState, pinned for the whole block so every send and
+  // readiness query the traversal makes resolves against a coherent snapshot.
+  const GraphState* g = active_.load(std::memory_order_acquire);
+  audioBlock_.fetch_add(1, std::memory_order_acq_rel);
+  currentBlockGraph_.store(g, std::memory_order_release);
 
-  // invalidate all dsp buffers
-  ResetDSP();
+  if (g != nullptr) {
+    // invalidate all dsp buffers
+    for (unsigned int i = 0; i < g->objects.size(); i++) {
+      g->objects[i]->ResetDSP();
+    }
 
-  // calculate all objects
-  for (const auto& any : objects) {
-    if (any.second->IsDSPStartPoint()) {
-      any.second->Calculate(thread);
+    // calculate all dsp start points; the push traversal fans out from here
+    for (unsigned int i = 0; i < g->startPoints.size(); i++) {
+      g->startPoints[i]->Calculate(thread);
     }
   }
 
@@ -81,10 +93,11 @@ void patcherImplementation::Calculate(YSE::THREAD thread) {
 
   // sum outputs
   int counter = 0;
-  for (const auto& any : objects) {
-    if (strcmp(any.second->Type(), YSE::OBJ::D_DAC) == 0) {
+  if (g != nullptr) {
+    for (unsigned int d = 0; d < g->dacs.size(); d++) {
+      pDac* dac = static_cast<pDac*>(g->dacs[d]);
       for (unsigned int i = 0; i < output.size(); i++) {
-        YSE::DSP::buffer* ptr = ((pDac*)any.second)->GetBuffer(i);
+        YSE::DSP::buffer* ptr = dac->GetBuffer(i);
         if (ptr != nullptr) {
           output[i] = *ptr;
         }
@@ -100,7 +113,9 @@ void patcherImplementation::Calculate(YSE::THREAD thread) {
     }
   }
 
-  mtx.unlock();
+  // Unpin: between blocks the topology helpers fall back to the live wiring
+  // (control-thread / standalone path) instead of a possibly-retired snapshot.
+  currentBlockGraph_.store(nullptr, std::memory_order_release);
 }
 
 void patcherImplementation::ResetDSP() {
@@ -119,14 +134,21 @@ void patcherImplementation::Connect(YSE::pHandle* from, int outlet, YSE::pHandle
   } else {
     INTERNAL::LogImpl().emit(E_ERROR, "Patcher: Invalid Connection");
   }
-  if (!fileHandlerActive) mtx.unlock();
+  // In batch mode (ParseJSON) publish once at the end; otherwise swap now.
+  if (!fileHandlerActive) {
+    RebuildAndPublish();
+    mtx.unlock();
+  }
 }
 
 void patcherImplementation::Disconnect(YSE::pHandle* from, int outlet, YSE::pHandle* to,
                                        int inlet) {
   if (!fileHandlerActive) mtx.lock();
   to->object->DisconnectInlet(from->object->GetOutlet(outlet), inlet);
-  if (!fileHandlerActive) mtx.unlock();
+  if (!fileHandlerActive) {
+    RebuildAndPublish();
+    mtx.unlock();
+  }
 }
 
 YSE::pHandle* patcherImplementation::CreateObject(const std::string& type,
@@ -137,6 +159,10 @@ YSE::pHandle* patcherImplementation::CreateObject(const std::string& type,
 
   if (type == OBJ::D_DAC) {
     object = new pDac((int)output.size());
+    // Give the DAC its patcher parent too, so its inlets resolve DSP-readiness
+    // from the pinned snapshot on the audio thread rather than the live wiring
+    // (issue #226).
+    object->SetParent(this);
   } else {
     object = Register().Get(type);
     if (object != nullptr) {
@@ -154,7 +180,11 @@ YSE::pHandle* patcherImplementation::CreateObject(const std::string& type,
 
   if (!fileHandlerActive) mtx.lock();
   objects.insert(std::pair<YSE::pHandle*, pObject*>(handle, object));
-  if (!fileHandlerActive) mtx.unlock();
+  AssignGraphIds(object);
+  if (!fileHandlerActive) {
+    RebuildAndPublish();
+    mtx.unlock();
+  }
   INTERNAL::LogImpl().emit(E_DEBUG, "Patcher: " + type + " created");
   return handle;
 }
@@ -166,25 +196,34 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
     handle->object->GetInlet(0)->SetInt(0, YSE::THREAD::T_GUI);
   }
 
+  pObject* object = handle->object;
   objects.erase(handle);
-
-  delete handle->object;
+  // Detach from peers so the next snapshot holds no reference to it, but do
+  // not free it yet — an in-flight audio block may still walk the retired
+  // snapshot that references it. The free is deferred to the reclaimer.
+  object->UnwireFromPeers();
+  if (!fileHandlerActive) RebuildAndPublish();
+  retiredObjects_.emplace_back(object, audioBlock_.load(std::memory_order_acquire));
+  // The handle is never referenced by a GraphState, so it can go immediately.
   delete handle;
+
   if (!fileHandlerActive) mtx.unlock();
 }
 
 void patcherImplementation::Clear() {
   if (!fileHandlerActive) mtx.lock();
 
+  std::uint64_t at = audioBlock_.load(std::memory_order_acquire);
   for (auto it = objects.begin(); it != objects.end(); ++it) {
     if (it->first->Type() == OBJ::G_METRO) {
       it->second->GetInlet(0)->SetInt(0, YSE::THREAD::T_GUI);
     }
-
-    delete it->first;
-    delete it->second;
+    it->second->UnwireFromPeers();
+    retiredObjects_.emplace_back(it->second, at);
+    delete it->first; // handle: not referenced by a GraphState
   }
   objects.clear();
+  if (!fileHandlerActive) RebuildAndPublish();
   if (!fileHandlerActive) mtx.unlock();
 }
 
@@ -270,6 +309,9 @@ void patcherImplementation::ParseJSON(const std::string& content) {
     }
   }
   fileHandlerActive = false;
+  // Every create/connect above ran in batch mode (no per-edit swap); publish
+  // the whole parsed graph in a single atomic swap now.
+  RebuildAndPublish();
   mtx.unlock();
 }
 
@@ -380,4 +422,94 @@ std::string patcherImplementation::GetRecieveObjectsAsString() {
 
 void patcherImplementation::SetHandler(YSE::oscHandler* handler) {
   oscHandle = handler;
+}
+
+void patcherImplementation::AssignGraphIds(pObject* object) {
+  for (int i = 0; i < object->NumInputs(); i++) {
+    PATCHER::inlet* in = object->GetInlet(i);
+    if (in != nullptr && in->GraphId() < 0) in->SetGraphId(nextInletId_++);
+  }
+  for (int i = 0; i < object->NumOutputs(); i++) {
+    PATCHER::outlet* out = object->GetOutlet(i);
+    if (out != nullptr && out->GraphId() < 0) out->SetGraphId(nextOutletId_++);
+  }
+}
+
+YSE::PATCHER::GraphState* patcherImplementation::BuildGraph() {
+  GraphState* g = new GraphState();
+  g->outletTargets.resize(nextOutletId_);
+  g->inletHasDsp.assign(nextInletId_, 0);
+
+  for (const auto& any : objects) {
+    pObject* object = any.second;
+    g->objects.push_back(object);
+    if (object->IsDSPStartPoint()) g->startPoints.push_back(object);
+    if (strcmp(object->Type(), YSE::OBJ::D_DAC) == 0) g->dacs.push_back(object);
+
+    for (int i = 0; i < object->NumOutputs(); i++) {
+      PATCHER::outlet* out = object->GetOutlet(i);
+      if (out == nullptr) continue;
+      int id = out->GraphId();
+      if (id >= 0 && id < nextOutletId_) g->outletTargets[id] = out->Targets();
+    }
+    for (int i = 0; i < object->NumInputs(); i++) {
+      PATCHER::inlet* in = object->GetInlet(i);
+      if (in == nullptr) continue;
+      int id = in->GraphId();
+      if (id >= 0 && id < nextInletId_) {
+        g->inletHasDsp[id] = in->HasActiveDSPConnection() ? 1 : 0;
+      }
+    }
+  }
+  return g;
+}
+
+void patcherImplementation::RebuildAndPublish() {
+  GraphState* next = BuildGraph();
+  // Only the control thread writes active_ (under mtx), so a relaxed load of
+  // the prior pointer is fine; the audio thread reads it with acquire.
+  const GraphState* old = active_.load(std::memory_order_relaxed);
+  active_.store(next, std::memory_order_release);
+  if (old != nullptr) {
+    retiredGraphs_.emplace_back(old, audioBlock_.load(std::memory_order_acquire));
+  }
+  DrainRetired();
+}
+
+void patcherImplementation::DrainRetired() {
+  const std::uint64_t now = audioBlock_.load(std::memory_order_acquire);
+  // Interim reclamation (issue #227 replaces this): a snapshot retired at block
+  // C is safe to free once the audio thread has started at least two later
+  // blocks, so no in-flight block can still hold it. Free graphs before the
+  // objects they point into.
+  for (std::size_t i = 0; i < retiredGraphs_.size();) {
+    if (now >= retiredGraphs_[i].second + 2) {
+      delete retiredGraphs_[i].first;
+      retiredGraphs_.erase(retiredGraphs_.begin() + i);
+    } else {
+      ++i;
+    }
+  }
+  for (std::size_t i = 0; i < retiredObjects_.size();) {
+    if (now >= retiredObjects_[i].second + 2) {
+      delete retiredObjects_[i].first;
+      retiredObjects_.erase(retiredObjects_.begin() + i);
+    } else {
+      ++i;
+    }
+  }
+}
+
+void patcherImplementation::FreeAllRetired() {
+  // Graphs first — they hold inlet* pointers into the objects.
+  for (std::size_t i = 0; i < retiredGraphs_.size(); i++) {
+    delete retiredGraphs_[i].first;
+  }
+  retiredGraphs_.clear();
+  const GraphState* g = active_.exchange(nullptr, std::memory_order_acq_rel);
+  delete g;
+  for (std::size_t i = 0; i < retiredObjects_.size(); i++) {
+    delete retiredObjects_[i].first;
+  }
+  retiredObjects_.clear();
 }

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -4,8 +4,13 @@
 #include "pHandle.hpp"
 #include "../dsp/buffer.hpp"
 #include "patcher.hpp"
+#include "graphState.h"
+#include <atomic>
+#include <cstdint>
 #include <map>
 #include <mutex>
+#include <utility>
+#include <vector>
 
 namespace YSE {
   namespace PATCHER {
@@ -28,6 +33,13 @@ namespace YSE {
       virtual const char* Type() const;
       virtual void ResetDSP();
       virtual void Calculate(THREAD thread);
+
+      // The GraphState pinned for the block currently being rendered, or null
+      // between blocks. Read by inlets/outlets to resolve topology without a
+      // lock (issue #226).
+      const GraphState* CurrentBlockGraph() const {
+        return currentBlockGraph_.load(std::memory_order_acquire);
+      }
 
       virtual void SetMessage(const std::string&, float) {}
 
@@ -59,10 +71,43 @@ namespace YSE {
       void SetHandler(oscHandler* handler);
 
     private:
+      // Compile the current object wiring into a fresh immutable GraphState.
+      // Control-thread only (allocates). See graphState.h.
+      GraphState* BuildGraph();
+      // Stamp lifetime-stable graph ids on a newly added object's inlets/outlets.
+      void AssignGraphIds(pObject* obj);
+      // Build the next GraphState, publish it with one atomic swap, retire the
+      // previous one, and reclaim anything the audio thread has moved past.
+      void RebuildAndPublish();
+      // Free retired GraphStates/objects the audio thread can no longer be
+      // using (interim reclamation; the real epoch scheme is issue #227).
+      void DrainRetired();
+      // Unconditionally free everything retired plus the active graph. Called
+      // from the destructor, where the audio thread is already stopped.
+      void FreeAllRetired();
+
       std::mutex mtx;
       bool fileHandlerActive;
       std::map<pHandle*, pObject*> objects;
       oscHandler* oscHandle = nullptr;
+
+      // Published topology snapshot the audio thread reads (issue #226). Only
+      // the control thread writes it, under mtx.
+      std::atomic<const GraphState*> active_{nullptr};
+      // Snapshot pinned for the duration of the block being rendered. Written
+      // by the audio thread at the start/end of Calculate.
+      std::atomic<const GraphState*> currentBlockGraph_{nullptr};
+      // Monotonic count of rendered blocks, used by the interim reclaimer to
+      // tell when the audio thread has advanced past a retired snapshot.
+      std::atomic<std::uint64_t> audioBlock_{0};
+      // Retired snapshots / deleted objects awaiting reclamation, tagged with
+      // the block count at retirement. Control-thread only, guarded by mtx.
+      std::vector<std::pair<const GraphState*, std::uint64_t>> retiredGraphs_;
+      std::vector<std::pair<pObject*, std::uint64_t>> retiredObjects_;
+      // Per-patcher dense id counters for inlets / outlets. Never reused, so
+      // ids stay stable across edits.
+      int nextInletId_ = 0;
+      int nextOutletId_ = 0;
 
       // Bus-prefix for inner gSend/gReceive routing (issue #122). Defaulted
       // to "patcher_<N>" in the ctor; mutated by SetName().

--- a/docs/design/patcher_graphstate.md
+++ b/docs/design/patcher_graphstate.md
@@ -1,0 +1,313 @@
+# Patcher `GraphState`: swappable topology + atomic publish
+
+Status: **design gate, pre-implementation**. Tracking issue:
+[#226][gh-226]. Parent epic: [#189 — make the patcher graph wait-free on
+the audio thread][gh-189].
+
+This document is the settled decision for issue [#226][gh-226]. Per the
+epic, the mechanism must be agreed *before* implementation code lands. It
+fixes the record for the sub-issues that follow — [#225][gh-225] (SPSC
+value-command queue), [#227][gh-227] (safe reclamation), [#228][gh-228]
+(off-thread parse/dump/clear/rename), [#229][gh-229] (TSan/ASan stress
+gate) — so they treat the graph-ownership model here as a fixed contract.
+
+This follows the design-issue-first pattern proven by
+[docs/design/synth_core.md][doc-synth] ([#151][gh-151]) and
+[docs/design/live_coding_dsl.md][doc-dsl] ([#120][gh-120]).
+
+## Table of contents
+
+1. [The bug](#the-bug)
+2. [Goal](#goal)
+3. [Decision summary](#decision-summary)
+4. [Mechanism: stable objects + swappable topology](#mechanism-stable-objects--swappable-topology)
+5. [`GraphState` contents](#graphstate-contents)
+6. [The send path: pinned graph + stable id](#the-send-path-pinned-graph--stable-id)
+7. [Why not the alternatives](#why-not-the-alternatives)
+8. [Memory ordering](#memory-ordering)
+9. [Structural edits: build and swap](#structural-edits-build-and-swap)
+10. [Reclamation handoff](#reclamation-handoff)
+11. [Scope of #226](#scope-of-226)
+12. [Open dependencies](#open-dependencies)
+
+## The bug
+
+Two contradictory synchronization regimes meet in
+[`patcherImplementation.cpp`][src-patcher]. `Calculate` takes `mtx` on the
+audio thread every block ([`patcherImplementation.cpp:65`][src-calc]),
+while every structural edit — `CreateObject`, `DeleteObject`, `Connect`,
+`Disconnect`, `ParseJSON` — mutates, under the same mutex, exactly the
+state the callback walks. Live-editing a playing patcher blocks the audio
+callback for the whole edit. That is the RT violation.
+
+The reason the mutex is *needed* is that the connection topology lives
+**inside the objects**:
+
+- [`outlet::connections`][src-outlet-h] — `std::vector<inlet*>`, the
+  fan-out targets an outlet pushes to.
+- [`inlet::dspConnection` and `inlet::connections`][src-inlet-h] — the
+  single DSP input and the reverse control-edge list.
+
+`Connect`/`Disconnect` `push_back`/`erase` on those vectors in place
+([`outlet.cpp:53-66`][src-outlet-connect], [`inlet.cpp:110-138`][src-inlet-connect]),
+so a reallocation can move the very array the audio thread is iterating in
+[`outlet::SendBuffer`][src-sendbuffer]. The mutex is papering over a
+data-ownership problem.
+
+## Goal
+
+`Calculate` reads the graph through a single `std::atomic<GraphState*>`
+load — **no mutex**. Structural edits build the next `GraphState`
+off-thread and publish it with one atomic pointer swap. The audio thread
+pins one coherent snapshot for the duration of a block.
+
+## Decision summary
+
+| Question | Decision |
+| --- | --- |
+| Mechanism | **Stable objects + swappable topology** (epic option 1). Objects allocated once, never rebuilt; DSP state preserved for free. |
+| Send-path resolution | **Pinned graph + stable id.** Audio thread pins the active `GraphState` once per block; outlets resolve targets from it by a construction-time dense id. |
+| Traversal model | **Unchanged** — the push/readiness scheduler is kept (see rationale below). Push-vs-pull is orthogonal to RT-safety; this issue moves *where topology is stored*, not *how the graph is walked*. |
+| Memory ordering | Publish `store(release)`; audio thread `load(acquire)` once per block, then pin. |
+| Reclamation | Retired `GraphState`/objects handed to a retire queue; freeing is [#227][gh-227]'s job — never on the audio thread. |
+
+### Why the traversal model is not touched
+
+The push/readiness scheme is not a legacy accident — it carries real
+semantics that a topological pull traversal does not replicate:
+
+1. **Readiness-gated fan-in.** [`CalculateIfReady`][src-calcifready] fires
+   an object only once *all* its DSP inputs have arrived
+   ([`WaitingForDSP`][src-waiting]). That is a data-driven topological
+   schedule for free; a mixer with N buffer inputs calculates exactly
+   when the last input lands.
+2. **The graph is heterogeneous, not pure-DSP.** Inlets carry buffers
+   **and** events — bang/int/float/list — and events also trigger
+   `CalculateIfReady` ([`inlet.cpp:48-103`][src-inlet-set]). Event outlets
+   fire *during* an object's `Calculate`; they are not latched buffers a
+   pull walk could read afterward. A pull model would still need the push
+   mechanism for event edges — i.e. both, which is worse.
+3. **Feedback.** Patcher DSP graphs routinely contain cycles. The
+   push + per-block `dspReady` scheme tolerates them; a strict
+   topological pull requires a DAG or hand-coded cycle-breaking.
+
+Decoupling topology into `GraphState` does **not** foreclose a future
+pull traversal — it *enables* one, because the hard part (getting
+topology out of the objects) is done here. If a pull walk ever proves
+worthwhile it becomes a localized change to `Calculate` alone. It is out
+of scope for this issue and the epic's stated decision.
+
+## Mechanism: stable objects + swappable topology
+
+Objects are allocated once and never rebuilt. All DSP history (filter
+state, delay lines, phase accumulators) lives inside the object and is
+therefore preserved across any edit for free — this is why the epic chose
+this over per-object `Clone()`.
+
+`GraphState` owns **only** the topology — the object set plus adjacency.
+It owns no DSP state and no buffers. Editing the graph means building a
+new `GraphState` that references the same stable objects with different
+wiring, then swapping the pointer.
+
+The in-object `outlet::connections`, `inlet::connections`, and
+`inlet::dspConnection` stop being the live topology. `GraphState` becomes
+the single source of truth; `DumpJSON` reads adjacency from the active
+`GraphState` rather than from the objects. (`dspReady` stays in the inlet
+— it is per-block state, written and read only on the audio thread.)
+
+## `GraphState` contents
+
+An immutable snapshot, built off-thread, read-only once published:
+
+- **Object list** — the objects to process this snapshot (for iteration
+  and to define lifetime membership).
+- **DSP start-points** — precomputed list of DSP objects with no active
+  DSP input. Replaces the per-block scan of every object testing
+  [`IsDSPStartPoint`][src-startpoint] in `Calculate`.
+- **DAC list** — precomputed, for the output-summing loop.
+- **Adjacency** — for each outlet, an immutable, resolved list of target
+  `inlet*`. Pointers are stable because objects are never rebuilt.
+  Indexed by the outlet's dense id (below), so lookup is O(1) with no
+  hashing on the hot path.
+- **Per-inlet has-DSP-input flags** — replaces the audio-thread reads of
+  `dspConnection` used by start-point selection and `WaitingForDSP`.
+
+Everything in `GraphState` is set at build time and never mutated after
+publication. Its internal vectors do not reallocate during reads.
+
+## The send path: pinned graph + stable id
+
+At the top of `Calculate`, the audio thread performs exactly one atomic
+load and pins the result for the whole block:
+
+```cpp
+void patcherImplementation::Calculate(THREAD thread) {
+  currentBlockGraph = active.load(std::memory_order_acquire); // once per block
+  // ... ResetDSP over currentBlockGraph->objects
+  // ... for each currentBlockGraph->startPoints: obj->Calculate(thread)
+  // ... sum currentBlockGraph->dacs into output
+}
+```
+
+`currentBlockGraph` is a plain (non-atomic) member: written only here, at
+the top of the block, and read only by the same audio thread during that
+block. It never changes mid-block, so every send within the block sees
+one coherent snapshot.
+
+Each outlet resolves its targets from the pinned graph:
+
+```cpp
+void outlet::SendBuffer(DSP::buffer* value, THREAD thread) {
+  for (inlet* in : owner->parentPatcher()->currentBlockGraph->targetsOf(graphId))
+    in->SetBuffer(value, thread);
+}
+```
+
+- **`graphId`** is a dense integer assigned to the outlet **once, at
+  construction**, and never rewritten. Because it never changes on a
+  swap, the audio thread never observes a torn id, and no object is
+  written during publication. `GraphState::targetsOf(id)` indexes a flat
+  vector — O(1), allocation-free, no hashing.
+- **Reaching the patcher** is via the owning object: an outlet is created
+  by its object (the `ADD_OUT_*` macro passes `this`), and `pObject`
+  already carries `parent` (the patcher, via `SetParent`). Two plain
+  pointer hops on the audio thread.
+
+This confines the implementation surface to `outlet`, `inlet`,
+`patcherImplementation`, and the two `ADD_OUT_*` / `ADD_IN_*` macros
+(to thread the owning-object pointer). **All ~40 object `Calculate`
+bodies are untouched** — they still call `outputs[i].SendBuffer(&buf,
+thread)` verbatim.
+
+## Why not the alternatives
+
+- **Thread `GraphState&` through the render.** Add a context parameter to
+  `Calculate` and `SendBuffer`. Explicit, no back-pointers — but it
+  touches every DSP object's `Calculate` signature and every send call
+  site (~40 objects + the macros). That is precisely the large mechanical
+  surface the epic chose stable-objects to avoid.
+- **GraphState-driven pull traversal.** Cleanest end-state for a
+  homogeneous DAG, but it reworks the execution model and does not fit
+  YSE's heterogeneous event+DSP+feedback graph (see rationale above).
+  Deferred, not foreclosed.
+
+## Memory ordering
+
+- **Publish** (control thread, after the new `GraphState` is fully
+  built): `active.store(next, std::memory_order_release)`. The release
+  fence guarantees every write that constructed `next` (its adjacency
+  vectors, target spans, start-point/DAC lists) is visible before the
+  pointer becomes visible.
+- **Read** (audio thread, once per block):
+  `active.load(std::memory_order_acquire)`. The acquire pairs with the
+  release, so the audio thread sees a fully constructed snapshot. Pinning
+  it in `currentBlockGraph` for the block guarantees coherence: no send
+  can straddle two topologies.
+
+A single `atomic<GraphState*>` (not per-outlet atomics) is required so a
+multi-edge edit — e.g. a disconnect + connect, or a create-with-wiring —
+publishes atomically and the audio thread never sees a half-applied
+topology.
+
+## Structural edits: build and swap
+
+`Connect`, `Disconnect`, `CreateObject`, `DeleteObject` stop mutating
+in-object vectors under `mtx`. Each instead, on the control thread:
+
+1. Copies the current `GraphState`'s adjacency into a mutable builder.
+2. Applies the edit:
+   - **Create** — allocate the object (allocation on the control thread
+     is fine), add it to the object list. No wiring yet.
+   - **Delete** — remove the object from the object list and drop every
+     edge touching it. The object is *not* freed here (see reclamation).
+   - **Connect / Disconnect** — add/remove the resolved edge; recompute
+     the affected start-point/has-DSP-input entries.
+3. Finalizes an immutable `GraphState` (recompute start-points, DAC list,
+   flat adjacency indexed by `graphId`).
+4. `active.store(next, release)`.
+5. Hands the retired `GraphState` (and, for Delete, the removed object) to
+   the retire queue.
+
+`Calculate` loses its `mtx.lock()`/`unlock()` entirely.
+
+## Reclamation handoff
+
+A retired `GraphState` (and any object removed by `Delete`) may still be
+referenced by an audio block in flight, so it **must not** be freed on the
+control thread immediately, and **never** on the audio thread. #226 only
+*hands off* the retired pointer to a retire queue; the epoch/hazard-style
+reclamation that frees it once the audio thread has provably advanced past
+it is [#227][gh-227]'s deliverable.
+
+Until #227 lands, #226 uses a conservative interim: retired snapshots
+accumulate in the retire list and are reclaimed by a simple
+deferred-by-one-block rule (a snapshot retired before block *N* is freed
+no earlier than the start of block *N+2*, once the audio thread has
+demonstrably loaded a newer pointer). This is correct but not optimal;
+#227 replaces it. Removed *objects* are held in the same list and freed
+under the same rule, so a deleted object outlives any block that could
+still touch it.
+
+## Scope of #226
+
+**In scope:**
+
+- Introduce `GraphState` and `patcherImplementation::active`
+  (`atomic<GraphState*>`).
+- `Create` / `Delete` / `Connect` / `Disconnect` → build-and-swap.
+- Remove `mtx` from `Calculate`; pin the snapshot once per block.
+- Redirect `DumpJSON` and start-point/`WaitingForDSP` reads to the active
+  `GraphState`.
+- Interim deferred reclamation (placeholder for #227).
+- Regression tests: an edit on a running patcher preserves audio
+  continuity and the topology takes effect; a delete does not free an
+  object still in use.
+
+**Out of scope (other sub-issues):**
+
+- Value/control message deferral via SPSC queue — [#225][gh-225].
+- Real epoch/hazard reclamation — [#227][gh-227].
+- Off-thread `ParseJSON` / `DumpJSON` / `Clear` / `SetName`, retiring the
+  `fileHandlerActive` hack — [#228][gh-228].
+- TSan/ASan concurrency stress gate — [#229][gh-229].
+
+## Open dependencies
+
+- **`fileHandlerActive`.** `ParseJSON` currently calls `CreateObject` /
+  `Connect` in a loop under one held lock, using `fileHandlerActive` to
+  skip per-call locking. Under build-and-swap this becomes one snapshot
+  built from many edits then published once. #226 keeps `ParseJSON`
+  functionally correct by building the full parsed graph into one builder
+  and swapping once; the *threading* rework (parse fully off-thread) is
+  #228. The `fileHandlerActive` flag is retired no later than #228.
+- **Interim reclamation vs. #227.** The deferred-by-one-block rule above
+  is the seam. If #227 lands concurrently, #226's interim is deleted in
+  favour of it; the retire-queue handoff API is designed to be the same
+  shape either way.
+- **Value path still synchronous until #225.** `PassBang`/`PassData` and
+  live param writes remain on their current path in #226; they read the
+  same pinned `GraphState` for fan-out, so they are consistent, but their
+  *deferral* is #225.
+
+<!-- link references -->
+[gh-189]: https://github.com/yvanvds/yse-soundengine/issues/189
+[gh-225]: https://github.com/yvanvds/yse-soundengine/issues/225
+[gh-226]: https://github.com/yvanvds/yse-soundengine/issues/226
+[gh-227]: https://github.com/yvanvds/yse-soundengine/issues/227
+[gh-228]: https://github.com/yvanvds/yse-soundengine/issues/228
+[gh-229]: https://github.com/yvanvds/yse-soundengine/issues/229
+[gh-151]: https://github.com/yvanvds/yse-soundengine/issues/151
+[gh-120]: https://github.com/yvanvds/yse-soundengine/issues/120
+[doc-synth]: synth_core.md
+[doc-dsl]: live_coding_dsl.md
+[src-patcher]: ../../YseEngine/patcher/patcherImplementation.cpp
+[src-calc]: ../../YseEngine/patcher/patcherImplementation.cpp#L65
+[src-outlet-h]: ../../YseEngine/patcher/outlet.h#L53
+[src-inlet-h]: ../../YseEngine/patcher/inlet.h#L84
+[src-outlet-connect]: ../../YseEngine/patcher/outlet.cpp#L53
+[src-inlet-connect]: ../../YseEngine/patcher/inlet.cpp#L110
+[src-sendbuffer]: ../../YseEngine/patcher/outlet.cpp#L47
+[src-calcifready]: ../../YseEngine/patcher/pObject.cpp#L34
+[src-waiting]: ../../YseEngine/patcher/inlet.cpp#L105
+[src-inlet-set]: ../../YseEngine/patcher/inlet.cpp#L48
+[src-startpoint]: ../../YseEngine/patcher/pObject.cpp#L17


### PR DESCRIPTION
## Summary

Makes the patcher graph wait-free on the audio thread. `Calculate` no longer takes the patcher mutex — topology is compiled into an immutable `GraphState` and published to the audio thread with a single `std::atomic<GraphState*>` swap.

This issue is the **design gate** for epic #189: the mechanism was agreed *before* code landed. The decision is recorded in-tree at [`docs/design/patcher_graphstate.md`](docs/design/patcher_graphstate.md) and on #226.

## Linked issue

Closes #226

## Design (settled at the gate)

- **Stable objects + swappable topology.** Objects are allocated once and never rebuilt, so DSP history is preserved across edits for free. `GraphState` owns only the object set, precomputed DSP start-points + DAC list, outlet→inlet adjacency, and per-inlet has-DSP flags.
- **Send path resolves against a per-block-pinned snapshot** via a construction-time dense outlet/inlet id. The audio thread does one `acquire` load at the top of `Calculate` and pins it; `Send*`/`WaitingForDSP` look up the snapshot when mid-block, else fall back to the live wiring (control-thread / standalone-object path). This confines the change to `outlet`/`inlet`/`patcherImplementation` + the two `ADD_OUT_*`/`ADD_IN_*` macros — **all ~40 object `Calculate` bodies are untouched**.
- **Traversal model kept.** The push/readiness scheduler is correct for YSE's heterogeneous event+DSP+feedback graph; push-vs-pull is orthogonal to RT-safety. Decoupling topology into `GraphState` *enables* a future pull walk rather than foreclosing it.
- **Memory ordering:** publish `store(release)` / audio-thread `load(acquire)`, pinned once per block so no send straddles two topologies. A single `atomic<GraphState*>` keeps multi-edge edits atomic.

## Changes

- `YseEngine/patcher/graphState.h` (new) — the immutable snapshot.
- `outlet` / `inlet` — stable `graphId`, snapshot-aware `Send*` / `WaitingForDSP`, `UnwireFromPeers`.
- `pObject` — `CurrentBlockGraph()` accessor, `UnwireFromPeers()`, `ADD_OUT_*` macros pass the owner.
- `patcherImplementation` — atomic `active`/pinned snapshot, **mtx-free** `Calculate`, build-and-swap for create/delete/connect/disconnect and `ParseJSON`, and a deferred retire queue (nothing freed on the audio thread).
- `Tests/patcher/test_patcher_graphstate.cpp` (new) + CMake registration.

## Scope / follow-ups (per epic #189)

Out of scope here, tracked separately: SPSC value-command queue (#225), real epoch/hazard reclamation (#227 — this PR uses an interim deferred-by-two-blocks reclaimer), off-thread parse/dump/clear/rename (#228), and the TSan/ASan concurrency stress gate (#229).

## Test plan

- [x] `python yse.py format` clean
- [x] `python yse.py analyze` on changed files — **no new findings** (the `readability-string-compare` hits are pre-existing `PassBang`/`PassData`, untouched)
- [x] Full suite: **16/16 ctest targets pass** (incl. `yse_tests_patcher` and `yse_tests_concurrency`)
- [x] New `test_patcher_graphstate.cpp`: **6 cases / 138 assertions pass** — verifies rendered output tracks live connect / disconnect / delete and a `ParseJSON` round-trip, plus a 64-iteration edit-while-rendering stress pass
- [ ] **ASan not run locally** — a *pre-existing, unrelated* link conflict blocks the ASan test binary: `Tests/system/test_named_bus.cpp` overrides `operator delete`, which collides with the ASan runtime (`duplicate symbol: operator delete`). This is independent of this change. Dedicated ASan/TSan coverage is epic #229's acceptance gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)