### PR TITLE
FIX: guard patcher Disconnect against missing outlet/inlet (#235)

### DIFF
--- a/Tests/patcher/test_graph.cpp
+++ b/Tests/patcher/test_graph.cpp
@@ -97,6 +97,54 @@ TEST_SUITE("patcher") {
     CHECK(sine->GetConnections(0) == 0u);
   }
 
+  // Regression for issue #235: Disconnect must guard a missing outlet/inlet the
+  // same way Connect does. A ~dac has no outlets, so from->GetOutlet(0) returns
+  // null; before the fix that null flowed into inlet::Disconnect and segfaulted
+  // (a disconnected inlet has dspConnection == nullptr == out, so it derefed the
+  // null outlet). These calls must be safe no-ops now, not crashes.
+  TEST_CASE("patcher: Disconnect on a source with no outlet is a safe no-op (issue #235)") {
+    YSE::patcher p;
+    p.create(2);
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    YSE::pHandle* add = p.CreateObject(YSE::OBJ::D_ADD);
+    REQUIRE(dac != nullptr);
+    REQUIRE(add != nullptr);
+
+    // ~dac has no outlets — outlet 0 does not exist. Must not crash.
+    p.Disconnect(dac, 0, add, 0);
+    CHECK(p.Objects() == 2u);
+  }
+
+  TEST_CASE("patcher: Disconnect with out-of-range outlet index is a safe no-op (issue #235)") {
+    YSE::patcher p;
+    p.create(2);
+    YSE::pHandle* sine = p.CreateObject(YSE::OBJ::D_SINE);
+    YSE::pHandle* add = p.CreateObject(YSE::OBJ::D_ADD);
+    REQUIRE(sine != nullptr);
+    REQUIRE(add != nullptr);
+
+    p.Connect(sine, 0, add, 0);
+    // Outlet 99 does not exist on a sine — GetOutlet returns null.
+    p.Disconnect(sine, 99, add, 0);
+    // The real edge is untouched and nothing crashed.
+    CHECK(sine->GetConnections(0) == 1u);
+  }
+
+  TEST_CASE("patcher: Disconnect with out-of-range inlet index is a safe no-op (issue #235)") {
+    YSE::patcher p;
+    p.create(2);
+    YSE::pHandle* sine = p.CreateObject(YSE::OBJ::D_SINE);
+    YSE::pHandle* add = p.CreateObject(YSE::OBJ::D_ADD);
+    REQUIRE(sine != nullptr);
+    REQUIRE(add != nullptr);
+
+    p.Connect(sine, 0, add, 0);
+    // Inlet 99 does not exist on an add — GetInlet returns null, and the
+    // former inputs[99] out-of-bounds index is avoided.
+    p.Disconnect(sine, 0, add, 99);
+    CHECK(sine->GetConnections(0) == 1u);
+  }
+
   TEST_CASE("patcher: connection target reports correct object ID and inlet index") {
     YSE::patcher p;
     p.create(2);

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -190,7 +190,18 @@ void patcherImplementation::Connect(YSE::pHandle* from, int outlet, YSE::pHandle
 void patcherImplementation::Disconnect(YSE::pHandle* from, int outlet, YSE::pHandle* to,
                                        int inlet) {
   std::scoped_lock lk(mtx);
-  to->object->DisconnectInlet(from->object->GetOutlet(outlet), inlet);
+  // Mirror ConnectUnlocked's guard: GetOutlet/GetInlet return null for an
+  // out-of-range pin. Passing a null outlet into inlet::Disconnect segfaults
+  // (a disconnected inlet has dspConnection == nullptr, so `dspConnection ==
+  // out` is true and it derefs the null outlet), and an out-of-range inlet
+  // indexes inputs[] out of bounds (issue #235).
+  PATCHER::outlet* out = from->object->GetOutlet(outlet);
+  PATCHER::inlet* in = to->object->GetInlet(inlet);
+  if (out != nullptr && in != nullptr) {
+    to->object->DisconnectInlet(out, inlet);
+  } else {
+    INTERNAL::LogImpl().emit(E_ERROR, "Patcher: Invalid Disconnection");
+  }
   RebuildAndPublish();
 }
 


### PR DESCRIPTION
## Summary

`patcherImplementation::Disconnect` null-dereferenced when given a pin that
does not exist. `Connect` guards both sides via `ConnectUnlocked`; `Disconnect`
did not — it passed `from->object->GetOutlet(outlet)` (which returns `nullptr`
for an out-of-range/absent outlet, e.g. a `~dac` has none) straight into
`inlet::Disconnect`, and indexed `inputs[inlet]` with no bounds check. A
disconnected inlet has `dspConnection == nullptr == out`, so `dspConnection ==
out` is true and it derefs the null outlet → segfault.

The fix mirrors `ConnectUnlocked`: resolve both pins through
`GetOutlet`/`GetInlet` (both return null for an out-of-range index) and only
call `DisconnectInlet` when both are non-null, logging `"Patcher: Invalid
Disconnection"` otherwise. Not on the audio-thread path; single-threaded fix,
no RT concerns.

## Linked issue
Closes #235

## Changes
- `YseEngine/patcher/patcherImplementation.cpp` — `Disconnect` now guards the
  outlet/inlet lookup before dispatching, matching `ConnectUnlocked`.
- `Tests/patcher/test_graph.cpp` — three regression tests: disconnect from a
  source with no outlet (`~dac`), out-of-range outlet index, out-of-range inlet
  index. Each verifies no crash and that a real edge is left intact.

## Test plan
- [x] `python yse.py format` clean (only the two changed files differ)
- [x] `python yse.py analyze` on both changed files — no new findings
- [x] Unit/regression tests pass (`python yse.py test`) — 17/17 test binaries pass; the 3 new patcher cases pass with the fix and **SEGFAULT** without it (verified by reverting the source and rebuilding: patcher binary failed with SEGFAULT, 2/17 failed)
- [x] Integration test: `yse_tests_integration` passes as part of the full `ctest` run. No dedicated end-to-end test added — the change is an internal API guard with no rendering/user-visible surface; the crash reproduces single-threaded with no audio device, so the unit-level regression tests exercise the real `patcher` public API end-to-end (real `Connect`/`Disconnect`, real graph rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)