### PR TITLE
FIX: join() waits on inQueue, eliminating threadPool teardown UAF (#239)

### DIFF
--- a/Tests/internal/test_threadpool.cpp
+++ b/Tests/internal/test_threadpool.cpp
@@ -10,6 +10,7 @@
 #include "internal/threadPool.h"
 #include <atomic>
 #include <chrono>
+#include <new>
 #include <thread>
 #include <vector>
 #include <memory>
@@ -137,6 +138,36 @@ TEST_SUITE("internal") {
       j->join();
 
     CHECK(counter.load() == N); // nothing dropped
+  }
+
+  TEST_CASE("threadPool: join() waits for the worker's final store (no teardown race)") {
+    // Regression for issue #239. activate() publishes completion as
+    // `isDone=true; inQueue=false;`, so inQueue is the worker's genuinely last
+    // store into the job. The old join() spun on isDone and returned in the
+    // window before that trailing inQueue store, letting the owner destroy the
+    // job while the worker still had a store pending — a teardown
+    // use-after-free the TSan CI caught on the patcher suite.
+    //
+    // Here we reuse a single storage slot: construct a job, dispatch it, join,
+    // destroy it, then immediately reconstruct another in the same bytes. If
+    // join() returns too early the worker's trailing store races the destructor
+    // and the placement-new that follows — exactly the "activate() inQueue store
+    // vs threadPoolJob() ctor" race from the issue's TSan trace. Build under
+    // TSan (build-linux-tsan) to observe the race; a plain build simply confirms
+    // every job still runs. With join() waiting on inQueue the reuse is safe.
+    threadPool pool(4, poolClass::render);
+    std::atomic<int> counter{0};
+
+    alignas(CountJob) unsigned char storage[sizeof(CountJob)];
+    constexpr int N = 20000;
+    for (int i = 0; i < N; ++i) {
+      auto* job = new (storage) CountJob(&counter);
+      pool.addJob(job);
+      job->join();
+      job->~CountJob();
+    }
+
+    CHECK(counter.load() == N);
   }
 
   TEST_CASE("threadPool: survives shutdown()/startup() cycling") {

--- a/YseEngine/internal/threadPool.cpp
+++ b/YseEngine/internal/threadPool.cpp
@@ -47,13 +47,22 @@ void YSE::INTERNAL::threadPoolJob::join() {
   // Bounded-spin wait, called from the audio callback (buffersToParent) — it
   // must never sleep or lock. The old implementation slept in 2 ms quanta,
   // burning ~70% of a 2.9 ms render block waiting on a worker (issue #188).
-  // Instead spin on the done flag, relaxing the CPU for a while and then
-  // yielding so a not-yet-scheduled worker can run. Render workers run at
-  // raised priority, so the yield path is rarely reached.
+  // Instead spin on a flag, relaxing the CPU for a while and then yielding so a
+  // not-yet-scheduled worker can run. Render workers run at raised priority, so
+  // the yield path is rarely reached.
+  //
+  // Wait on inQueue, not isDone (issue #239). activate() (and shutdown()) write
+  // inQueue=false *after* isDone=true, so inQueue is the worker's genuinely last
+  // store into this job. Spinning on isDone let join() return in the window
+  // between those two stores; the owner could then destroy the job while the
+  // worker still had inQueue=false pending, landing that store in freed (or
+  // reused) memory — a teardown use-after-free the TSan CI caught on the patcher
+  // suite. Waiting on inQueue guarantees the worker is completely finished with
+  // this job's memory before join() returns. A job that was never queued has
+  // inQueue==false and returns immediately.
   constexpr int YIELD_AFTER = 8192;
   int spins = 0;
-  while (!isDone) {
-    if (!inQueue) return; // never queued, or already drained by shutdown()
+  while (inQueue) {
     if (spins < YIELD_AFTER) {
       cpuRelax();
       ++spins;
@@ -135,8 +144,12 @@ void YSE::INTERNAL::threadPool::shutdown() {
   // thread is the only consumer of the ring now.
   threadPoolJob* job = nullptr;
   while (jobs.try_pop(job)) {
-    job->inQueue = false;
+    // inQueue must be the last store, matching activate() and join()'s wait
+    // flag (issue #239): a join() racing this drain returns only once inQueue is
+    // clear, so isDone must land first or the trailing store lands in freed
+    // memory.
     job->isDone = true;
+    job->inQueue = false;
   }
 
   for (auto i = threads.begin(); i != threads.end(); ++i) {


### PR DESCRIPTION
## Summary

`threadPoolJob::activate()` publishes completion as `run(); isDone = true; inQueue = false;`, so `inQueue` is the worker's genuinely **last** store into the job. `join()` spun on `isDone` and could return in the window *between* those two stores — the owner was then free to destroy the job while the worker still had the trailing `inQueue = false` store pending. When the job lives inside a larger object (e.g. `patcherImplementation::reclaimJobs_`, #227), that store lands in freed or stack-reused memory: a teardown use-after-free that the TSan CI caught on the patcher suite (a reconstructed job's `threadPoolJob()` ctor racing the prior pass's `activate()`).

## Linked issue

Closes #239

## Changes

- **`join()` waits on `inQueue`, not `isDone`** (`YseEngine/internal/threadPool.cpp`). This is the issue's "have `join()` also wait for the queue flag" option: since `inQueue` is the worker's last write, once `join()` observes it clear the worker is provably finished with the job's memory. A never-queued job has `inQueue == false` and still returns immediately. No new spins/sleeps/locks — the bounded spin+yield stays intact, so `join()` remains safe on the audio callback path (#188).
- **`shutdown()` drain reordered** to store `isDone` *before* `inQueue`, so `inQueue` stays the last write there too (the "same inversion" audit the issue asked for). Otherwise a `join()` racing the drain could return on `inQueue == false` while `isDone = true` was still pending.
- **`activate()` unchanged** — it already writes `inQueue` last.
- **Regression test** (`Tests/internal/test_threadpool.cpp`): reuses one storage slot (construct → dispatch → `join()` → destroy → reconstruct) so a too-early `join()` makes the worker's trailing store race the destructor + placement-new — exactly the issue's TSan trace.

## Test plan

- [x] `clang-format --dry-run --Werror` clean on both files
- [x] `python yse.py analyze` clean on both changed files (no user-code findings)
- [x] Full unit/integration suite passes on Windows: `python yse.py test` — 17/17 ctest targets pass
- [x] **New test catches the bug**: on unpatched `dev`, the new test reports `ThreadSanitizer: data race` (main-thread ctor write vs T1 `activate()` atomic write on the reused slot) under the `tests-tsan` preset
- [x] **Fix is clean under TSan**: with the fix, the `internal` suite (incl. the new test) and the `patcher` suite (215 cases — the issue's acceptance target) run with zero TSan reports (`setarch -R`, `halt_on_error=1`), reproduced locally via `tools/ci-linux/Dockerfile.sanitizers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
