### PR TITLE
FIX: apply doppler multiplicatively and slew it at block rate (#208)

### DIFF
--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -573,6 +573,110 @@ TEST_SUITE("sound") {
     CHECK(Impl::computeSpeakerOverlap(speakerAngle, sourceAngle) == doctest::Approx(panTerm));
   }
 
+  // ─── Doppler ratio: multiplicative + scaled + clamped (#208) ────────────────
+  //
+  // Regression tests for the additive, unsmoothed doppler. computeDopplerRatio
+  // returns a playback-rate *multiplier*: 1.0 when nothing moves, > 1 for a
+  // closing pair (pitch up), < 1 for a receding pair (pitch down). The old code
+  // added `1 - 1/ratio` to the pitch instead of multiplying, which only matched
+  // near pitch = 1. These call the pure helper directly so the assertions are
+  // exact and independent of the update-tick timing that used to warble it.
+  //
+  // Geometry convention: `dist` is the source→listener axis (source position
+  // minus listener position, i.e. from listener toward source in the engine's
+  // `newPos - Listener().newPos`). A source velocity pointing along +dist moves
+  // it *away* from the listener (receding); pointing along -dist moves it toward
+  // the listener (approaching).
+
+  TEST_CASE("doppler: a stationary source/listener pair yields ratio 1.0 (#208)") {
+    using Impl = YSE::SOUND::implementationObject;
+    const float r =
+        Impl::computeDopplerRatio(YSE::Pos(0.f), YSE::Pos(0.f), YSE::Pos(10.f, 0.f, 0.f), 1.f);
+    CHECK(r == doctest::Approx(1.f));
+  }
+
+  TEST_CASE("doppler: a source approaching the listener pitches up (ratio > 1) (#208)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // Source sits at +10 on x; velocity toward the listener is -x (along -dist).
+    const YSE::Pos dist(10.f, 0.f, 0.f);
+    const YSE::Pos approaching(-30.f, 0.f, 0.f); // 30 m/s toward listener
+    const float r = Impl::computeDopplerRatio(approaching, YSE::Pos(0.f), dist, 1.f);
+    CHECK(r > 1.f);
+    // Physical value: (344 + 0) / (344 + (-30)) = 344/314 ≈ 1.0955.
+    CHECK(r == doctest::Approx(344.f / 314.f));
+  }
+
+  TEST_CASE("doppler: a source receding from the listener pitches down (ratio < 1) (#208)") {
+    using Impl = YSE::SOUND::implementationObject;
+    const YSE::Pos dist(10.f, 0.f, 0.f);
+    const YSE::Pos receding(30.f, 0.f, 0.f); // 30 m/s away from listener (along +dist)
+    const float r = Impl::computeDopplerRatio(receding, YSE::Pos(0.f), dist, 1.f);
+    CHECK(r < 1.f);
+    // Physical value: (344 + 0) / (344 + 30) = 344/374 ≈ 0.9198.
+    CHECK(r == doctest::Approx(344.f / 374.f));
+  }
+
+  TEST_CASE("doppler: is multiplicative, not additive (the #208 fix)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // The bug added `1 - 1/ratio` to pitch. For a receding source the physical
+    // ratio is 344/374. The additive linearisation would have produced
+    // 1 + (1 - 374/344) = 1 - 30/344 ≈ 0.9128, whereas the correct multiplier is
+    // 344/374 ≈ 0.9198. Require the helper to return the true ratio, not the
+    // linearised value — they differ enough to distinguish.
+    const YSE::Pos dist(10.f, 0.f, 0.f);
+    const float ratio =
+        Impl::computeDopplerRatio(YSE::Pos(30.f, 0.f, 0.f), YSE::Pos(0.f), dist, 1.f);
+    const float additive = 1.f + (1.f - 374.f / 344.f); // what the old code applied
+    CHECK(ratio == doctest::Approx(344.f / 374.f));
+    CHECK(ratio != doctest::Approx(additive));
+    CHECK(ratio > additive); // the correct multiplier is the larger of the two here
+  }
+
+  TEST_CASE("doppler: dopplerScale amplifies the deviation from unity (#208)") {
+    using Impl = YSE::SOUND::implementationObject;
+    const YSE::Pos dist(10.f, 0.f, 0.f);
+    const YSE::Pos vel(30.f, 0.f, 0.f); // receding
+    const float base = Impl::computeDopplerRatio(vel, YSE::Pos(0.f), dist, 1.f);
+    const float scaled = Impl::computeDopplerRatio(vel, YSE::Pos(0.f), dist, 2.f);
+    const float off = Impl::computeDopplerRatio(vel, YSE::Pos(0.f), dist, 0.f);
+    // scale 0 disables the effect; scale 2 doubles the deviation from 1.
+    CHECK(off == doctest::Approx(1.f));
+    CHECK(scaled == doctest::Approx(1.f + (base - 1.f) * 2.f));
+  }
+
+  TEST_CASE("doppler: listener motion contributes to the ratio (#208)") {
+    using Impl = YSE::SOUND::implementationObject;
+    const YSE::Pos dist(10.f, 0.f, 0.f);
+    // Listener moving toward the source (+x, along +dist) raises the numerator
+    // and pitches the sound up.
+    const float r = Impl::computeDopplerRatio(YSE::Pos(0.f), YSE::Pos(30.f, 0.f, 0.f), dist, 1.f);
+    CHECK(r > 1.f);
+    CHECK(r == doctest::Approx(374.f / 344.f));
+  }
+
+  TEST_CASE("doppler: a co-located pair returns 1.0 rather than dividing by zero (#208)") {
+    using Impl = YSE::SOUND::implementationObject;
+    const float r =
+        Impl::computeDopplerRatio(YSE::Pos(5.f, 0.f, 0.f), YSE::Pos(0.f), YSE::Pos(0.f), 1.f);
+    CHECK(r == doctest::Approx(1.f));
+  }
+
+  TEST_CASE("doppler: the ratio is clamped to a sane band for super-sonic speeds (#208)") {
+    using Impl = YSE::SOUND::implementationObject;
+    const YSE::Pos dist(10.f, 0.f, 0.f);
+    // Source closing far faster than the speed of sound: denominator goes
+    // non-positive. The helper must not return a negative or unbounded rate.
+    const float closing =
+        Impl::computeDopplerRatio(YSE::Pos(-1000.f, 0.f, 0.f), YSE::Pos(0.f), dist, 1.f);
+    CHECK(closing > 0.f);
+    CHECK(closing <= 4.f + 1e-4f);
+    // Receding far faster than sound: stays positive and clamped, never negative.
+    const float fleeing =
+        Impl::computeDopplerRatio(YSE::Pos(1000.f, 0.f, 0.f), YSE::Pos(0.f), dist, 1.f);
+    CHECK(fleeing >= 0.25f - 1e-4f);
+    CHECK(fleeing <= 1.f);
+  }
+
   // ─── Manager update loop / lifecycle ─────────────────────────────────────────
 
   TEST_CASE("sound impl: sync() detects head==nullptr after destructor and releases impl") {

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -12,6 +12,14 @@
 #include "../utils/fileFunctions.hpp"
 #include "../patcher/patcherImplementation.h"
 
+namespace {
+  // Time constant (ms) over which the doppler playback-rate ratio is slewed in
+  // dsp(). Long enough to iron out the stepwise, jittery update-tick target
+  // into an audible glide, short enough that the pitch still tracks a fast
+  // mover without lag. See issue #208.
+  constexpr Int DOPPLER_SLEW_MS = 30;
+} // namespace
+
 YSE::SOUND::implementationObject::implementationObject(sound* head)
   : _head_streaming(false),
     _head_length(0),
@@ -28,7 +36,7 @@ YSE::SOUND::implementationObject::implementationObject(sound* head)
     newPos(0.f),
     lastPos(0.f),
     velocityVec(0.f),
-    velocity(0.f),
+    dopplerRatio(1.f),
     pitch(1.f),
     size(1.0f),
     isVirtual(false),
@@ -491,10 +499,12 @@ void YSE::SOUND::implementationObject::update() {
   ///////////////////////////////////////////
   // calculate doppler effect
   ///////////////////////////////////////////
-  Flt vel = velocity; // avoid using atomic all the time
-  if (!doppler)
-    vel = 0;
-  else {
+  // Doppler is a frequency *ratio* applied multiplicatively to the playback
+  // rate (see computeDopplerRatio / issue #208). update() computes the stepwise
+  // target here; dsp() slews it at block rate so an uneven update tick can't
+  // warble the pitch. A ratio of 1.0 means "no shift".
+  Flt ratio = 1.0f;
+  if (doppler) {
     velocityVec = (newPos - lastPos) * (1 / INTERNAL::Time().delta());
 
     Pos listenerVelocity;
@@ -502,22 +512,14 @@ void YSE::SOUND::implementationObject::update() {
     listenerVelocity.y = INTERNAL::ListenerImpl().vel.y.load();
     listenerVelocity.z = INTERNAL::ListenerImpl().vel.z.load();
 
-    if (velocityVec == Pos(0) && listenerVelocity == Pos(0))
-      vel = 0;
-    else {
+    if (!(velocityVec == Pos(0) && listenerVelocity == Pos(0))) {
       Pos dist = relative ? newPos : newPos - INTERNAL::ListenerImpl().newPos;
-      if (dist != Pos(0)) {
-        Flt rSound = Dot(velocityVec, dist) / dist.length();
-        Flt rList = Dot(listenerVelocity, dist) / dist.length();
-        vel = 1 - (440 / (((344.0f + rList) / (344.0f + rSound)) * 440));
-        vel *= INTERNAL::Settings().dopplerScale;
-      }
+      ratio = computeDopplerRatio(velocityVec, listenerVelocity, dist,
+                                  INTERNAL::Settings().dopplerScale);
     }
   }
   lastPos = newPos;
-  // disregard rounding errors
-  if (abs(vel) < 0.01f) vel = 0.0f;
-  velocity = vel; // back to atomic
+  dopplerRatio = ratio; // back to atomic; slewed in dsp()
 
   ///////////////////////////////////////////
   // calculate angle
@@ -656,6 +658,13 @@ Bool YSE::SOUND::implementationObject::dsp() {
   ///////////////////////////////////////////
   // fill buffer
   ///////////////////////////////////////////
+  // Slew the doppler ratio toward its latest (stepwise) target at block rate so
+  // the playback rate glides instead of stepping. Playback rate is the ratio
+  // times the user pitch — doppler is multiplicative, never additive (#208).
+  dopplerSlew.setIfNew(dopplerRatio, DOPPLER_SLEW_MS);
+  dopplerSlew.update();
+  Flt playbackRate = pitch * dopplerSlew();
+
   DSP::dspSourceObject* src = source_dsp.load(
       std::memory_order_acquire); // NOSONAR S8417: intentional acquire — pairs with release in
                                   // create()/Manager::update() to read user-supplied dsp source
@@ -669,8 +678,8 @@ Bool YSE::SOUND::implementationObject::dsp() {
   //   synth->process(status_dsp);
   // }
   else if (playerType == PT_FILE &&
-           file->read(filebuffer, filePtr, STANDARD_BUFFERSIZE, pitch + velocity, looping,
-                      status_dsp, bufferVolume) == false) {
+           file->read(filebuffer, filePtr, STANDARD_BUFFERSIZE, playbackRate, looping, status_dsp,
+                      bufferVolume) == false) {
     // non looping sound has reached end of file
     /*filePtr = 0;
     _status = SS_STOPPED;
@@ -867,6 +876,39 @@ Flt YSE::SOUND::implementationObject::computeSpeakerOverlap(Flt angleA, Flt angl
   // this speaker face the source" pan use one consistent curve. Coincident
   // speakers overlap fully (1), opposite speakers not at all (0). (#207)
   return (1 + cos(angleA - angleB)) * 0.5f;
+}
+
+Flt YSE::SOUND::implementationObject::computeDopplerRatio(const Pos& sourceVel,
+                                                          const Pos& listenerVel, const Pos& dist,
+                                                          Flt dopplerScale) {
+  constexpr Flt speedOfSound = 344.0f; // m/s, dry air ~20°C
+  // Two octaves either way. A super-sonic closing speed would otherwise drive
+  // the denominator toward (or past) zero and blow the playback rate up or
+  // negative; clamping keeps the audio thread safe for any input. (#208)
+  constexpr Flt minRatio = 0.25f;
+  constexpr Flt maxRatio = 4.0f;
+
+  Pos d = dist; // local copy: Pos::length() is non-const
+  Flt len = d.length();
+  if (len == 0.f) return 1.0f; // co-located: no well-defined radial axis, no shift
+
+  // Radial (along the source→listener axis) components of each velocity.
+  Flt rSource = Dot(sourceVel, d) / len;
+  Flt rList = Dot(listenerVel, d) / len;
+
+  // Observed = emitted * (c + rList) / (c + rSource). Applied multiplicatively
+  // to the playback rate, unlike the old additive `1 - 1/ratio` linearisation
+  // which was only accurate near pitch = 1 and low speeds.
+  Flt denom = speedOfSound + rSource;
+  if (denom <= 0.f) return maxRatio; // source closing at/above the speed of sound
+  Flt ratio = (speedOfSound + rList) / denom;
+
+  // dopplerScale amplifies/attenuates the deviation from unity, not the ratio
+  // itself, so scale = 0 disables the effect and scale = 1 is physical.
+  ratio = 1.0f + (ratio - 1.0f) * dopplerScale;
+
+  Clamp(ratio, minRatio, maxRatio);
+  return ratio;
 }
 
 YSE::SOUND::implementationObject::virtualAction

--- a/YseEngine/sound/soundImplementation.h
+++ b/YseEngine/sound/soundImplementation.h
@@ -160,6 +160,25 @@ namespace YSE {
       */
       static Flt computeSpeakerOverlap(Flt angleA, Flt angleB);
 
+      /** Doppler playback-rate multiplier for a moving source/listener pair.
+
+          The observed frequency is the emitted frequency times a *ratio*
+          ``(c + rList) / (c + rSource)`` where ``c`` is the speed of sound and
+          ``rSource`` / ``rList`` are the radial (along the source→listener axis)
+          components of the source and listener velocities. Doppler is a
+          frequency ratio, so it must be applied multiplicatively to the
+          playback speed (``pitch * ratio``), not added to it — the old additive
+          linearisation was only accurate at pitch = 1 and low speeds. Returns
+          exactly 1.0 (no shift) when neither party moves or the pair is
+          co-located. ``dopplerScale`` scales the deviation from unity, and the
+          result is clamped to a sane band so a super-sonic closing speed can't
+          drive the playback rate negative or unbounded on the audio thread.
+          Kept as a pure static helper so the ratio math stays unit-testable in
+          isolation. See issue #208.
+      */
+      static Flt computeDopplerRatio(const Pos& sourceVel, const Pos& listenerVel, const Pos& dist,
+                                     Flt dopplerScale);
+
       void removeInterface();
 
       OBJECT_IMPLEMENTATION_STATE getStatus();
@@ -237,7 +256,12 @@ namespace YSE {
       Flt distance;
       Flt angle;
       // for pitch shift and doppler
-      Flt velocity;
+      // dopplerRatio is a playback-rate *multiplier* (1.0 = no shift), written
+      // by update() on the control thread and read by dsp() on the audio thread.
+      // dopplerSlew slews that stepwise target at block rate so an uneven
+      // update tick rate can't inject a pitch warble (issue #208).
+      Flt dopplerRatio;
+      DSP::lint dopplerSlew;
       Flt pitch;
       // the distance before distance attenuation begins.
       Flt size;


### PR DESCRIPTION
## Summary

Doppler was applied **additively** to the playback speed and its velocity
term was recomputed unsmoothed each update tick, so fast movers warbled and
non-unity `speed` got the wrong doppler amount (#208).

Doppler is a frequency *ratio*: the playback rate must be `pitch * ratio`,
not `pitch + velocity`. The old `velocity = 1 - 1/ratio` linearisation was
only accurate at pitch = 1 and low speeds, and a hard `|vel| < 0.01`
deadzone stepped the pitch by up to 1% when crossed.

## Linked issue

Closes #208

## Changes

- **`computeDopplerRatio()`** — a pure, unit-testable static helper (same
  pattern as #205/#206/#207) returning the multiplicative ratio
  `(c + rList)/(c + rSource)`. It scales the *deviation from unity* by
  `dopplerScale` (so scale 0 disables, scale 1 is physical), returns 1.0 for
  the co-located / at-rest cases, and clamps the result to `[0.25, 4.0]` so a
  super-sonic closing speed can't drive the audio-thread playback rate
  negative or unbounded.
- **Block-rate smoothing** — `dsp()` slews the stepwise ratio target with a
  `DSP::lint` (30 ms) so the playback rate glides instead of stepping; the
  hard deadzone is gone.
- **Playback rate** is now `pitch * dopplerSlew()` (was `pitch + velocity`).
- The `velocity` member (an additive delta) becomes `dopplerRatio` (a
  multiplier, default 1.0).

RT-safety: no allocation/lock/blocking added on the audio path — the slew is
a scalar add per block and the ratio math is branch + a couple of divides.

## Test plan

- [x] `yse.py format` clean (whole tree already conformant)
- [x] `yse.py analyze YseEngine/sound/soundImplementation.cpp` — no new
  findings in modified code (3 warnings reported are all pre-existing lines:
  172 dead-store, 527 dead-store, 625 swapped-args)
- [x] Unit tests pass — full suite green: **17/17 ctest executables**, and
  the new doppler cases run as **8 cases / 17 assertions, all passing**
  (`yse_tests --test-suite=sound --test-case="doppler*"`)
- [x] Added 8 regression tests for the ratio math (1.0 at rest, pitch up on
  approach / down on recede, multiplicative-not-additive, `dopplerScale`
  scaling, listener-motion contribution, co-located divide-by-zero guard,
  and the super-sonic clamp band)

No integration/e2e test: the change is DSP math on the audio-callback path.
Following the established #205/#206/#207 approach, the audio-thread math is
extracted into a pure static helper and verified with exact unit assertions;
the slewing itself is `DSP::lint`, already covered by `Tests/dsp/test_ramp.cpp`.
Driving real doppler end-to-end would need a running audio device (unavailable
in CI's null-device harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)