### PR TITLE
FIX: sound::sync() writes into the user-owned interface object — UAF window with ~sound() (#191)

### DIFF
--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -127,14 +127,28 @@ TEST_SUITE("sound") {
     drainSoundManager();
     // time>0 sends both messages — exercises the VOLUME_TIME arm too.
     s.volume(0.5f, 100u);
-    // Read the interface mirror *before* drainSoundManager: sync() overwrites
-    // _volume from currentVolume_dsp (= 0 until dsp() runs in the audio
-    // callback, which never fires under TestHelpers::engineInit's null
-    // device), so checking after drain would observe the clobber instead of
-    // the value we just set.
     CHECK(s.volume() == doctest::Approx(0.5f));
     drainSoundManager();
     CHECK(true);
+  }
+
+  // Regression for issue #191: sync() used to push the live dsp volume back
+  // into the user-owned interface object (`h->_volume = currentVolume_dsp`),
+  // a use-after-free window against ~sound() AND a clobber of the getter's
+  // last-set cache. The write-through is gone; volume() must survive a full
+  // sync cycle and keep returning the value the user set (like every sibling
+  // getter). Pre-fix this observed the clobber (currentVolume_dsp == 0 under
+  // the null device, since dsp() never runs) and returned 0.0 instead of 0.5.
+  TEST_CASE("sound impl: sync() no longer clobbers the volume getter (#191)") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::sound s;
+    s.create(g_src);
+    drainSoundManager();
+    s.volume(0.5f);
+    // Drive several sync() cycles — exactly the path that used to write through
+    // the freed interface pointer. The set value must persist.
+    drainSoundManager();
+    CHECK(s.volume() == doctest::Approx(0.5f));
   }
 
   TEST_CASE("sound impl: SPEED message is parsed without crash") {

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -366,9 +366,15 @@ void YSE::SOUND::implementationObject::sendMessage(const messageObject& message)
 }
 
 void YSE::SOUND::implementationObject::sync() {
-  // Snapshot head once: ~sound() on another thread can race the null check
-  // and null head via removeInterface() between the check and the deref
-  // below, producing a SEGV at the offset of `_volume` from null.
+  // Snapshot head once so we can detect that ~sound() has run: removeInterface()
+  // nulls `head` (release store) when the user object is destroyed, and this
+  // acquire load observes that. We use the snapshot ONLY to branch on
+  // destruction — sync() must never write through it. ~sound() can complete
+  // (and the user-owned interface storage be reclaimed) at any point after the
+  // load, so a store back through `h` would be a use-after-free (issue #191).
+  // All values the interface reads back are published through impl-side atomics
+  // (`_head_time`, `_head_status`, ...) that outlive the interface, never pushed
+  // into the interface object.
   sound* h =
       head.load(std::memory_order_acquire); // NOSONAR S8417: intentional acquire — snapshot head
                                             // once to avoid race with ~sound()/removeInterface()
@@ -397,7 +403,11 @@ void YSE::SOUND::implementationObject::sync() {
   // sync dsp values
   currentVolume_upd = currentVolume_dsp;
   _head_time = currentFilePos;
-  h->_volume = currentVolume_dsp;
+  // NB: the actual playing volume is intentionally NOT pushed back into the
+  // user-owned interface object here. Doing so (`h->_volume = ...`) raced
+  // ~sound() and wrote freed memory (issue #191). `sound::volume()` returns
+  // the last-set (clamped) value from its own cache, consistent with every
+  // sibling getter (speed/spread/size/pos), none of which sync() writes to.
   status_upd = status_dsp;
   _head_status = status_upd;
 }


### PR DESCRIPTION
## Summary
`SOUND::implementationObject::sync()` snapshotted `head` (acknowledging in the comment the `~sound()` race that the null check guards) but then executed `h->_volume = currentVolume_dsp` — a store **into the user-owned `YSE::sound` interface object**. Nothing prevents `~sound()` from completing (via `removeInterface()`, e.g. on stack scope exit) and the object's storage being reclaimed between the acquire load and that store, so the write is a use-after-free. It's a narrow (few-hundred-ns) window, but it's exercised on every sync of every sound, forever. Found by the 2026-07-02 lock-free architecture audit.

## Linked issue
Closes #191

## Changes
- **`YseEngine/sound/soundImplementation.cpp`** — remove the `h->_volume = currentVolume_dsp;` write-through in `sync()`. `sync()` now uses the `head` snapshot **only** to branch on destruction; it never writes through it. Comments updated to record the invariant.
- **`Tests/sound/test_sound_impl.cpp`** — new regression test `sync() no longer clobbers the volume getter (#191)`, plus simplification of the pre-existing VOLUME test (its old workaround comment described the very clobber this removes).

### Note on the fix approach (deviation from the issue's proposed mechanism)
The issue proposed adding a live `aFlt _head_volume` impl-side mirror for `volume()` to read. On investigation that conflicts with the established contract: `sound::volume()` is a **last-set-value cache**, identical to its siblings `speed()` / `spread()` / `size()` / `pos()`, none of which `sync()` writes back — and 10+ existing tests (round-trip, clamp at `test_sound_state.cpp:295-329`, and the bus tests) assert exactly that. A live mirror stays `0` under the null test device (dsp() never ramps), which would gut that coverage and change the C API `yse_sound_get_volume` semantics. So the write-through is simply **deleted**: this fully closes the UAF (sync writes nothing through the user-owned head) and makes `volume()` consistent with every sibling getter, with no behavior change to the documented/tested getter contract. No new atomic, nothing added to the audio-thread path.

## Real-time / audio-thread discipline
`sync()` runs on the audio-callback-driven manager update. The change only *removes* a store; it adds no allocation, lock, or blocking. Net RT footprint is strictly smaller.

## Test plan
- [x] `python yse.py test` — all 17 ctest suites pass (sound suite: 129 cases / 263,594 assertions, 0 failed).
- [x] Regression test verified to **fail on unpatched code**: with the `h->_volume = ...` line temporarily restored, `sync() no longer clobbers the volume getter (#191)` fails with `0 == Approx(0.5)`; passes once the write-through is removed.
- [x] `python yse.py analyze YseEngine/sound/soundImplementation.cpp` — no new findings in modified code (3 reported warnings at lines 172/543/643 are pre-existing backlog, unrelated to the edited `sync()` region).

🤖 Generated with [Claude Code](https://claude.com/claude-code)