### PR TITLE
FIX: TimerThread worker UAF — copy deadline to stack before wait_until (#240)

### DIFF
--- a/Tests/patcher/test_timerthread.cpp
+++ b/Tests/patcher/test_timerthread.cpp
@@ -135,6 +135,25 @@ TEST_SUITE("patcher") {
     CHECK(t.empty());
   }
 
+  TEST_CASE("timerThread: cancel while the worker parks in wait_until (regression #240)") {
+    // The worker parks in wait_until(lock, timer.next), where `timer` is a
+    // reference into the `active` map node. A concurrent ClearTimer erases and
+    // frees that node while the wait has the lock released; wait_until then
+    // re-reads timer.next after re-locking to compute its return status. Before
+    // the fix that read touched freed memory (ASan heap-use-after-free at
+    // TimerThread.cpp:51). Churn add→park→cancel many times to hit the window.
+    YSE::PATCHER::timerThread t;
+    for (int i = 0; i < 500; ++i) {
+      // 200ms deadline so the worker enters wait_until rather than firing;
+      // the callback must never run within this loop.
+      auto id = t.Add(200, 0, [] {});
+      // Give the worker a beat to pick up the timer and park in wait_until.
+      std::this_thread::sleep_for(1ms);
+      t.ClearTimer(id); // frees the node the parked wait_until references
+    }
+    CHECK(t.empty());
+  }
+
   TEST_CASE("timerThread: setInterval with chrono duration overloads") {
     YSE::PATCHER::timerThread t;
     std::atomic<int> count{0};

--- a/YseEngine/patcher/time/TimerThread.cpp
+++ b/YseEngine/patcher/time/TimerThread.cpp
@@ -48,7 +48,13 @@ void timerThread::timerThreadWorker() {
         timer.waitCond->notify_all();
       }
     } else {
-      wakeUp.wait_until(lock, timer.next);
+      // Copy the deadline onto the stack before waiting: `timer` references a
+      // node of `active`, and a concurrent ClearTimer/Clear can erase (free)
+      // that node while wait_until has the lock released. wait_until re-reads
+      // the time_point after re-acquiring the lock to compute its return
+      // status, so passing timer.next directly is a use-after-free (#240).
+      Timestamp deadline = timer.next;
+      wakeUp.wait_until(lock, deadline);
     }
   }
 }


### PR DESCRIPTION
## Summary
The patcher timer worker parked in `wakeUp.wait_until(lock, timer.next)`, where `timer` is a reference into a node of the `active` `unordered_map`. libstdc++'s `wait_until` re-reads that `time_point` **after** its internal cond-wait re-acquires the mutex (to compute the timeout/no_timeout return status). During the unlocked wait window a concurrent `ClearTimer`/`Clear` legitimately erases — and frees — that map node and notifies the worker; `wait_until` then dereferences the freed `timer.next` → ASan heap-use-after-free at `TimerThread.cpp:51`.

The fix copies the deadline into a stack-local `Timestamp` under the lock and waits on that, so `wait_until` never references the map node across the wait. `Add`/`Remove` are untouched and stay cheap — they run on the control thread (gMetro toggles), not the audio callback.

## Linked issue
Closes #240

## Changes
- `YseEngine/patcher/time/TimerThread.cpp` — copy `timer.next` into a stack-local `deadline` before `wait_until`, with an explanatory comment.
- `Tests/patcher/test_timerthread.cpp` — new churn regression test (add → let the worker park in `wait_until` → cancel) that reproduces the UAF.

## Test plan
Verified in the `tools/ci-linux` container (gcc 13, Ubuntu 24.04) under AddressSanitizer, matching the environment in the issue:
- [x] `yse_tests --test-suite=patcher` is **ASan-clean** with the fix — 209 cases / 4023 assertions pass.
- [x] The **same suite aborts** with `heap-use-after-free` (chrono `time_since_epoch`) on the unpatched code — the new regression test fails without the fix and passes with it.
- [x] `clang-tidy` clean on both changed files (`yse.py analyze`).
- [x] `clang-format --dry-run --Werror` clean on both changed files.

No integration test added: this is engine-internal threading with no user-visible UI/flow surface; the ASan-under-real-worker-thread regression test **is** the end-to-end exercise of the affected path (real timer worker thread firing against a concurrent canceller).

## Out of scope (filed separately)
Running the *full* suite under ASan surfaced an **unrelated pre-existing** stack-buffer-overflow in `DSP::sqrtFunc` (8-byte `long` read from a 4-byte float on LP64) — filed as #242. It is ASan-only and does not affect the normal (non-sanitized) CI suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)