### PR TITLE
FIX: run occlusion callback on the control thread, not the audio callback (#209)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -222,7 +222,7 @@ sound.create(patcher, channel, volume);           // modular synthesis
 
 **Play intent states:** `SI_NONE / SI_PLAY / SI_STOP / SI_PAUSE / SI_TOGGLE / SI_RESTART`
 
-**Per-sound properties:** position (Pos), size (rolloff distance), speed (negative → reverse playback), volume (with fade time), spread, relative, doppler, occlusion (0–1 LPF amount).
+**Per-sound properties:** position (Pos), size (rolloff distance), speed (negative → reverse playback), volume (with fade time), spread, relative, doppler, occlusion (0–1 gain duck: `finalGain *= 1 - occlusion`).
 
 ---
 
@@ -230,13 +230,15 @@ sound.create(patcher, channel, volume);           // modular synthesis
 
 **Files:** [listener.hpp](YseEngine/listener.hpp), [implementations/listenerImplementation.cpp](YseEngine/implementations/listenerImplementation.cpp)
 
-`YSE::Listener()` is a singleton representing the listener's point of view. Per-frame pipeline for each active sound: inverse-distance attenuation, angle → stereo/surround pan, doppler shift from radial velocity, optional user-supplied occlusion callback → LPF.
+`YSE::Listener()` is a singleton representing the listener's point of view. Per-frame pipeline for each active sound: inverse-distance attenuation, angle → stereo/surround pan, doppler shift from radial velocity, optional user-supplied occlusion callback → gain duck (`finalGain *= 1 - occlusion`).
 
 **Occlusion hook:**
 
 ```cpp
 system& occlusionCallback(float(*func)(const Pos& source, const Pos& listener));
 ```
+
+The callback runs on the **control thread** (inside `System().update()`), once per occlusion-enabled sound per tick — never on the audio callback thread. Its clamped result is handed to the audio thread over the sound message queue, so a raycast that locks or allocates cannot stall the audio callback ([#209](https://github.com/yvanvds/yse-soundengine/issues/209)).
 
 **Output channel configurations:** `CT_MONO CT_STEREO CT_QUAD CT_51 CT_51SIDE CT_61 CT_71 CT_CUSTOM`
 

--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -348,31 +348,66 @@ TEST_SUITE("sound") {
     CHECK(true);
   }
 
-  // ─── Occlusion callback path ─────────────────────────────────────────────────
+  // ─── Occlusion callback path (issue #209) ────────────────────────────────────
+  //
+  // The user occlusion callback must run on the CONTROL thread (inside
+  // System().update() -> SOUND::updateOcclusion()), never on the audio callback
+  // thread (SOUND::Manager().update(), which the device callback drives). Its
+  // clamped result reaches the implementation over the sound message queue as an
+  // OCCLUSION_VALUE message. Pre-#209 the callback ran inside
+  // implementationObject::update() on the audio thread — a real-time violation.
 
-  TEST_CASE("sound impl: update() invokes occlusion callback when occlusion is enabled") {
+  TEST_CASE(
+      "sound impl: occlusion callback runs on the control thread, not the audio thread (#209)") {
     if (!TestHelpers::engineInit()) return;
     YSE::sound s;
     s.create(g_src);
     s.occlusion(true);
     drainSoundManager();
+
     g_occlusionCallCount = 0;
     YSE::System().occlusionCallback(occlusionStub);
+
+    // Audio-thread path: pumping the manager (exactly what the device callback
+    // does) must NOT invoke the user callback. Pre-#209 this ran the callback in
+    // implementationObject::update() and the count would be > 0 — the regression.
     drainSoundManager(12);
-    // Callback may be invoked multiple times across the update iterations.
+    CHECK(g_occlusionCallCount == 0);
+
+    // Control-thread path: the driver invoked from System().update() runs it.
+    YSE::SOUND::updateOcclusion();
     CHECK(g_occlusionCallCount > 0);
+
+    // The delivered OCCLUSION_VALUE message must parse cleanly on the next sync.
+    drainSoundManager();
+
     // Reset the callback so it doesn't leak into other tests.
     YSE::System().occlusionCallback(nullptr);
   }
 
-  TEST_CASE("sound impl: update() skips occlusion when callback is null") {
+  TEST_CASE("sound impl: updateOcclusion() is a no-op when the callback is null (#209)") {
     if (!TestHelpers::engineInit()) return;
     YSE::sound s;
     s.create(g_src);
     s.occlusion(true);
     YSE::System().occlusionCallback(nullptr);
+    YSE::SOUND::updateOcclusion(); // no callback installed -> nothing to run
     drainSoundManager(12);
     CHECK(true);
+  }
+
+  TEST_CASE(
+      "sound impl: updateOcclusion() only runs callbacks for occlusion-enabled sounds (#209)") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::sound s;
+    s.create(g_src);
+    // Deliberately do NOT enable occlusion on this sound.
+    drainSoundManager();
+    g_occlusionCallCount = 0;
+    YSE::System().occlusionCallback(occlusionStub);
+    YSE::SOUND::updateOcclusion();
+    CHECK(g_occlusionCallCount == 0);
+    YSE::System().occlusionCallback(nullptr);
   }
 
   // ─── Virtual-sound finder budget ─────────────────────────────────────────────

--- a/YseEngine/sound/sound.hpp
+++ b/YseEngine/sound/sound.hpp
@@ -32,6 +32,7 @@ namespace YSE {
       LOOP,
       INTENT,
       OCCLUSION,
+      OCCLUSION_VALUE,
       DSP,
       TIME,
       RELATIVE,

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -445,6 +445,12 @@ void YSE::SOUND::implementationObject::parseMessage(const messageObject& message
     occlusionActive = message.boolValue;
     break;
   }
+  case MESSAGE::OCCLUSION_VALUE: {
+    // Result of the user occlusion callback, computed on the control thread in
+    // SOUND::updateOcclusion() and already clamped to [0, 1] there (issue #209).
+    occlusion_dsp = message.floatValue;
+    break;
+  }
   case MESSAGE::DSP: {
     addDSP(*(DSP::dspObject*)message.ptrValue);
     break;
@@ -540,10 +546,12 @@ void YSE::SOUND::implementationObject::update() {
   ///////////////////////////////////////////
   // sound occlusion (optional)
   ///////////////////////////////////////////
-  if (System().occlusionCallback() != nullptr && occlusionActive) {
-    occlusion_dsp = System().occlusionCallback()(newPos, INTERNAL::ListenerImpl().newPos);
-    Clamp(occlusion_dsp, 0.f, 1.f);
-  }
+  // The user occlusion callback is NOT invoked here: update() runs on the audio
+  // callback thread (deviceManager::doOnCallback -> SOUND::Manager().update()),
+  // and user raycast code must never run there (issue #209). The callback now
+  // runs on the control thread in SOUND::updateOcclusion() (driven by
+  // System().update()); its clamped result arrives via the OCCLUSION_VALUE
+  // message and is stored in occlusion_dsp, which dsp() applies as a gain duck.
 
   ///////////////////////////////////////////
   // dsp processing (optional)

--- a/YseEngine/sound/soundInterface.cpp
+++ b/YseEngine/sound/soundInterface.cpp
@@ -43,6 +43,38 @@ namespace {
     std::lock_guard<std::mutex> lock(soundNameMutex());
     soundNames().erase(name);
   }
+
+  // Registry of sounds with occlusion enabled (issue #209). The user occlusion
+  // callback used to run inside SOUND::implementationObject::update(), which
+  // executes on the audio callback thread — a real-time violation, since the
+  // callback typically raycasts through game-world geometry (locks, allocation,
+  // blocking I/O). Instead we track the occlusion-enabled interface objects here
+  // and run their callbacks on the control thread in SOUND::updateOcclusion(),
+  // delivering the result to the implementation over the existing message queue.
+  //
+  // Registration and iteration both happen on the application thread (occlusion
+  // setter / destructor / System().update()); the mutex is a cheap defensive
+  // guard against construction from multiple threads and never sits on the
+  // audio path.
+  std::mutex& occlusionMutex() {
+    static std::mutex m;
+    return m;
+  }
+
+  std::unordered_set<YSE::sound*>& occlusionSounds() {
+    static std::unordered_set<YSE::sound*> s;
+    return s;
+  }
+
+  void registerOcclusion(YSE::sound* s) {
+    std::lock_guard<std::mutex> lock(occlusionMutex());
+    occlusionSounds().insert(s);
+  }
+
+  void unregisterOcclusion(YSE::sound* s) {
+    std::lock_guard<std::mutex> lock(occlusionMutex());
+    occlusionSounds().erase(s);
+  }
 } // namespace
 
 YSE::sound::sound()
@@ -62,6 +94,9 @@ YSE::sound::sound()
 
 YSE::sound::~sound() {
   unregisterFromBus();
+  // Drop out of the control-thread occlusion registry before the interface goes
+  // away, so updateOcclusion() can never touch a destroyed sound (issue #209).
+  unregisterOcclusion(this);
   if (pimpl != nullptr) {
     pimpl->removeInterface();
     Log().sendMessage("removed sound");
@@ -346,6 +381,13 @@ Bool YSE::sound::isStopped() {
 void YSE::sound::occlusion(Bool value) {
   if (_occlusion != value) {
     _occlusion = value;
+    // Enrol / withdraw from the control-thread occlusion driver (issue #209).
+    // The driver only runs the user callback for sounds that are registered.
+    if (value) {
+      registerOcclusion(this);
+    } else {
+      unregisterOcclusion(this);
+    }
     SOUND::messageObject m;
     m.ID = SOUND::OCCLUSION;
     m.boolValue = value;
@@ -455,5 +497,46 @@ void YSE::sound::moveTo(channel& target) {
     m.ID = SOUND::MOVE;
     m.ptrValue = _parent;
     pimpl->sendMessage(m);
+  }
+}
+
+void YSE::SOUND::updateOcclusion() {
+  // Runs on the application (control) thread, driven once per System().update().
+  // This is the whole point of issue #209: the user occlusion callback must not
+  // execute on the audio callback thread, where a raycast's locks / allocations
+  // / blocking I/O would cause priority-inversion stalls and dropouts.
+  occlusionFunc cb = System().occlusionCallback();
+  if (cb == nullptr) return;
+
+  const Flt df = INTERNAL::Settings().distanceFactor;
+  // Scale the listener position exactly as listenerImplementation::update()
+  // does (newPos = pos * distanceFactor), but compute it here from the atomic
+  // listener position so we never read the audio thread's non-atomic newPos.
+  const Pos listenerScaled = Listener().pos() * df;
+
+  // Snapshot the registry under the lock, then invoke callbacks with the lock
+  // released. A user callback that (pathologically) creates or destroys a sound
+  // would otherwise re-enter the registry mutex and deadlock, or mutate the set
+  // mid-iteration.
+  std::vector<YSE::sound*> snapshot;
+  {
+    std::lock_guard<std::mutex> lock(occlusionMutex());
+    snapshot.assign(occlusionSounds().begin(), occlusionSounds().end());
+  }
+
+  for (YSE::sound* s : snapshot) {
+    if (s->pimpl == nullptr) continue; // create() not (yet) succeeded
+    Flt occ = cb(s->_pos * df, listenerScaled);
+    Clamp(occ, 0.f, 1.f);
+    // Only enqueue when the value changes — matches the compare-then-send
+    // pattern of every other setter and keeps the SPSC queue near-empty when
+    // occlusion is static.
+    if (s->_occlusionValue != occ) {
+      s->_occlusionValue = occ;
+      SOUND::messageObject m;
+      m.ID = SOUND::OCCLUSION_VALUE;
+      m.floatValue = occ;
+      s->pimpl->sendMessage(m);
+    }
   }
 }

--- a/YseEngine/sound/soundInterface.hpp
+++ b/YseEngine/sound/soundInterface.hpp
@@ -24,6 +24,16 @@
 
 namespace YSE {
 
+  namespace SOUND {
+    // Control-thread occlusion driver (issue #209). Invoked once per
+    // System().update() on the application thread; runs every registered
+    // sound's user occlusion callback off the audio callback thread and
+    // delivers the result to the implementation via the message queue.
+    // Declared here so the sound interface can befriend it; defined in
+    // soundInterface.cpp.
+    void updateOcclusion();
+  } // namespace SOUND
+
   /**
    *  @brief A playable instance of an audio source.
    *
@@ -360,6 +370,11 @@ namespace YSE {
     Bool _doppler;
     Bool _pan2D;
     Bool _occlusion;
+    // Last occlusion value delivered to the implementation. Cached so the
+    // control-thread driver only enqueues an OCCLUSION_VALUE message when the
+    // callback result actually changes (issue #209), matching the compare-then-
+    // send pattern used by every other setter.
+    Flt _occlusionValue{0.f};
 
     UInt _fadeAndStopTime;
     DSP::dspObject* _dsp;
@@ -373,6 +388,9 @@ namespace YSE {
     bool _busOwner{false};
 
     friend class SOUND::implementationObject;
+    // The control-thread occlusion driver reads _pos / pimpl / _occlusionValue
+    // and enqueues OCCLUSION_VALUE messages directly (issue #209).
+    friend void SOUND::updateOcclusion();
   };
 } // namespace YSE
 

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -88,6 +88,11 @@ Bool YSE::system::initShared(bool openDevice) {
 
 void YSE::system::update() {
   INTERNAL::Global().flagForUpdate();
+  // Run user occlusion callbacks on this (control) thread and hand the results
+  // to the audio thread via the sound message queue. Keeps user raycast code
+  // off the audio callback path (issue #209). No-op when no callback is
+  // installed or no sound has occlusion enabled.
+  SOUND::updateOcclusion();
   // Drain any publishes the audio thread queued since the last update tick
   // and dispatch them synchronously to their subscribers. Cheap when empty:
   // a single SPSC peek + early exit.

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -22,9 +22,12 @@ namespace YSE {
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *
-   *  Given the source and listener positions, return the attenuation factor
-   *  in the range [0.0, 1.0]: 0 means fully occluded, 1 means audible without
-   *  obstruction. Typical implementations raycast through game-world geometry.
+   *  Given the source and listener positions, return the occlusion amount in
+   *  the range [0.0, 1.0]: 0 means no obstruction (full volume), 1 means fully
+   *  occluded (silent). The engine applies it as a gain duck
+   *  (``finalGain *= 1 - occlusion``). Typical implementations raycast through
+   *  game-world geometry. See ``system::occlusionCallback`` for the threading
+   *  contract — this runs on the control thread, not the audio callback.
    */
   typedef float (*occlusionFunc)(const Pos& source, const Pos& listener);
 
@@ -161,10 +164,20 @@ namespace YSE {
 
     /** @brief Install a sound-occlusion callback.
      *
-     *  The engine calls the function for every pair of (source, listener)
-     *  positions to compute how much a sound should be attenuated by world
-     *  geometry. Typical implementations issue a raycast through the game
-     *  physics engine. Pass ``nullptr`` to disable.
+     *  The engine calls the function for every occlusion-enabled sound to
+     *  compute how much it should be attenuated by world geometry. The returned
+     *  factor is applied as a gain duck (``finalGain *= 1 - occlusion``).
+     *  Typical implementations issue a raycast through the game physics engine.
+     *  Pass ``nullptr`` to disable.
+     *
+     *  @note **Threading.** The callback runs on the thread that calls
+     *        ``System().update()`` (the application/control thread), once per
+     *        occlusion-enabled sound per update tick — never on the audio
+     *        callback thread. The result is delivered to the audio thread over
+     *        the lock-free sound message queue. This means a raycast that takes
+     *        locks or allocates cannot stall the audio callback (issue #209),
+     *        but it also means the callback must not block ``update()`` for
+     *        long.
      *
      *  @see occlusionFunc
      */


### PR DESCRIPTION
## Summary

The user-supplied occlusion callback executed on the **audio callback thread**. `SOUND::implementationObject::update()` called `System().occlusionCallback()(...)`, and `update()` runs inside the device callback (`deviceManager::doOnCallback` → `SOUND::Manager().update()` → per-sound `update()`). Occlusion callbacks typically raycast through game-world geometry, so this placed user locks / allocations / blocking I/O on the real-time path — once per occlusion-enabled sound per tick. This is a latent RT violation of the same class as the 2026-07-02 lock-free audit (#185–#201).

This PR moves the callback off the audio thread onto the control thread, delivering results to the audio thread over the existing lock-free sound message queue.

## Linked issue

Closes #209

## Changes

- **New control-thread driver.** Occlusion-enabled sounds are tracked in an app-side registry (`soundInterface.cpp`); `SOUND::updateOcclusion()` runs once per `System().update()`, invokes each user callback, clamps the result, and enqueues it as a new `OCCLUSION_VALUE` message. The audio thread only *reads* the delivered value in `dsp()` — no user code runs there anymore.
- Value is computed from the same inputs the audio thread used (`source pos * distanceFactor`, `listener pos * distanceFactor`) but read from atomic/control-thread state; re-sent only when it changes (matches the compare-then-send pattern of every other setter, keeps the SPSC queue near-empty when occlusion is static).
- Registry snapshotted under a mutex, then callbacks run with the lock released (defends against a callback that re-enters the sound API).
- **Doc fixes flagged by the issue.** Occlusion is a gain duck (`finalGain *= 1 - occlusion`), not a low-pass filter; and the `occlusionFunc` return-value direction was documented inverted (0 was described as "fully occluded", but the DSP and Demo08 treat **1** as fully occluded). `PROJECT_OVERVIEW.md` and the API docs now match the implementation and document the control-thread execution contract.

No behavior change to the DSP; no C API surface touched (occlusion callback registration is C++ only).

## Test plan

- [x] `yse.py format` clean (idempotent on touched files)
- [x] `yse.py analyze` clean on modified sources — no new findings in changed code (pre-existing baseline findings only)
- [x] Unit tests pass — `yse_tests_sound` and full ctest suite: **17/17 suites pass**
- [x] Reworked occlusion tests in `test_sound_impl.cpp` are a regression: they assert the callback does **NOT** fire on the audio-thread path (`SOUND::Manager().update()`) and **DOES** fire on the control-thread path (`SOUND::updateOcclusion()`). The audio-thread assertion (`callCount == 0`) fails on the pre-fix code, which invoked the callback inside `update()`.

No separate integration test added: the engine has no headless audio-callback harness in CI (the audio thread never fires under the null device used by `engineInit`), so "the callback runs on thread X" is exercised by driving the two update paths directly — which is what the reworked unit tests do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
