### PR TITLE
TEST: patcher concurrency stress harness + TSan/ASan gate (#229)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,3 +202,54 @@ jobs:
         env:
           LSAN_OPTIONS: ${{ matrix.asan && format('suppressions={0}/tools/lsan/python.supp', github.workspace) || '' }}
         run: ctest --test-dir ${{ matrix.bdir }} -L python --output-on-failure
+
+  build-sanitizers:
+    # Patcher concurrency acceptance gate (issue #229, epic #189): drive
+    # concurrent live-edit + render of a patcher under Thread- and
+    # AddressSanitizer so a regression in the wait-free graph model (a data race
+    # or a use-after-free of a retired GraphState/object on the audio thread) is
+    # caught. Both legs build only the tests-<san> preset and run just the
+    # patcher concurrency test (the preset filters by name). Local repro:
+    # tools/ci-linux/Dockerfile.sanitizers.
+    #
+    # Same trigger gate as the `build` job: continuous on push to dev/master,
+    # plus feature-branch PRs; skipped on release/sync PRs whose head is dev or
+    # master (the push that landed those SHAs already ran this).
+    if: github.event_name == 'push' || (github.head_ref != 'dev' && github.head_ref != 'master')
+    name: Sanitizers (${{ matrix.san }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        san: [tsan, asan]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install dependencies
+        # libclang-rt-dev ships libclang_rt.{asan,tsan}; not pulled in by the base
+        # clang package, so the sanitizer legs fail to link without it.
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            cmake \
+            ninja-build \
+            pkg-config \
+            clang \
+            libclang-rt-dev \
+            portaudio19-dev \
+            libsndfile1-dev \
+            librtmidi-dev
+      - name: Lower ASLR entropy for the sanitizer runtime
+        # ubuntu-latest runners ship vm.mmap_rnd_bits=32, which the ASan/TSan
+        # shadow mapping cannot accommodate ("unexpected memory mapping" abort).
+        # 28 is the entropy the sanitizer runtimes are built for.
+        run: sudo sysctl -w vm.mmap_rnd_bits=28
+      - name: Configure (tests-${{ matrix.san }})
+        run: cmake --preset tests-${{ matrix.san }}
+      - name: Build
+        run: cmake --build --preset tests-${{ matrix.san }}
+      - name: Run patcher concurrency gate
+        # The tests-${san} test preset filters to yse_tests_patcher_concurrency
+        # and sets ASAN_OPTIONS=detect_leaks=0 on the asan leg (the process-global
+        # thread pools / named bus are intentionally never torn down).
+        run: ctest --preset tests-${{ matrix.san }} --output-on-failure

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -92,6 +92,46 @@
       }
     },
     {
+      "name": "tests-asan",
+      "displayName": "Debug + Tests + ASan (Linux/clang)",
+      "description": "tests-debug under AddressSanitizer with clang — the heap/use-after-free half of the #229 patcher concurrency acceptance gate (epic #189). Leak detection is disabled via ASAN_OPTIONS=detect_leaks=0 in the test preset, because the process-global thread pools / named bus are intentionally never torn down; this gate is about UAF on the live-edit path, not leaks. Linux only.",
+      "inherits": "tests-debug",
+      "binaryDir": "${sourceDir}/build-tests-asan",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "tests-tsan",
+      "displayName": "Debug + Tests + TSan (Linux/clang)",
+      "description": "tests-debug under ThreadSanitizer with clang — the data-race half of the #229 patcher concurrency acceptance gate (epic #189). Drives concurrent live-edit + render of a patcher and must be race-free. Linux only.",
+      "inherits": "tests-debug",
+      "binaryDir": "${sourceDir}/build-tests-tsan",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer",
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=thread"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
       "name": "bench",
       "displayName": "Release + Benchmarks",
       "description": "Release build with the Bench/ suite enabled (fetches google-benchmark on first configure)",
@@ -175,6 +215,26 @@
       }
     },
     {
+      "name": "tests-asan",
+      "displayName": "Debug + Tests + ASan",
+      "configurePreset": "tests-asan",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "tests-tsan",
+      "displayName": "Debug + Tests + TSan",
+      "configurePreset": "tests-tsan",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
       "name": "bench",
       "displayName": "Release + Benchmarks",
       "configurePreset": "bench"
@@ -222,6 +282,33 @@
       "environment": {
         "LSAN_OPTIONS": "suppressions=${sourceDir}/tools/lsan/python.supp"
       },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "tests-asan",
+      "displayName": "ASan patcher concurrency test",
+      "configurePreset": "tests-asan",
+      "output": { "outputOnFailure": true },
+      "filter": { "include": { "name": "yse_tests_patcher_concurrency" } },
+      "environment": {
+        "ASAN_OPTIONS": "detect_leaks=0"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "tests-tsan",
+      "displayName": "TSan patcher concurrency test",
+      "configurePreset": "tests-tsan",
+      "output": { "outputOnFailure": true },
+      "filter": { "include": { "name": "yse_tests_patcher_concurrency" } },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(YSE_TEST_SOURCES
   patcher/test_patcher_graphstate.cpp
   patcher/test_patcher_setparams.cpp
   patcher/test_patcher_value_queue.cpp
+  patcher/test_patcher_concurrency.cpp
   patcher/test_timerthread.cpp
   channel/test_channel.cpp
   channel/test_channel_concurrency.cpp
@@ -181,6 +182,18 @@ add_test(
 )
 set_tests_properties(yse_tests_patcher PROPERTIES LABELS patcher TIMEOUT 300)
 
+# Patcher concurrency stress test (issue #229), registered on its own so the
+# sanitizer CI legs can target just it (`ctest -R yse_tests_patcher_concurrency`)
+# under TSan/ASan without paying for the whole suite — the `concurrency` label
+# is shared with the channel/sound/reverb concurrency tests, so the sanitizer
+# presets match by name, not by label. It also runs as part of yse_tests_patcher.
+add_test(
+  NAME    yse_tests_patcher_concurrency
+  COMMAND yse_tests --test-case=concurrency:* --duration=true
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_patcher_concurrency PROPERTIES LABELS "patcher;concurrency" TIMEOUT 300)
+
 add_test(
   NAME    yse_tests_channel
   COMMAND yse_tests --test-suite=channel
@@ -306,6 +319,7 @@ set_source_files_properties(
   patcher/test_patcher_graphstate.cpp
   patcher/test_patcher_setparams.cpp
   patcher/test_patcher_value_queue.cpp
+  patcher/test_patcher_concurrency.cpp
   patcher/test_timerthread.cpp
   PROPERTIES COMPILE_FLAGS "${_patcher_test_suppress}"
 )

--- a/Tests/patcher/test_patcher_concurrency.cpp
+++ b/Tests/patcher/test_patcher_concurrency.cpp
@@ -1,0 +1,300 @@
+// Concurrency stress test for the patcher (issue #229) — the acceptance gate
+// for epic #189 (wait-free graph rearchitecture).
+//
+// The races the epic fixes were found by code audit, not by a test: nothing
+// exercised concurrent live editing of a *rendering* patcher, so a regression
+// would slip through. This test drives one thread rendering blocks
+// (`Calculate`, the audio-thread entry point) while other threads mutate the
+// same patcher, and is meant to be run under ThreadSanitizer + AddressSanitizer
+// (see the `tsan` / `asan` presets and the CI legs). On pre-epic code it trips
+// TSan/ASan almost immediately; on post-epic code it must stay clean.
+//
+// Threading model — deliberately mirrors the ownership split the epic designed:
+//   * one render thread  : the audio thread. Calls `Calculate` in a tight loop,
+//                          lock-free, reading only the published GraphState.
+//   * one editor thread  : the structural / file-handler control path. Owns the
+//                          entire handle lifecycle (create/delete/connect/
+//                          disconnect/ParseJSON/Clear/SetName), so no other
+//                          thread can ever touch a freed handle. All of these
+//                          serialise on the patcher's `mtx`.
+//   * two value threads  : the value control path. PassBang/PassData address
+//                          receivers by *name* (never by handle), so they are
+//                          safe regardless of what the editor does to the graph,
+//                          and two of them stress the multi-producer queue.
+//
+// Coverage is limited to the paths the epic already made safe. In-place
+// `pHandle::SetParams` re-parse (which reallocates a live object's pins and is
+// NOT routed through the swap) is a separate, still-open race tracked as #234;
+// this harness is extended to drive it once that lands. Pin-count reallocation
+// is exercised here only through the safe paths: creating `gGate`/`gSwitch`
+// with varying pin counts (the `PARM_PARSE` grow runs off-thread under `mtx`
+// before the swap) and re-parsing whole graphs via ParseJSON.
+//
+// doctest assertion macros are not thread-safe, so the worker threads call none
+// of them: a race/UAF is caught by the sanitizer aborting the process, and the
+// logical post-conditions are asserted on the main thread after every worker
+// has joined. Logging is silenced for the duration — the engine logger writes a
+// shared ofstream without a lock (a debug build logs on every edit), so leaving
+// it on would trip TSan on the logger rather than on the code under test.
+//
+// No audio device required.
+
+#include <doctest/doctest.h>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <random>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "patcher/patcherImplementation.h"
+#include "patcher/pHandle.hpp"
+#include "patcher/pObjectList.hpp"
+#include "dsp/buffer.hpp"
+#include "implementations/logImplementation.h"
+
+using YSE::PATCHER::patcherImplementation;
+
+namespace {
+
+  // Receiver names shared between the editor (which creates/destroys them) and
+  // the value threads (which target them by name). A small pool keeps the "hit"
+  // rate high while still racing creation/deletion, so both the delivered and
+  // the not-found value paths are exercised.
+  const char* const kReceiverNames[] = {"a", "b", "c"};
+  constexpr int kReceiverCount = 3;
+
+  // A raii guard that silences the global logger for the lifetime of the test
+  // and restores the previous level on the way out. Set before any worker
+  // thread starts and restored after all have joined, so the single write to
+  // the shared `level` happens-before / happens-after every read.
+  struct LogSilencer {
+    YSE::ERROR_LEVEL previous;
+    LogSilencer() : previous(YSE::INTERNAL::LogImpl().getLevel()) {
+      YSE::INTERNAL::LogImpl().setLevel(YSE::EL_NONE);
+    }
+    ~LogSilencer() {
+      YSE::INTERNAL::LogImpl().setLevel(previous);
+    }
+  };
+
+  // A small, self-contained graph (noise -> dac, plus a receiver named "a")
+  // dumped once at setup. The editor re-parses this via ParseJSON to exercise
+  // the file-handler swap path with a known, bounded object set.
+  std::string makeSavedGraph() {
+    patcherImplementation seed(1, nullptr);
+    YSE::pHandle* noise = seed.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = seed.CreateObject(YSE::OBJ::D_DAC, "");
+    seed.Connect(noise, 0, dac, 0);
+    seed.CreateObject(YSE::OBJ::G_RECEIVE, "a");
+    return seed.DumpJSON();
+  }
+
+  // A live object the editor owns: its handle plus a stable, monotonically
+  // increasing creation order. Edges are only ever added from a lower `seq` to a
+  // higher one, so the message/DSP graph the editor builds is always acyclic —
+  // a value delivered into it can't feed back and recurse forever (patcher
+  // objects have no message-loop guard; feedback recursion is a separate,
+  // pre-existing hazard, tracked as #236). `seq` is a fixed total order, so the
+  // acyclicity survives deletions (which shuffle vector positions).
+  struct Node {
+    YSE::pHandle* h;
+    int seq;
+  };
+
+  // The editor thread body: a deterministic (fixed-seed) randomized mix of every
+  // safe control-thread operation, run for `iterations` steps. It owns `live`,
+  // the set of handles it has created and not yet deleted, so it never hands a
+  // freed handle to any other thread (there is none) or reuses one itself.
+  void runEditor(patcherImplementation& p, const std::string& savedGraph, int iterations) {
+    // Fixed seed on purpose: a stress failure must be replayable bit-for-bit, so
+    // the editor's operation stream is deterministic across runs.
+    std::mt19937 rng(0xC0FFEE); // NOLINT(cert-msc51-cpp,bugprone-random-generator-seed)
+    auto pick = [&](int n) { return static_cast<int>(rng() % static_cast<unsigned>(n)); };
+
+    std::vector<Node> live;
+    live.reserve(32);
+    int nextRecv = 0;
+    int nextSeq = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+      // Weighted operation choice: mostly cheap create/connect/disconnect churn,
+      // with rarer heavyweight file-handler ops so the swap/retire/reclaim path
+      // runs constantly without the object set exploding.
+      int op = pick(100);
+
+      if (op < 30 && live.size() < 20) {
+        // CREATE — spread across plain, DSP and pin-reallocating generic types.
+        // gSend/gReceive bus feedback is deliberately out of scope: gSend
+        // publishes through the process-global NamedBus, a different subsystem
+        // from the patcher GraphState epic. gReceive is kept (it is the value-
+        // queue delivery target); gSend is not created here.
+        int kind = pick(5);
+        YSE::pHandle* h = nullptr;
+        switch (kind) {
+        case 0:
+          h = p.CreateObject(YSE::OBJ::D_NOISE, "");
+          break;
+        case 1:
+          h = p.CreateObject(YSE::OBJ::D_DAC, "");
+          break;
+        case 2:
+          // gGate with 2..5 outlets: PARM_PARSE grows `outputs` at construction.
+          h = p.CreateObject(YSE::OBJ::G_GATE, std::to_string(2 + pick(4)));
+          break;
+        case 3:
+          // gSwitch with 2..5 inlets: PARM_PARSE grows `inputs` at construction.
+          h = p.CreateObject(YSE::OBJ::G_SWITCH, std::to_string(2 + pick(4)));
+          break;
+        case 4:
+          h = p.CreateObject(YSE::OBJ::G_RECEIVE, kReceiverNames[nextRecv++ % kReceiverCount]);
+          break;
+        default:
+          break;
+        }
+        if (h != nullptr) live.push_back({h, nextSeq++});
+
+      } else if (op < 55 && live.size() >= 2) {
+        // CONNECT outlet 0 -> inlet 0, always from the lower-seq object to the
+        // higher-seq one so the graph stays acyclic (see Node). Only when both
+        // pins actually exist (a ~dac has no outlet, a ~noise no inlet). This
+        // models a well-behaved editor; the harness targets concurrency, not
+        // input validation — Disconnect with a missing pin is a separate latent
+        // null-deref, tracked as #235.
+        int a = pick(static_cast<int>(live.size()));
+        int b = pick(static_cast<int>(live.size()));
+        if (live[a].seq > live[b].seq) std::swap(a, b);
+        if (a != b && live[a].h->GetOutputs() > 0 && live[b].h->GetInputs() > 0)
+          p.Connect(live[a].h, 0, live[b].h, 0);
+
+      } else if (op < 70 && live.size() >= 2) {
+        // DISCONNECT — harmless if the pair was never connected, as long as both
+        // pins exist and the direction matches a possible CONNECT (lower -> higher).
+        int a = pick(static_cast<int>(live.size()));
+        int b = pick(static_cast<int>(live.size()));
+        if (live[a].seq > live[b].seq) std::swap(a, b);
+        if (a != b && live[a].h->GetOutputs() > 0 && live[b].h->GetInputs() > 0)
+          p.Disconnect(live[a].h, 0, live[b].h, 0);
+
+      } else if (op < 82 && !live.empty()) {
+        // DELETE a random live object and drop it from our set.
+        int a = pick(static_cast<int>(live.size()));
+        p.DeleteObject(live[a].h);
+        live.erase(live.begin() + a);
+
+      } else if (op < 90) {
+        // RENAME — re-anchors every gReceive bus subscription.
+        p.SetName("stress_" + std::to_string(pick(4)));
+
+      } else if (op < 96) {
+        // FILE-HANDLER: clear the whole graph then re-parse the saved one in a
+        // single swap. Clear frees every handle we own, so reset `live` too;
+        // the re-parsed objects are owned by the patcher (untracked here) and
+        // reclaimed by the next Clear or at teardown.
+        p.Clear();
+        live.clear();
+        p.ParseJSON(savedGraph);
+
+      } else {
+        // DUMP — reads the object set under mtx; cheap consistency exercise.
+        volatile std::size_t n = p.DumpJSON().size();
+        (void)n;
+      }
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("patcher") {
+
+  TEST_CASE("concurrency: live-edit a rendering patcher under sanitizers") {
+    LogSilencer silence;
+
+    patcherImplementation p(1, nullptr);
+
+    // Seed a baseline so the very first rendered block has a graph to walk.
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    p.Connect(noise, 0, dac, 0);
+    p.CreateObject(YSE::OBJ::G_RECEIVE, "a");
+
+    const std::string savedGraph = makeSavedGraph();
+
+    std::atomic<bool> stop{false};
+    std::atomic<std::uint64_t> blocks{0};
+
+    // Audio thread: render continuously, lock-free.
+    std::thread render([&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        p.Calculate(YSE::T_DSP);
+        blocks.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+
+    // Value threads: flood bang/int/float/list at the receiver-name pool. Names
+    // are re-resolved against the pinned snapshot on the audio thread, so a
+    // concurrently-deleted receiver simply drops the message.
+    auto valueBody = [&](int seed) {
+      std::mt19937 rng(static_cast<unsigned>(0xA5 + seed));
+      while (!stop.load(std::memory_order_relaxed)) {
+        const char* to = kReceiverNames[rng() % kReceiverCount];
+        switch (rng() % 4) {
+        case 0:
+          p.PassBang(to, YSE::T_GUI);
+          break;
+        case 1:
+          p.PassData(static_cast<int>(rng() % 1000), to, YSE::T_GUI);
+          break;
+        case 2:
+          p.PassData(static_cast<float>(rng() % 1000) * 0.01f, to, YSE::T_GUI);
+          break;
+        case 3:
+          p.PassData(std::string("v") + std::to_string(rng() % 100), to, YSE::T_GUI);
+          break;
+        default:
+          break;
+        }
+      }
+    };
+    std::thread value0(valueBody, 0);
+    std::thread value1(valueBody, 1);
+
+    // Editor thread: the structural / file-handler churn. When it finishes the
+    // stress window is over.
+    std::thread editor([&] { runEditor(p, savedGraph, 4000); });
+
+    editor.join();
+    stop.store(true, std::memory_order_relaxed);
+    value0.join();
+    value1.join();
+    render.join();
+
+    // The audio thread kept running throughout.
+    CHECK(blocks.load() > 0);
+
+    // The patcher is still fully functional after the storm: a known graph
+    // renders audio again.
+    p.Clear();
+    YSE::pHandle* n2 = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* d2 = p.CreateObject(YSE::OBJ::D_DAC, "");
+    p.Connect(n2, 0, d2, 0);
+    p.Calculate(YSE::T_DSP);
+    CHECK_FALSE(p.output[0].isSilent());
+
+    // Retired state drains on the background pool rather than piling up until
+    // teardown. Keep the epoch advancing so any snapshot inside the +2 grace
+    // can cross it, then assert only a handful remain pending.
+    for (int spins = 0; spins < 2000 && p.PendingRetired() > 4; ++spins) {
+      p.Connect(n2, 0, d2, 0);
+      p.Calculate(YSE::T_DSP);
+      p.Disconnect(n2, 0, d2, 0);
+      p.Calculate(YSE::T_DSP);
+      p.Calculate(YSE::T_DSP);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    CHECK(p.PendingRetired() <= 4);
+  }
+
+} // TEST_SUITE("patcher")

--- a/Tests/system/test_named_bus.cpp
+++ b/Tests/system/test_named_bus.cpp
@@ -45,6 +45,22 @@ namespace {
 
 } // namespace
 
+// ThreadSanitizer ships its own replaceable operator new/delete in
+// libclang_rt.tsan_cxx, so defining ours too is a multiple-definition link
+// error (issue #229 wired a TSan build of this binary). Skip the allocation
+// probe under TSan: the audio-path checks below assert g_alloc_count == 0, which
+// then holds trivially because the counter is never touched. ASan tolerates the
+// override, so it is kept there.
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define YSE_UNDER_TSAN 1
+#endif
+#endif
+#if defined(__SANITIZE_THREAD__)
+#define YSE_UNDER_TSAN 1
+#endif
+
+#ifndef YSE_UNDER_TSAN
 void* operator new(std::size_t n) {
   if (g_alloc_probe_active.load(std::memory_order_relaxed))
     g_alloc_count.fetch_add(1, std::memory_order_relaxed);
@@ -72,6 +88,7 @@ void operator delete(void* p, std::size_t) noexcept {
 void operator delete(void* p, const std::nothrow_t&) noexcept {
   std::free(p);
 }
+#endif // YSE_UNDER_TSAN
 
 TEST_SUITE("system") {
 

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -712,6 +712,13 @@ void patcherImplementation::DeliverPendingValues(const GraphState* g) {
 }
 
 std::string patcherImplementation::GetRecieveObjectsAsString() {
+  // Reached from the PassBang/PassData not-found log path on the control thread
+  // (the target receiver was concurrently removed). Scan `objects` under mtx so
+  // it is never read while another control thread mutates the graph — mtx is
+  // control-thread only and never blocks the audio callback (issue #226). The
+  // callers release mtx in EnqueueValue before falling through here, so there is
+  // no re-entrancy.
+  std::scoped_lock lk(mtx);
   std::string result;
   for (auto& x : objects) {
 

--- a/tools/ci-linux/Dockerfile.sanitizers
+++ b/tools/ci-linux/Dockerfile.sanitizers
@@ -1,0 +1,45 @@
+# Clang + sanitizer-runtime image for reproducing the patcher concurrency
+# acceptance gate (issue #229) locally. Mirrors the `clang+tsan` / `clang+asan`
+# legs in .github/workflows/build.yml so a sanitizer failure can be reproduced
+# from Windows without waiting on CI.
+#
+# Usage from PowerShell at repo root (TSan needs an unconfined seccomp profile
+# and ASLR disabled, so the container runs the binary under `setarch -R`):
+#   docker build -t yse-ci-san -f tools/ci-linux/Dockerfile.sanitizers .
+#   docker run --rm --security-opt seccomp=unconfined -e SAN=tsan \
+#       -v "${PWD}:/workspace" yse-ci-san
+#   docker run --rm --security-opt seccomp=unconfined -e SAN=asan \
+#       -v "${PWD}:/workspace" yse-ci-san
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+        clang \
+        libclang-rt-dev \
+        cmake \
+        ninja-build \
+        pkg-config \
+        portaudio19-dev \
+        libsndfile1-dev \
+        librtmidi-dev \
+        util-linux \
+        ca-certificates \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# SAN selects the sanitizer (tsan|asan). ASan disables the leak detector: the
+# process-global thread pools / named bus are intentionally never torn down, so
+# this gate is about use-after-free on the live-edit path, not leaks. The test
+# binary is launched by CTest under `setarch -R` (ASLR off) so TSan's shadow
+# mapping is stable under Docker.
+CMD ["bash", "-c", "set -ex && \
+    SAN=${SAN:-tsan} && \
+    PRESET=tests-${SAN} && \
+    export ASAN_OPTIONS=detect_leaks=0 && \
+    cmake --preset ${PRESET} && \
+    cmake --build --preset ${PRESET} && \
+    setarch -R ctest --preset ${PRESET} --output-on-failure"]

--- a/yse.py
+++ b/yse.py
@@ -86,6 +86,21 @@ def cmd_build(args):
 
 
 def cmd_test(args):
+    sanitizer = getattr(args, "sanitizer", None)
+    if sanitizer:
+        # ASan/TSan gate for the #229 patcher concurrency stress test. clang +
+        # sanitizer runtime are Linux-only here (Windows/MSYS2 clang ships no
+        # TSan and no ASan leak detector), matching the preset conditions.
+        if IS_WINDOWS:
+            print("error: --sanitizer builds require Linux/clang (see the "
+                  "tests-asan / tests-tsan presets).")
+            sys.exit(1)
+        preset = "tests-asan" if sanitizer == "asan" else "tests-tsan"
+        run(["cmake", "--preset", preset])
+        run(["cmake", "--build", "--preset", preset])
+        run(["ctest", "--preset", preset])
+        return
+
     preset = "tests-debug-python" if args.python else "tests-debug"
     build_dir = "build-tests-python" if args.python else "build-tests"
     run(["cmake", "--preset", preset])
@@ -931,6 +946,12 @@ def build_parser():
         help="Enable the embedded-CPython live-coding feature (YSE_ENABLE_PYTHON=ON; "
              "uses the tests-debug-python preset so the embedded-interpreter suite "
              "runs; desktop only)",
+    )
+    p.add_argument(
+        "--sanitizer", choices=["asan", "tsan"],
+        help="Build the patcher concurrency stress test (#229) under Address- or "
+             "ThreadSanitizer (tests-asan / tests-tsan presets) and run just that "
+             "test. Linux/clang only.",
     )
     p.set_defaults(func=cmd_test)
 


### PR DESCRIPTION
## Summary

Adds the concurrency acceptance gate for epic #189 (wait-free patcher graph):
a stress test that live-edits a **rendering** patcher from multiple threads,
run under ThreadSanitizer and AddressSanitizer. The races the epic fixed were
found by code audit, not by a test — nothing previously exercised concurrent
editing of a rendering patcher, so a regression would have slipped through.

This harness is what surfaced #237 (audio thread reads a retired object while
the reclaimer frees it). With #237 and #234 now landed on `dev`, **both the
TSan and ASan gates are green** on the current epic code.

## Linked issue

Closes #229

## Changes

- `Tests/patcher/test_patcher_concurrency.cpp` — one render thread
  (`Calculate`, lock-free), one editor thread (create/delete/connect/
  disconnect/ParseJSON/Clear/SetName), and two value threads (PassBang/PassData
  floods to gReceive targets by name). Exercises pin-count reallocation via
  `gGate`/`gSwitch` create + whole-graph ParseJSON. Worker threads use no
  doctest macros (not thread-safe); a race/UAF is caught by the sanitizer, and
  post-conditions are asserted on the main thread after all workers join.
- `tests-asan` / `tests-tsan` CMake presets (configure + build + test), plus
  `python yse.py test --sanitizer asan|tsan` (Linux/clang only).
- `build-sanitizers` CI matrix in `build.yml` (tsan + asan legs, blocking),
  and `tools/ci-linux/Dockerfile.sanitizers` for local repro from Windows.
- `patcherImplementation::GetRecieveObjectsAsString()` now scans `objects`
  under `mtx` — it is reachable from the PassBang/PassData not-found log path on
  a control thread and must not read `objects` while another control thread
  mutates the graph. `mtx` is control-thread only and never blocks the audio
  callback (#226); callers release `mtx` in `EnqueueValue` before falling
  through, so there is no re-entrancy.
- `Tests/system/test_named_bus.cpp` — the throwing/nothrow `operator new`/
  `delete` overrides are skipped under TSan (its runtime ships its own, so
  defining ours is a multiple-definition link error); ASan keeps them.

Scope note: the in-place `pHandle::SetParams` re-parse case (once tracked under
#234, now landed) is intentionally **not** added here — it is a distinct test
extension, not part of the epic-acceptance gate this issue defines, and can be a
follow-up. Two latent hazards the harness surfaced are filed separately: #235
(Disconnect null-deref) and #236 (unbounded message feedback recursion).

## Test plan

- [x] `clang-format --dry-run --Werror` clean on all changed C++ files
- [x] `python yse.py analyze` clean on changed files (constant RNG seed carries
      a focused `// NOLINT` — deterministic replay is the point of a stress test)
- [x] Full unit suite: `python yse.py test` — 17/17 pass (includes the new
      `yse_tests_patcher_concurrency`)
- [x] **TSan gate green** — `Dockerfile.sanitizers`, `SAN=tsan`: patcher
      concurrency test passes (this is the leg that deterministically caught #237
      before it was fixed)
- [x] **ASan gate green** — `Dockerfile.sanitizers`, `SAN=asan`: passes with
      `ASAN_OPTIONS=detect_leaks=0` (process-global pools/named bus are never
      torn down; this gate is UAF, not leaks)