### PR TITLE
FIX: delete per-impl streaming soundFile on teardown (#218)

### DIFF
--- a/Tests/sound/test_sound_streaming.cpp
+++ b/Tests/sound/test_sound_streaming.cpp
@@ -29,6 +29,7 @@
 #include "yse.hpp"
 #include "internal/lsfSoundfile.h"
 #include "internal/time.h"
+#include "sound/soundManager.h"
 #include "dsp/buffer.hpp"
 #include "support/null_device.hpp"
 
@@ -348,6 +349,51 @@ TEST_SUITE("sound") {
     } // ~soundFile joins the refill job before freeing the handle/buffers
 
     CHECK(true); // reaching here without a crash / ASan report is the assertion
+  }
+
+  // 8. A streaming sound owns its per-impl soundFile directly (allocated with
+  //    `new` in implementationObject::create). Before issue #218,
+  //    ~implementationObject never deleted that owned file, so every streaming
+  //    sound leaked its soundFile (handle + two ~172 KB stream buffers) for the
+  //    process lifetime. Drive one streaming sound through the full public-API
+  //    lifecycle and assert the live-soundFile count returns to its baseline
+  //    once the slow-pool deleteJob has torn the impl down. Without the fix the
+  //    count stays at baseline + 1 and the final CHECK fails.
+  TEST_CASE("streaming: per-impl soundFile is freed on teardown (issue #218)") {
+    if (!TestHelpers::engineInit()) return;
+
+    std::vector<float> src;
+    std::string path = writeWav(2 * S, src);
+
+    const long baseline = soundFile::liveInstances();
+
+    {
+      YSE::sound s;
+      s.create(path.c_str(), nullptr, false, 1.0f, /*streaming*/ true);
+      // create() allocates the owned streaming soundFile synchronously, so one
+      // extra instance is live immediately.
+      CHECK(soundFile::liveInstances() == baseline + 1);
+      // Pump the manager so the impl is set up and promoted to inUse (the audio
+      // thread is paused under engineInit, so the test thread drives update()).
+      for (int i = 0; i < 15; ++i) {
+        YSE::INTERNAL::Time().update();
+        YSE::SOUND::Manager().update();
+        std::this_thread::sleep_for(std::chrono::milliseconds(3));
+      }
+      CHECK(soundFile::liveInstances() == baseline + 1);
+    } // ~sound() nulls the head; the next sync() releases the impl.
+
+    // Pump until the slow-pool deleteJob has run ~implementationObject (which,
+    // with the fix, deletes the owned streaming file). Poll with a deadline so
+    // the test doesn't depend on an exact iteration count for async teardown.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < deadline && soundFile::liveInstances() != baseline) {
+      YSE::INTERNAL::Time().update();
+      YSE::SOUND::Manager().update();
+      std::this_thread::sleep_for(std::chrono::milliseconds(3));
+    }
+
+    CHECK(soundFile::liveInstances() == baseline);
   }
 
 } // TEST_SUITE("sound")

--- a/YseEngine/internal/abstractSoundFile.cpp
+++ b/YseEngine/internal/abstractSoundFile.cpp
@@ -12,6 +12,12 @@
 #include <string.h>
 #include <cassert>
 
+std::atomic<long> YSE::INTERNAL::abstractSoundFile::s_liveInstances{0};
+
+long YSE::INTERNAL::abstractSoundFile::liveInstances() {
+  return s_liveInstances.load(std::memory_order_acquire);
+}
+
 YSE::INTERNAL::abstractSoundFile::abstractSoundFile(bool interleaved)
   : useInterleavedBuffer(interleaved),
     _iBuffer(nullptr),
@@ -27,6 +33,9 @@ YSE::INTERNAL::abstractSoundFile::abstractSoundFile(bool interleaved)
     _frontTerminal(false),
     idleTime(0) {
   _refillJob.owner = this;
+  // All constructors delegate here, so this single increment covers every
+  // abstractSoundFile instance (issue #218 test oracle).
+  s_liveInstances.fetch_add(1, std::memory_order_release);
 }
 
 YSE::INTERNAL::abstractSoundFile::abstractSoundFile(const std::string& fileName, bool interleaved)
@@ -643,7 +652,9 @@ Bool YSE::INTERNAL::abstractSoundFile::contains(MULTICHANNELBUFFER* buffer) {
   return this->_multiChannelBuffer == buffer;
 }
 
-YSE::INTERNAL::abstractSoundFile::~abstractSoundFile() {}
+YSE::INTERNAL::abstractSoundFile::~abstractSoundFile() {
+  s_liveInstances.fetch_sub(1, std::memory_order_release);
+}
 
 Int YSE::INTERNAL::abstractSoundFile::channels() {
   return _channels;

--- a/YseEngine/internal/abstractSoundFile.h
+++ b/YseEngine/internal/abstractSoundFile.h
@@ -63,6 +63,15 @@ namespace YSE {
       UInt length(); // length of the source in frames
       FILESTATE getState(); // current state of the file, (ready, invalid or loading)
 
+      // Live-instance accounting for tests (issue #218). Returns the number of
+      // abstractSoundFile objects currently alive, so a test can assert that a
+      // streaming sound's per-impl soundFile is actually freed on teardown (the
+      // leak was that ~implementationObject never deleted it). Incremented in
+      // the base constructor and decremented in the destructor — both run off
+      // the audio thread (main thread / slow pool), so this counter is never
+      // touched on any real-time path.
+      static long liveInstances();
+
       // set
       abstractSoundFile& reset(); // indicate that stream needs to reset (after stop)
       // Seek a streaming sound to an absolute frame (issue #217). Called on the
@@ -185,6 +194,10 @@ namespace YSE {
     private:
       // default constructor should only be used internally
       abstractSoundFile(bool interleaved);
+
+      // Count of live abstractSoundFile instances (issue #218 test oracle).
+      // Never mutated on the audio thread — see liveInstances() above.
+      static std::atomic<long> s_liveInstances;
     };
 
   } // namespace INTERNAL

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -76,9 +76,23 @@ YSE::SOUND::implementationObject::~implementationObject() {
                                         // in doThisWhenReady() / Manager::update() handshake
     parent->disconnect(this);
   }
-  // only streams should delete their source. Other files are shared.
-  if (file != nullptr && !streaming) {
-    file->release(this);
+  if (file != nullptr) {
+    if (streaming) {
+      // Streaming impls own their soundFile outright — it is allocated with
+      // `new` in create() and never registered with the shared-file manager,
+      // so nothing else will ever free it. Delete it exactly once here (issue
+      // #218). This destructor runs on the slow-pool deleteJob
+      // (managerDeleteJob::run erasing from the implementations list), never
+      // the audio thread — which is the only place blocking is allowed,
+      // because ~soundFile join()s an in-flight back-buffer refill before
+      // freeing its handle/buffers (constraint from #185).
+      delete file;
+      file = nullptr;
+    } else {
+      // Other files are shared and reference-counted by the manager; just drop
+      // our client reference so the GC can reclaim it once idle.
+      file->release(this);
+    }
   }
   if (post_dsp && post_dsp->calledfrom) post_dsp->calledfrom = nullptr;
   if (sound* h = head.load(


### PR DESCRIPTION
## Summary

Streaming sounds allocate their `INTERNAL::soundFile` per-impl and own it directly (`file = new INTERNAL::soundFile(...)` in `implementationObject::create()`). Unlike the non-streaming path — shared files owned by `managerObject::soundFiles` and garbage-collected — this per-impl `file` was only deleted on the create-failure paths. On the normal lifecycle (impl reaches `OBJECT_DELETE`, the slow-pool `deleteJob` frees it), `~implementationObject` never deleted `file`, so every streaming sound leaked its `soundFile` (handle + two ~172 KB stream buffers) for the process lifetime.

The fix deletes the owned streaming `file` exactly once in `~implementationObject`. That destructor runs on the slow-pool `deleteJob` (`managerDeleteJob::run` erasing from the `implementations` `forward_list`), **never the audio thread** — the only place blocking is acceptable, because `~soundFile` `join()`s an in-flight back-buffer refill before freeing its handle/buffers (constraint from #185).

## Linked issue
Closes #218

## Changes
- `soundImplementation.cpp`: `~implementationObject` now `delete`s the owned `file` when `streaming`, and drops the shared-client reference (`file->release`) otherwise. Non-streaming behaviour is unchanged.
- `abstractSoundFile.{h,cpp}`: add a `static long liveInstances()` counter (incremented in the base ctor, decremented in the dtor — both run on the main thread / slow pool, never a real-time path) as a deterministic test oracle for the leak.
- `test_sound_streaming.cpp`: regression test that drives one streaming sound through its full public-API lifecycle and asserts the live-`soundFile` count returns to baseline after the slow-pool `deleteJob` tears the impl down.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on all changed files (v22.1.4)
- [x] `python yse.py analyze` clean — no new user-code findings on the changed `.cpp` files (only pre-existing baseline warnings remain)
- [x] Regression test **fails without the fix** (`liveInstances() == 1`, baseline `0`) and **passes with it** — verified by reverting only the destructor change and rebuilding
- [x] Full suite green: `python yse.py test` → 16/16 ctest executables pass; sound suite 105 cases / 262,587 assertions pass

No integration/e2e layer applies here: this is engine-internal lifecycle/memory behaviour with no user-visible rendering flow. The deterministic instance-counter unit test exercises the real create → setup → release → slow-pool `deleteJob` path end-to-end, which is the observable surface for this leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)