### PR TITLE
FIX: stop reverbManager copy-assigning pimpl on the audio thread (#192)

### DIFF
--- a/Tests/reverb/test_reverb_concurrency.cpp
+++ b/Tests/reverb/test_reverb_concurrency.cpp
@@ -84,4 +84,49 @@ TEST_SUITE("reverb") {
     CHECK(true);
   }
 
+  // ─── Global reverb setters race with update() (issue #192) ───────────────────
+
+  TEST_CASE("reverb concurrency: global reverb setters race with update()") {
+    if (!TestHelpers::engineInit()) return;
+
+    // Regression for issue #192. The manager used to copy-assign globalReverb
+    // into its audio-thread scratch object (`calculatedValues = globalReverb`),
+    // aliasing pimpl. From then on the audio-thread setters on calculatedValues
+    // pushed into globalReverb's SPSC message queue while the main thread also
+    // produced via the public global-reverb setters — a dual-producer queue.
+    // Here the setter thread is the (single, legitimate) producer and update()
+    // is the consumer; with the fix there is exactly one producer. Under TSan
+    // the old code trips a data race, and the SPSC queue can corrupt/crash even
+    // without it.
+    YSE::reverb& gr = YSE::REVERB::Manager().getGlobalReverb();
+    gr.setActive(true);
+
+    std::atomic<bool> stop{false};
+    std::thread setter([&]() {
+      const YSE::REVERB_PRESET presets[] = {YSE::REVERB_HALL, YSE::REVERB_CAVE, YSE::REVERB_ROOM,
+                                            YSE::REVERB_OFF};
+      int i = 0;
+      while (!stop.load(std::memory_order_acquire)) {
+        gr.setPreset(presets[i & 3]);
+        gr.setActive((i & 1) == 0);
+        gr.setDryWetBalance(0.5f, 0.5f);
+        ++i;
+        std::this_thread::sleep_for(std::chrono::microseconds(20));
+      }
+    });
+
+    // Audio side: no positioned reverbs are in range, so update() takes the
+    // partial == 0 steady-state branch that used to alias pimpl.
+    for (int i = 0; i < 2000; ++i) {
+      YSE::INTERNAL::Time().update();
+      YSE::REVERB::Manager().update();
+    }
+
+    stop.store(true, std::memory_order_release);
+    setter.join();
+
+    drainReverbs(40);
+    CHECK(true);
+  }
+
 } // TEST_SUITE("reverb")

--- a/Tests/reverb/test_reverb_concurrency.cpp
+++ b/Tests/reverb/test_reverb_concurrency.cpp
@@ -125,8 +125,16 @@ TEST_SUITE("reverb") {
     stop.store(true, std::memory_order_release);
     setter.join();
 
+    // The global reverb is a process-scoped singleton whose state persists
+    // across test cases (engineInit() runs System().init() only once). This
+    // test mutates its `active` flag, so restore the clean post-init state
+    // (active == true) — otherwise the order-dependent case
+    // "reverb: Manager global reverb is active after engine init" fails
+    // whenever the linker registers this TU first (as on Linux CI).
+    gr.setActive(true);
+
     drainReverbs(40);
-    CHECK(true);
+    CHECK(gr.getActive() == true);
   }
 
 } // TEST_SUITE("reverb")

--- a/Tests/reverb/test_reverb_dsp.cpp
+++ b/Tests/reverb/test_reverb_dsp.cpp
@@ -15,6 +15,7 @@
 // sequentially so there is no data-race concern.
 
 #include <doctest/doctest.h>
+#include <type_traits>
 // Channel headers must precede reverbManager.h because the manager references
 // CHANNEL::implementationObject without a forward declaration.
 // types.hpp defines Bool/Flt/UInt etc. needed by channelMessage.h.
@@ -128,6 +129,21 @@ TEST_SUITE("reverb") {
     CHECK(YSE::REVERB::DAMP != YSE::REVERB::DRY_WET);
     CHECK(YSE::REVERB::DRY_WET != YSE::REVERB::MODULATION);
     CHECK(YSE::REVERB::MODULATION != YSE::REVERB::REFLECTION);
+  }
+
+  // ─── reverb copy semantics (issue #192) ──────────────────────────────────────
+
+  TEST_CASE("reverb: copy-assignment is deleted (issue #192)") {
+    // A reverb owns a raw pimpl the engine tracks by interface identity.
+    // Copy-assigning default-copies pimpl, aliasing two interfaces onto one
+    // implementation — which the manager used to do on the audio thread
+    // (`calculatedValues = globalReverb`), turning the impl's SPSC message
+    // queue into a dual-producer queue. Copy-assignment must stay deleted so
+    // this cannot recur. (This is also enforced at compile time: reinstating
+    // the assignment would fail the static_assert below.)
+    static_assert(!std::is_copy_assignable<YSE::reverb>::value,
+                  "reverb must not be copy-assignable (issue #192)");
+    CHECK_FALSE(std::is_copy_assignable<YSE::reverb>::value);
   }
 
   // ─── reverb interface default state (no engine required) ─────────────────────

--- a/YseEngine/reverb/reverbImplementation.cpp
+++ b/YseEngine/reverb/reverbImplementation.cpp
@@ -70,6 +70,24 @@ void YSE::REVERB::implementationObject::sync() {
   }
 }
 
+void YSE::REVERB::implementationObject::copyParamsInto(YSE::reverb& dst) const {
+  // Copy only the DSP parameter fields. Never touch dst.pimpl / connection /
+  // global state: the manager folds the global reverb into its audio-thread
+  // scratch object and must not alias the two interfaces onto one impl, which
+  // would make the impl's SPSC message queue dual-produced (issue #192).
+  dst.active = active;
+  dst.roomsize = roomsize;
+  dst.damp = damp;
+  dst.wet = wet;
+  dst.dry = dry;
+  dst.modFrequency = modFrequency;
+  dst.modWidth = modWidth;
+  for (Int i = 0; i < 4; i++) {
+    dst.earlyPtr[i] = earlyPtr[i];
+    dst.earlyGain[i] = earlyGain[i];
+  }
+}
+
 void YSE::REVERB::implementationObject::parseMessage(const messageObject& message) {
   switch (message.ID) {
   case MESSAGE::POSITION: {

--- a/YseEngine/reverb/reverbImplementation.h
+++ b/YseEngine/reverb/reverbImplementation.h
@@ -34,6 +34,18 @@ namespace YSE {
       void setStatus(OBJECT_IMPLEMENTATION_STATE value);
 
       void sync();
+
+      /**
+      Copy only the DSP parameter fields of this (audio-thread-synced)
+      implementation into the interface object `dst`, leaving `dst`'s pimpl,
+      connection and global state untouched. Used by managerObject on the
+      audio thread to fold the global reverb into its scratch interface
+      without aliasing pimpls (issue #192). Reading from the impl — which the
+      audio thread owns after sync() — also avoids the data race on the
+      interface's own parameter fields, which the main thread writes.
+      */
+      void copyParamsInto(reverb& dst) const;
+
       virtual void parseMessage(const messageObject& message); // < Parse all messages, if any
       inline void sendMessage(const messageObject& message) {
         messages.push(message);

--- a/YseEngine/reverb/reverbInterface.hpp
+++ b/YseEngine/reverb/reverbInterface.hpp
@@ -51,6 +51,17 @@ namespace YSE {
     reverb(bool global = false);
     ~reverb();
 
+    /**
+     *  @brief Copy-assignment is deleted.
+     *
+     *  A ``reverb`` owns a raw ``pimpl`` that the engine tracks by interface
+     *  identity. Copy-assigning would alias two interfaces onto a single
+     *  implementation and turn that impl's single-producer/single-consumer
+     *  message queue into a dual-producer queue on the audio thread
+     *  (issue #192). Copying a reverb is never valid — forbid it.
+     */
+    reverb& operator=(const reverb&) = delete;
+
     /** @brief Initialise the reverb.
      *
      *  Must be called after ``System().init()`` and before any other method on

--- a/YseEngine/reverb/reverbManager.cpp
+++ b/YseEngine/reverb/reverbManager.cpp
@@ -237,23 +237,32 @@ void YSE::REVERB::managerObject::update() {
 
     // if partial == 0, we can just use the global reverb object
     else if (partial == 0) {
-      calculatedValues = globalReverb;
+      // Fold in the global reverb by copying only its DSP parameter fields —
+      // never its pimpl (issue #192). Source the values from the impl the
+      // audio thread just sync()'d, not the interface fields the main thread
+      // writes concurrently.
+      if (globalReverb.pimpl != nullptr) {
+        globalReverb.pimpl->copyParamsInto(calculatedValues);
+      }
       return; // important because active could be overwritten at the end of this function
     }
 
     // if sum of partial reverbs < 1 we have to add (part of) the global reverb
     else if (partial < 1) {
-      if (globalReverb.getActive()) {
-        calculatedValues.roomsize += globalReverb.roomsize * (1 - partial);
-        calculatedValues.damp += globalReverb.damp * (1 - partial);
-        calculatedValues.wet += globalReverb.wet * (1 - partial);
-        calculatedValues.dry += globalReverb.dry * (1 - partial);
-        calculatedValues.modFrequency += globalReverb.modFrequency * (1 - partial);
-        calculatedValues.modWidth += globalReverb.modWidth * (1 - partial);
+      // Read the global reverb's parameters from its synced impl (issue #192);
+      // the interface fields are written by the main thread and racy here.
+      const implementationObject* g = globalReverb.pimpl;
+      if (g != nullptr && g->active) {
+        calculatedValues.roomsize += g->roomsize * (1 - partial);
+        calculatedValues.damp += g->damp * (1 - partial);
+        calculatedValues.wet += g->wet * (1 - partial);
+        calculatedValues.dry += g->dry * (1 - partial);
+        calculatedValues.modFrequency += g->modFrequency * (1 - partial);
+        calculatedValues.modWidth += g->modWidth * (1 - partial);
         for (Int j = 0; j < 4; j++) {
-          calculatedValues.earlyGain[j] += globalReverb.earlyGain[j] * (1 - partial);
-          calculatedValues.earlyPtr[j] = static_cast<Int>(
-              calculatedValues.earlyPtr[j] + globalReverb.earlyGain[j] * (1 - partial));
+          calculatedValues.earlyGain[j] += g->earlyGain[j] * (1 - partial);
+          calculatedValues.earlyPtr[j] =
+              static_cast<Int>(calculatedValues.earlyPtr[j] + g->earlyGain[j] * (1 - partial));
         }
       }
     }


### PR DESCRIPTION
## Summary
`REVERB::managerObject::update()` folded the global reverb into its audio-thread scratch object with `calculatedValues = globalReverb`. `reverb` had no user-defined copy-assignment, so this default-copied every member **including the raw `pimpl`**, aliasing `calculatedValues`' implementation onto `globalReverb`'s. Consequences on the audio-callback path:

1. **Dual-producer SPSC queue.** After the copy, the audio-thread setters on `calculatedValues` (`setPreset(REVERB_OFF)`, `setActive`, `setDryWetBalance`) pushed into **globalReverb's** message queue via the aliased `pimpl`, while the main thread also produced through the public global-reverb setters. Two producers on one single-producer/single-consumer `lfQueue` → corruption (and an allocating `push` on the audio thread).
2. **Unsynchronized reads.** The `partial == 0` copy and the `partial < 1` blend read globalReverb's plain interface fields (`roomsize`, `damp`, …) unsynchronized against the main-thread setters.
3. The `partial == 0` branch is the steady state for any app without positioned reverbs, so this was the common case.

## Linked issue
Closes #192

## Changes
- **`reverb`**: `= delete` copy-assignment so an aliasing `pimpl` copy can never recur.
- **`implementationObject::copyParamsInto(reverb&)`**: new method (the impl is already a friend of `reverb`) that copies **only** the DSP parameter fields — never `pimpl`/connection/global state. It reads the impl's own fields, which the audio thread owns after `sync()`, so it is free of the main-thread race.
- **`managerObject::update()`**: fold the global reverb by reading its synced impl (`globalReverb.pimpl`) instead of the racy interface fields, in both the `partial == 0` and `partial < 1` branches.

This matches the issue's proposed minimal fix (copy only params + delete copy-assign; read impl-side values the manager already owns). Scope kept tight — the noted-in-passing uninitialised `size`/`rolloff` in the `reverb` constructor is filed separately as #263.

## Test plan
- [x] `python yse.py format` clean (no diffs on changed files)
- [x] `python yse.py analyze YseEngine/reverb/` clean (no findings on changed files; only suppressed baseline/non-user-code noise)
- [x] `python yse.py test` — all 17 suites pass (0 failed), incl. `yse_tests_reverb` and `yse_tests_concurrency`
- [x] New tests execute and pass (verified directly): `reverb: copy-assignment is deleted (issue #192)` and `reverb concurrency: global reverb setters race with update()`

### Test coverage rationale
- **Deterministic guard**: a `static_assert(!std::is_copy_assignable<YSE::reverb>)` — reinstating the copy-assignment (the root cause) fails compilation, permanently locking in the fix.
- **Concurrency guard**: a new stress test races main-thread global-reverb setters against audio-thread `update()`. With the fix there is exactly one producer on the queue; the old aliasing made `update()` a second producer. This is TSan-catchable (the project's TSan gate is the intended verifier for this class of race), matching the existing `test_reverb_concurrency.cpp` conventions. No integration/e2e test: the change is on the internal audio-thread DSP path with no user-visible/rendered surface to drive end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)