### PR TITLE
FIX: fade + hysteresis at virtualization boundary (clicks/flutter) (#206)

### DIFF
--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -438,6 +438,86 @@ TEST_SUITE("sound") {
     CHECK(Impl::computeVirtualDist(2.f, 10.f, 0.0f) >= 0.f);
   }
 
+  // ─── Virtualization boundary: hysteresis + farewell fade (#206) ─────────────
+  //
+  // Two independent regressions for the hard-mute-without-fade / flutter bug:
+  //  1. virtualFinder::inRange applies a ~10% hysteresis band around the cutoff
+  //     so a sound sitting on the boundary can't toggle real/virtual each tick.
+  //  2. computeVirtualAction gives a sound crossing to virtual exactly one
+  //     farewell block (rendered, gains forced to 0) before it goes silent, so
+  //     its contribution ramps to zero instead of stepping (clicking).
+
+  TEST_CASE("virtualFinder: hysteresis widens the real region for already-real sounds (#206)") {
+    YSE::virtualFinder vf(10);
+    vf.setLimit(2);
+    // Mirror the production cycle (SOUND::Manager: reset -> add -> calculate);
+    // reset() zeroes the entry counter and seeds calculatedMax to 10, so each
+    // of the 10 bins spans 1.0 and the histogram of {1,2,3,4,5} yields a finite
+    // cutoff `range` (== 4.0 here).
+    vf.reset();
+    vf.add(1.f);
+    vf.add(2.f);
+    vf.add(3.f);
+    vf.add(4.f);
+    vf.add(5.f);
+    vf.calculate();
+
+    // Sweep candidate distances. For every value the region kept real when the
+    // sound was ALREADY real must be a superset of the region promoted from
+    // virtual: `promoted ⇒ keptReal`. And the two verdicts must differ for at
+    // least one value — otherwise the thresholds coincide and there is no
+    // hysteresis, which is exactly the flutter the fix removes.
+    bool differsSomewhere = false;
+    for (float v = 0.f; v <= 12.f; v += 0.05f) {
+      const bool keptReal = vf.inRange(v, /*wasReal=*/true);
+      const bool promoted = vf.inRange(v, /*wasReal=*/false);
+      CHECK((keptReal || !promoted)); // promoted implies keptReal
+      if (keptReal != promoted) differsSomewhere = true;
+    }
+    CHECK(differsSomewhere);
+  }
+
+  TEST_CASE("virtualFinder: under the budget every sound is real regardless of state (#206)") {
+    YSE::virtualFinder vf(10);
+    vf.setLimit(50); // limit far above the number of entries -> nobody virtual
+    vf.reset();
+    vf.add(1.f);
+    vf.add(9.f);
+    vf.calculate();
+    CHECK(vf.inRange(9.f, /*wasReal=*/true) == true);
+    CHECK(vf.inRange(9.f, /*wasReal=*/false) == true);
+  }
+
+  TEST_CASE("computeVirtualAction: a real sound renders normally, no fade (#206)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // Fresh real sound.
+    auto a = Impl::computeVirtualAction(/*real=*/true, /*wasVirtual=*/false);
+    CHECK(a.render);
+    CHECK_FALSE(a.fadeOut);
+    CHECK_FALSE(a.nowVirtual);
+    // Re-entry from virtual: renders again, clears the virtual state, no fade.
+    auto b = Impl::computeVirtualAction(/*real=*/true, /*wasVirtual=*/true);
+    CHECK(b.render);
+    CHECK_FALSE(b.fadeOut);
+    CHECK_FALSE(b.nowVirtual);
+  }
+
+  TEST_CASE("computeVirtualAction: first block going virtual gets one farewell fade (#206)") {
+    using Impl = YSE::SOUND::implementationObject;
+    auto a = Impl::computeVirtualAction(/*real=*/false, /*wasVirtual=*/false);
+    CHECK(a.render); // still rendered this block...
+    CHECK(a.fadeOut); // ...but with gains forced to 0 so it ramps to silence
+    CHECK(a.nowVirtual);
+  }
+
+  TEST_CASE("computeVirtualAction: an already-virtual sound stays silent (#206)") {
+    using Impl = YSE::SOUND::implementationObject;
+    auto a = Impl::computeVirtualAction(/*real=*/false, /*wasVirtual=*/true);
+    CHECK_FALSE(a.render); // skipped entirely — no repeated fade, no click
+    CHECK_FALSE(a.fadeOut);
+    CHECK(a.nowVirtual);
+  }
+
   // ─── Manager update loop / lifecycle ─────────────────────────────────────────
 
   TEST_CASE("sound impl: sync() detects head==nullptr after destructor and releases impl") {

--- a/YseEngine/internal/virtualFinder.cpp
+++ b/YseEngine/internal/virtualFinder.cpp
@@ -56,10 +56,14 @@ void YSE::virtualFinder::add(Flt value) {
   bin[sort]++;
 }
 
-bool YSE::virtualFinder::inRange(Flt value) {
+bool YSE::virtualFinder::inRange(Flt value, bool wasReal) {
   if (entries < currentLimit) return true;
-  if (value < range) return true;
-  return false;
+  // Hysteresis (issue #206): a sound already real holds on until it drifts ~5%
+  // past the cutoff, while a virtual sound must come ~5% inside the cutoff
+  // before it is promoted back. The ~10% gap between the two thresholds keeps a
+  // sound hovering at the boundary from toggling every tick as `range` wobbles.
+  Flt threshold = wasReal ? range * 1.05f : range * 0.95f;
+  return value < threshold;
 }
 
 void YSE::virtualFinder::calculate() {

--- a/YseEngine/internal/virtualFinder.h
+++ b/YseEngine/internal/virtualFinder.h
@@ -23,7 +23,12 @@ namespace YSE {
     void setLimit(Int value);
     Int getLimit();
     void calculate();
-    bool inRange(Flt value); // check if this value is ok according to the last calculations
+    // Check if this value is still in range according to the last calculation.
+    // `wasReal` is this sound's state on the previous block: a ~10% hysteresis
+    // band around the cutoff (real sounds hold on 5% past it, virtual sounds
+    // must come 5% inside it) stops a sound sitting on the boundary from
+    // fluttering real/virtual on consecutive update ticks (issue #206).
+    bool inRange(Flt value, bool wasReal);
     virtualFinder(Int resolution); // argument is the initial resolution. This can be adjusted
                                    // internally when needed.
 

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -31,6 +31,8 @@ YSE::SOUND::implementationObject::implementationObject(sound* head)
     velocity(0.f),
     pitch(1.f),
     size(1.0f),
+    isVirtual(false),
+    virtualFadeOut(false),
     setVolume(false),
     volumeValue(0),
     volumeTime(0),
@@ -589,7 +591,26 @@ Bool YSE::SOUND::implementationObject::dsp() {
   }
 
   if (status_dsp == SS_STOPPED || status_dsp == SS_PAUSED) return false;
-  if (parent->allowVirtual && !VirtualSoundFinder().inRange(virtualDist)) return false;
+
+  ///////////////////////////////////////////
+  // virtualization (issue #206)
+  ///////////////////////////////////////////
+  // A sound crossing the virtualization threshold must not be hard-muted
+  // between two blocks (that steps its contribution to zero in one buffer — an
+  // audible click). Instead it gets exactly one farewell block whose channel
+  // gains are forced to 0, so the 50-sample ramp in dspFunc_calculateGain()
+  // slides it down to silence. inRange() applies a hysteresis band around the
+  // cutoff so a sound sitting on the boundary doesn't flutter real/virtual.
+  if (parent->allowVirtual) {
+    bool real = VirtualSoundFinder().inRange(virtualDist, /*wasReal=*/!isVirtual);
+    virtualAction act = computeVirtualAction(real, isVirtual);
+    isVirtual = act.nowVirtual;
+    virtualFadeOut = act.fadeOut;
+    if (!act.render) return false;
+  } else {
+    isVirtual = false;
+    virtualFadeOut = false;
+  }
 
   ///////////////////////////////////////////
   // set volume at sound level
@@ -798,6 +819,10 @@ void YSE::SOUND::implementationObject::toChannels() {
 
       // add volume control now
       if (occlusionActive) parent->outConf[j].finalGain *= 1 - occlusion_dsp;
+      // Farewell block for a sound going virtual (#206): target gain 0 so
+      // dspFunc_calculateGain() ramps from lastGain down to silence instead of
+      // the sound simply vanishing on the next (skipped) block.
+      if (virtualFadeOut) parent->outConf[j].finalGain = 0.f;
       dspFunc_calculateGain(j, x);
       channelBuffer *= fader();
       parent->out[j] += channelBuffer;
@@ -834,6 +859,18 @@ Flt YSE::SOUND::implementationObject::computeVirtualDist(Flt distance, Flt size,
   constexpr Flt minVolume = 0.0001f;
   if (volume < minVolume) volume = minVolume;
   return effectiveDist / volume;
+}
+
+YSE::SOUND::implementationObject::virtualAction
+YSE::SOUND::implementationObject::computeVirtualAction(bool real, bool wasVirtual) {
+  // Real: render normally (re-entry from virtual ramps back up from the 0 that
+  // the farewell block left in lastGain, so no stale-gain jump either).
+  if (real) return {/*render=*/true, /*fadeOut=*/false, /*nowVirtual=*/false};
+  // First block going virtual: still render, but with gains forced to 0 so the
+  // block ramps down to silence (one farewell fade instead of a click).
+  if (!wasVirtual) return {/*render=*/true, /*fadeOut=*/true, /*nowVirtual=*/true};
+  // Already faded out on a previous block: stay silent (skip render entirely).
+  return {/*render=*/false, /*fadeOut=*/false, /*nowVirtual=*/true};
 }
 
 bool YSE::SOUND::implementationObject::sortSoundObjects(implementationObject* lhs,

--- a/YseEngine/sound/soundImplementation.h
+++ b/YseEngine/sound/soundImplementation.h
@@ -139,6 +139,19 @@ namespace YSE {
       */
       static Flt computeVirtualDist(Flt distance, Flt size, Flt volume);
 
+      /** The per-block virtualization decision, kept as a pure static helper so
+          the transition logic stays unit-testable in isolation (see issue #206).
+          @param real       The VirtualSoundFinder's hysteresis-aware verdict for
+                            this block (true = the sound should be audible).
+          @param wasVirtual This sound's virtual state after the previous block.
+       */
+      struct virtualAction {
+        bool render; // run dsp() + toChannels() for this block?
+        bool fadeOut; // force channel gains to 0 so the block ramps to silence
+        bool nowVirtual; // this sound's virtual state after this block
+      };
+      static virtualAction computeVirtualAction(bool real, bool wasVirtual);
+
       void removeInterface();
 
       OBJECT_IMPLEMENTATION_STATE getStatus();
@@ -226,6 +239,9 @@ namespace YSE {
       // virtual sound calculation
 
       Flt virtualDist; // gain sum of all channels
+      Bool isVirtual; // this sound's virtual state after the previous dsp block (#206)
+      Bool virtualFadeOut; // set in dsp(), read in toChannels(): force gains to 0 for
+                           // one farewell block so going virtual fades instead of clicks (#206)
 
       // volume
       // TODO: check if ramp getValue is threadsafe


### PR DESCRIPTION
## Summary

Fixes the audible click and on/off flutter when a sound crosses the
virtualization threshold (issue #206).

Previously `dsp()` returned false the moment a sound went virtual, so
`toChannels()` was skipped and the sound's contribution stepped to zero in a
single block — a click proportional to how loud it still was. The 50-sample
gain ramp in `dspFunc_calculateGain()` never ran because that code was never
reached. And with no hysteresis, a sound sitting on the boundary toggled
real/virtual every update tick as `range` wobbled.

## Linked issue

Closes #206

## Changes

- **Farewell fade.** A sound transitioning to virtual now gets exactly one
  more block: it still renders, but the channel gains are forced to 0 so the
  existing 50-sample ramp slides it down to silence, then it is dropped.
  Re-entry ramps back up from the 0 the farewell block left in `lastGain`, so
  the stale-gain jump on re-entry is gone too.
- **Hysteresis.** `virtualFinder::inRange()` now takes the sound's previous
  state and applies a ~10% band around the cutoff (real sounds hold on 5% past
  it, virtual sounds must come 5% inside it), so a boundary sound can't
  flutter.
- The per-block decision is factored into the pure static helper
  `computeVirtualAction()` (mirroring `computeVirtualDist` from #205) so the
  transition logic is unit-testable in isolation. RT-safe: no alloc/lock/IO on
  the audio path.

## Test plan

- [x] `yse.py format` clean (no diff on changed files)
- [x] `yse.py analyze` on both changed engine files — no new findings in
  modified code (the 3 remaining are pre-existing dead-store / swapped-arg /
  integer-division warnings on untouched lines)
- [x] Unit tests pass — full ctest suite **17/17** green; 5 new `#206` cases
  (255 assertions in the `sound` TU): virtualFinder hysteresis band,
  under-budget always-real, and all four `computeVirtualAction` transitions
  (real render, re-entry, first-virtual fade, already-virtual silence). The
  hysteresis test fails if the band is removed (thresholds coincide).
- [x] Integration suite (`yse_tests_integration`) passes; the real
  audio-mix path through `dsp()`/`toChannels()` is exercised by the existing
  manager-drain / virtual-budget sound tests, which now run the new branch.

No sample-accurate e2e assertion on the ramp shape: capturing a single
sound's pre-mix contribution needs private `toChannels()` + channel `out`
access, and the finder's histogram is adaptive, so the fade's ramp isn't
deterministically observable end-to-end. The transition logic is instead
pinned by the pure-helper unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
