### PR TITLE
FIX: make live pHandle::SetParams RT-safe — deferred scalar apply + replacement rebuild (#234)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(YSE_TEST_SOURCES
   patcher/test_c_api_metadata.cpp
   patcher/test_patcher_bus.cpp
   patcher/test_patcher_graphstate.cpp
+  patcher/test_patcher_setparams.cpp
   patcher/test_patcher_value_queue.cpp
   patcher/test_timerthread.cpp
   channel/test_channel.cpp
@@ -303,6 +304,7 @@ set_source_files_properties(
   patcher/test_c_api_metadata.cpp
   patcher/test_patcher_bus.cpp
   patcher/test_patcher_graphstate.cpp
+  patcher/test_patcher_setparams.cpp
   patcher/test_patcher_value_queue.cpp
   patcher/test_timerthread.cpp
   PROPERTIES COMPILE_FLAGS "${_patcher_test_suppress}"

--- a/Tests/patcher/test_patcher_setparams.cpp
+++ b/Tests/patcher/test_patcher_setparams.cpp
@@ -1,0 +1,302 @@
+// Regression tests for RT-safe live SetParams (issue #234).
+//
+// Before this change, pHandle::SetParams re-parsed a live object's params in
+// place on the control thread — writing scalar fields through void* and
+// letting PARM_PARSE grow/shrink the very inputs/outputs vectors the audio
+// thread indexes while rendering the pinned snapshot (a reallocation UAF).
+//
+// Now (see docs/design/patcher_live_params.md):
+//  - scalar params are pre-parsed into a POD plan and applied by the audio
+//    thread at the top of the next Calculate (deferred, allocation-free);
+//  - pin-count / string re-parses build a replacement object off the live
+//    path and publish it with the usual GraphState swap, preserving handle
+//    identity, storage ID, GUI properties, and surviving connections.
+//
+// These tests drive patcherImplementation directly (Calculate is the
+// audio-thread entry point). No audio device required.
+
+#include <doctest/doctest.h>
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include "patcher/patcherImplementation.h"
+#include "patcher/pHandle.hpp"
+#include "patcher/pObjectList.hpp"
+#include "sinks.hpp"
+
+using TestHelpers::MultiSink;
+using YSE::PATCHER::patcherImplementation;
+
+TEST_SUITE("patcher") {
+
+  // ---- Scalar path: deferred apply on the audio thread ----
+
+  TEST_CASE("setparams: scalar params defer to the next Calculate") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* f = p.CreateObject(YSE::OBJ::G_FLOAT, "1.5");
+    REQUIRE(f != nullptr);
+    CHECK(std::stof(f->GetGuiValue()) == doctest::Approx(1.5f));
+
+    // The stored param string updates eagerly (GetParams/DumpJSON coherence),
+    // but the live field must not move until the audio thread applies it.
+    f->SetParams("42.5");
+    CHECK(f->GetParams() == "42.5");
+    CHECK(std::stof(f->GetGuiValue()) == doctest::Approx(1.5f));
+
+    p.Calculate(YSE::T_DSP);
+    CHECK(std::stof(f->GetGuiValue()) == doctest::Approx(42.5f));
+  }
+
+  TEST_CASE("setparams: a scalar re-parse does not republish or retire anything") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* sine = p.CreateObject(YSE::OBJ::D_SINE, "440");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    p.Connect(sine, 0, dac, 0);
+    p.Calculate(YSE::T_DSP);
+    REQUIRE_FALSE(p.output[0].isSilent());
+
+    // Scalar params ride the queue; no GraphState is rebuilt and no object is
+    // replaced, so the retire lists must not grow — that is the observable
+    // difference from the structural path (and it is why in-flight DSP state
+    // survives a frequency tweak).
+    const std::size_t retiredBefore = p.PendingRetired();
+    const unsigned int idBefore = sine->GetID();
+    sine->SetParams("880");
+    CHECK(p.PendingRetired() == retiredBefore);
+    CHECK(sine->GetID() == idBefore);
+    CHECK(sine->GetParams() == "880");
+
+    p.Calculate(YSE::T_DSP);
+    CHECK_FALSE(p.output[0].isSilent());
+  }
+
+  TEST_CASE("setparams: a queued scalar plan for a deleted object is dropped safely") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* f = p.CreateObject(YSE::OBJ::G_FLOAT, "0");
+    REQUIRE(f != nullptr);
+
+    // Enqueue, then delete before the audio thread drains. The plan's target
+    // is absent from the pinned snapshot, so the ops must be dropped without
+    // touching the retired object (an ASan build trips otherwise).
+    f->SetParams("7");
+    p.DeleteObject(f);
+    p.Calculate(YSE::T_DSP);
+    p.Calculate(YSE::T_DSP);
+  }
+
+  TEST_CASE("setparams: empty args are a no-op on the scalar path") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* f = p.CreateObject(YSE::OBJ::G_FLOAT, "3");
+    f->SetParams("");
+    p.Calculate(YSE::T_DSP);
+    CHECK(f->GetParams() == "3");
+    CHECK(std::stof(f->GetGuiValue()) == doctest::Approx(3.f));
+  }
+
+  // ---- Structural path: replacement object + swap ----
+
+  TEST_CASE("setparams: gGate pin growth keeps identity and surviving connections") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* gate = p.CreateObject(YSE::OBJ::G_GATE, "2");
+    REQUIRE(gate != nullptr);
+    REQUIRE(gate->GetOutputs() == 2);
+
+    MultiSink sinkA, sinkB;
+    YSE::pHandle hA(&sinkA), hB(&sinkB);
+    p.Connect(gate, 0, &hA, 0);
+    p.Connect(gate, 1, &hB, 0);
+
+    const unsigned int idBefore = gate->GetID();
+    gate->SetParams("4");
+
+    // The re-parse is structural: visible immediately, same handle, same
+    // storage ID, params updated, both wired outlets preserved.
+    CHECK(gate->GetOutputs() == 4);
+    CHECK(gate->GetID() == idBefore);
+    CHECK(gate->GetParams() == "4");
+    CHECK(gate->GetConnections(0) == 1);
+    CHECK(gate->GetConnections(1) == 1);
+
+    // The replacement routes like a freshly created gGate: select outlet 1,
+    // send a value, and the preserved edge must deliver it.
+    gate->SetIntData(0, 1);
+    gate->SetIntData(1, 99);
+    CHECK(sinkA.gotInt);
+    CHECK(sinkA.intValue == 99);
+    CHECK_FALSE(sinkB.gotInt);
+
+    gate->SetIntData(0, 2);
+    gate->SetIntData(1, 55);
+    CHECK(sinkB.gotInt);
+    CHECK(sinkB.intValue == 55);
+  }
+
+  TEST_CASE("setparams: gGate pin shrink drops the removed outlets' edges") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* gate = p.CreateObject(YSE::OBJ::G_GATE, "4");
+    REQUIRE(gate->GetOutputs() == 4);
+
+    MultiSink sinkKept, sinkDropped;
+    YSE::pHandle hKept(&sinkKept), hDropped(&sinkDropped);
+    p.Connect(gate, 0, &hKept, 0);
+    p.Connect(gate, 3, &hDropped, 0);
+
+    gate->SetParams("2");
+    CHECK(gate->GetOutputs() == 2);
+    CHECK(gate->GetConnections(0) == 1);
+
+    gate->SetIntData(0, 1);
+    gate->SetIntData(1, 12);
+    CHECK(sinkKept.gotInt);
+    CHECK_FALSE(sinkDropped.gotInt);
+    p.Calculate(YSE::T_DSP);
+  }
+
+  TEST_CASE("setparams: gSwitch inlet growth preserves incoming edges") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* sw = p.CreateObject(YSE::OBJ::G_SWITCH, "2");
+    REQUIRE(sw->GetInputs() == 3); // selector + 2 value inlets
+    p.Connect(noise, 0, sw, 0);
+    REQUIRE(noise->GetConnections(0) == 1);
+
+    sw->SetParams("4");
+    CHECK(sw->GetInputs() == 5);
+    // The buffer edge into the surviving inlet was rewired onto the
+    // replacement — the source outlet still has exactly one live target.
+    CHECK(noise->GetConnections(0) == 1);
+    p.Calculate(YSE::T_DSP);
+  }
+
+  TEST_CASE("setparams: gRoute list re-parse rebuilds the outlet set") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* route = p.CreateObject(YSE::OBJ::G_ROUTE, "a b");
+    REQUIRE(route->GetOutputs() == 3); // one per token + fall-through
+
+    route->SetParams("x y z");
+    CHECK(route->GetOutputs() == 4);
+    CHECK(route->GetParams() == "x y z");
+  }
+
+  TEST_CASE("setparams: gReceive dataName re-parse redirects value delivery") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* recv = p.CreateObject(YSE::OBJ::G_RECEIVE, "alpha");
+    MultiSink sink;
+    YSE::pHandle hSink(&sink);
+    p.Connect(recv, 0, &hSink, 0);
+
+    CHECK(p.PassData(1, "alpha", YSE::T_GUI));
+    p.Calculate(YSE::T_DSP);
+    CHECK(sink.intValue == 1);
+
+    // Replacing the receiver re-registers it under the new name; the outlet
+    // connection to the sink survives the swap.
+    recv->SetParams("beta 0");
+    CHECK_FALSE(p.PassData(2, "alpha", YSE::T_GUI));
+    CHECK(p.PassData(3, "beta", YSE::T_GUI));
+    p.Calculate(YSE::T_DSP);
+    CHECK(sink.intValue == 3);
+  }
+
+  TEST_CASE("setparams: DumpJSON round-trips a live re-parse") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* gate = p.CreateObject(YSE::OBJ::G_GATE, "2");
+    YSE::pHandle* sine = p.CreateObject(YSE::OBJ::D_SINE, "440");
+    gate->SetParams("4");
+    sine->SetParams("880");
+
+    patcherImplementation copy(1, nullptr);
+    copy.ParseJSON(p.DumpJSON());
+    REQUIRE(copy.Objects() == 2);
+    for (unsigned int i = 0; i < copy.Objects(); i++) {
+      YSE::pHandle* h = copy.GetHandleFromList(i);
+      if (std::string(h->Type()) == YSE::OBJ::G_GATE) {
+        CHECK(h->GetParams() == "4");
+        CHECK(h->GetOutputs() == 4);
+      } else {
+        CHECK(h->GetParams() == "880");
+      }
+    }
+  }
+
+  TEST_CASE("setparams: replacements retire through the background pool") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* gate = p.CreateObject(YSE::OBJ::G_GATE, "2");
+
+    for (int i = 0; i < 50; ++i) {
+      gate->SetParams(i % 2 == 0 ? "3" : "2");
+      p.Calculate(YSE::T_DSP);
+    }
+
+    // Same drain pattern as the #227 reclaim test: keep the epoch moving so
+    // the pool can cross the +2 grace for the retired objects and graphs.
+    for (int spins = 0; spins < 2000 && p.PendingRetired() > 4; ++spins) {
+      gate->SetParams(spins % 2 == 0 ? "3" : "2");
+      p.Calculate(YSE::T_DSP);
+      p.Calculate(YSE::T_DSP);
+      p.Calculate(YSE::T_DSP);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    CHECK(p.PendingRetired() <= 4);
+  }
+
+  // ---- Concurrency: live SetParams against a rendering patcher ----
+  //
+  // The #234 acceptance: concurrent pHandle::SetParams — including the
+  // gGate/gSwitch pin re-parse — against a rendering patcher must be clean
+  // under TSan and ASan. This is the seed for the #229 harness extension.
+
+  TEST_CASE("setparams: concurrent re-parse against a rendering patcher") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* sine = p.CreateObject(YSE::OBJ::D_SINE, "440");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    YSE::pHandle* gate = p.CreateObject(YSE::OBJ::G_GATE, "2");
+    YSE::pHandle* sw = p.CreateObject(YSE::OBJ::G_SWITCH, "2");
+    // Two stable receivers hammer the gate through the RT-safe value path:
+    // "sel" re-selects outlet 1 (a structural replacement resets the
+    // selection) and "val" makes the gate index outputs[activeOutlet - 1] on
+    // the audio thread — the exact read the old in-place re-parse raced with
+    // its pop_back/emplace_back reallocation. A third receiver has its own
+    // dataName churned to cover the string-param replacement.
+    YSE::pHandle* recvSel = p.CreateObject(YSE::OBJ::G_RECEIVE, "sel");
+    YSE::pHandle* recvVal = p.CreateObject(YSE::OBJ::G_RECEIVE, "val");
+    YSE::pHandle* recvRep = p.CreateObject(YSE::OBJ::G_RECEIVE, "tgt");
+    p.Connect(sine, 0, dac, 0);
+    p.Connect(recvSel, 0, gate, 0);
+    p.Connect(recvVal, 0, gate, 1);
+
+    std::atomic<bool> stop{false};
+    std::thread render([&] {
+      while (!stop.load(std::memory_order_acquire)) {
+        p.Calculate(YSE::T_DSP);
+      }
+    });
+
+    // Control thread: scalar re-parses on the DSP object interleaved with
+    // structural re-parses (pin growth/shrink on gGate/gSwitch, dataName
+    // re-parse on gReceive) and value traffic that fans out into the
+    // just-replaced objects during the block.
+    for (int i = 0; i < 400; ++i) {
+      sine->SetParams(i % 2 == 0 ? "880" : "440");
+      gate->SetParams(i % 2 == 0 ? "8" : "2");
+      sw->SetParams(i % 2 == 0 ? "5" : "2");
+      recvRep->SetParams(i % 2 == 0 ? "tgtB 0" : "tgt 0");
+      p.PassData(1, "sel", YSE::T_GUI);
+      p.PassData(i, "val", YSE::T_GUI);
+      p.PassData(i, "tgt", YSE::T_GUI);
+    }
+
+    stop.store(true, std::memory_order_release);
+    render.join();
+
+    // The patcher is still coherent: the last re-parse won, and a final
+    // block renders the sine through the preserved wiring.
+    CHECK(gate->GetOutputs() == 2);
+    CHECK(sw->GetInputs() == 3);
+    p.Calculate(YSE::T_DSP);
+    p.Calculate(YSE::T_DSP);
+    CHECK_FALSE(p.output[0].isSilent());
+  }
+
+} // TEST_SUITE("patcher")

--- a/YseEngine/patcher/inlet.h
+++ b/YseEngine/patcher/inlet.h
@@ -46,6 +46,16 @@ namespace YSE {
       bool Connect(outlet* out);
       void Disconnect(outlet* out);
 
+      // The live (control-thread) incoming edges: the control-edge sources
+      // and the single DSP source. Read by the structural-replacement rewiring
+      // of a live SetParams re-parse (issue #234); control thread only.
+      inline const std::vector<outlet*>& Sources() const {
+        return connections;
+      }
+      inline outlet* DspSource() const {
+        return dspConnection;
+      }
+
       // Drop this inlet's incoming edges and remove it from the outlets that
       // fed it, so a deleted object leaves no dangling reference in the next
       // GraphState (issue #226). Mirrors the destructor's peer cleanup but

--- a/YseEngine/patcher/pHandle.cpp
+++ b/YseEngine/patcher/pHandle.cpp
@@ -1,6 +1,7 @@
 
 #include "pHandle.hpp"
 #include "patcher.hpp"
+#include "patcherImplementation.h"
 #include "pEnums.h"
 #include "pObject.h"
 #include "../implementations/logImplementation.h"
@@ -35,7 +36,18 @@ void YSE::pHandle::SetListData(unsigned int inlet, const std::string& value) {
 
 void YSE::pHandle::SetParams(const std::string& args) {
   INTERNAL::LogImpl().emit(E_DEBUG, "Handle: Passing arguments: " + args);
-  object->SetParams(args);
+  // An object owned by a patcher may be rendering right now: never re-parse
+  // it in place (that mutates pin vectors and param fields the audio thread
+  // reads — issue #234). Route through the patcher, which stages an RT-safe
+  // scalar apply or a structural replacement. `parent` is the owning
+  // patcherImplementation by construction (see pObject::CurrentBlockGraph);
+  // a standalone object (unit tests) keeps the synchronous parse.
+  PATCHER::pObject* parent = object->Parent();
+  if (parent != nullptr) {
+    static_cast<PATCHER::patcherImplementation*>(parent)->SetObjectParams(this, args);
+  } else {
+    object->SetParams(args);
+  }
 }
 
 std::string YSE::pHandle::GetGuiProperty(const std::string& key) {

--- a/YseEngine/patcher/pObject.h
+++ b/YseEngine/patcher/pObject.h
@@ -53,6 +53,27 @@ namespace YSE {
       void SetParams(const std::string& args);
       const std::string& GetParams();
 
+      // Live-SetParams support (issue #234). A re-parse on a published object
+      // must not mutate it in place; the owning patcher asks these to decide
+      // and stage the RT-safe route instead.
+      bool ParamsNeedRebuild() const {
+        return parms.NeedsRebuild();
+      }
+      int BuildParamPlan(const std::string& args, ParamOp* ops, int cap) {
+        return parms.BuildPlan(args, ops, cap);
+      }
+      // Take over the persistent identity of the object this one replaces:
+      // the storage ID (DumpJSON references) and the GUI properties. Pin
+      // layout, params, and DSP state are deliberately not copied — the
+      // replacement was just built from the new param string.
+      void CopyStorageIdentity(const pObject& from) {
+        ID = from.ID;
+        guiProperties = from.guiProperties;
+      }
+      inline pObject* Parent() const {
+        return parent;
+      }
+
       // Returns false when the inlet refuses the connection (it already has a
       // buffer source, or the edge is a duplicate). The caller must not record
       // the edge on the outlet side in that case: a one-sided outlet->inlet

--- a/YseEngine/patcher/parameters.cpp
+++ b/YseEngine/patcher/parameters.cpp
@@ -45,6 +45,60 @@ const std::string& Parameters::Get() {
   return current;
 }
 
+bool Parameters::NeedsRebuild() const {
+  if (onClear != nullptr || onParse != nullptr) return true;
+  for (const parameter& p : parms) {
+    if (p.type == STRING || p.type == LIST) return true;
+  }
+  return false;
+}
+
+int Parameters::BuildPlan(const std::string& args, ParamOp* ops, int cap) {
+  if (args.size() == 0) return 0;
+
+  int count = 0;
+  size_t pos = 0;
+  unsigned int currentArg = 0;
+  std::string arg = args + " "; // important to get the last argument
+  std::string token;
+  while ((pos = arg.find(' ')) != std::string::npos) {
+    token = arg.substr(0, pos);
+
+    if (currentArg < parms.size()) {
+      if (count >= cap) return -1;
+      switch (parms[currentArg].type) {
+      case FLOAT:
+      case ATOMIC_FLOAT: {
+        ops[count].type = parms[currentArg].type;
+        ops[count].dest = parms[currentArg].value;
+        ops[count].f = std::stof(token);
+        count++;
+        break;
+      }
+      case INT:
+      case ATOMIC_INT: {
+        ops[count].type = parms[currentArg].type;
+        ops[count].dest = parms[currentArg].value;
+        ops[count].i = std::stoi(token);
+        count++;
+        break;
+      }
+      default:
+        // STRING/LIST (or unknown) cannot be patched in place — signal the
+        // caller to take the structural-rebuild path instead.
+        return -1;
+      }
+    } else {
+      INTERNAL::LogImpl().emit(E_DEBUG, "Too many arguments for this object.");
+    }
+    arg.erase(0, pos + 1);
+    currentArg++;
+  }
+
+  current = args;
+  return count;
+}
+
 void Parameters::Set(const std::string& args) {
   if (onClear != nullptr) onClear();
   if (args.size() == 0) return;

--- a/YseEngine/patcher/parameters.h
+++ b/YseEngine/patcher/parameters.h
@@ -24,6 +24,18 @@ namespace YSE {
 
     typedef std::function<void()> parmFunc;
 
+    // One pre-parsed scalar write of a live SetParams re-parse (issue #234).
+    // Built on the control thread by Parameters::BuildPlan and applied with a
+    // plain/atomic store on the audio thread at the top of the next block, so
+    // the live field is never written concurrently with the render that reads
+    // it. POD on purpose: plans ride a bounded lock-free queue by value.
+    struct ParamOp {
+      PARM_TYPE type;
+      void* dest;
+      int i;
+      float f;
+    };
+
     // Per-parameter documentation entry. Populated via PARAM_DOC in object
     // constructors; the order is expected to match the Register() call order
     // for the corresponding object.
@@ -45,6 +57,22 @@ namespace YSE {
       void Register(std::vector<std::string>& list);
 
       void Set(const std::string& args);
+
+      // Whether a live re-parse must rebuild the object instead of patching
+      // scalar fields (issue #234): true when the object registered
+      // clear/parse callbacks (they translate params into pin structure) or
+      // any STRING/LIST param (strings cannot be written allocation-free and
+      // are read on both threads once the object is published).
+      bool NeedsRebuild() const;
+
+      // Tokenize `args` exactly like Set(), but record the scalar writes into
+      // `ops` instead of touching the live fields, and update the stored
+      // param string. Returns the number of ops written, 0 for empty args, or
+      // -1 when the plan does not fit `cap` (or a non-scalar param sneaks in)
+      // — the caller must then fall back to the structural rebuild. Parse
+      // errors (std::stof on garbage) throw here, on the calling thread,
+      // exactly as Set() does. Only meaningful when NeedsRebuild() is false.
+      int BuildPlan(const std::string& args, ParamOp* ops, int cap);
 
       void RegisterClear(parmFunc f);
       void RegisterParse(parmFunc f);

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -8,6 +8,7 @@
 #include "genericObjects/gSend.h"
 #include "pHandle.hpp"
 #include "../utils/json.hpp"
+#include <algorithm>
 #include <atomic>
 #include <cstring>
 #include <mutex>
@@ -99,9 +100,12 @@ void patcherImplementation::Calculate(YSE::THREAD thread) {
   audioBlock_.fetch_add(1, std::memory_order_acq_rel);
   currentBlockGraph_.store(g, std::memory_order_release);
 
-  // Deliver queued value messages (PassBang/PassData) before rendering, now
-  // that the snapshot is pinned so their fan-out resolves through it. This is
-  // where inlet handlers run — only ever on the audio thread (issue #225).
+  // Apply queued scalar param plans first (issue #234), then deliver queued
+  // value messages (PassBang/PassData), both before rendering and against the
+  // pinned snapshot. Param stores land before any handler or render read of
+  // this block, so a SetParams that precedes a PassData on the control thread
+  // is also observed in that order here.
+  ApplyPendingParams(g);
   DeliverPendingValues(g);
 
   if (g != nullptr) {
@@ -253,6 +257,139 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
   ScheduleReclaim();
   // The handle is never referenced by a GraphState, so it can go immediately.
   delete handle;
+}
+
+void patcherImplementation::SetObjectParams(YSE::pHandle* handle, const std::string& args) {
+  std::scoped_lock lk(mtx);
+  pObject* object = handle->object;
+  if (object == nullptr) return;
+
+  if (!object->ParamsNeedRebuild()) {
+    // Scalar-only params: pre-parse into a POD plan on this thread (parse
+    // errors throw here, never on the audio thread) and hand it to the audio
+    // thread for an allocation-free apply at the top of the next block. The
+    // stored param string is updated eagerly, so GetParams/DumpJSON reflect
+    // the new args immediately.
+    ParamMsg msg{};
+    msg.target = object;
+    const int count = object->BuildParamPlan(args, msg.ops, (int)kParamOpsCap);
+    if (count == 0) return; // nothing to apply (empty args or no scalar writes)
+    if (count > 0) {
+      msg.count = count;
+      if (!paramQueue_.try_push(msg)) {
+        // Backpressure: never block or allocate — drop and log, like the
+        // value queue. The queue drains every block, so sustained loss means
+        // the audio thread is stalled.
+        INTERNAL::LogImpl().emit(E_ERROR, "Patcher: param queue full; dropped SetParams for " +
+                                              std::string(object->Type()));
+      }
+      return;
+    }
+    // count < 0: the plan overflowed the inline cap. Fall through to the
+    // structural rebuild, which is correct for any object.
+  }
+  ReplaceObjectUnlocked(handle, args);
+}
+
+void patcherImplementation::ApplyPendingParams(const GraphState* g) {
+  // Audio thread. Drain the whole queue every block so it can't grow
+  // unbounded. A plan is applied only when its target is still in the pinned
+  // snapshot: a replaced/deleted object is simply absent and the plan is
+  // dropped. The pointer is compared, never dereferenced, and a retired
+  // object outlives any block that could still pin a snapshot holding it
+  // (issue #227's two-block grace), so the comparison itself is safe.
+  ParamMsg msg;
+  while (paramQueue_.try_pop(msg)) {
+    if (g == nullptr) continue;
+    bool present = false;
+    for (pObject* obj : g->objects) {
+      if (obj == msg.target) {
+        present = true;
+        break;
+      }
+    }
+    if (!present) continue;
+    for (int i = 0; i < msg.count; i++) {
+      const ParamOp& op = msg.ops[i];
+      switch (op.type) {
+      case PARM_TYPE::FLOAT:
+        *((float*)op.dest) = op.f;
+        break;
+      case PARM_TYPE::ATOMIC_FLOAT:
+        ((std::atomic<float>*)op.dest)->store(op.f, std::memory_order_relaxed);
+        break;
+      case PARM_TYPE::INT:
+        *((int*)op.dest) = op.i;
+        break;
+      case PARM_TYPE::ATOMIC_INT:
+        ((std::atomic<int>*)op.dest)->store(op.i, std::memory_order_relaxed);
+        break;
+      default:
+        break; // STRING/LIST never ride the scalar queue
+      }
+    }
+  }
+}
+
+void patcherImplementation::ReplaceObjectUnlocked(YSE::pHandle* handle, const std::string& args) {
+  pObject* old = handle->object;
+  pObject* fresh = Register().Get(old->Type());
+  if (fresh == nullptr) {
+    // Not registry-built (the DAC) — but the DAC registers no params, so a
+    // re-parse can never legitimately land here. Leave the object untouched.
+    INTERNAL::LogImpl().emit(E_ERROR, "Patcher: cannot rebuild " + std::string(old->Type()) +
+                                          " for a live SetParams; params unchanged");
+    return;
+  }
+
+  // Params first, then parent — the same order as CreateObjectUnlocked, so a
+  // gReceive/gSend anchors its bus subscription/address under the *new*
+  // dataName. The object is not yet published: pin callbacks may freely
+  // grow/shrink its inlets/outlets here.
+  fresh->SetParams(args);
+  fresh->CopyStorageIdentity(*old);
+  fresh->SetParent(this);
+  AssignGraphIds(fresh);
+
+  // Rewire the peers' edges onto the replacement for every pin index that
+  // survives the re-parse; edges on removed pins are dropped, like the old
+  // in-place pop_back did. Inlet-first (issue #237): record the edge on the
+  // source outlet only when the destination inlet accepted it.
+  const int ins = std::min(old->NumInputs(), fresh->NumInputs());
+  for (int i = 0; i < ins; i++) {
+    PATCHER::inlet* oldIn = old->GetInlet(i);
+    PATCHER::inlet* freshIn = fresh->GetInlet(i);
+    if (oldIn == nullptr || freshIn == nullptr) continue;
+    for (PATCHER::outlet* src : oldIn->Sources()) {
+      if (freshIn->Connect(src)) src->Connect(freshIn);
+    }
+    if (PATCHER::outlet* dsp = oldIn->DspSource()) {
+      if (freshIn->Connect(dsp)) dsp->Connect(freshIn);
+    }
+  }
+  const int outs = std::min(old->NumOutputs(), fresh->NumOutputs());
+  for (int o = 0; o < outs; o++) {
+    PATCHER::outlet* oldOut = old->GetOutlet(o);
+    PATCHER::outlet* freshOut = fresh->GetOutlet(o);
+    if (oldOut == nullptr || freshOut == nullptr) continue;
+    for (PATCHER::inlet* dest : oldOut->Targets()) {
+      if (dest->Connect(freshOut)) freshOut->Connect(dest);
+    }
+  }
+
+  // Detach the old object so the next snapshot holds no reference to it, swap
+  // the handle over, and publish. The old object is freed by the reclaimer
+  // once the audio thread has provably advanced past every snapshot that
+  // could still reference it — exactly like DeleteObject.
+  old->UnwireFromPeers();
+  objects[handle] = fresh;
+  handle->object = fresh;
+  RebuildAndPublish();
+  {
+    std::scoped_lock rlk(reclaimMtx_);
+    retiredObjects_.emplace_back(old, audioBlock_.load(std::memory_order_acquire));
+  }
+  ScheduleReclaim();
 }
 
 void patcherImplementation::Clear() {

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -49,6 +49,13 @@ namespace YSE {
       void DeleteObject(pHandle* obj);
       void Clear();
 
+      // Live SetParams re-parse on an object this patcher owns (issue #234).
+      // Never mutates a published object: scalar params are pre-parsed into a
+      // ParamMsg and applied by the audio thread at the top of the next block;
+      // pin-count / string re-parses build a replacement object off the live
+      // path and publish it with the usual GraphState swap. Control thread.
+      void SetObjectParams(YSE::pHandle* handle, const std::string& args);
+
       void Connect(pHandle* from, int outlet, pHandle* to, int inlet);
       void Disconnect(pHandle* from, int outlet, pHandle* to, int inlet);
 
@@ -135,6 +142,32 @@ namespace YSE {
       // iff a matching receiver exists (so the caller only falls back to OSC
       // when there is genuinely no in-patcher target).
       bool EnqueueValue(ValueMsg& msg, const std::string& to);
+
+      // ---- Live SetParams (issue #234) ----
+
+      // Scalar param writes staged per SetParams call. POD so it rides the
+      // lock-free queue by value — nothing to reclaim. `target` is compared
+      // (never dereferenced) against the pinned snapshot's object list before
+      // the ops are applied, which makes delivery safe across a concurrent
+      // DeleteObject, exactly like the by-name value messages.
+      static constexpr std::size_t kParamOpsCap = 8;
+      static constexpr std::size_t kParamQueueCapacity = 64;
+      struct ParamMsg {
+        pObject* target;
+        int count;
+        ParamOp ops[kParamOpsCap];
+      };
+
+      // Audio thread, top of Calculate (before the value drain): apply every
+      // queued scalar plan whose target is still in the pinned snapshot.
+      // Plain/atomic stores only — no allocation, no locks.
+      void ApplyPendingParams(const GraphState* g);
+
+      // Structural re-parse: build a replacement object with the new params
+      // off the live path, transfer identity (storage ID, GUI properties, the
+      // pHandle), rewire surviving pin indices, publish, and retire the old
+      // object through the epoch reclaimer. Caller holds mtx.
+      void ReplaceObjectUnlocked(YSE::pHandle* handle, const std::string& args);
 
       // Unlocked cores of CreateObject / Connect: do the structural mutation
       // assuming mtx is already held and publish nothing. The public wrappers
@@ -237,6 +270,9 @@ namespace YSE {
       // audio thread, draining in Calculate. mpmcQueue is a superset of SPSC, so
       // concurrent producers are safe too.
       YSE::mpmcQueue<ValueMsg> valueQueue_{kValueQueueCapacity};
+      // Deferred scalar param plans (issue #234). Producers: control threads
+      // in SetObjectParams. Consumer: the audio thread in ApplyPendingParams.
+      YSE::mpmcQueue<ParamMsg> paramQueue_{kParamQueueCapacity};
       // Audio-thread-only scratch buffer for delivering List payloads. Reserved
       // to kValueListCap in the ctor so assigning any inline list value reuses
       // this buffer instead of allocating on the audio thread, while still

--- a/docs/design/patcher_live_params.md
+++ b/docs/design/patcher_live_params.md
@@ -1,0 +1,212 @@
+# Patcher live `SetParams`: deferred scalar apply + structural replacement
+
+Status: **design gate, settled**. Tracking issue:
+[#234][gh-234]. Parent epic: [#189 — make the patcher graph wait-free on
+the audio thread][gh-189]. Companion decision:
+[patcher_graphstate.md](patcher_graphstate.md) ([#226][gh-226]).
+
+This document settles the design gate in issue [#234][gh-234]: how a live
+`pHandle::SetParams` re-parse becomes RT-safe without bypassing the
+GraphState swap and without mutating a published object.
+
+## Table of contents
+
+1. [The bug](#the-bug)
+2. [Decision summary](#decision-summary)
+3. [Classification: scalar vs structural params](#classification-scalar-vs-structural-params)
+4. [Scalar path: pre-parsed plan, applied on the audio thread](#scalar-path-pre-parsed-plan-applied-on-the-audio-thread)
+5. [Structural path: replacement object + swap](#structural-path-replacement-object--swap)
+6. [Why not the alternatives](#why-not-the-alternatives)
+7. [Behavioral notes](#behavioral-notes)
+8. [Scope](#scope)
+
+## The bug
+
+`pHandle::SetParams` → `pObject::SetParams` → `Parameters::Set` runs on
+the control thread with no patcher `mtx` and no `GraphState` swap. It
+writes plain `int`/`float`/`std::string` fields through `void*`
+([`parameters.cpp`][src-parameters]) and its `PARM_PARSE` callbacks
+grow/shrink the live `inputs`/`outputs` vectors
+([`gGate.cpp`][src-ggate], `gSwitch`, `gRoute`) — the very vectors and
+fields the audio thread reads while rendering the pinned snapshot. That
+violates the stable-objects invariant [#226][gh-226] rests on ("objects
+are allocated once and never mutated after publication"): a concurrent
+re-parse is a reallocation UAF on the audio thread, and a racing
+`std::string` write is an SSO↔heap UAF.
+
+## Decision summary
+
+**Option C from the issue — a hybrid — implemented as two regimes that
+already exist in the epic's architecture:**
+
+| Param change | Mechanism |
+| --- | --- |
+| Scalar (`int`/`float`/atomic variants) | **Deferred RT-safe apply.** Parse on the control thread into a POD plan; deliver through a bounded lock-free queue (the [#225][gh-225] pattern); apply with plain/atomic stores at the top of `Calculate`, only if the target object is in the pinned snapshot. |
+| Structural (pin-count re-parse via `PARM_CLEAR`/`PARM_PARSE`) **or any `STRING`/`LIST` param** | **Replacement object + swap.** Build a fresh instance of the same type off the live path, apply the params pre-publication, transfer identity (storage ID, GUI properties, the `pHandle`), rewire preserved connections up to the new pin counts, `RebuildAndPublish()`, retire the old object through the [#227][gh-227] epoch reclaimer. |
+
+Routing: `pHandle::SetParams` on an object owned by a patcher goes
+through `patcherImplementation::SetObjectParams` (under `mtx`, like every
+other edit). A standalone object (no parent — unit tests) keeps the
+synchronous `Parameters::Set`, as do `CreateObjectUnlocked`/`ParseJSON`,
+which parse params on freshly built objects **before** publication.
+
+## Classification: scalar vs structural params
+
+The split is decided **per object, at registration time**
+(`Parameters::NeedsRebuild()`), not per call:
+
+- **Structural** if the object registered `PARM_CLEAR`/`PARM_PARSE`
+  callbacks — those exist precisely to translate params into pin
+  structure (`gGate`, `gSwitch`, `gRoute`) — **or** registered any
+  `STRING`/`LIST` param (`gReceive`/`gSend` `dataName`, `gText`,
+  `gMessage`, `gList`).
+- **Scalar** otherwise: every plain/atomic `int`/`float` param. This is
+  all the DSP objects' live params (`pSine`/`dSaw` frequency, the filter
+  cutoffs/Q, `pLine`, `gMetro` period, the math operands, MIDI channels,
+  `gFloat`/`gInt` value, …), which is exactly the set where preserving
+  in-flight DSP state matters.
+
+Why strings are structural: a `std::string` cannot be written
+allocation-free, and the live fields are read on *both* threads
+(`dataName` by `DispatchToReceiver` on the audio thread and by
+`EnqueueValue`/`BuildGraph` on the control thread). Applying the write on
+either thread races the other. Building the string into a fresh,
+not-yet-published object removes the mutation entirely — published
+objects' strings become immutable, extending the stable-objects
+invariant. It also fixes a latent gap for free: replacing a
+`gReceive`/`gSend` runs `SetParent`, which re-anchors the bus
+subscription / cached bus address under the *new* `dataName` (the old
+in-place write left them stale).
+
+## Scalar path: pre-parsed plan, applied on the audio thread
+
+The epic's target architecture already assigns "live param changes to
+existing objects" to the value-command regime. Concretely:
+
+- **Control thread (under `mtx`):** tokenize `args` exactly as
+  `Parameters::Set` does, but write the values into a POD
+  `ParamMsg { pObject* target; count; ops[kParamOpsCap] }` where each op
+  is `{PARM_TYPE, void* dest, int|float value}` — no live field is
+  touched. `parms.current` *is* updated eagerly (control-side state, read
+  by `GetParams`/`DumpJSON` under the same regime as today), so dumps and
+  round-trips reflect the new args immediately. Parse errors
+  (`std::stof` on garbage) throw on the control thread, exactly as
+  before — never on the audio thread. The msg rides a bounded
+  `mpmcQueue` (the [#225][gh-225] `ValueMsg` pattern: POD by value,
+  nothing to reclaim; full queue → drop + log, never block).
+- **Audio thread (top of `Calculate`, before `DeliverPendingValues`):**
+  drain the queue; for each msg, apply the ops with plain stores
+  (atomics via their store) **only if `target` is in the pinned
+  snapshot's object list**. That membership check makes delivery safe
+  across a concurrent `DeleteObject`, exactly like the by-name
+  re-resolution of value messages: a deleted object is simply absent and
+  the msg is dropped.
+
+Why the dangling-`target` ABA cannot happen: the queue is drained in
+full at the top of *every* block, so a msg never survives past the first
+`Calculate` after its enqueue; a deleted object's free is gated on the
+audio epoch advancing **two further blocks** past retirement
+([#227][gh-227]). Enqueue happens-before the delete (the caller holds a
+live `pHandle`), so the pointer is compared — never dereferenced — while
+the allocation is still parked in the retire list.
+
+Ops per msg are capped (`kParamOpsCap = 8`; today's richest scalar
+object registers 2). An object that ever exceeds the cap falls back to
+the structural path, which is correct for any object — the cap is a
+fallback trigger, not a correctness boundary.
+
+## Structural path: replacement object + swap
+
+A pin-count re-parse is a structural edit, so it uses the structural
+machinery. Under `mtx`, `ReplaceObjectUnlocked`:
+
+1. Creates a fresh instance of the same `Type()` from the registry and
+   applies `SetParams(args)` synchronously — the object is not yet
+   published, so callbacks may freely grow/shrink its pins.
+2. Transfers identity: the storage `ID` (so `DumpJSON` references stay
+   stable) and the GUI properties; the existing `pHandle` is re-pointed
+   at the fresh object, so handle identity is preserved for the C API.
+3. `SetParent(this)` (after params, mirroring `CreateObjectUnlocked`) and
+   `AssignGraphIds` — fresh pins get fresh dense ids; ids are never
+   reused.
+4. Rewires the peers' edges onto the fresh object for every pin index
+   that survives (`i < min(old, new)`), inlet-first per the [#237
+   discipline][gh-237] so no one-sided edge can be recorded. Edges on
+   removed pins are dropped — same outcome as the old in-place
+   `pop_back`.
+5. `UnwireFromPeers()` on the old object, `RebuildAndPublish()`, and
+   retires the old object through the epoch reclaimer exactly like
+   `DeleteObject` (tagged after its covering graph, freed on the
+   background pool).
+
+**DSP-state preservation is not violated where it matters.** The epic's
+decision protects in-flight DSP state across *edits elsewhere in the
+graph*; a param re-parse targets the object itself, and every structural
+object is a generic router with no DSP history. For the scalar set —
+where state genuinely matters (oscillator phase, filter history, ramp
+position) — the deferred apply mutates nothing structural and preserves
+state perfectly. Re-instantiation semantics for arg re-parses is also
+the established Max/Pd behavior (editing creation args rebuilds the
+object; Max preserves connections, which this does too).
+
+## Why not the alternatives
+
+- **A — deferred apply for everything.** `Parameters::Set` parses,
+  allocates, and runs pin-mutating callbacks; none of that is RT-safe,
+  and pre-parsing cannot help a `PARM_PARSE` that must reallocate pin
+  vectors the audio thread is indexing. Deferred apply is kept only for
+  the pre-parsed scalar subset, where the audio-thread work is a handful
+  of stores.
+- **B — replacement for everything.** Correct but needlessly loses DSP
+  state (phase resets, filter zaps — audible clicks) for the common case
+  of tweaking a numeric param, and the scalar set is exactly where the
+  epic's preserve-state decision has teeth. Kept only where there is no
+  DSP state to lose.
+- **Quiesce-and-mutate in place** (publish a snapshot without the
+  object, wait out the epoch grace, mutate, republish): preserves
+  control state, but blocks the control thread on the audio epoch —
+  unbounded when the engine is paused (the epoch stalls) — and silences
+  the object for the wait. Rejected on the pause-deadlock alone.
+
+## Behavioral notes
+
+- Scalar params take effect at the top of the **next rendered block**;
+  `GetParams`/`DumpJSON` reflect the new string immediately. Structural
+  re-parses are visible immediately (`GetOutputs`/`GetInputs` query the
+  fresh object through the same handle).
+- Transient *control* state of structural objects (`gGate`
+  `activeOutlet`, `gSwitch` `activeInlet`) resets on re-parse —
+  re-instantiation semantics, as in Max/Pd.
+- A replaced `gReceive` stays bus-subscribed until the old instance is
+  reclaimed (its destructor unsubscribes), so a bus publish inside the
+  ~2-block grace can transiently reach both instances — the same
+  transient `DeleteObject` has today; not widened by this change.
+- If the value queue is full the msg is dropped **with a log**, like the
+  #225 value path; `GetParams` will already report the new string. The
+  queue is drained every block, so sustained loss requires a stalled
+  audio thread.
+
+## Scope
+
+**In scope ([#234][gh-234]):** the routing through
+`SetObjectParams`, `Parameters::NeedsRebuild`/plan building, the
+`ParamMsg` queue + `Calculate` drain, `ReplaceObjectUnlocked`, unit
+tests for both paths, and a focused render-vs-`SetParams` concurrency
+test (the seed for the [#229][gh-229] harness extension).
+
+**Out of scope:** deferring `pHandle::SetBang/SetIntData/...` value
+pokes (they still run inlet handlers on the calling thread — a remaining
+epic gap tracked by [#189][gh-189]/[#229][gh-229], same regime as
+`PassData` and orthogonal to params); explicit early unsubscribe of
+replaced/deleted `gReceive` instances.
+
+<!-- link references -->
+[gh-189]: https://github.com/yvanvds/yse-soundengine/issues/189
+[gh-225]: https://github.com/yvanvds/yse-soundengine/issues/225
+[gh-226]: https://github.com/yvanvds/yse-soundengine/issues/226
+[gh-227]: https://github.com/yvanvds/yse-soundengine/issues/227
+[gh-229]: https://github.com/yvanvds/yse-soundengine/issues/229
+[gh-234]: https://github.com/yvanvds/yse-soundengine/issues/234
+[gh-237]: https://github.com/yvanvds/yse-soundengine/issues/237
+[src-parameters]: ../../YseEngine/patcher/parameters.cpp
+[src-ggate]: ../../YseEngine/patcher/genericObjects/gGate.cpp


### PR DESCRIPTION
## Summary

A live `pHandle::SetParams` re-parsed a published object in place on the control thread — writing scalar fields through `void*` and letting `PARM_PARSE` reallocate the very `inputs`/`outputs` vectors the audio thread indexes mid-block. This PR routes it through the patcher and settles the issue's design gate as **option C (hybrid)**, recorded in-tree at [`docs/design/patcher_live_params.md`](docs/design/patcher_live_params.md) and on the issue:

- **Scalar params** (plain/atomic `int`/`float` — all DSP objects' live params) → pre-parsed on the control thread into a POD `ParamMsg`, applied by the audio thread at the top of the next `Calculate` against the pinned snapshot (target-membership check makes it safe across a concurrent `DeleteObject`; full-drain-per-block + the #227 two-block grace rule out pointer ABA). In-flight DSP state is preserved — no phase resets or filter zaps on a frequency tweak.
- **Structural re-parses** (`gGate`/`gSwitch`/`gRoute` pin re-parse, plus any `STRING`/`LIST` param) → replacement object built off the live path, identity transferred (storage ID, GUI props, same `pHandle`), surviving pins rewired inlet-first (#237 discipline), published via the usual `GraphState` swap, old object retired through the #227 reclaimer. Published objects' strings become immutable; a replaced `gReceive`/`gSend` re-anchors its bus subscription under the new `dataName` (the old in-place write left it stale).

Standalone objects (unit tests) and pre-publication parses (`CreateObjectUnlocked`/`ParseJSON`) keep the synchronous path.

## Linked issue

Closes #234

## Changes

- `YseEngine/patcher/parameters.{h,cpp}` — `ParamOp`, `NeedsRebuild()`, `BuildPlan()`
- `YseEngine/patcher/patcherImplementation.{h,cpp}` — `SetObjectParams`, `ApplyPendingParams` (drained in `Calculate` before the value queue), `ReplaceObjectUnlocked`, bounded lock-free `paramQueue_`
- `YseEngine/patcher/pHandle.cpp` — routes `SetParams` through the owning patcher
- `YseEngine/patcher/pObject.h`, `inlet.h` — small public surface for plan building, identity transfer, and rewiring
- `Tests/patcher/test_patcher_setparams.cpp` — 12 cases: deferred-apply semantics, delete-race drop, replacement identity/rewiring (grow + shrink), `gReceive` redirection, DumpJSON round-trip, reclaim draining, and a render-vs-SetParams concurrency stress (seed for the #229 harness)
- `docs/design/patcher_live_params.md` — the settled design gate

## Test plan

- [x] `python yse.py format` — clean (no diffs outside this change)
- [x] `python yse.py analyze` on the changed TUs — no new findings (one pre-existing `performance-faster-string-find` in the untouched `Parameters::Set`)
- [x] `python yse.py test` — 16/16 suites pass on Windows (incl. the 12 new cases)
- [x] Sanitizers (Linux container, `tools/ci-linux`): the concurrency stress **fails on the unpatched engine under TSan** with the exact #234 races (`_M_realloc_insert`/`pop_back` on live pin vectors vs the render thread) and is **TSan-clean and ASan-clean with the fix** (all 12 cases ASan-clean). Remaining TSan reports across test boundaries are pre-existing and now tracked: #239 (threadPool `join()`/`activate()` teardown race), #240 (timerThread UAF) — both reproduced on unpatched `dev`.
- Integration/e2e: not applicable — engine-internal concurrency fix with no user-visible flow beyond the patcher API, which the concurrency stress and the existing integration suite (passing) already drive end-to-end against a rendering patcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
