### PR TITLE
FIX: guard midifileManager implementations list against main/audio race (#190)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(YSE_TEST_SOURCES
   reverb/test_reverb_dsp.cpp
   reverb/test_reverb_concurrency.cpp
   midi/test_midifile.cpp
+  midi/test_midifile_concurrency.cpp
   midi/test_devicemanager.cpp
   midi/test_midi_in.cpp
   music/test_scale.cpp

--- a/Tests/midi/test_midifile_concurrency.cpp
+++ b/Tests/midi/test_midifile_concurrency.cpp
@@ -1,0 +1,94 @@
+// Concurrency stress tests for MIDI::Manager (issue #190).
+//
+// Before the fix, `MIDI::managerObject` kept a single `forward_list` that the
+// main thread mutated (emplace_front from the `MIDI::file` constructor) while
+// the audio thread walked and erase_after'd it in update(), and `fileImpl::head`
+// was a plain pointer nulled by the main thread while the audio thread read it.
+// Creating/destroying `MIDI::file` objects while the engine ticked update() was
+// therefore a data race / use-after-free.
+//
+// The fix mirrors the reverb/channel managers:
+//   - canonical `implementations` list guarded by a mutex (main vs slow-pool),
+//   - a lock-free SPSC inbox handing new impls to the audio thread,
+//   - an audio-thread-owned `inUse` working list,
+//   - a slow-pool deleteJob that reaps OBJECT_DELETE impls (never freed on the
+//     audio thread),
+//   - `head` promoted to std::atomic.
+//
+// These tests churn create/destroy from one and then two threads while the test
+// thread stands in for the audio thread by driving update(). Run under TSan/ASan
+// (the yse_tests_tsan / _asan targets) they assert the race is gone.
+
+#include <doctest/doctest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include "yse.hpp"
+#include "midi/midifile.hpp"
+#include "midi/midifileManager.h"
+#include "support/null_device.hpp"
+
+namespace {
+
+  // Stand in for the audio callback: drive MIDI::Manager().update() a handful of
+  // times so the inbox drains, orphans are retired, and the slow-pool deleteJob
+  // gets enqueued and reaps freed impls.
+  void drainMidi(int iterations = 8, int sleepMs = 2) {
+    for (int i = 0; i < iterations; ++i) {
+      YSE::MIDI::Manager().update();
+      if (sleepMs > 0) std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("midi") {
+
+  // ─── Single-thread churn ─────────────────────────────────────────────────────
+
+  TEST_CASE("midifile concurrency: single-thread create/destroy churn does not crash") {
+    if (!TestHelpers::engineInit()) return;
+
+    constexpr int N = 200;
+    for (int i = 0; i < N; ++i) {
+      YSE::MIDI::file f;
+      f.create("churn.mid");
+      if ((i & 0x0f) == 0) drainMidi(2);
+    }
+
+    drainMidi(40);
+    CHECK(true);
+  }
+
+  // ─── Two-thread churn ────────────────────────────────────────────────────────
+
+  TEST_CASE("midifile concurrency: two-thread create/destroy churn does not crash") {
+    if (!TestHelpers::engineInit()) return;
+
+    std::atomic<bool> workerDone{false};
+    constexpr int N = 100;
+
+    // Worker plays the main-thread role: it constructs/destroys file objects,
+    // which emplace_front into `implementations` and null `head`.
+    std::thread worker([&]() {
+      for (int i = 0; i < N; ++i) {
+        YSE::MIDI::file f;
+        f.create("churn.mid");
+        std::this_thread::sleep_for(std::chrono::microseconds(50));
+      }
+      workerDone.store(true, std::memory_order_release);
+    });
+
+    // Test thread plays the audio-thread role: it drains the inbox and retires
+    // orphans while the worker churns.
+    int safety = 5000;
+    while (!workerDone.load(std::memory_order_acquire) && --safety > 0) {
+      drainMidi(2, 0);
+    }
+    worker.join();
+
+    drainMidi(40);
+    CHECK(true);
+  }
+
+} // TEST_SUITE("midi")

--- a/YseEngine/midi/midifileImplementation.cpp
+++ b/YseEngine/midi/midifileImplementation.cpp
@@ -13,6 +13,7 @@
 YSE::MIDI::fileImpl::fileImpl(file* head)
   : head(head),
     intent(SS_STOPPED),
+    objectStatus(OBJECT_READY),
     hasFile(false)
 //, startSample(0)
 {}
@@ -157,9 +158,17 @@ currentSample - startSample); currentEvent++; currentSample =
 }*/
 
 void YSE::MIDI::fileImpl::removeInterface() {
-  head = nullptr;
+  head.store(nullptr);
 }
 
 bool YSE::MIDI::fileImpl::hasInterface() {
-  return (head != nullptr);
+  return (head.load() != nullptr);
+}
+
+YSE::OBJECT_IMPLEMENTATION_STATE YSE::MIDI::fileImpl::getStatus() const {
+  return objectStatus.load();
+}
+
+void YSE::MIDI::fileImpl::setStatus(YSE::OBJECT_IMPLEMENTATION_STATE value) {
+  objectStatus.store(value);
 }

--- a/YseEngine/midi/midifileImplementation.h
+++ b/YseEngine/midi/midifileImplementation.h
@@ -12,6 +12,7 @@
 #define MIDIFILEIMPLEMENTATION_H_INCLUDED
 
 #include <string>
+#include <atomic>
 #include "../internalHeaders.h"
 // #include "../synth/synthImplementation.h"
 #include <forward_list>
@@ -38,17 +39,40 @@ namespace YSE {
       // this is called only by a synth destructor which still
       // has pointers to this file acive
       // void removeDevice(SYNTH::implementationObject * player);
+
+      // Called by the main thread from ~file(); publishes head==null so the
+      // audio thread observes the orphaned impl on its next update() tick.
       void removeInterface();
+
+      // Read by the audio thread in managerObject::update() to detect orphans.
       bool hasInterface();
 
+      OBJECT_IMPLEMENTATION_STATE getStatus() const;
+      void setStatus(OBJECT_IMPLEMENTATION_STATE value);
+
+      // Used by the slow-pool managerDeleteJob's remove_if over the canonical
+      // `implementations` list. The audio thread promotes an orphaned impl to
+      // OBJECT_DELETE only after removing it from its own `inUse` list, so by
+      // the time the slow pool can free it nothing on the audio thread still
+      // references it.
+      static bool canBeDeleted(const fileImpl& impl) {
+        return impl.objectStatus.load() == OBJECT_DELETE;
+      }
+
     private:
-      // interface object
-      file* head;
+      // Interface object. Atomic: the main thread nulls it in removeInterface()
+      // while the audio thread reads it in hasInterface() (issue #190).
+      std::atomic<file*> head;
 
       // MidiFile midiFile;
       // MidiMessageSequence sequence;
 
       std::atomic<SOUND_STATUS> intent;
+
+      // Lifecycle state for the audio-thread/slow-pool handoff. Starts
+      // OBJECT_READY (there is no async setup stage) and only ever moves to
+      // OBJECT_DELETE once the audio thread has retired the impl from `inUse`.
+      std::atomic<OBJECT_IMPLEMENTATION_STATE> objectStatus;
 
       bool hasFile;
       // int startSample;

--- a/YseEngine/midi/midifileManager.cpp
+++ b/YseEngine/midi/midifileManager.cpp
@@ -16,18 +16,76 @@ YSE::MIDI::managerObject& YSE::MIDI::Manager() {
   return m;
 }
 
+YSE::MIDI::managerObject::managerObject() : mgrDelete(this), runDelete(false) {}
+
+YSE::MIDI::managerObject::~managerObject() noexcept {
+  try {
+    // Wait for any in-flight delete job before tearing down the lists it reads.
+    mgrDelete.join();
+
+    // Drain any pointers still queued by the main thread; they reference impls
+    // owned by `implementations` and are freed when that list is cleared.
+    fileImpl* drained;
+    while (toLoadInbox.try_pop(drained)) {
+      (void)drained;
+    }
+
+    inUse.clear();
+    implementations.clear();
+  } catch (...) {
+    INTERNAL::LogImpl().emit(E_ERROR, "MIDI::Manager destructor swallowed exception");
+  }
+}
+
 YSE::MIDI::fileImpl* YSE::MIDI::managerObject::addImplementation(YSE::MIDI::file* head) {
-  implementations.emplace_front(head);
-  return &implementations.front();
+  fileImpl* impl = nullptr;
+  {
+    std::scoped_lock lk(implementationsMutex);
+    implementations.emplace_front(head);
+    impl = &implementations.front();
+  }
+  // Hand the impl off to the audio thread via the lock-free inbox. The audio
+  // thread owns the working `inUse` list, so it — not the main thread — decides
+  // when the impl participates in update() (issue #190).
+  toLoadInbox.push(impl);
+  return impl;
 }
 
 void YSE::MIDI::managerObject::update() {
-  auto previous = implementations.before_begin();
-  for (auto i = implementations.begin(); i != implementations.end(); ++i) {
-    if (!(*i).hasInterface()) {
-      implementations.erase_after(previous);
-      return;
+  ///////////////////////////////////////////
+  // drain the main→audio inbox of newly-created impls into the working list
+  ///////////////////////////////////////////
+  {
+    fileImpl* p;
+    while (toLoadInbox.try_pop(p))
+      inUse.emplace_front(p);
+  }
+
+  ///////////////////////////////////////////
+  // enqueue the slow-pool delete job for impls retired on the previous tick.
+  // Deferring by a tick guarantees the orphan is already out of `inUse` before
+  // the slow pool can free it — no audio-thread free, no dangling `inUse` entry.
+  ///////////////////////////////////////////
+  if (runDelete && !mgrDelete.isQueued()) {
+    INTERNAL::Global().addSlowJob(&mgrDelete);
+  }
+  runDelete = false;
+
+  ///////////////////////////////////////////
+  // retire orphaned impls (interface destroyed) from the working list. The
+  // impl is flagged OBJECT_DELETE and left in `implementations` for the
+  // slow-pool deleteJob to reap — it is never freed on the audio thread.
+  ///////////////////////////////////////////
+  auto previous = inUse.before_begin();
+  for (auto i = inUse.begin(); i != inUse.end();) {
+    if (!(*i)->hasInterface()) {
+      fileImpl* ptr = *i;
+      i = inUse.erase_after(previous);
+      ptr->setStatus(OBJECT_DELETE);
+      runDelete = true;
+      continue;
     }
-    previous++;
+    previous = i;
+    ++i;
   }
 }

--- a/YseEngine/midi/midifileManager.h
+++ b/YseEngine/midi/midifileManager.h
@@ -11,19 +11,55 @@
 #ifndef MIDIFILEMANAGER_H_INCLUDED
 #define MIDIFILEMANAGER_H_INCLUDED
 
+#include <forward_list>
+#include <mutex>
 #include "midifileImplementation.h"
 #include "midifile.hpp"
+#include "../internal/threadPool.h"
+#include "../internal/managerJobs.hpp"
+#include "../utils/lfQueue.hpp"
 
 namespace YSE {
   namespace MIDI {
 
     class managerObject {
     public:
+      using ImplementationType = fileImpl;
+
+      managerObject();
+      ~managerObject() noexcept;
+
       fileImpl* addImplementation(file* head);
       void update();
 
     private:
+      // Canonical list of all fileImpls. Touched by the main thread
+      // (addImplementation emplace_front) and by the slow-pool deleteJob
+      // (remove_if). Guarded by implementationsMutex — never iterated on the
+      // audio thread (issue #190).
       std::forward_list<fileImpl> implementations;
+
+      // Guards `implementations` between main thread and slow-pool worker.
+      std::mutex implementationsMutex;
+
+      // Lock-free SPSC inbox: the main thread pushes a new impl here from
+      // addImplementation(); the audio thread drains it into `inUse` at the top
+      // of update(). MIDI files need no async setup, so impls go straight into
+      // use — there is no intermediate `toLoad` stage.
+      lfQueue<fileImpl*> toLoadInbox;
+
+      // Audio-thread-owned working list. update() iterates and erases from this
+      // list only; the impls it points at live in `implementations`.
+      std::forward_list<fileImpl*> inUse;
+
+      // Reaps impls flagged OBJECT_DELETE off the audio thread on the slow pool.
+      INTERNAL::managerDeleteJob<managerObject> mgrDelete;
+
+      // Set by the audio thread when it retires an orphaned impl from `inUse`;
+      // drives the deleteJob enqueue on the following tick.
+      aBool runDelete;
+
+      friend class INTERNAL::managerDeleteJob<managerObject>;
     };
 
     managerObject& Manager();


### PR DESCRIPTION
## Summary
`MIDI::managerObject` kept a single `forward_list` that the **main thread** mutated (`emplace_front` from the `MIDI::file` constructor) while the **audio thread** walked and `erase_after`'d it in `update()` (via `deviceManager::doOnCallback`). `fileImpl::head` was also a plain pointer nulled by the main thread in `removeInterface()` while the audio thread read it in `hasInterface()`, and orphaned nodes were destroyed/freed on the audio callback. Creating/destroying `MIDI::file` objects while the engine ran was therefore a data race + use-after-free, and violated real-time discipline (free on the audio thread).

This adopts the same lock-free pattern the reverb/channel/sound managers already use.

## Linked issue
Closes #190

## Changes
- `midifileManager`: canonical `implementations` list now guarded by `implementationsMutex` (main-thread `emplace` vs slow-pool `deleteJob` `remove_if`); it is **never** iterated on the audio thread.
- Added a lock-free SPSC `toLoadInbox` that hands new impls from the main thread to the audio thread.
- Added an audio-thread-owned `inUse` working list — the only list `update()` iterates/erases.
- Orphaned impls are flagged `OBJECT_DELETE` and reaped by the shared `INTERNAL::managerDeleteJob` on the slow pool, so **nothing is freed on the audio callback**. The delete job is deferred by one `update()` tick so the orphan is out of `inUse` before the slow pool can free it.
- `fileImpl::head` promoted to `std::atomic<file*>`; added an atomic `objectStatus` plus `getStatus`/`setStatus`/`canBeDeleted` for the handoff.
- Added a manager constructor/destructor to wire `mgrDelete` and to join + drain + clear on teardown.

## Test plan
- [x] `python yse.py format` — clean (only the changed files touched; already conformant).
- [x] `python yse.py analyze YseEngine/midi/` (clang-tidy) — no new findings in the changed files (all output suppressed as baseline/non-user).
- [x] `python yse.py test` — full ctest suite **17/17 passed**, including `yse_tests_midi` and `yse_tests_concurrency`.
- [x] New regression tests: `Tests/midi/test_midifile_concurrency.cpp` — single-thread and two-thread `MIDI::file` create/destroy churn while a stand-in audio thread drives `update()` (test-case names match the `* concurrency: *` filter, so they run in the concurrency leg too).
- [ ] Sanitizer demonstration of the race is **not runnable locally**: the MSYS2/Windows clang toolchain here ships no ASan/TSan runtime (`yse.py --sanitizer` is gated to Linux). The TSan/ASan CI legs are the definitive gate — same as the existing reverb/channel/sound concurrency tests. Without instrumentation the data race does not deterministically crash, so a non-sanitized run passes on both patched and unpatched code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
