### PR TITLE
FIX: reclaim retired patcher GraphState/objects on the background pool (#227)

### DIFF
--- a/Tests/patcher/test_patcher_graphstate.cpp
+++ b/Tests/patcher/test_patcher_graphstate.cpp
@@ -17,6 +17,8 @@
 #include "patcher/pHandle.hpp"
 #include "patcher/pObjectList.hpp"
 #include "dsp/buffer.hpp"
+#include <chrono>
+#include <thread>
 
 using YSE::PATCHER::patcherImplementation;
 
@@ -93,6 +95,69 @@ TEST_SUITE("patcher") {
       p.Calculate(YSE::T_DSP);
       CHECK(p.output[0].isSilent());
     }
+  }
+
+  // ---- Background reclamation of retired GraphState/objects (issue #227) ----
+
+  TEST_CASE("reclaim: deleting a source leaves its former sink usable") {
+    // The retired source's inlet/outlet destructors call Disconnect on their
+    // peers; UnwireFromPeers must have cleared that wiring at delete time so the
+    // deferred teardown touches only the retired object, never the live dac. If
+    // it didn't, the dac's inlet would be left dangling and reusing it would
+    // corrupt the graph.
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    p.Connect(noise, 0, dac, 0);
+    p.Calculate(YSE::T_DSP);
+    REQUIRE_FALSE(p.output[0].isSilent());
+
+    p.DeleteObject(noise);
+    p.Calculate(YSE::T_DSP);
+    CHECK(p.output[0].isSilent());
+
+    // Wire a fresh source into the surviving dac and render: the dac's inlet
+    // must still be clean.
+    YSE::pHandle* noise2 = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    p.Connect(noise2, 0, dac, 0);
+    p.Calculate(YSE::T_DSP);
+    CHECK_FALSE(p.output[0].isSilent());
+  }
+
+  TEST_CASE("reclaim: the background pool drains retired snapshots, not the dtor") {
+    // Every connect/disconnect retires a GraphState. If reclamation were broken
+    // the retire lists would grow with the edit count (only the destructor would
+    // ever free them). With the background pool draining once the audio epoch has
+    // advanced two blocks past retirement, the pending count stays small no
+    // matter how many edits churn through. Each Calculate advances the epoch.
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+
+    for (int i = 0; i < 200; ++i) {
+      p.Connect(noise, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      p.Disconnect(noise, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      p.Calculate(YSE::T_DSP);
+    }
+
+    // Let the background worker catch up. Re-arm with a light edit each spin so a
+    // reclaimer that gave up on a momentarily-stalled epoch is retriggered; the
+    // rendered blocks keep the epoch moving so it can cross the +2 grace.
+    for (int spins = 0; spins < 2000 && p.PendingRetired() > 4; ++spins) {
+      p.Connect(noise, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      p.Disconnect(noise, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      p.Calculate(YSE::T_DSP);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    // A handful of just-retired snapshots may still be inside the +2 grace, but
+    // the 400+ retired over the churn must be gone — reclaimed by the pool, not
+    // waiting for teardown.
+    CHECK(p.PendingRetired() <= 4);
   }
 
   TEST_CASE("graphstate: ParseJSON publishes a renderable graph in one swap") {

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -10,8 +10,11 @@
 #include "../utils/json.hpp"
 #include <atomic>
 #include <cstring>
+#include <mutex>
 #include <string>
+#include <vector>
 #include "../implementations/logImplementation.h"
+#include "../internal/global.h"
 
 using namespace YSE::PATCHER;
 
@@ -38,6 +41,12 @@ patcherImplementation::patcherImplementation(int mainOutputs, YSE::patcher* head
   // Pre-size the audio-thread list-delivery scratch so SetList never allocates
   // on the callback path (issue #225).
   listScratch_.reserve(kValueListCap);
+  // Wire the two reclaim jobs into a ping-pong pair (issue #227): each re-arms
+  // the other so a reclaim pass with remaining work never re-enqueues itself.
+  reclaimJobs_[0].owner = this;
+  reclaimJobs_[0].sibling = &reclaimJobs_[1];
+  reclaimJobs_[1].owner = this;
+  reclaimJobs_[1].sibling = &reclaimJobs_[0];
 }
 
 void patcherImplementation::SetName(const std::string& n) {
@@ -60,10 +69,18 @@ void patcherImplementation::SetName(const std::string& n) {
 }
 
 patcherImplementation::~patcherImplementation() {
+  // Stop scheduling and re-arming reclaim passes first, so the joins below
+  // terminate instead of chasing a self-perpetuating ping-pong.
+  shuttingDown_.store(true, std::memory_order_release);
   // memory cleanup
   Clear();
+  // A reclaim pass already handed to the background pool may still be draining
+  // the retire lists; wait for both halves of the ping-pong to finish before we
+  // free those lists from under them. shuttingDown_ guarantees neither re-arms.
+  reclaimJobs_[0].join();
+  reclaimJobs_[1].join();
   // The audio thread is stopped at destruction, so reclaim unconditionally:
-  // the deferred retire lists (and the final published snapshot) are freed
+  // the remaining retire lists (and the final published snapshot) are freed
   // here rather than waiting on the block counter.
   FreeAllRetired();
 }
@@ -217,7 +234,14 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
   // snapshot that references it. The free is deferred to the reclaimer.
   object->UnwireFromPeers();
   if (!fileHandlerActive) RebuildAndPublish();
-  retiredObjects_.emplace_back(object, audioBlock_.load(std::memory_order_acquire));
+  // Tag the object only after RebuildAndPublish has retired the graph that last
+  // referenced it, so its epoch is >= that graph's — the graphs-first drain then
+  // guarantees no retired graph outlives an object it points into.
+  {
+    std::scoped_lock lk(reclaimMtx_);
+    retiredObjects_.emplace_back(object, audioBlock_.load(std::memory_order_acquire));
+  }
+  ScheduleReclaim();
   // The handle is never referenced by a GraphState, so it can go immediately.
   delete handle;
 
@@ -227,17 +251,28 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
 void patcherImplementation::Clear() {
   if (!fileHandlerActive) mtx.lock();
 
-  std::uint64_t at = audioBlock_.load(std::memory_order_acquire);
+  std::vector<pObject*> doomed;
+  doomed.reserve(objects.size());
   for (auto it = objects.begin(); it != objects.end(); ++it) {
     if (it->first->Type() == OBJ::G_METRO) {
       it->second->GetInlet(0)->SetInt(0, YSE::THREAD::T_GUI);
     }
     it->second->UnwireFromPeers();
-    retiredObjects_.emplace_back(it->second, at);
+    doomed.push_back(it->second);
     delete it->first; // handle: not referenced by a GraphState
   }
   objects.clear();
   if (!fileHandlerActive) RebuildAndPublish();
+  // Tag the removed objects only after their covering graph has been retired by
+  // RebuildAndPublish, so each object's epoch is >= that graph's (see the
+  // graphs-first invariant in ReclaimElapsed).
+  {
+    std::scoped_lock lk(reclaimMtx_);
+    const std::uint64_t at = audioBlock_.load(std::memory_order_acquire);
+    for (pObject* obj : doomed)
+      retiredObjects_.emplace_back(obj, at);
+  }
+  ScheduleReclaim();
   if (!fileHandlerActive) mtx.unlock();
 }
 
@@ -331,6 +366,11 @@ void patcherImplementation::ParseJSON(const std::string& content) {
 
 unsigned int patcherImplementation::Objects() {
   return static_cast<unsigned int>(objects.size());
+}
+
+std::size_t patcherImplementation::PendingRetired() {
+  std::scoped_lock lk(reclaimMtx_);
+  return retiredGraphs_.size() + retiredObjects_.size();
 }
 
 YSE::pHandle* patcherImplementation::GetHandleFromList(unsigned int obj) {
@@ -585,16 +625,29 @@ void patcherImplementation::RebuildAndPublish() {
   const GraphState* old = active_.load(std::memory_order_relaxed);
   active_.store(next, std::memory_order_release);
   if (old != nullptr) {
+    std::scoped_lock lk(reclaimMtx_);
     retiredGraphs_.emplace_back(old, audioBlock_.load(std::memory_order_acquire));
   }
-  DrainRetired();
+  ScheduleReclaim();
 }
 
-void patcherImplementation::DrainRetired() {
-  const std::uint64_t now = audioBlock_.load(std::memory_order_acquire);
-  // Interim reclamation (issue #227 replaces this): a snapshot retired at block
-  // C is safe to free once the audio thread has started at least two later
-  // blocks, so no in-flight block can still hold it. Free graphs before the
+void patcherImplementation::ScheduleReclaim() {
+  if (shuttingDown_.load(std::memory_order_acquire)) return;
+  // One pending pass is enough: it drains everything currently safe. isQueued()
+  // covers both a job waiting in the ring and one mid-run, so either half of the
+  // ping-pong being live suppresses a duplicate enqueue.
+  if (reclaimJobs_[0].isQueued() || reclaimJobs_[1].isQueued()) return;
+  // A background job: never runs inline on the caller and never blocks the audio
+  // thread. If the pool is inactive the job is simply not queued; the retire
+  // lists then wait for the next edit or for the destructor's FreeAllRetired.
+  INTERNAL::Global().addSlowJob(&reclaimJobs_[0]);
+}
+
+bool patcherImplementation::ReclaimElapsed(std::uint64_t now) {
+  // A snapshot retired at block C is safe to free once the audio thread has
+  // started at least two later blocks: the last block that could still hold it
+  // finished its render before block C+2's counter bump, which this pass's
+  // acquire load of audioBlock_ synchronizes-with. Free graphs before the
   // objects they point into.
   for (std::size_t i = 0; i < retiredGraphs_.size();) {
     if (now >= retiredGraphs_[i].second + 2) {
@@ -611,6 +664,26 @@ void patcherImplementation::DrainRetired() {
     } else {
       ++i;
     }
+  }
+  return !retiredGraphs_.empty() || !retiredObjects_.empty();
+}
+
+void patcherImplementation::RunReclaimPass(reclaimJob* next) {
+  bool remaining;
+  bool advancing;
+  {
+    std::scoped_lock lk(reclaimMtx_);
+    const std::uint64_t now = audioBlock_.load(std::memory_order_acquire);
+    remaining = ReclaimElapsed(now);
+    // The epoch moved since the previous pass -> the audio thread is live and
+    // will keep crossing retirement thresholds, so it is worth another pass. A
+    // frozen epoch means the engine is paused/stopped (leftovers aren't being
+    // raced) or nothing new became safe; either way, stop.
+    advancing = (now != lastReclaimEpoch_);
+    lastReclaimEpoch_ = now;
+  }
+  if (remaining && advancing && !shuttingDown_.load(std::memory_order_acquire)) {
+    INTERNAL::Global().addSlowJob(next);
   }
 }
 

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -6,6 +6,7 @@
 #include "patcher.hpp"
 #include "graphState.h"
 #include "../utils/mpmcQueue.hpp"
+#include "../internal/threadPool.h"
 #include <atomic>
 #include <cstdint>
 #include <map>
@@ -57,6 +58,13 @@ namespace YSE {
       unsigned int Objects();
       YSE::pHandle* GetHandleFromList(unsigned int obj);
       YSE::pHandle* GetHandleFromID(unsigned int objID);
+
+      // Number of retired GraphStates + objects still awaiting background
+      // reclamation (issue #227). Diagnostics / tests only: takes reclaimMtx_,
+      // so control-thread only. A value that stays small across many edits shows
+      // the background pool is draining retired state rather than letting it pile
+      // up until teardown.
+      std::size_t PendingRetired();
 
       std::vector<YSE::DSP::buffer> output;
 
@@ -134,11 +142,47 @@ namespace YSE {
       // Stamp lifetime-stable graph ids on a newly added object's inlets/outlets.
       void AssignGraphIds(pObject* obj);
       // Build the next GraphState, publish it with one atomic swap, retire the
-      // previous one, and reclaim anything the audio thread has moved past.
+      // previous one, and schedule background reclamation.
       void RebuildAndPublish();
-      // Free retired GraphStates/objects the audio thread can no longer be
-      // using (interim reclamation; the real epoch scheme is issue #227).
-      void DrainRetired();
+
+      // ---- Epoch reclamation on the background pool (issue #227) ----
+      //
+      // A retired GraphState (or object removed by Delete/Clear) can still be
+      // referenced by an audio block in flight, so it must be freed neither on
+      // the audio thread nor on the control thread the instant it is retired.
+      // Instead it is parked, tagged with the block count at retirement, and
+      // freed on the background pool once the audio thread has provably advanced
+      // two blocks past that epoch — at which point no in-flight Calculate can
+      // still hold it (the `+2` grace is proven in the .cpp). The audio thread
+      // only bumps audioBlock_; it never allocates, frees, or waits.
+      struct reclaimJob : INTERNAL::threadPoolJob {
+        patcherImplementation* owner = nullptr;
+        // The other half of a ping-pong pair. A threadPoolJob cannot re-enqueue
+        // *itself* from inside run() (activate() clears its queued/done flags
+        // after run() returns, which would swallow the re-enqueue), so a pass
+        // that still has work hands off to its sibling instead.
+        reclaimJob* sibling = nullptr;
+        void run() override {
+          owner->RunReclaimPass(sibling);
+        }
+      };
+
+      // Free every retired item whose grace period has elapsed relative to
+      // `now`; returns true if any retired items are still pending. Frees graphs
+      // before objects — a graph holds inlet* into the objects, and an object is
+      // always tagged at an epoch >= the graph that last referenced it, so any
+      // graph still pointing into an object freed here is freed in the same pass.
+      // Caller holds reclaimMtx_.
+      bool ReclaimElapsed(std::uint64_t now);
+      // Background-pool body: drain what is safe now and, while the audio epoch
+      // keeps advancing and items remain, hand off to `next` so the final edit's
+      // items are reclaimed without waiting for another edit. A stalled epoch
+      // (engine paused/stopped) ends the chain — leftovers aren't being raced
+      // and are freed at the next edit or at teardown.
+      void RunReclaimPass(reclaimJob* next);
+      // Control thread: enqueue a reclaim pass on the background pool unless one
+      // is already pending or the patcher is being torn down. Coalesced.
+      void ScheduleReclaim();
       // Unconditionally free everything retired plus the active graph. Called
       // from the destructor, where the audio thread is already stopped.
       void FreeAllRetired();
@@ -154,13 +198,28 @@ namespace YSE {
       // Snapshot pinned for the duration of the block being rendered. Written
       // by the audio thread at the start/end of Calculate.
       std::atomic<const GraphState*> currentBlockGraph_{nullptr};
-      // Monotonic count of rendered blocks, used by the interim reclaimer to
+      // Monotonic count of rendered blocks; the reclaimer reads it (acquire) to
       // tell when the audio thread has advanced past a retired snapshot.
       std::atomic<std::uint64_t> audioBlock_{0};
+
       // Retired snapshots / deleted objects awaiting reclamation, tagged with
-      // the block count at retirement. Control-thread only, guarded by mtx.
+      // the block count at retirement. Produced by the control thread and drained
+      // by the background pool, so guarded by reclaimMtx_ (never taken on the
+      // audio thread). reclaimMtx_ is an inner lock: an edit already holding mtx
+      // may take it, but the background reclaimer takes only reclaimMtx_.
+      std::mutex reclaimMtx_;
       std::vector<std::pair<const GraphState*, std::uint64_t>> retiredGraphs_;
       std::vector<std::pair<pObject*, std::uint64_t>> retiredObjects_;
+      // Two-element ping-pong so a reclaim pass that still has work can re-arm
+      // without re-enqueuing itself (see reclaimJob). Wired up in the ctor.
+      reclaimJob reclaimJobs_[2];
+      // Epoch observed by the previous reclaim pass; a pass re-arms only when the
+      // epoch has moved since, so a stalled audio thread can't spin the pool.
+      // Guarded by reclaimMtx_.
+      std::uint64_t lastReclaimEpoch_ = 0;
+      // Set once at teardown to stop scheduling and re-arming reclaim passes so
+      // the destructor's joins terminate. Read on the background pool.
+      std::atomic<bool> shuttingDown_{false};
       // Per-patcher dense id counters for inlets / outlets. Never reused, so
       // ids stay stable across edits.
       int nextInletId_ = 0;

--- a/docs/design/patcher_graphstate.md
+++ b/docs/design/patcher_graphstate.md
@@ -248,6 +248,23 @@ demonstrably loaded a newer pointer). This is correct but not optimal;
 under the same rule, so a deleted object outlives any block that could
 still touch it.
 
+> **Update ([#227][gh-227], landed):** the interim now runs on the
+> background pool instead of the control thread. Each structural edit
+> parks retired snapshots/objects (tagged with `audioBlock_`) under a
+> dedicated `reclaimMtx_` and schedules a `reclaimJob` on
+> `INTERNAL::threadPool` (`poolClass::background`). The job frees anything
+> the audio thread has advanced two blocks past — the same `+2` epoch
+> rule, now observed with an `acquire` load so the free happens-after the
+> last render that could touch it — and, while the epoch keeps advancing
+> and work remains, hands off to a sibling job (a `threadPoolJob` cannot
+> re-enqueue itself from inside `run()`) so the final edit's items are
+> reclaimed without waiting for another edit. A stalled epoch (paused
+> engine) ends the chain; leftovers are freed at the next edit or at
+> teardown (`FreeAllRetired`). The audio thread still only bumps
+> `audioBlock_` — no allocation, free, or wait. Objects are tagged only
+> *after* their covering graph is retired, so an object is never freed
+> while a retired graph still points into it.
+
 ## Scope of #226
 
 **In scope:**


### PR DESCRIPTION
## Summary

Replaces #226's interim control-thread reclamation with epoch reclamation on the **background pool** (`INTERNAL::threadPool`, `poolClass::background`), so retired `GraphState`s and deleted patcher objects are freed off both the audio and control threads once the audio thread has provably advanced past them.

Part of epic #189; depends on the merged #226 (`GraphState`/atomic-publish).

## Linked issue

Closes #227

## Changes

- **Background reclamation.** Each structural edit parks the retired snapshot/object (tagged with `audioBlock_`) under a dedicated `reclaimMtx_` (taken only by the control and background threads — never the audio thread) and schedules a `reclaimJob` on the background pool. The job frees anything the audio thread has advanced **two blocks** past — the same proven `+2` epoch rule from #226, now read with an `acquire` load so the free *happens-after* the last render that could still touch it.
- **Self-reschedule.** While the epoch keeps advancing and work remains, the pass hands off to a **sibling** job so the final edit's items are reclaimed without waiting for another edit. A `threadPoolJob` can't re-enqueue *itself* from inside `run()` (`activate()` clears its queued/done flags after `run()` returns), hence the ping-pong pair. A stalled epoch (paused/stopped engine — nothing is racing the leftovers) ends the chain; anything left is freed at the next edit or at teardown (`FreeAllRetired`).
- **Audio thread unchanged.** It still only bumps `audioBlock_` — no allocation, free, or wait on the callback path.
- **Latent ordering fix.** `Clear()` tagged removed objects *before* retiring their covering graph, so an object could be freed while a not-yet-safe retired graph still pointed into it. Objects are now tagged only *after* `RebuildAndPublish`, guaranteeing `object.epoch >= covering graph.epoch`; combined with the graphs-first drain, no retired graph ever outlives an object it references.
- **Diagnostics.** `PendingRetired()` exposes the retire-list depth for tests.
- **Docs.** Update note added to `docs/design/patcher_graphstate.md`'s reclamation section.

## Test plan

- [x] `yse.py format` clean
- [x] `yse.py analyze YseEngine/patcher/patcherImplementation.cpp` clean (49 warnings, all suppressed as non-user-code / baseline filters — no new user findings)
- [x] Unit tests pass — all 16 suites (`yse.py test`), including two new regression tests:
  - `reclaim: deleting a source leaves its former sink usable` — the retired object's `~inlet`/`~outlet` must touch only the retired wiring (cleared by `UnwireFromPeers`), never the live peer; proven by wiring a fresh source into the surviving DAC after the delete.
  - `reclaim: the background pool drains retired snapshots, not the dtor` — 400+ retired snapshots over a churn loop must drop to `PendingRetired() <= 4` (they reach 0), which would stay ~400 if reclamation never ran.
- [ ] **TSan/ASan not run locally.** Windows ASan ships no leak detector (the ASan preset is Linux-gated), and #227's acceptance explicitly defers concurrency verification under TSan/ASan to the stress-test sub-issue **#229**. The new churn test does exercise the background reclaimer concurrently with edits/renders on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)