### PR TITLE
FIX: nothrow operator new/delete overrides in named-bus test (#219)

### DIFF
--- a/Tests/system/test_named_bus.cpp
+++ b/Tests/system/test_named_bus.cpp
@@ -52,10 +52,24 @@ void* operator new(std::size_t n) {
   throw std::bad_alloc{};
 }
 
+// Route the nothrow form through malloc too. libsndfile's sndfile.hh allocates
+// SNDFILE_ref with `new (std::nothrow)`; without this override that allocation
+// would go through the default (ASan-instrumented) operator new while the
+// matching delete below frees it with std::free, which AddressSanitizer flags
+// as an alloc-dealloc-mismatch (issue #219).
+void* operator new(std::size_t n, const std::nothrow_t&) noexcept {
+  if (g_alloc_probe_active.load(std::memory_order_relaxed))
+    g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+  return std::malloc(n == 0 ? 1 : n);
+}
+
 void operator delete(void* p) noexcept {
   std::free(p);
 }
 void operator delete(void* p, std::size_t) noexcept {
+  std::free(p);
+}
+void operator delete(void* p, const std::nothrow_t&) noexcept {
   std::free(p);
 }
 


### PR DESCRIPTION
## Summary
`Tests/system/test_named_bus.cpp` replaces the global throwing `operator new` and both `operator delete` forms (routing through `malloc`/`free`) to count allocations during a scoped probe, but leaves `operator new(size_t, const std::nothrow_t&)` as the default. When a soundfile-loading test shares the same binary, libsndfile's `sndfile.hh` allocates `SNDFILE_ref` via `new (std::nothrow)` — served by the default (ASan-instrumented) allocator — while the matching `delete` frees it with the overridden `std::free`. AddressSanitizer flags that as a hard `alloc-dealloc-mismatch` and aborts, blocking the `sound` suite under ASan (the #185 streaming sanitizer coverage).

## Linked issue
Closes #219

## Changes
- Add `operator new(std::size_t, const std::nothrow_t&) noexcept` (counted, `malloc`-backed) and the matching `operator delete(void*, const std::nothrow_t&) noexcept` (`std::free`) so **every** allocation route goes through `malloc` consistently and no allocation/deallocation crosses allocator boundaries.
- Counting stays gated on `g_alloc_probe_active`, so the probe semantics are unchanged.

I chose fix option (a) from the issue over the "scoped counting allocator" option (b): the test's purpose is to prove `publish()` performs no *global* heap allocation (STL / `std::function`), and the only way to observe those is to replace the global `operator new`. A counting allocator scoped to the test can't see `publish()`'s allocations through global `new`, so option (b) as described would defeat the test. Option (a) is the minimal, consistent fix.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on the changed file
- [x] `python yse.py analyze Tests/system/test_named_bus.cpp` clean (0 findings in user code)
- [x] Full `python yse.py test` — 16/16 ctest binaries pass, incl. `yse_tests_system`
- [x] Named-bus cases run directly: 8/8 cases, 25/25 assertions pass

Note: the ASan `alloc-dealloc-mismatch` itself only reproduces under the Linux-Docker ASan leg with a soundfile-loading test in the same binary (per the issue and project notes); it is not reproducible on the Windows MSYS2 desktop build. The change is a standard, self-contained allocator-override addition validated by reasoning + the passing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)