### PR TITLE
FIX: bound message send recursion to break feedback loops (#236)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(YSE_TEST_SOURCES
   patcher/test_patcher_setparams.cpp
   patcher/test_patcher_value_queue.cpp
   patcher/test_patcher_concurrency.cpp
+  patcher/test_patcher_feedback_loop.cpp
   patcher/test_timerthread.cpp
   channel/test_channel.cpp
   channel/test_channel_concurrency.cpp
@@ -320,6 +321,7 @@ set_source_files_properties(
   patcher/test_patcher_setparams.cpp
   patcher/test_patcher_value_queue.cpp
   patcher/test_patcher_concurrency.cpp
+  patcher/test_patcher_feedback_loop.cpp
   patcher/test_timerthread.cpp
   PROPERTIES COMPILE_FLAGS "${_patcher_test_suppress}"
 )

--- a/Tests/patcher/test_patcher_feedback_loop.cpp
+++ b/Tests/patcher/test_patcher_feedback_loop.cpp
@@ -1,0 +1,85 @@
+// Regression tests for issue #236 — a feedback loop in the message send path
+// must terminate instead of recursing until the stack overflows.
+//
+// Before the fix, a single value entering a message cycle recursed through
+// outlet::Send* without bound (observed STATUS_STACK_OVERFLOW 0xC00000FD).
+// The wait-free depth guard in outlet.cpp caps the send depth so any cycle
+// unwinds instead of crashing. These tests build the two cycle shapes called
+// out in the issue and prove the process survives delivering into them.
+//
+// Two shapes:
+//   1. Purely local wired cycle among generic objects — no engine, no bus.
+//      Two gReceive nodes wired output->input in a ring; a value driven into
+//      one recurses through outlet::SendInt on the live wiring.
+//   2. The canonical bus-routed gSend/gReceive feedback: a send and a receive
+//      with the same dataName in one patcher, the receive's output wired back
+//      into the send's inlet. Publishing a value makes the T_GUI bus dispatch
+//      re-enter the send synchronously. This needs a live engine because the
+//      bus only routes between init() and close().
+
+#include <doctest/doctest.h>
+#include <string>
+
+#include "yse.hpp"
+#include "patcher/patcher.hpp"
+#include "patcher/pHandle.hpp"
+#include "patcher/pObjectList.hpp"
+#include "patcher/genericObjects/gReceive.h"
+#include "patcher/sinks.hpp"
+#include "support/null_device.hpp"
+
+using TestHelpers::MultiSink;
+
+TEST_SUITE("patcher") {
+
+  TEST_CASE("feedback loop: local wired gReceive ring terminates instead of overflowing") {
+    // gReceive forwards whatever hits its inlet straight to its outlet, so two
+    // of them wired output->input form a message ring with no bus involved.
+    YSE::PATCHER::gReceive a;
+    YSE::PATCHER::gReceive b;
+
+    // a.out -> b.in  and  b.out -> a.in : a closed cycle.
+    a.ConnectOutlet(b.GetInlet(0), 0);
+    b.ConnectInlet(a.GetOutlet(0), 0);
+    b.ConnectOutlet(a.GetInlet(0), 0);
+    a.ConnectInlet(b.GetOutlet(0), 0);
+
+    // Deliver one value into the ring. Without the depth guard this recurses
+    // until the stack overflows; with it, the fan-out is dropped once the
+    // ceiling is hit and control returns here.
+    a.GetInlet(0)->SetInt(1, YSE::T_GUI);
+
+    // Reaching this line at all is the assertion: the cycle terminated.
+    CHECK(true);
+  }
+
+  TEST_CASE("feedback loop: bus-routed gSend/gReceive cycle terminates instead of overflowing") {
+    REQUIRE(TestHelpers::engineInit());
+
+    YSE::patcher p;
+    p.name("loop.feedback").create(2);
+
+    // send "a" and receive "a" in the same patcher: the send publishes on the
+    // bus, the receive (same dataName) is subscribed to it.
+    YSE::pHandle* send = p.CreateObject(YSE::OBJ::G_SEND, "a");
+    YSE::pHandle* recv = p.CreateObject(YSE::OBJ::G_RECEIVE, "a");
+    REQUIRE(send != nullptr);
+    REQUIRE(recv != nullptr);
+
+    // Wire the receive's output back into the send's inlet, closing the loop,
+    // and also into a sink so we can confirm the value actually circulated.
+    MultiSink sink;
+    YSE::pHandle sinkHandle(&sink);
+    p.Connect(recv, 0, send, 0);
+    p.Connect(recv, 0, &sinkHandle, 0);
+
+    // One value into the send. On T_GUI the bus dispatches synchronously, so
+    // recv -> send -> publish -> recv ... would recurse without bound. The
+    // guard breaks it; control must return here.
+    send->SetIntData(0, 7);
+
+    CHECK(sink.gotInt);
+    CHECK(sink.intValue == 7);
+  }
+
+} // TEST_SUITE("patcher")

--- a/YseEngine/patcher/outlet.cpp
+++ b/YseEngine/patcher/outlet.cpp
@@ -7,6 +7,44 @@
 
 using namespace YSE::PATCHER;
 
+namespace {
+  // Wait-free recursion guard for the synchronous message send path (issue
+  // #236). A feedback cycle in the message graph — e.g. a gSend/gReceive pair
+  // whose receive output is wired back into the send's inlet, or a purely
+  // local cycle among generic objects — has no natural termination: a single
+  // value entering the cycle recurses through outlet::Send* until the stack
+  // overflows (STATUS_STACK_OVERFLOW). Every fan-out edge, whether it travels
+  // the local wiring, the in-patcher PassData dispatch, or the global bus,
+  // passes back through outlet::Send*, so a depth ceiling here breaks any
+  // cycle regardless of the route taken.
+  //
+  // RT-safety: the counter is thread_local, so each thread (control/GUI and
+  // each audio render thread) tracks its own send depth independently. Reading
+  // and mutating it is a plain TLS load/store — no allocation, no lock, no
+  // syscall — so this is safe on the audio-thread fan-out path where PassData
+  // dispatches synchronously (T_DSP). When the ceiling is reached the fan-out
+  // is dropped, terminating the cycle instead of crashing.
+  //
+  // The ceiling is chosen well above any realistic acyclic fan-out depth (a
+  // message chain that deep is already pathological) yet low enough that the
+  // bounded stack usage stays comfortably within the smallest render-thread
+  // stack.
+  constexpr unsigned int kMaxSendDepth = 64;
+  thread_local unsigned int tSendDepth = 0;
+
+  // RAII depth tracker. ``allowed`` is false when constructing this frame would
+  // exceed the ceiling, in which case the caller must not fan out.
+  struct SendDepthGuard {
+    bool allowed;
+    SendDepthGuard() : allowed(tSendDepth < kMaxSendDepth) {
+      ++tSendDepth;
+    }
+    ~SendDepthGuard() {
+      --tSendDepth;
+    }
+  };
+} // namespace
+
 outlet::outlet(pObject* owner, YSE::OUT_TYPE type) : type(type), owner(owner) {}
 
 outlet::~outlet() {
@@ -30,6 +68,8 @@ const std::vector<YSE::PATCHER::inlet*>& outlet::resolveTargets() const {
 }
 
 void outlet::SendBang(YSE::THREAD thread) {
+  SendDepthGuard guard;
+  if (!guard.allowed) return;
   const auto& targets = resolveTargets();
   for (unsigned int i = 0; i < targets.size(); i++) {
     targets[i]->SetBang(thread);
@@ -37,6 +77,8 @@ void outlet::SendBang(YSE::THREAD thread) {
 }
 
 void outlet::SendFloat(float value, YSE::THREAD thread) {
+  SendDepthGuard guard;
+  if (!guard.allowed) return;
   const auto& targets = resolveTargets();
   for (unsigned int i = 0; i < targets.size(); i++) {
     targets[i]->SetFloat(value, thread);
@@ -44,6 +86,8 @@ void outlet::SendFloat(float value, YSE::THREAD thread) {
 }
 
 void outlet::SendInt(int value, YSE::THREAD thread) {
+  SendDepthGuard guard;
+  if (!guard.allowed) return;
   const auto& targets = resolveTargets();
   for (unsigned int i = 0; i < targets.size(); i++) {
     targets[i]->SetInt(value, thread);
@@ -51,6 +95,8 @@ void outlet::SendInt(int value, YSE::THREAD thread) {
 }
 
 void outlet::SendList(const std::string& value, YSE::THREAD thread) {
+  SendDepthGuard guard;
+  if (!guard.allowed) return;
   const auto& targets = resolveTargets();
   for (unsigned int i = 0; i < targets.size(); i++) {
     targets[i]->SetList(value, thread);
@@ -58,6 +104,8 @@ void outlet::SendList(const std::string& value, YSE::THREAD thread) {
 }
 
 void outlet::SendMessage(const std::string& value, YSE::THREAD thread) {
+  SendDepthGuard guard;
+  if (!guard.allowed) return;
   const auto& targets = resolveTargets();
   for (unsigned int i = 0; i < targets.size(); i++) {
     targets[i]->SetMessage(value, thread);
@@ -65,6 +113,8 @@ void outlet::SendMessage(const std::string& value, YSE::THREAD thread) {
 }
 
 void outlet::SendBuffer(YSE::DSP::buffer* value, YSE::THREAD thread) {
+  SendDepthGuard guard;
+  if (!guard.allowed) return;
   const auto& targets = resolveTargets();
   for (unsigned int i = 0; i < targets.size(); i++) {
     targets[i]->SetBuffer(value, thread);


### PR DESCRIPTION
## Summary
A feedback loop in the patcher message graph recursed through `outlet::Send*`
without bound until the stack overflowed (`STATUS_STACK_OVERFLOW 0xC00000FD`).
The clearest form goes through the global `NamedBus`: a `send a` / `receive a`
pair in one patcher with the receive output wired back into the send inlet;
delivering a single value recurses forever. A purely local wired cycle among
generic objects has the same problem without the bus.

This adds a wait-free recursion guard so any feedback cycle terminates instead
of crashing.

## Linked issue
Closes #236

## Changes
- `YseEngine/patcher/outlet.cpp`: a `thread_local` send-depth counter with an
  RAII guard at the single fan-out chokepoint (`outlet::Send{Bang,Float,Int,List,Message,Buffer}`).
  Every fan-out edge — local wiring, in-patcher `PassData`, or the global bus —
  passes back through `outlet::Send*`, so capping depth here breaks any cycle
  regardless of route. Ceiling is 64, far above any realistic acyclic fan-out.
- `Tests/patcher/test_patcher_feedback_loop.cpp`: regression tests for both
  cycle shapes in the issue.
- `Tests/CMakeLists.txt`: register the new TU.

## Real-time safety
The message send path may run on the audio thread (synchronous `T_DSP`
`PassData` dispatch). The guard is a plain thread-local load/store — no
allocation, no lock, no syscall, no blocking — so it is safe on that path. Each
thread tracks its own send depth independently.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on changed files
- [x] `python yse.py analyze` clean on both changed files (no user-code findings)
- [x] Unit + integration suite: `python yse.py test` — 17/17 CTest groups pass, 0 failed
- [x] New regression tests (`--test-case="feedback loop:*"`): 2/2 pass, 6 assertions
- [x] Verified both new tests **fail without the fix**: raising the ceiling to
      disable the guard makes both cases exit `0xC00000FD` (stack overflow),
      confirming they catch the regression

The integration suite (`yse_tests_integration`) runs the real engine end-to-end
and passes; the bus-routed feedback test also drives a live engine (`engineInit`)
through the real `NamedBus` dispatch, exercising the user-visible flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
