### PR TITLE
FIX: defer patcher value delivery via a lock-free command queue (#225)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(YSE_TEST_SOURCES
   patcher/test_c_api_metadata.cpp
   patcher/test_patcher_bus.cpp
   patcher/test_patcher_graphstate.cpp
+  patcher/test_patcher_value_queue.cpp
   patcher/test_timerthread.cpp
   channel/test_channel.cpp
   channel/test_channel_concurrency.cpp
@@ -302,6 +303,7 @@ set_source_files_properties(
   patcher/test_c_api_metadata.cpp
   patcher/test_patcher_bus.cpp
   patcher/test_patcher_graphstate.cpp
+  patcher/test_patcher_value_queue.cpp
   patcher/test_timerthread.cpp
   PROPERTIES COMPILE_FLAGS "${_patcher_test_suppress}"
 )

--- a/Tests/patcher/test_generic_objects.cpp
+++ b/Tests/patcher/test_generic_objects.cpp
@@ -3,8 +3,10 @@
 //
 // gSend is parent-coupled: its SetXValue handlers cast `parent` to
 // `patcherImplementation*` and call PassData on it.  The realistic path is
-// therefore exercised through a real `YSE::patcher` containing both gSend and
-// gReceive with matching dataNames.
+// therefore exercised through a patcher containing both gSend and gReceive with
+// matching dataNames.  Because control-thread PassData now defers delivery to
+// the audio thread (issue #225), the gSend->gReceive case drives
+// patcherImplementation directly so it can drain the value queue via Calculate.
 //
 // gMetro spawns a background TimerThread tick.  Tests stop the metro before
 // destruction (Toggle 0) so the dtor's id==0 branch runs and no temporary
@@ -13,6 +15,7 @@
 #include <doctest/doctest.h>
 #include <string>
 #include "patcher/patcher.hpp"
+#include "patcher/patcherImplementation.h"
 #include "patcher/pHandle.hpp"
 #include "patcher/pObjectList.hpp"
 #include "patcher/genericObjects/gGate.h"
@@ -381,8 +384,10 @@ TEST_SUITE("patcher") {
   }
 
   TEST_CASE("gSend -> gReceive: matching dataName carries bang/int/float/list") {
-    YSE::patcher p;
-    p.create(2);
+    // Driven from the control thread, so gSend's PassData fan-out is deferred to
+    // the audio thread (issue #225). Use patcherImplementation directly so the
+    // value queue can be drained with an explicit Calculate.
+    YSE::PATCHER::patcherImplementation p(2, nullptr);
     YSE::pHandle* send = p.CreateObject(YSE::OBJ::G_SEND, "channelA");
     YSE::pHandle* recv = p.CreateObject(YSE::OBJ::G_RECEIVE, "channelA");
     REQUIRE(send != nullptr);
@@ -396,6 +401,11 @@ TEST_SUITE("patcher") {
     send->SetIntData(0, 11);
     send->SetFloatData(0, 0.125f);
     send->SetListData(0, "msg body");
+
+    // Drain the in-patcher value queue. (When the global bus is active gSend
+    // also delivers via the bus, but this Calculate covers the local path too;
+    // deferral itself is covered by test_patcher_value_queue.)
+    p.Calculate(YSE::T_DSP);
 
     CHECK(sink.gotBang);
     CHECK(sink.gotInt);

--- a/Tests/patcher/test_patcher_value_queue.cpp
+++ b/Tests/patcher/test_patcher_value_queue.cpp
@@ -1,0 +1,146 @@
+// Regression tests for the SPSC value-command queue (issue #225).
+//
+// Before this change, patcherImplementation::PassBang / PassData ran the target
+// gReceive's inlet handler *synchronously on the control/GUI thread*, racing the
+// audio thread's Calculate (a genuine UAF through Parameters::Set). Now a value
+// message is enqueued and delivered on the audio thread when Calculate drains
+// the queue at the top of a block.
+//
+// These tests drive patcherImplementation directly (the audio-thread entry
+// point is Calculate) and observe an external sink wired to the receiver's
+// outlet, so they can assert the load-bearing property: nothing is delivered
+// until Calculate runs, and then exactly the queued values arrive. A receiver
+// removed between enqueue and drain must drop the message without touching the
+// retired object. No audio device required.
+
+#include <doctest/doctest.h>
+#include <string>
+#include "patcher/patcherImplementation.h"
+#include "patcher/pHandle.hpp"
+#include "patcher/pObjectList.hpp"
+#include "sinks.hpp"
+
+using TestHelpers::MultiSink;
+using YSE::PATCHER::patcherImplementation;
+
+namespace {
+  // Build a patcher holding a gReceive named `name`, with `sink` wired to the
+  // receiver's outlet. Returns the receiver's handle (owned by the patcher).
+  YSE::pHandle* wireReceiver(patcherImplementation& p, const std::string& name, MultiSink& sink,
+                             YSE::pHandle& sinkHandle) {
+    YSE::pHandle* recv = p.CreateObject(YSE::OBJ::G_RECEIVE, name);
+    REQUIRE(recv != nullptr);
+    p.Connect(recv, 0, &sinkHandle, 0);
+    return recv;
+  }
+} // namespace
+
+TEST_SUITE("patcher") {
+
+  TEST_CASE("value queue: PassData defers delivery until the next Calculate") {
+    patcherImplementation p(1, nullptr);
+    MultiSink sink;
+    YSE::pHandle sinkHandle(&sink);
+    wireReceiver(p, "target", sink, sinkHandle);
+
+    // Enqueued, not delivered: the old code poked the inlet here and the sink
+    // would already show the value. It must stay empty until the audio thread
+    // drains.
+    CHECK(p.PassData(42, "target", YSE::T_GUI));
+    CHECK_FALSE(sink.gotInt);
+
+    // The drain happens at the top of Calculate.
+    p.Calculate(YSE::T_DSP);
+    CHECK(sink.gotInt);
+    CHECK(sink.intValue == 42);
+  }
+
+  TEST_CASE("value queue: bang, float and list all deliver on drain") {
+    patcherImplementation p(1, nullptr);
+    MultiSink sink;
+    YSE::pHandle sinkHandle(&sink);
+    wireReceiver(p, "ch", sink, sinkHandle);
+
+    CHECK(p.PassBang("ch", YSE::T_GUI));
+    CHECK(p.PassData(0.25f, "ch", YSE::T_GUI));
+    CHECK(p.PassData(std::string("hello world"), "ch", YSE::T_GUI));
+    CHECK_FALSE(sink.gotBang);
+    CHECK_FALSE(sink.gotFloat);
+    CHECK_FALSE(sink.gotList);
+
+    p.Calculate(YSE::T_DSP);
+    CHECK(sink.gotBang);
+    CHECK(sink.gotFloat);
+    CHECK(sink.floatValue == doctest::Approx(0.25f));
+    CHECK(sink.gotList);
+    CHECK(sink.listValue == "hello world");
+  }
+
+  TEST_CASE("value queue: several messages queued between blocks all arrive in one drain") {
+    patcherImplementation p(1, nullptr);
+    MultiSink sink;
+    YSE::pHandle sinkHandle(&sink);
+    wireReceiver(p, "acc", sink, sinkHandle);
+
+    for (int i = 1; i <= 5; ++i) {
+      CHECK(p.PassData(i, "acc", YSE::T_GUI));
+    }
+    CHECK_FALSE(sink.gotInt);
+
+    p.Calculate(YSE::T_DSP);
+    // The last message wins (each overwrites intValue in the sink).
+    CHECK(sink.gotInt);
+    CHECK(sink.intValue == 5);
+  }
+
+  TEST_CASE("value queue: PassData to an unknown target returns false and delivers nothing") {
+    patcherImplementation p(1, nullptr);
+    MultiSink sink;
+    YSE::pHandle sinkHandle(&sink);
+    wireReceiver(p, "target", sink, sinkHandle);
+
+    // No receiver named "missing" and no OSC handler: the call reports failure.
+    CHECK_FALSE(p.PassData(7, "missing", YSE::T_GUI));
+    p.Calculate(YSE::T_DSP);
+    CHECK_FALSE(sink.gotInt);
+  }
+
+  TEST_CASE("value queue: a receiver deleted before the drain drops the message safely") {
+    patcherImplementation p(1, nullptr);
+    MultiSink sink;
+    YSE::pHandle sinkHandle(&sink);
+    YSE::pHandle* recv = wireReceiver(p, "gone", sink, sinkHandle);
+
+    // Target exists at enqueue time, so the value is accepted...
+    CHECK(p.PassData(99, "gone", YSE::T_GUI));
+    // ...but it is removed before the audio thread drains. The drain re-resolves
+    // the target against the current snapshot, finds nothing, and must not touch
+    // the retired object (an ASan build would trip if it did).
+    p.DeleteObject(recv);
+    p.Calculate(YSE::T_DSP);
+    CHECK_FALSE(sink.gotInt);
+  }
+
+  TEST_CASE("value queue: overfilling the queue drops with no crash and keeps delivering") {
+    patcherImplementation p(1, nullptr);
+    MultiSink sink;
+    YSE::pHandle sinkHandle(&sink);
+    wireReceiver(p, "spam", sink, sinkHandle);
+
+    // Push well past the fixed queue depth without draining. Excess messages are
+    // dropped (logged), never block or crash the producer.
+    for (int i = 0; i < 1000; ++i) {
+      p.PassData(i, "spam", YSE::T_GUI);
+    }
+    p.Calculate(YSE::T_DSP);
+    CHECK(sink.gotInt); // whatever survived the bound still delivers
+
+    // The queue is healthy afterwards: a fresh message delivers on the next block.
+    sink.reset();
+    CHECK(p.PassData(123, "spam", YSE::T_GUI));
+    p.Calculate(YSE::T_DSP);
+    CHECK(sink.gotInt);
+    CHECK(sink.intValue == 123);
+  }
+
+} // TEST_SUITE("patcher")

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -9,6 +9,7 @@
 #include "pHandle.hpp"
 #include "../utils/json.hpp"
 #include <atomic>
+#include <cstring>
 #include <string>
 #include "../implementations/logImplementation.h"
 
@@ -19,6 +20,11 @@ namespace {
   // name (issue #122). Distinct from pObject::CreateID() so the patcher
   // counter is not perturbed by inner-object construction.
   std::atomic<unsigned int> g_nextPatcherIndex{0};
+
+  // Shared empty list argument for DispatchToReceiver on the non-list value
+  // kinds (Bang/Int/Float), so those paths pass a std::string& without building
+  // a temporary. Never read for those kinds.
+  const std::string kEmptyList;
 } // namespace
 
 patcherImplementation::patcherImplementation(int mainOutputs, YSE::patcher* head)
@@ -29,6 +35,9 @@ patcherImplementation::patcherImplementation(int mainOutputs, YSE::patcher* head
     patcherName("patcher_" +
                 std::to_string(g_nextPatcherIndex.fetch_add(1, std::memory_order_relaxed))) {
   output.resize(mainOutputs);
+  // Pre-size the audio-thread list-delivery scratch so SetList never allocates
+  // on the callback path (issue #225).
+  listScratch_.reserve(kValueListCap);
 }
 
 void patcherImplementation::SetName(const std::string& n) {
@@ -73,6 +82,11 @@ void patcherImplementation::Calculate(YSE::THREAD thread) {
   const GraphState* g = active_.load(std::memory_order_acquire);
   audioBlock_.fetch_add(1, std::memory_order_acq_rel);
   currentBlockGraph_.store(g, std::memory_order_release);
+
+  // Deliver queued value messages (PassBang/PassData) before rendering, now
+  // that the snapshot is pinned so their fan-out resolves through it. This is
+  // where inlet handlers run — only ever on the audio thread (issue #225).
+  DeliverPendingValues(g);
 
   if (g != nullptr) {
     // invalidate all dsp buffers
@@ -337,14 +351,15 @@ YSE::pHandle* patcherImplementation::GetHandleFromID(unsigned int objID) {
 }
 
 bool patcherImplementation::PassBang(const std::string& to, YSE::THREAD thread) {
-  for (auto& x : objects) {
-    if (strcmp(x.second->Type(), OBJ::G_RECEIVE) == 0) {
-      if (to.compare(x.second->DataName()) == 0) {
-        x.second->GetInlet(0)->SetBang(thread);
-        return true;
-      }
-    }
+  if (thread == YSE::T_DSP) {
+    // Already on the audio thread (a gSend fanning out during traversal):
+    // deliver synchronously against the pinned snapshot, same block, no lock.
+    return DispatchToReceiver(currentBlockGraph_.load(std::memory_order_acquire), ValueKind::Bang,
+                              to.c_str(), 0, 0.f, kEmptyList, thread);
   }
+  ValueMsg msg{};
+  msg.kind = ValueKind::Bang;
+  if (EnqueueValue(msg, to)) return true;
   if (oscHandle != nullptr) {
     oscHandle->Send(to);
     return true;
@@ -355,14 +370,14 @@ bool patcherImplementation::PassBang(const std::string& to, YSE::THREAD thread) 
 }
 
 bool patcherImplementation::PassData(int value, const std::string& to, YSE::THREAD thread) {
-  for (auto& x : objects) {
-    if (strcmp(x.second->Type(), OBJ::G_RECEIVE) == 0) {
-      if (to.compare(x.second->DataName()) == 0) {
-        x.second->GetInlet(0)->SetInt(value, thread);
-        return true;
-      }
-    }
+  if (thread == YSE::T_DSP) {
+    return DispatchToReceiver(currentBlockGraph_.load(std::memory_order_acquire), ValueKind::Int,
+                              to.c_str(), value, 0.f, kEmptyList, thread);
   }
+  ValueMsg msg{};
+  msg.kind = ValueKind::Int;
+  msg.intVal = value;
+  if (EnqueueValue(msg, to)) return true;
   if (oscHandle != nullptr) {
     oscHandle->Send(to, value);
     return true;
@@ -373,14 +388,14 @@ bool patcherImplementation::PassData(int value, const std::string& to, YSE::THRE
 }
 
 bool patcherImplementation::PassData(float value, const std::string& to, YSE::THREAD thread) {
-  for (auto& x : objects) {
-    if (strcmp(x.second->Type(), OBJ::G_RECEIVE) == 0) {
-      if (to.compare(x.second->DataName()) == 0) {
-        x.second->GetInlet(0)->SetFloat(value, thread);
-        return true;
-      }
-    }
+  if (thread == YSE::T_DSP) {
+    return DispatchToReceiver(currentBlockGraph_.load(std::memory_order_acquire), ValueKind::Float,
+                              to.c_str(), 0, value, kEmptyList, thread);
   }
+  ValueMsg msg{};
+  msg.kind = ValueKind::Float;
+  msg.floatVal = value;
+  if (EnqueueValue(msg, to)) return true;
   if (oscHandle != nullptr) {
     oscHandle->Send(to, value);
     return true;
@@ -392,14 +407,29 @@ bool patcherImplementation::PassData(float value, const std::string& to, YSE::TH
 
 bool patcherImplementation::PassData(const std::string& value, const std::string& to,
                                      YSE::THREAD thread) {
-  for (auto& x : objects) {
-    if (strcmp(x.second->Type(), OBJ::G_RECEIVE) == 0) {
-      if (to.compare(x.second->DataName()) == 0) {
-        x.second->GetInlet(0)->SetList(value, thread);
-        return true;
-      }
-    }
+  if (thread == YSE::T_DSP) {
+    // Synchronous audio-thread delivery takes the value by reference — no inline
+    // buffer, so no length limit on this path.
+    return DispatchToReceiver(currentBlockGraph_.load(std::memory_order_acquire), ValueKind::List,
+                              to.c_str(), 0, 0.f, value, thread);
   }
+  // The deferred payload rides the queue inline; over-long values can't take the
+  // RT-safe path. Log and drop rather than truncate or allocate — but still let
+  // OSC (control-thread, no length limit) handle it if wired.
+  if (value.size() >= kValueListCap) {
+    INTERNAL::LogImpl().emit(
+        E_FILE_ERROR, "Patcher: list value too long for value queue, dropped (to " + to + ")");
+    if (oscHandle != nullptr) {
+      oscHandle->Send(to, value);
+      return true;
+    }
+    return false;
+  }
+
+  ValueMsg msg{};
+  msg.kind = ValueKind::List;
+  std::memcpy(msg.listVal, value.c_str(), value.size() + 1);
+  if (EnqueueValue(msg, to)) return true;
   if (oscHandle != nullptr) {
     oscHandle->Send(to, value);
     return true;
@@ -407,6 +437,90 @@ bool patcherImplementation::PassData(const std::string& value, const std::string
   INTERNAL::LogImpl().emit(E_FILE_ERROR, "Cannot find target " + to + ". Valid targets are" +
                                              GetRecieveObjectsAsString());
   return false;
+}
+
+bool patcherImplementation::DispatchToReceiver(const GraphState* g, ValueKind kind, const char* to,
+                                               int intVal, float floatVal,
+                                               const std::string& listVal, YSE::THREAD thread) {
+  if (g == nullptr) return false;
+  for (pObject* obj : g->objects) {
+    if (strcmp(obj->Type(), OBJ::G_RECEIVE) != 0) continue;
+    if (obj->DataName() != to) continue;
+    PATCHER::inlet* in = obj->GetInlet(0);
+    if (in == nullptr) return true; // matched, but nothing to deliver into
+    switch (kind) {
+    case ValueKind::Bang:
+      in->SetBang(thread);
+      break;
+    case ValueKind::Int:
+      in->SetInt(intVal, thread);
+      break;
+    case ValueKind::Float:
+      in->SetFloat(floatVal, thread);
+      break;
+    case ValueKind::List:
+      in->SetList(listVal, thread);
+      break;
+    }
+    return true;
+  }
+  return false;
+}
+
+bool patcherImplementation::EnqueueValue(ValueMsg& msg, const std::string& to) {
+  // The target receiver is carried by name and re-resolved on the audio thread.
+  // Over-long names can't ride the inline buffer; treat as "no in-patcher
+  // target" so the caller can still try OSC, and log rather than truncate.
+  if (to.size() >= kValueNameCap) {
+    INTERNAL::LogImpl().emit(E_FILE_ERROR,
+                             "Patcher: receiver name too long for value queue: " + to);
+    return false;
+  }
+  std::memcpy(msg.target, to.c_str(), to.size() + 1);
+
+  // Does a matching gReceive exist in this patcher? Scan under mtx so `objects`
+  // is never read concurrently with a structural edit. mtx is control-thread
+  // only now (issue #226) and never blocks the audio thread.
+  bool found = false;
+  mtx.lock();
+  for (auto& x : objects) {
+    if (strcmp(x.second->Type(), OBJ::G_RECEIVE) == 0 && to == x.second->DataName()) {
+      found = true;
+      break;
+    }
+  }
+  mtx.unlock();
+  if (!found) return false;
+
+  if (!valueQueue_.try_push(msg)) {
+    // Backpressure: the audio thread hasn't drained yet. Never block or allocate
+    // on the control thread — drop and log. The target existed, so return true
+    // regardless (don't spuriously fall back to OSC for a real in-patcher one).
+    INTERNAL::LogImpl().emit(E_ERROR, "Patcher: value queue full; dropped message to " + to);
+  }
+  return true;
+}
+
+void patcherImplementation::DeliverPendingValues(const GraphState* g) {
+  // Audio thread. Drain the whole queue every block so it can't grow unbounded,
+  // even when the patcher is empty (no snapshot to deliver into -> dropped).
+  // Re-resolving each target by name against the pinned snapshot is what makes
+  // this safe across a concurrent delete: a removed receiver is simply absent.
+  // Dispatch with T_GUI semantics (these messages originated on the control
+  // thread): set the parameter / forward the value; this block's own traversal
+  // renders it.
+  ValueMsg msg;
+  while (valueQueue_.try_pop(msg)) {
+    if (g == nullptr) continue;
+    if (msg.kind == ValueKind::List) {
+      // assign() into the reserved scratch reuses its buffer (no allocation on
+      // the audio thread) while giving SetList the std::string& it expects.
+      listScratch_.assign(msg.listVal);
+      DispatchToReceiver(g, msg.kind, msg.target, 0, 0.f, listScratch_, YSE::T_GUI);
+    } else {
+      DispatchToReceiver(g, msg.kind, msg.target, msg.intVal, msg.floatVal, kEmptyList, YSE::T_GUI);
+    }
+  }
 }
 
 std::string patcherImplementation::GetRecieveObjectsAsString() {

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -5,6 +5,7 @@
 #include "../dsp/buffer.hpp"
 #include "patcher.hpp"
 #include "graphState.h"
+#include "../utils/mpmcQueue.hpp"
 #include <atomic>
 #include <cstdint>
 #include <map>
@@ -62,7 +63,13 @@ namespace YSE {
       aBool controlledBySound;
       std::atomic<patcher*> head;
 
-      // for external data input
+      // for external data input. These run on the control/GUI thread: they no
+      // longer poke inlets directly (that raced the audio thread's Calculate and
+      // was a genuine UAF through Parameters::Set — issue #225). Instead a value
+      // message is enqueued on a lock-free queue and delivered to the inlet on
+      // the audio thread at the top of the next Calculate. The bool return still
+      // means "a matching gReceive exists in this patcher (message enqueued)";
+      // when none exists the call falls back to the OSC handler as before.
       bool PassBang(const std::string& to, THREAD thread);
       bool PassData(int value, const std::string& to, THREAD thread);
       bool PassData(float value, const std::string& to, THREAD thread);
@@ -71,6 +78,56 @@ namespace YSE {
       void SetHandler(oscHandler* handler);
 
     private:
+      // Kinds of deferred value message carried on the SPSC command queue
+      // (issue #225). One per PassBang / PassData overload.
+      enum class ValueKind : std::uint8_t { Bang, Int, Float, List };
+
+      // Longest target (gReceive) name and list payload that ride the queue
+      // inline. Names/values longer than this can't be delivered through the
+      // RT-safe path; the control thread logs and drops rather than truncating
+      // silently or allocating. Chosen well above any realistic identifier /
+      // space-separated value list.
+      static constexpr std::size_t kValueNameCap = 64;
+      static constexpr std::size_t kValueListCap = 256;
+      // Fixed queue depth (messages buffered between two audio blocks). Bounded
+      // and allocated once; a full queue drops-with-log, never blocks the
+      // control thread and never allocates on the audio thread.
+      static constexpr std::size_t kValueQueueCapacity = 256;
+
+      // A deferred value delivery. Trivially copyable (POD) so it can ride the
+      // lock-free mpmcQueue by value — no heap, so nothing to reclaim. The
+      // target receiver is carried by name and re-resolved against the pinned
+      // GraphState on the audio thread, which makes delivery inherently safe
+      // across a concurrent DeleteObject: a removed receiver is simply absent
+      // from the snapshot and the message is dropped.
+      struct ValueMsg {
+        ValueKind kind;
+        int intVal;
+        float floatVal;
+        char target[kValueNameCap]; // null-terminated gReceive DataName()
+        char listVal[kValueListCap]; // null-terminated; List kind only
+      };
+
+      // Deliver every queued value message against the pinned snapshot. Audio
+      // thread only, called from Calculate after currentBlockGraph_ is stored so
+      // value propagation resolves through the snapshot. Dispatches with T_GUI
+      // semantics (set the parameter; the block's own traversal renders it).
+      void DeliverPendingValues(const GraphState* g);
+
+      // Find the gReceive named `to` in snapshot g and deliver the value to its
+      // inlet 0. Audio thread only (no allocation: `to` is a C-string and the
+      // list value is a caller-owned reference). Returns true iff a matching
+      // receiver exists. Shared by the deferred drain and the synchronous
+      // audio-thread path (gSend fan-out during traversal).
+      bool DispatchToReceiver(const GraphState* g, ValueKind kind, const char* to, int intVal,
+                              float floatVal, const std::string& listVal, THREAD thread);
+
+      // Control thread. Copies `to` into msg.target, checks whether a matching
+      // gReceive exists in this patcher, and if so enqueues msg. Returns true
+      // iff a matching receiver exists (so the caller only falls back to OSC
+      // when there is genuinely no in-patcher target).
+      bool EnqueueValue(ValueMsg& msg, const std::string& to);
+
       // Compile the current object wiring into a fresh immutable GraphState.
       // Control-thread only (allocates). See graphState.h.
       GraphState* BuildGraph();
@@ -108,6 +165,17 @@ namespace YSE {
       // ids stay stable across edits.
       int nextInletId_ = 0;
       int nextOutletId_ = 0;
+
+      // Lock-free command queue for deferred value delivery (issue #225).
+      // Producers: control/GUI threads (PassBang / PassData). Consumer: the
+      // audio thread, draining in Calculate. mpmcQueue is a superset of SPSC, so
+      // concurrent producers are safe too.
+      YSE::mpmcQueue<ValueMsg> valueQueue_{kValueQueueCapacity};
+      // Audio-thread-only scratch buffer for delivering List payloads. Reserved
+      // to kValueListCap in the ctor so assigning any inline list value reuses
+      // this buffer instead of allocating on the audio thread, while still
+      // handing inlet::SetList the const std::string& it expects.
+      std::string listScratch_;
 
       // Bus-prefix for inner gSend/gReceive routing (issue #122). Defaulted
       // to "patcher_<N>" in the ctor; mutated by SetName().


### PR DESCRIPTION
## Summary

`PassBang` / `PassData` ran the target `gReceive`'s inlet handler synchronously on the control/GUI thread, racing the audio thread's `Calculate` — a genuine UAF through `Parameters::Set` (a `std::string` write via `void*`, SSO↔heap). This moves value delivery off the control thread so inlet handlers only ever run on the audio thread.

Part of epic #189 (patcher wait-free rearchitecture); builds on the `GraphState`/atomic-publish machinery from #226.

## Linked issue

Closes #225

## Changes

- **Control-thread `PassBang`/`PassData`** enqueue a POD message on a per-patcher lock-free `YSE::mpmcQueue`. `Calculate` drains it at the top of a block, after the `GraphState` is pinned, so value fan-out resolves through the snapshot and handlers run only on the audio thread.
- **Delete-safety by construction:** the target receiver is carried by name and re-resolved against the pinned snapshot on the audio thread. A receiver deleted between enqueue and drain is simply absent → no dangling reference, no dependence on reclamation timing.
- **`gSend` fan-out (audio thread, `T_DSP`)** delivers synchronously against the pinned snapshot with no lock, preserving same-block in-patcher send/receive. (Enqueuing on that path would have locked `mtx` on the audio thread — a new RT violation — so the two paths are split on `thread`.)
- **No audio-thread allocation:** message payloads are inline and bounded (drop-with-log on overflow, never silent truncation), and List delivery reuses a pre-reserved scratch `std::string` so `SetList` never allocates on the callback.

## Behavior change (intended)

Control-thread `gSend`→`gReceive` in-patcher delivery is now deferred to the next audio block rather than synchronous — the whole point of #225. Imperceptible for a rendered patcher; a patcher driven purely from the control thread with no `Calculate` won't deliver in-patcher values until it is rendered.

## Out of scope

`DeleteObject`/`Clear` still call `inlet::SetInt(0)` directly on the control thread to stop a `gMetro`. That's a teardown-path poke, not a `Pass*`/live-param value — left to the teardown sub-issues (#227/#228) to keep this PR focused.

## Test plan

- [x] `clang-format` clean (`python yse.py format`)
- [x] `clang-tidy` — no new findings in modified code (`python yse.py analyze`)
- [x] Full suite passes — 16/16 CTest targets (`python yse.py test`), incl. patcher, concurrency, integration
- [x] New `Tests/patcher/test_patcher_value_queue.cpp` (6 cases): deferral, per-kind delivery, delete-before-drain safety, unknown target, queue overflow. The `gSend`→`gReceive` test now drains via `Calculate` to reflect the deferred path.
- [ ] ASan/TSan: **not run** — the local Windows/MSYS2 ASan build has a *pre-existing* `duplicate symbol: operator new/delete` link error (`test_named_bus.cpp`), unrelated to this change. Sanitizer validation is the dedicated job of epic sub-issue #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
