### PR TITLE
FIX: seek the file handle on streaming setFilePos (#217)

### DIFF
--- a/Tests/sound/test_sound_streaming.cpp
+++ b/Tests/sound/test_sound_streaming.cpp
@@ -228,6 +228,104 @@ TEST_SUITE("sound") {
     }
   }
 
+  // 6. Seeking a streaming sound to an absolute frame re-primes the stream from
+  //    that frame (issue #217). Before the fix, setFilePos assigned an absolute
+  //    frame to the buffer-local filePtr and never re-seeked the handle, so
+  //    playback landed somewhere in the resident 1 s window instead of the target.
+  TEST_CASE("streaming: seek re-primes the stream from the requested frame") {
+    if (!TestHelpers::engineInit()) return;
+
+    std::vector<float> src;
+    std::string path = writeWav(3 * S, src); // long enough to seek well past buffer 0
+    soundFile f(path);
+    f.create(true);
+    REQUIRE(waitReady(f));
+
+    Flt pos = 0.f, vol = 1.f;
+    SOUND_STATUS intent = YSE::SS_PLAYING_FULL_VOLUME;
+    std::vector<float> out;
+
+    // Play a little from the start so we are mid-stream, then seek forward to an
+    // absolute frame that lies beyond the initially-primed front buffer.
+    for (int b = 0; b < 4; ++b) {
+      readBlock(f, pos, false, intent, vol, out);
+      breathe(b);
+    }
+
+    const long target = 2 * S + 5000; // absolute frame, past buffer 0's window
+    f.seek(target, false);
+    // Mirror the audio thread: filePtr (pos) resets to the new front buffer start.
+    pos = 0.f;
+    vol = 1.f;
+    intent = YSE::SS_PLAYING_FULL_VOLUME;
+
+    // Playback must resume with the samples at `target`, sample-accurate.
+    long frame = target;
+    const long verifyTo = target + 3 * static_cast<long>(YSE::STANDARD_BUFFERSIZE);
+    for (int b = 0; frame < verifyTo; ++b) {
+      bool stopped = readBlock(f, pos, false, intent, vol, out);
+      REQUIRE_FALSE(stopped);
+      for (UInt j = 0; j < YSE::STANDARD_BUFFERSIZE && frame < verifyTo; ++j, ++frame) {
+        CHECK(out[j] == doctest::Approx(src[static_cast<size_t>(frame)]).epsilon(0.0001));
+      }
+      breathe(b);
+    }
+  }
+
+  // 7. Seeking backward (to a frame before the current window) also re-seeks the
+  //    handle, and a subsequent stop/reset still returns to frame 0 — i.e. the
+  //    seek target does not leak into the reset path (issue #217).
+  TEST_CASE("streaming: seek backward then reset returns to frame 0") {
+    if (!TestHelpers::engineInit()) return;
+
+    std::vector<float> src;
+    std::string path = writeWav(3 * S, src);
+    soundFile f(path);
+    f.create(true);
+    REQUIRE(waitReady(f));
+
+    Flt pos = 0.f, vol = 1.f;
+    SOUND_STATUS intent = YSE::SS_PLAYING_FULL_VOLUME;
+    std::vector<float> out;
+
+    // Advance past the first buffer boundary.
+    for (int b = 0; b < 400; ++b) {
+      readBlock(f, pos, false, intent, vol, out);
+      breathe(b);
+    }
+
+    // Seek back to a small non-zero frame and verify the samples there.
+    const long target = 1234;
+    f.seek(target, false);
+    pos = 0.f;
+    vol = 1.f;
+    intent = YSE::SS_PLAYING_FULL_VOLUME;
+    long frame = target;
+    for (int b = 0; b < 8; ++b) {
+      bool stopped = readBlock(f, pos, false, intent, vol, out);
+      REQUIRE_FALSE(stopped);
+      for (UInt j = 0; j < YSE::STANDARD_BUFFERSIZE; ++j, ++frame) {
+        CHECK(out[j] == doctest::Approx(src[static_cast<size_t>(frame)]).epsilon(0.0001));
+      }
+      breathe(b);
+    }
+
+    // A stop/reset must still return to frame 0 (seek target cleared by reset()).
+    f.reset();
+    pos = 0.f;
+    vol = 1.f;
+    intent = YSE::SS_PLAYING_FULL_VOLUME;
+    frame = 0;
+    for (int b = 0; b < 8; ++b) {
+      bool stopped = readBlock(f, pos, false, intent, vol, out);
+      REQUIRE_FALSE(stopped);
+      for (UInt j = 0; j < YSE::STANDARD_BUFFERSIZE; ++j, ++frame) {
+        CHECK(out[j] == doctest::Approx(src[static_cast<size_t>(frame)]).epsilon(0.0001));
+      }
+      breathe(b);
+    }
+  }
+
   // 5. Destroying a streaming soundFile while a refill is in flight must not crash
   //    or touch freed memory (the dtor joins the refill job). Run under ASan/TSan
   //    in CI for the real teardown-race coverage.

--- a/YseEngine/internal/abstractSoundFile.cpp
+++ b/YseEngine/internal/abstractSoundFile.cpp
@@ -667,10 +667,33 @@ YSE::INTERNAL::abstractSoundFile& YSE::INTERNAL::abstractSoundFile::reset() {
   _frontValidFrames = 0;
   _frontTerminal = false;
   _frontBufferBase = 0;
+  _seekTarget.store(0, std::memory_order_relaxed);
   _needsReset.store(true, std::memory_order_relaxed);
   _fillGen.fetch_add(1, std::memory_order_release);
   _backReady.store(false, std::memory_order_relaxed);
   return *this;
+}
+
+void YSE::INTERNAL::abstractSoundFile::seek(Long frame, Bool loop) {
+  // Audio-thread entry point for a play-position change on a streaming sound
+  // (issue #217). Like reset() this empties the audio-owned front state and bumps
+  // the fill generation so any refill that started before this seek (stale
+  // position) is discarded rather than played. The difference is the target
+  // frame: the next disk fill seeks to `frame` instead of 0. The disk seek and
+  // fill run on the slow pool (fillBuffer via requestRefill), never here.
+  if (frame < 0) frame = 0;
+  if (frame > _length) frame = _length;
+  _frontValidFrames = 0;
+  _frontTerminal = false;
+  _frontBufferBase = frame;
+  _seekTarget.store(frame, std::memory_order_relaxed);
+  _needsReset.store(true, std::memory_order_relaxed);
+  _fillGen.fetch_add(1, std::memory_order_release);
+  _backReady.store(false, std::memory_order_relaxed);
+  // Prompt the from-`frame` refill now so a read() soon after finds it ready.
+  // The read() path re-requests if this one is dropped (stale back buffer), so
+  // scheduling is guaranteed even under a racing in-flight fill.
+  requestRefill(loop);
 }
 
 bool YSE::INTERNAL::abstractSoundFile::inUse(Flt dt) {

--- a/YseEngine/internal/abstractSoundFile.h
+++ b/YseEngine/internal/abstractSoundFile.h
@@ -65,6 +65,12 @@ namespace YSE {
 
       // set
       abstractSoundFile& reset(); // indicate that stream needs to reset (after stop)
+      // Seek a streaming sound to an absolute frame (issue #217). Called on the
+      // audio thread: it never touches the disk. It resets the audio-owned front
+      // state and arms an async re-prime from `frame` on the slow pool, so the
+      // next read() swaps in a buffer filled from the requested position. Mirrors
+      // reset()/streamReprime but with an arbitrary target frame instead of 0.
+      void seek(Long frame, Bool loop);
 
       // to keep track of clients
       void attach(SOUND::implementationObject* impl);
@@ -140,6 +146,11 @@ namespace YSE {
       // Written by the audio thread (reset() on stop), read/cleared by the slow
       // pool (fillBackBuffer) — must be atomic now that the fill is off-thread.
       std::atomic<Bool> _needsReset;
+      // Absolute frame the next disk fill should seek to when _needsReset is
+      // observed. Written by the audio thread (reset() -> 0, seek() -> target),
+      // read by the slow pool in fillBuffer(). Atomic for the cross-thread hand-
+      // off. (issue #217)
+      std::atomic<Long> _seekTarget{0};
 
       // Double-buffer publication (issue #185). Writer = slow pool, reader = audio.
       // _backValidFrames/_backTerminal/_backGen are written before the _backReady

--- a/YseEngine/internal/lsfSoundfile.cpp
+++ b/YseEngine/internal/lsfSoundfile.cpp
@@ -121,8 +121,11 @@ void YSE::INTERNAL::soundFile::loadNonStreaming() {
 
 UInt YSE::INTERNAL::soundFile::fillBuffer(Flt* dest, Bool loop) {
   if (_needsReset.exchange(false, std::memory_order_relaxed)) {
-    handle->seek(0, SEEK_SET);
-    _streamPos = 0;
+    // Seek to the frame armed by the audio thread: 0 after a stop/reset, or the
+    // requested absolute frame after a setFilePos seek (issue #217).
+    Long target = _seekTarget.load(std::memory_order_relaxed);
+    handle->seek(target, SEEK_SET);
+    _streamPos = (Int)target;
   }
   Int framesToRead = STREAM_BUFFERSIZE;
   Flt* ptr = dest;

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -617,7 +617,19 @@ Bool YSE::SOUND::implementationObject::dsp() {
   ///////////////////////////////////////////
   if (setFilePos) {
     Clamp(newFilePos, 0.f, static_cast<Flt>(file->length()));
-    filePtr = newFilePos;
+    if (streaming) {
+      // For a streaming sound filePtr is buffer-local (issue #185), so an
+      // absolute frame index can't just be assigned to it. Arm an async seek:
+      // the disk seek + re-prime from `newFilePos` runs on the slow pool (never
+      // the audio thread), and filePtr resets to the start of the freshly primed
+      // front buffer. _frontBufferBase is set to the target inside seek(). (#217)
+      file->seek(static_cast<Long>(newFilePos), looping);
+      filePtr = 0.f;
+    } else {
+      // Non-streaming: the whole file is resident, so filePtr is a valid
+      // absolute index into the buffer.
+      filePtr = newFilePos;
+    }
     setFilePos = false;
   }
 


### PR DESCRIPTION
## Summary
Streaming `setFilePos` never actually seeked. After #185 `filePtr` is
buffer-local, so `SOUND::implementationObject::dsp()` assigning an absolute
frame index to it put playback somewhere inside whatever ~1 s window happened
to be resident, and nothing re-seeked the libsndfile handle or re-primed the
stream. Non-streaming sounds were unaffected (the whole file is resident, so an
absolute `filePtr` is a valid index).

## Linked issue
Closes #217

## Changes
- **`abstractSoundFile::seek(frame, loop)`** (new): audio-thread entry point
  mirroring `reset()`/`streamReprime` but arming an async re-prime from an
  arbitrary target frame. Resets the audio-owned front state, sets
  `_frontBufferBase` to the target, publishes the target via a new atomic
  `_seekTarget`, bumps `_fillGen` (so an in-flight pre-seek fill is discarded on
  the next swap), and requests a slow-pool refill. **The disk seek runs in
  `fillBuffer()` on the slow pool — never on the audio thread.**
- **`reset()`** now clears `_seekTarget` to 0 so a stop after a seek still
  returns to frame 0 (the seek target does not leak into the reset path).
- **`fillBuffer()`** (lsf backend) seeks the handle to `_seekTarget` instead of
  hard-coded 0 when it observes `_needsReset`.
- **`soundImplementation::dsp()`** routes a streaming `setFilePos` through
  `file->seek(...)` and resets `filePtr` to the new front-buffer start; the
  non-streaming branch is unchanged.

## Test plan
- [x] `python yse.py format` clean (only the 5 touched files changed)
- [x] `python yse.py analyze` on the 4 changed sources — no new findings in the
  modified regions (the pre-existing `soundImplementation.cpp` deadcode/swapped-
  arg findings are untouched backlog)
- [x] Unit tests pass — `python yse.py test`, 16/16 ctest suites green
- [x] Two new streaming cases in `test_sound_streaming.cpp` (seek forward past
  the primed window; seek backward then reset-to-0), asserting sample-accurate
  playback from the requested frame

Note on integration coverage: the streaming test harness deliberately drives
`INTERNAL::soundFile::read()`/`seek()` directly with the audio stream paused
(as the existing stop/re-prime case #4 does), rather than routing through a live
`dsp()`/message flow. The new cases therefore validate the core seek machinery
(`seek()` + `fillBuffer()` target seek); the 4-line `dsp()` glue that selects
seek-vs-assign is not independently exercisable at this layer without a full
live-audio integration rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)