### PR TITLE
FIX: correct parenthesization of speaker-density term (#207)

### DIFF
--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -19,6 +19,7 @@
 
 #include <doctest/doctest.h>
 #include <chrono>
+#include <cmath>
 #include <thread>
 #include "yse.hpp"
 #include "sound/soundInterface.hpp"
@@ -516,6 +517,60 @@ TEST_SUITE("sound") {
     CHECK_FALSE(a.render); // skipped entirely — no repeated fade, no click
     CHECK_FALSE(a.fadeOut);
     CHECK(a.nowVirtual);
+  }
+
+  // ─── Speaker-density overlap weight (#207) ──────────────────────────────────
+  //
+  // Regression tests for the mis-parenthesized density term. The overlap weight
+  // that toChannels() sums into `effective` must be the same cardioid as the pan
+  // term: (1 + cos(Δ)) * 0.5f, range [0..1]. The pre-fix code multiplied 0.5f
+  // into cos only — (1 + cos(Δ) * 0.5f) — giving range [0.5..1.5], offset by
+  // +0.5 per speaker pair. These call the pure helper directly so the assertions
+  // are exact and independent of any speaker layout.
+
+  TEST_CASE("speakerOverlap: coincident speakers overlap fully (== 1) (#207)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // Δ = 0. Fixed formula: (1 + 1) * 0.5 = 1.0. Pre-fix: 1 + 1*0.5 = 1.5.
+    CHECK(Impl::computeSpeakerOverlap(0.f, 0.f) == doctest::Approx(1.f));
+    CHECK(Impl::computeSpeakerOverlap(1.2f, 1.2f) == doctest::Approx(1.f));
+  }
+
+  TEST_CASE("speakerOverlap: opposite speakers do not overlap (== 0) (#207)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // Δ = π. Fixed formula: (1 + (-1)) * 0.5 = 0.0. Pre-fix: 1 + (-1)*0.5 = 0.5.
+    CHECK(Impl::computeSpeakerOverlap(0.f, static_cast<float>(YSE::Pi)) == doctest::Approx(0.f));
+  }
+
+  TEST_CASE("speakerOverlap: perpendicular speakers give the half weight (#207)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // Δ = π/2. Fixed formula: (1 + 0) * 0.5 = 0.5. Pre-fix: 1 + 0*0.5 = 1.0.
+    CHECK(Impl::computeSpeakerOverlap(0.f, static_cast<float>(YSE::Pi) * 0.5f) ==
+          doctest::Approx(0.5f));
+  }
+
+  TEST_CASE("speakerOverlap: weight stays within [0..1] across a full sweep (#207)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // Pre-fix the range was [0.5..1.5]; the fixed cardioid must never leave
+    // [0..1] for any angular separation. Step through a full turn in integer
+    // increments to keep the loop induction non-floating-point.
+    for (int i = 0; i <= 360; ++i) {
+      const float d = static_cast<float>(i) * static_cast<float>(YSE::Pi) / 180.f;
+      const float w = Impl::computeSpeakerOverlap(0.f, d);
+      CHECK(w >= -1e-4f);
+      CHECK(w <= 1.f + 1e-4f);
+    }
+  }
+
+  TEST_CASE("speakerOverlap: mirrors the pan term's parenthesization (#207)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // The overlap weight must use the exact same curve as the pan term in
+    // toChannels(): initPan = (1 + cos(speakerAngle - sourceAngle)) * 0.5f.
+    // Recompute the pan formula independently and require a match — this is the
+    // relationship the bug broke.
+    const float speakerAngle = 0.7f;
+    const float sourceAngle = 2.1f;
+    const float panTerm = (1.f + std::cos(speakerAngle - sourceAngle)) * 0.5f;
+    CHECK(Impl::computeSpeakerOverlap(speakerAngle, sourceAngle) == doctest::Approx(panTerm));
   }
 
   // ─── Manager update loop / lifecycle ─────────────────────────────────────────

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -795,7 +795,7 @@ void YSE::SOUND::implementationObject::toChannels() {
       // effective speakers
       for (UInt j = 0; j < parent->outConf.size(); j++) {
         parent->outConf[i].effective +=
-            (1 + cos(parent->outConf[i].angle - parent->outConf[j].angle) * 0.5f);
+            computeSpeakerOverlap(parent->outConf[i].angle, parent->outConf[j].angle);
       }
       // initial gain
       parent->outConf[i].initGain = parent->outConf[i].initPan / parent->outConf[i].effective;
@@ -859,6 +859,14 @@ Flt YSE::SOUND::implementationObject::computeVirtualDist(Flt distance, Flt size,
   constexpr Flt minVolume = 0.0001f;
   if (volume < minVolume) volume = minVolume;
   return effectiveDist / volume;
+}
+
+Flt YSE::SOUND::implementationObject::computeSpeakerOverlap(Flt angleA, Flt angleB) {
+  // Cardioid weight in [0..1] — the same parenthesization as the pan term above
+  // so a "how much do these two speakers overlap" weight and a "how much does
+  // this speaker face the source" pan use one consistent curve. Coincident
+  // speakers overlap fully (1), opposite speakers not at all (0). (#207)
+  return (1 + cos(angleA - angleB)) * 0.5f;
 }
 
 YSE::SOUND::implementationObject::virtualAction

--- a/YseEngine/sound/soundImplementation.h
+++ b/YseEngine/sound/soundImplementation.h
@@ -152,6 +152,14 @@ namespace YSE {
       };
       static virtualAction computeVirtualAction(bool real, bool wasVirtual);
 
+      /** Cardioid overlap weight between two speakers, in [0..1]. Used by the
+          density compensation in toChannels() to count how many speakers
+          effectively overlap a given one (coincident speakers -> 1, opposite
+          speakers -> 0). Kept as a pure static helper so the weighting stays
+          unit-testable and mirrors the pan term's parenthesization. See #207.
+      */
+      static Flt computeSpeakerOverlap(Flt angleA, Flt angleB);
+
       void removeInterface();
 
       OBJECT_IMPLEMENTATION_STATE getStatus();


### PR DESCRIPTION
## Summary

The speaker-density compensation weight in `implementationObject::toChannels()` used a different parenthesization than the pan term it mirrors. It applied `0.5f` to `cos()` only — `(1 + cos(Δ) * 0.5f)`, range `[0.5..1.5]` — instead of the cardioid `(1 + cos(Δ)) * 0.5f`, range `[0..1]`. The result is a `+0.5` offset per speaker pair.

Energy normalization (`ratio = initGain²/power`) cancels any per-speaker-constant factor, so symmetric layouts are unaffected. But on irregular `CT_CUSTOM` rings — exactly where density compensation is meant to help — the wrong weighting skews the relative speaker gains.

The weight is extracted into a pure static helper `computeSpeakerOverlap()`, following the `computeVirtualDist` / `computeVirtualAction` convention from #205/#206, so the cardioid is unit-testable without an audio device. The parenthesization is fixed in that helper.

Scope note: #211 (moving this O(N²) term out of the hot loop) is tracked separately and intentionally not touched here.

## Linked issue

Closes #207

## Changes

- `YseEngine/sound/soundImplementation.{h,cpp}` — add `computeSpeakerOverlap(angleA, angleB)` returning `(1 + cos(Δ)) * 0.5f`; call it from the density loop in `toChannels()`.
- `Tests/sound/test_sound_impl.cpp` — 5 regression tests for the overlap weight (coincident == 1, opposite == 0, perpendicular == 0.5, `[0..1]` over a full turn, and a match against an independently-computed pan term).

## Test plan

- [x] `python yse.py format` clean (only the 3 touched files change)
- [x] `python yse.py analyze` on both changed `.cpp` — no new findings in modified lines (only pre-existing baseline items)
- [x] Full unit + integration suite: `python yse.py test` — 17/17 ctest suites pass
- [x] New tests verified to **fail on the unpatched formula** (185 assertions fail: coincident gives 1.5 not 1.0, etc.) and pass with the fix
- [x] Not adding a full audio-render integration test: the term feeds a gain calculation gated behind the audio callback (no device fires under the null-device test harness); the pure helper drives the exact math the bug lived in, which is the testable surface here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
