### PR TITLE
FIX: retire fileHandlerActive; build patcher file handlers under one lock (#228)

### DIFF
--- a/Tests/patcher/test_patcher_graphstate.cpp
+++ b/Tests/patcher/test_patcher_graphstate.cpp
@@ -173,4 +173,48 @@ TEST_SUITE("patcher") {
     CHECK_FALSE(dst.output[0].isSilent());
   }
 
+  // ---- Off-thread file handlers / retired fileHandlerActive (issue #228) ----
+
+  TEST_CASE("filehandlers: ParseJSON publishes exactly one graph for the whole file") {
+    // The parse builds every object + connection under one lock and swaps once.
+    // On a fresh patcher active_ starts null, so a correct single publish retires
+    // nothing. If the per-edit publish had crept back (the old fileHandlerActive
+    // batching lost), each CreateObject/Connect would retire an intermediate
+    // graph and PendingRetired() would climb with the object/edge count.
+    patcherImplementation src(1, nullptr);
+    src.Connect(src.CreateObject(YSE::OBJ::D_NOISE, ""), 0, src.CreateObject(YSE::OBJ::D_DAC, ""),
+                0);
+    std::string dump = src.DumpJSON();
+
+    patcherImplementation dst(1, nullptr);
+    dst.ParseJSON(dump);
+    CHECK(dst.PendingRetired() == 0);
+    dst.Calculate(YSE::T_DSP);
+    CHECK_FALSE(dst.output[0].isSilent());
+  }
+
+  TEST_CASE("filehandlers: Clear silences the next block and is reclaim-safe") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    p.Connect(noise, 0, dac, 0);
+    p.Calculate(YSE::T_DSP);
+    REQUIRE_FALSE(p.output[0].isSilent());
+
+    // Clearing a rendering patcher publishes an empty graph and retires the old
+    // objects; a block that ran the retired snapshot must not touch freed memory
+    // (an ASan build would trip). The next block renders silence.
+    p.Clear();
+    p.Calculate(YSE::T_DSP);
+    CHECK(p.output[0].isSilent());
+
+    // The patcher is reusable after a clear: re-parse a fresh graph into it.
+    patcherImplementation src(1, nullptr);
+    src.Connect(src.CreateObject(YSE::OBJ::D_NOISE, ""), 0, src.CreateObject(YSE::OBJ::D_DAC, ""),
+                0);
+    p.ParseJSON(src.DumpJSON());
+    p.Calculate(YSE::T_DSP);
+    CHECK_FALSE(p.output[0].isSilent());
+  }
+
 } // TEST_SUITE("patcher")

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -34,7 +34,6 @@ patcherImplementation::patcherImplementation(int mainOutputs, YSE::patcher* head
   : pObject(false),
     controlledBySound(false),
     head(head),
-    fileHandlerActive(false),
     patcherName("patcher_" +
                 std::to_string(g_nextPatcherIndex.fetch_add(1, std::memory_order_relaxed))) {
   output.resize(mainOutputs);
@@ -155,8 +154,8 @@ void patcherImplementation::ResetDSP() {
   }
 }
 
-void patcherImplementation::Connect(YSE::pHandle* from, int outlet, YSE::pHandle* to, int inlet) {
-  if (!fileHandlerActive) mtx.lock();
+void patcherImplementation::ConnectUnlocked(YSE::pHandle* from, int outlet, YSE::pHandle* to,
+                                            int inlet) {
   PATCHER::outlet* out = from->object->GetOutlet(outlet);
   PATCHER::inlet* in = to->object->GetInlet(inlet);
   if (out != nullptr && in != nullptr) {
@@ -165,26 +164,23 @@ void patcherImplementation::Connect(YSE::pHandle* from, int outlet, YSE::pHandle
   } else {
     INTERNAL::LogImpl().emit(E_ERROR, "Patcher: Invalid Connection");
   }
-  // In batch mode (ParseJSON) publish once at the end; otherwise swap now.
-  if (!fileHandlerActive) {
-    RebuildAndPublish();
-    mtx.unlock();
-  }
+}
+
+void patcherImplementation::Connect(YSE::pHandle* from, int outlet, YSE::pHandle* to, int inlet) {
+  std::scoped_lock lk(mtx);
+  ConnectUnlocked(from, outlet, to, inlet);
+  RebuildAndPublish();
 }
 
 void patcherImplementation::Disconnect(YSE::pHandle* from, int outlet, YSE::pHandle* to,
                                        int inlet) {
-  if (!fileHandlerActive) mtx.lock();
+  std::scoped_lock lk(mtx);
   to->object->DisconnectInlet(from->object->GetOutlet(outlet), inlet);
-  if (!fileHandlerActive) {
-    RebuildAndPublish();
-    mtx.unlock();
-  }
+  RebuildAndPublish();
 }
 
-YSE::pHandle* patcherImplementation::CreateObject(const std::string& type,
-                                                  const std::string& args) {
-  YSE::pHandle* handle = nullptr;
+YSE::pHandle* patcherImplementation::CreateObjectUnlocked(const std::string& type,
+                                                          const std::string& args) {
   pObject* object = nullptr;
   INTERNAL::LogImpl().emit(E_DEBUG, "Patcher: Trying to create " + type);
 
@@ -207,21 +203,23 @@ YSE::pHandle* patcherImplementation::CreateObject(const std::string& type,
     return nullptr;
   }
 
-  handle = new YSE::pHandle(object);
-
-  if (!fileHandlerActive) mtx.lock();
+  YSE::pHandle* handle = new YSE::pHandle(object);
   objects.insert(std::pair<YSE::pHandle*, pObject*>(handle, object));
   AssignGraphIds(object);
-  if (!fileHandlerActive) {
-    RebuildAndPublish();
-    mtx.unlock();
-  }
   INTERNAL::LogImpl().emit(E_DEBUG, "Patcher: " + type + " created");
   return handle;
 }
 
+YSE::pHandle* patcherImplementation::CreateObject(const std::string& type,
+                                                  const std::string& args) {
+  std::scoped_lock lk(mtx);
+  YSE::pHandle* handle = CreateObjectUnlocked(type, args);
+  if (handle != nullptr) RebuildAndPublish();
+  return handle;
+}
+
 void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
-  if (!fileHandlerActive) mtx.lock();
+  std::scoped_lock lk(mtx);
 
   if (handle->Type() == OBJ::G_METRO) {
     handle->object->GetInlet(0)->SetInt(0, YSE::THREAD::T_GUI);
@@ -233,23 +231,21 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
   // not free it yet — an in-flight audio block may still walk the retired
   // snapshot that references it. The free is deferred to the reclaimer.
   object->UnwireFromPeers();
-  if (!fileHandlerActive) RebuildAndPublish();
+  RebuildAndPublish();
   // Tag the object only after RebuildAndPublish has retired the graph that last
   // referenced it, so its epoch is >= that graph's — the graphs-first drain then
   // guarantees no retired graph outlives an object it points into.
   {
-    std::scoped_lock lk(reclaimMtx_);
+    std::scoped_lock rlk(reclaimMtx_);
     retiredObjects_.emplace_back(object, audioBlock_.load(std::memory_order_acquire));
   }
   ScheduleReclaim();
   // The handle is never referenced by a GraphState, so it can go immediately.
   delete handle;
-
-  if (!fileHandlerActive) mtx.unlock();
 }
 
 void patcherImplementation::Clear() {
-  if (!fileHandlerActive) mtx.lock();
+  std::scoped_lock lk(mtx);
 
   std::vector<pObject*> doomed;
   doomed.reserve(objects.size());
@@ -262,18 +258,17 @@ void patcherImplementation::Clear() {
     delete it->first; // handle: not referenced by a GraphState
   }
   objects.clear();
-  if (!fileHandlerActive) RebuildAndPublish();
+  RebuildAndPublish();
   // Tag the removed objects only after their covering graph has been retired by
   // RebuildAndPublish, so each object's epoch is >= that graph's (see the
   // graphs-first invariant in ReclaimElapsed).
   {
-    std::scoped_lock lk(reclaimMtx_);
+    std::scoped_lock rlk(reclaimMtx_);
     const std::uint64_t at = audioBlock_.load(std::memory_order_acquire);
     for (pObject* obj : doomed)
       retiredObjects_.emplace_back(obj, at);
   }
   ScheduleReclaim();
-  if (!fileHandlerActive) mtx.unlock();
 }
 
 using json = nlohmann::json;
@@ -281,15 +276,16 @@ std::string patcherImplementation::DumpJSON() {
   json j;
   int counter = 0;
 
-  mtx.lock();
-  fileHandlerActive = true;
-  for (const auto& any : objects) {
-    std::string name = "object " + std::to_string(counter);
-    any.second->DumpJson(j[name]);
-    counter++;
+  // Read a consistent object set under mtx. mtx is control-thread only (issue
+  // #226), so serialising here never blocks the audio callback.
+  {
+    std::scoped_lock lk(mtx);
+    for (const auto& any : objects) {
+      std::string name = "object " + std::to_string(counter);
+      any.second->DumpJson(j[name]);
+      counter++;
+    }
   }
-  fileHandlerActive = false;
-  mtx.unlock();
 
   std::string result = j.dump(2, ' ', true);
   return result;
@@ -300,13 +296,18 @@ void patcherImplementation::ParseJSON(const std::string& content) {
 
   std::map<int, pHandle*> OldIDs;
 
-  mtx.lock();
-  fileHandlerActive = true;
+  // Build the whole parsed graph under one lock and publish it with a single
+  // atomic swap at the end (issue #228): the audio thread never sees a
+  // partial graph — it keeps rendering the previously-published snapshot until
+  // RebuildAndPublish below installs the finished one. The *Unlocked cores do
+  // the create/connect work without re-taking mtx or publishing per edit, which
+  // is what let the old fileHandlerActive re-entrancy flag be retired.
+  std::scoped_lock lk(mtx);
   // restore objects first
   for (auto obj = j.begin(); obj != j.end(); ++obj) {
     std::string type = obj.value()["type"].get<std::string>();
     std::string args = obj.value()["parms"].get<std::string>();
-    pHandle* handle = CreateObject(type, args);
+    pHandle* handle = CreateObjectUnlocked(type, args);
 
     // handle can be null if called without gui context
     if (handle != nullptr) {
@@ -351,17 +352,16 @@ void patcherImplementation::ParseJSON(const std::string& content) {
         }
 
         if (targetHandle != nullptr && sourceHandle != nullptr) {
-          Connect(sourceHandle, outlet, targetHandle, inlet);
+          ConnectUnlocked(sourceHandle, outlet, targetHandle, inlet);
         }
       }
       outlet++;
     }
   }
-  fileHandlerActive = false;
-  // Every create/connect above ran in batch mode (no per-edit swap); publish
-  // the whole parsed graph in a single atomic swap now.
+  // Every create/connect above mutated only the freshly-built objects (never
+  // referenced by the still-active snapshot); publish the whole parsed graph in
+  // a single atomic swap now.
   RebuildAndPublish();
-  mtx.unlock();
 }
 
 unsigned int patcherImplementation::Objects() {

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -136,6 +136,14 @@ namespace YSE {
       // when there is genuinely no in-patcher target).
       bool EnqueueValue(ValueMsg& msg, const std::string& to);
 
+      // Unlocked cores of CreateObject / Connect: do the structural mutation
+      // assuming mtx is already held and publish nothing. The public wrappers
+      // lock and publish once; ParseJSON drives these directly so an entire
+      // parsed graph is built under one lock and swapped in with a single
+      // publish (this is why no per-op re-entrancy flag is needed — issue #228).
+      pHandle* CreateObjectUnlocked(const std::string& type, const std::string& args);
+      void ConnectUnlocked(pHandle* from, int outlet, pHandle* to, int inlet);
+
       // Compile the current object wiring into a fresh immutable GraphState.
       // Control-thread only (allocates). See graphState.h.
       GraphState* BuildGraph();
@@ -188,7 +196,6 @@ namespace YSE {
       void FreeAllRetired();
 
       std::mutex mtx;
-      bool fileHandlerActive;
       std::map<pHandle*, pObject*> objects;
       oscHandler* oscHandle = nullptr;
 


### PR DESCRIPTION
## Summary

Completes the patcher wait-free epic (#189) sub-issue #228. Its three
dependencies — #225 (SPSC value queue), #226 (GraphState atomic publish),
#227 (background reclamation) — are already merged.

Since #226 moved the audio thread off `mtx` (`Calculate` now reads topology
through one atomic `GraphState` load), the file-handler paths
`ParseJSON`/`DumpJSON`/`Clear`/`SetName` **no longer block the callback**.
The remaining deliverable of #228 is the hygiene half: retiring the
`fileHandlerActive` re-entrancy hack that suppressed per-op locking/publishing
while `ParseJSON` held `mtx` and called `CreateObject`/`Connect` in a loop.

## Linked issue

Closes #228

## Changes

- Replace `fileHandlerActive` with the standard public-wrapper /
  private-unlocked-core split:
  - `CreateObjectUnlocked` / `ConnectUnlocked` do the structural mutation
    assuming `mtx` is held and publish nothing.
  - Public `CreateObject` / `Connect` / `Disconnect` / `DeleteObject` /
    `Clear` take `mtx` via `std::scoped_lock` and `RebuildAndPublish` once.
  - `ParseJSON` locks once, drives the `*Unlocked` cores in a loop, and swaps
    the whole parsed graph in with a single publish at the end — unchanged
    single-swap behaviour; the audio thread only ever sees the finished graph.
  - `DumpJSON` reads the object set under the control-only `mtx` (never blocks
    the callback).
- Remove the `fileHandlerActive` member from the header.
- `SetName` is unchanged (already correct; its #122/#187 rename behaviour is
  covered by the existing bus tests).

No topology or behaviour change. TSan/ASan concurrency stress is the separate
epic acceptance gate (#229).

## Test plan

- [x] `python yse.py format` clean (only the 3 touched files)
- [x] `python yse.py analyze YseEngine/patcher/patcherImplementation.cpp` — no new findings (49 warnings all suppressed by the baseline / non-user-code)
- [x] unit tests pass — `python yse.py test`, 16/16 binaries; patcher suite includes two new #228 regressions (ParseJSON publishes exactly one graph for the whole file; Clear silences the next block and stays reclaim-safe)
- [x] no new integration test: engine-internal RT/lifecycle code with no user-visible UI flow, exercised directly through `Calculate` (the audio-thread entry) in the doctest suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)