### PR TITLE
FIX: refuse one-sided outlet edges so no GraphState holds a freed inlet (#237)

### DIFF
--- a/Tests/patcher/test_patcher_graphstate.cpp
+++ b/Tests/patcher/test_patcher_graphstate.cpp
@@ -193,6 +193,60 @@ TEST_SUITE("patcher") {
     CHECK_FALSE(dst.output[0].isSilent());
   }
 
+  // ---- One-sided edges from refused connections (issue #237) ----
+
+  TEST_CASE("connect: a refused buffer connection leaves no one-sided outlet edge") {
+    // An inlet holds at most one buffer source (dspConnection is a single
+    // slot), so a second buffer connection into the same inlet is refused on
+    // the inlet side. The outlet must not record the edge in that case: a
+    // one-sided outlet->inlet edge is invisible to Disconnect and
+    // UnwireFromPeers (both clean up from the inlet's records), so it gets
+    // compiled into every GraphState built after the target object is deleted
+    // and the audio thread walks a freed inlet through the *live* snapshot —
+    // the #237 use-after-free.
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noiseA = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* noiseB = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* sw = p.CreateObject(YSE::OBJ::G_SWITCH, "3");
+
+    p.Connect(noiseA, 0, sw, 0);
+    CHECK(noiseA->GetConnections(0) == 1);
+
+    // Second buffer source into the same inlet: refused by the inlet, so the
+    // outlet side must stay clean too.
+    p.Connect(noiseB, 0, sw, 0);
+    CHECK(noiseB->GetConnections(0) == 0);
+  }
+
+  TEST_CASE("connect: deleting the target of a refused connection leaves no dangling edge") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noiseA = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* noiseB = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* sw = p.CreateObject(YSE::OBJ::G_SWITCH, "3");
+    p.Connect(noiseA, 0, sw, 0);
+    p.Connect(noiseB, 0, sw, 0); // refused: inlet 0 already has a buffer source
+
+    p.DeleteObject(sw);
+    CHECK(noiseA->GetConnections(0) == 0);
+    CHECK(noiseB->GetConnections(0) == 0);
+
+    // Keep rendering while the background pool reclaims the deleted gSwitch.
+    // Both noises are start points, so every block resolves their outlet
+    // targets from the pinned snapshot; a leftover one-sided edge would make
+    // these blocks read the freed inlet (an ASan/TSan build trips here).
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    for (int spins = 0; spins < 2000 && p.PendingRetired() > 4; ++spins) {
+      p.Connect(noiseA, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      p.Disconnect(noiseA, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      p.Calculate(YSE::T_DSP);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    p.Calculate(YSE::T_DSP);
+    CHECK(p.output[0].isSilent());
+  }
+
   TEST_CASE("filehandlers: Clear silences the next block and is reclaim-safe") {
     patcherImplementation p(1, nullptr);
     YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");

--- a/YseEngine/patcher/pObject.cpp
+++ b/YseEngine/patcher/pObject.cpp
@@ -67,8 +67,8 @@ void pObject::SetParams(const std::string& args) {
   parms.Set(args);
 }
 
-void pObject::ConnectInlet(outlet* from, int inlet) {
-  inputs[inlet].Connect(from);
+bool pObject::ConnectInlet(outlet* from, int inlet) {
+  return inputs[inlet].Connect(from);
 }
 
 void pObject::DisconnectInlet(outlet* from, int inlet) {

--- a/YseEngine/patcher/pObject.h
+++ b/YseEngine/patcher/pObject.h
@@ -53,7 +53,13 @@ namespace YSE {
       void SetParams(const std::string& args);
       const std::string& GetParams();
 
-      void ConnectInlet(outlet* from, int toPin);
+      // Returns false when the inlet refuses the connection (it already has a
+      // buffer source, or the edge is a duplicate). The caller must not record
+      // the edge on the outlet side in that case: a one-sided outlet->inlet
+      // edge is invisible to Disconnect/UnwireFromPeers and ends up as a
+      // dangling inlet* in every GraphState built after the target object is
+      // deleted (issue #237).
+      bool ConnectInlet(outlet* from, int toPin);
       void DisconnectInlet(outlet* from, int toPin);
 
       virtual void ConnectOutlet(inlet* dest, int toPin);

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -159,8 +159,19 @@ void patcherImplementation::ConnectUnlocked(YSE::pHandle* from, int outlet, YSE:
   PATCHER::outlet* out = from->object->GetOutlet(outlet);
   PATCHER::inlet* in = to->object->GetInlet(inlet);
   if (out != nullptr && in != nullptr) {
-    from->object->ConnectOutlet(in, outlet);
-    to->object->ConnectInlet(out, inlet);
+    // Ask the inlet first: it refuses a second buffer source (and duplicate
+    // edges). Only record the edge on the outlet when the inlet accepted it —
+    // a one-sided outlet->inlet edge survives Disconnect/UnwireFromPeers (both
+    // clean up from the inlet's records) and gets compiled into every later
+    // GraphState, so once the target object is deleted and reclaimed the audio
+    // thread reads a freed inlet through the *live* snapshot (issue #237).
+    if (to->object->ConnectInlet(out, inlet)) {
+      from->object->ConnectOutlet(in, outlet);
+    } else {
+      INTERNAL::LogImpl().emit(E_ERROR,
+                               "Patcher: connection refused (duplicate edge or inlet already has "
+                               "a buffer source)");
+    }
   } else {
     INTERNAL::LogImpl().emit(E_ERROR, "Patcher: Invalid Connection");
   }


### PR DESCRIPTION
## Summary
Root-causes and fixes the #237 TSan use-after-free between the background reclaimer and the audio thread. The `+2` epoch grace from #227 is **sound** — the racing pointer was never in a retired snapshot. The real bug: `ConnectUnlocked` recorded every edge on the outlet side unconditionally, while `inlet::Connect` refuses a second buffer source (`dspConnection` is a single slot). The refused edge survived only in `outlet::connections`, invisible to `Disconnect`/`UnwireFromPeers` (both driven from the inlet's records), so `BuildGraph` compiled the stale `inlet*` into every later GraphState — including the **live** one. Once `DeleteObject` retired the target and the reclaimer freed it after the grace, every subsequent audio block walked the freed inlet through the current snapshot. That's why it reproduced 5/5 deterministically and why the #229 harness (random `outlet 0 → inlet 0` wiring) hits it constantly.

## Linked issue
Closes #237

Unblocks #229 (the concurrency acceptance gate is TSan/ASan-clean with this fix; verified locally against the harness branch).

## Changes
- `pObject::ConnectInlet` returns the inlet's verdict (bool) instead of swallowing it.
- `ConnectUnlocked` is transactional: the inlet is asked first; the outlet only records the edge when the inlet accepted it. Refusals (duplicate edge or occupied buffer slot) are logged. `ParseJSON` inherits the behavior via the shared unlocked core.
- Two regression tests in `test_patcher_graphstate.cpp` — single-threaded and deterministic, so they bite without sanitizers: a refused buffer connection must leave the outlet side clean, and deleting the target of a refused connection must leave no dangling edge while the reclaimer frees it under rendering.

No reclamation-code changes: the #227 epoch/happens-before design was worked through in detail — reads through retired snapshots are covered up to `now − 1` by the release sequence on `audioBlock_`, so the `+2` grace holds.

## Test plan
- [x] Regression tests fail on unpatched code (2 assertions) and pass with the fix
- [x] Full Windows suite: 16/16 test binaries pass (`python yse.py test`)
- [x] clang-tidy clean on all changed files (`python yse.py analyze <file>`); `yse.py format` clean
- [x] Acceptance harness (#229 branch merged into a throwaway branch, `tools/ci-linux` Docker image): **TSan clean 5/5, ASan clean** — vs 5/5 TSan failures pre-fix
- [x] No separate integration test: no user-visible surface outside the engine; the #229 stress harness is the end-to-end gate for this path and it is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)