### PR TITLE
FIX: sqrtFunc reads 8-byte long from 4-byte float — ASan stack-buffer-overflow on LP64 (#242)

### DIFF
--- a/YseEngine/dsp/math_functions.cpp
+++ b/YseEngine/dsp/math_functions.cpp
@@ -10,6 +10,7 @@
 
 #include "math_functions.h"
 #include <math.h>
+#include <cstdint>
 #include <cstring>
 
 #define LOGTEN 2.302585092994f
@@ -131,7 +132,8 @@ void YSE::DSP::sqrtFunc(Flt* in, Flt* out, UInt length) {
   sqrtTable& s = SqrtTable();
   while (length--) {
     float f = *in;
-    long l = *(long*)(in++);
+    std::uint32_t l;
+    std::memcpy(&l, in++, sizeof(l));
     if (f < 0)
       *out++ = 0;
     else {


### PR DESCRIPTION
## Summary
`sqrtFunc` (the fast bit-hack square root) type-punned its input float through `*(long*)`. On LP64 targets (Linux/macOS) `long` is 8 bytes, so the read pulled 8 bytes out of a 4-byte `Flt` slot — a strict-aliasing violation and, for a single-element buffer, a 4-byte read past the end of the stack buffer (ASan stack-buffer-overflow). The code only worked by accident on LLP64 (Windows/MSVC), where `long` is 4 bytes.

The bit manipulation that follows (`(l >> 23) & 0xff`, `(l >> 13) & 0x3ff`) targets the 32-bit IEEE-754 layout, so a fixed-width 32-bit integer is the intended type.

## Linked issue
Closes #242

## Changes
- `YseEngine/dsp/math_functions.cpp`: read the float's bit pattern into a `std::uint32_t` via `std::memcpy` instead of `*(long*)`. Allocation-free / RT-safe, as required for a DSP scalar path. Added `<cstdint>`.
- Behaviour is unchanged on LLP64 (where `long` was already 4 bytes).

## Test plan
No new test needed — the existing `sqrtFunc: negative input returns zero` case (`Tests/dsp/test_math_scalars.cpp:185`) is exactly the ASan repro: it aborts without the fix on LP64 and passes with it.

- [x] `clang-tidy` (`python yse.py analyze`) clean on the modified file
- [x] `clang-format --dry-run --Werror` clean
- [x] Full test suite passes on Windows (`python yse.py test`) — 16/16 suites
- [x] **gcc 13 ASan build on Ubuntu 24.04 (LP64, Docker)** — `sqrtFunc` tests run ASan-clean; the stack-buffer-overflow no longer fires and the `sqrtFunc` accuracy test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)