### PR TITLE
FIX: defer off-control-thread T_GUI bus publishes to the control thread (#193)

### DIFF
--- a/Tests/sound/test_sound_bus.cpp
+++ b/Tests/sound/test_sound_bus.cpp
@@ -9,6 +9,7 @@
 #include <doctest/doctest.h>
 
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "sound/soundInterface.hpp"
@@ -183,6 +184,37 @@ TEST_SUITE("sound") {
     s2.name("clearme");
     publishFloat("sound.clearme.volume", 0.2f);
     CHECK(s2.volume() == doctest::Approx(0.2f));
+  }
+
+  TEST_CASE("sound bus: off-thread volume publish is deferred, never raced onto the SPSC queue") {
+    // Regression for issue #193 at the level the bug actually bites: a
+    // gMetro-style T_GUI publish arriving on another thread must not run the
+    // sound's volume() setter inline — that would push into the sound's
+    // single-producer message queue concurrently with the application/control
+    // thread and cross-link its block list. The publish is instead deferred
+    // and applied on the control thread in drainPending(). Before the fix the
+    // volume would already read 0.5 before the drain (dispatched on the worker
+    // thread), failing the first check.
+    if (!TestHelpers::engineInit()) return;
+    SilentSource src;
+    YSE::sound s;
+    s.create(src);
+    s.name("mt193");
+
+    std::thread worker([] {
+      YSE::INTERNAL::Bus().publish("sound.mt193.volume", YSE::INTERNAL::BusValue{0.5f}, YSE::T_GUI);
+    });
+    worker.join();
+
+    // Deferred: not applied on the worker thread.
+    CHECK(s.volume() == doctest::Approx(0.0f));
+
+    // Applied on the control (test main) thread when the inbox is drained.
+    YSE::INTERNAL::Bus().drainPending();
+    CHECK(s.volume() == doctest::Approx(0.5f));
+
+    // `s` is destroyed at scope exit, which unsubscribes and releases the
+    // process-global "mt193" name — no shared-state residue for later cases.
   }
 
 } // TEST_SUITE("sound")

--- a/Tests/system/test_named_bus.cpp
+++ b/Tests/system/test_named_bus.cpp
@@ -275,6 +275,96 @@ TEST_SUITE("system") {
       bus.unsubscribe(h);
   }
 
+  TEST_CASE("named bus: off-control-thread T_GUI publish is deferred to drainPending") {
+    // Regression for issue #193: a T_GUI publish is only safe to dispatch
+    // inline on the control thread, because a subscriber callback runs an
+    // interface setter that pushes into a per-implementation single-producer
+    // message queue. The gMetro timer thread (and script threads) publish
+    // T_GUI too; inline dispatch there would race the control thread on those
+    // SPSC queues. Such publishes must be deferred to the control thread's
+    // drainPending() instead. Before the fix this callback fired synchronously
+    // on the worker thread (hits == 1 before the drain, dispatched on the
+    // worker's id) — both checks below would fail.
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    std::atomic<int> hits{0};
+    std::thread::id dispatchThread;
+    auto h = bus.subscribe("ch.mt.gui", [&](const YSE::INTERNAL::BusValue& v) {
+      if (std::get_if<int>(&v)) {
+        dispatchThread = std::this_thread::get_id();
+        hits.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+
+    // Publish from a worker thread standing in for the gMetro timer thread.
+    std::thread worker([&] { bus.publish("ch.mt.gui", YSE::INTERNAL::BusValue{7}, YSE::T_GUI); });
+    worker.join();
+
+    // Deferred, exactly like a T_DSP publish — nothing delivered yet.
+    CHECK(hits.load() == 0);
+
+    // Drained and dispatched on the control (test main) thread.
+    bus.drainPending();
+    CHECK(hits.load() == 1);
+    CHECK(dispatchThread == std::this_thread::get_id());
+
+    bus.unsubscribe(h);
+  }
+
+  TEST_CASE("named bus: control-thread T_GUI publish still dispatches synchronously") {
+    // The fix must not regress the common case: a T_GUI publish issued on the
+    // control thread (which is where the bus was constructed and where
+    // drainPending() runs) still fires its subscribers inline, no drain needed.
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    int received = 0;
+    auto h = bus.subscribe("ch.ct.gui", [&](const YSE::INTERNAL::BusValue& v) {
+      if (auto* i = std::get_if<int>(&v)) received = *i;
+    });
+
+    bus.publish("ch.ct.gui", YSE::INTERNAL::BusValue{55}, YSE::T_GUI);
+    CHECK(received == 55); // synchronous, before any drainPending()
+
+    bus.unsubscribe(h);
+  }
+
+  TEST_CASE("named bus: deferred publish preserves string/list payloads") {
+    // The off-control-thread inbox carries a full BusValue, so payload kinds
+    // the fixed-footprint audio pool drops (string, list) survive the deferral
+    // and arrive intact on drainPending() (issue #193).
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    std::string gotStr;
+    std::vector<float> gotList;
+    auto h = bus.subscribe("ch.mt.payload", [&](const YSE::INTERNAL::BusValue& v) {
+      if (auto* s = std::get_if<std::string>(&v))
+        gotStr = *s;
+      else if (auto* l = std::get_if<std::vector<float>>(&v))
+        gotList = *l;
+    });
+
+    std::thread worker([&] {
+      bus.publish("ch.mt.payload", YSE::INTERNAL::BusValue{std::string("hi")}, YSE::T_GUI);
+      bus.publish("ch.mt.payload", YSE::INTERNAL::BusValue{std::vector<float>{4.0f, 5.0f}},
+                  YSE::T_GUI);
+    });
+    worker.join();
+
+    CHECK(gotStr.empty());
+    CHECK(gotList.empty());
+
+    bus.drainPending();
+    CHECK(gotStr == "hi");
+    REQUIRE(gotList.size() == 2);
+    CHECK(gotList[0] == doctest::Approx(4.0f));
+    CHECK(gotList[1] == doctest::Approx(5.0f));
+
+    bus.unsubscribe(h);
+  }
+
   TEST_CASE("named bus: duplicate subscriptions on a name each get called") {
     REQUIRE(TestHelpers::engineInit());
     auto& bus = YSE::INTERNAL::Bus();

--- a/YseEngine/internal/namedBus.cpp
+++ b/YseEngine/internal/namedBus.cpp
@@ -11,7 +11,9 @@
 #include "namedBus.h"
 
 #include <algorithm>
+#include <mutex>
 #include <thread>
+#include <utility>
 
 namespace YSE {
   namespace INTERNAL {
@@ -47,7 +49,8 @@ namespace YSE {
     } // namespace
 
     NamedBus::NamedBus()
-      : generation_(g_busGeneration.fetch_add(1, std::memory_order_relaxed) + 1) {
+      : generation_(g_busGeneration.fetch_add(1, std::memory_order_relaxed) + 1),
+        controlThread_(std::this_thread::get_id()) {
       const std::size_t count = provisionedQueueCount();
       audioQueues_.reserve(count);
       for (std::size_t i = 0; i < count; ++i) {
@@ -108,8 +111,26 @@ namespace YSE {
         return;
       }
 
-      // Main-thread / GUI path: synchronous dispatch.
-      dispatch(name, value);
+      // Control-thread / GUI path. Only the control thread may dispatch
+      // synchronously: a subscriber callback runs an interface setter, which
+      // pushes into a per-implementation single-producer message queue, and
+      // that queue tolerates exactly one producer. A T_GUI publish arriving on
+      // another thread (the gMetro timer thread propagating a bang, a script
+      // thread) must therefore NOT dispatch inline — doing so would race the
+      // control thread on those SPSC queues and cross-link their block lists
+      // (issue #193). Park it for the next drainPending() instead.
+      if (std::this_thread::get_id() == controlThread_) {
+        dispatch(name, value);
+        return;
+      }
+
+      // Off-control-thread publish. These producers are control-rate threads
+      // (never the audio callback, which only ever publishes on T_DSP above),
+      // so taking a mutex here does not touch the real-time path.
+      {
+        std::lock_guard<std::mutex> lock(pendingMutex_);
+        pendingControl_.emplace_back(name, value);
+      }
     }
 
     SubHandle NamedBus::subscribe(const std::string& name, Subscriber callback) {
@@ -155,6 +176,21 @@ namespace YSE {
           }
           dispatch(std::string(msg.nameStorage), value);
         }
+      }
+
+      // Drain T_GUI publishes that were deferred from a non-control thread
+      // (issue #193): the gMetro timer thread or a script thread parked them
+      // here instead of dispatching inline, which would have raced the control
+      // thread on the per-implementation SPSC message queues. Swap the inbox
+      // out under the lock, then dispatch with the lock released so a
+      // subscriber may re-enter publish() / subscribe() without deadlocking.
+      std::vector<std::pair<std::string, BusValue>> deferred;
+      {
+        std::lock_guard<std::mutex> lock(pendingMutex_);
+        deferred.swap(pendingControl_);
+      }
+      for (auto& entry : deferred) {
+        dispatch(entry.first, entry.second);
       }
     }
 

--- a/YseEngine/internal/namedBus.h
+++ b/YseEngine/internal/namedBus.h
@@ -22,8 +22,10 @@
 #include <cstring>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -49,7 +51,17 @@ namespace YSE {
 
       // Publish a value to `name`.
       //
-      //   thread == T_GUI : dispatch synchronously to every subscriber.
+      //   thread == T_GUI : if the caller is the control thread (the one that
+      //                     constructed the bus and runs drainPending()),
+      //                     dispatch synchronously to every subscriber. A T_GUI
+      //                     publish arriving on ANY other thread — the gMetro
+      //                     timer thread, a script thread — is instead parked in
+      //                     the control-thread inbox and dispatched on the next
+      //                     drainPending(). Inline dispatch off the control
+      //                     thread would run a subscriber's setter, which pushes
+      //                     into a per-implementation single-producer message
+      //                     queue, concurrently with the control thread's own
+      //                     setters — corrupting that SPSC queue (issue #193).
       //   thread == T_DSP : enqueue into this thread's lock-free SPSC queue.
       //                     Multiple render threads publish concurrently (the
       //                     audio callback thread plus every fast-pool worker
@@ -116,6 +128,25 @@ namespace YSE {
       // thread may have cached a slot against — engine restart builds a fresh
       // NamedBus that may reuse the same address (issue #187).
       const std::uint64_t generation_;
+
+      // Identity of the control thread: the thread that constructs the bus
+      // (System::init runs on it) and that also runs subscribe(), dispatch()
+      // and drainPending(). Set once at construction and only ever read
+      // thereafter, so no synchronisation is needed — the constructing thread
+      // happens-before every other thread that later publishes. A T_GUI
+      // publish comparing unequal to this is off the control thread and must be
+      // deferred rather than dispatched inline (issue #193).
+      const std::thread::id controlThread_;
+
+      // T_GUI publishes that arrived on a non-control thread (gMetro timer
+      // thread, script thread), parked here and drained on the control thread
+      // in drainPending(). Guarded by pendingMutex_. The producers are
+      // control-rate threads that may lock; the audio thread never reaches this
+      // path (it publishes only on T_DSP, handled lock-free above). Holding a
+      // full BusValue keeps every payload kind — bang / int / float / string /
+      // list — intact, unlike the fixed-footprint audio-path pool.
+      std::mutex pendingMutex_;
+      std::vector<std::pair<std::string, BusValue>> pendingControl_;
 
       mutable std::shared_mutex subsMutex_;
       std::unordered_map<std::string, std::vector<Subscription>> subs_;

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -362,6 +362,22 @@ void YSE::SOUND::implementationObject::doThisWhenReady() {
 }
 
 void YSE::SOUND::implementationObject::sendMessage(const messageObject& message) {
+#ifndef NDEBUG
+  // Single-producer contract (issue #193): `messages` is an SPSC queue, so
+  // every push must originate on the same control thread. The engine keeps
+  // this true by deferring off-thread bus publishes (the gMetro timer thread,
+  // a script thread) to the control thread in NamedBus::drainPending(). A
+  // firing assert means an interface setter was driven concurrently from a
+  // second thread — fix that caller rather than widening the queue.
+  const std::thread::id caller = std::this_thread::get_id();
+  if (!_producerThreadKnown) {
+    _producerThread = caller;
+    _producerThreadKnown = true;
+  } else {
+    assert(caller == _producerThread &&
+           "sound message queue pushed from more than one thread (issue #193)");
+  }
+#endif
   messages.push(message);
 }
 

--- a/YseEngine/sound/soundImplementation.h
+++ b/YseEngine/sound/soundImplementation.h
@@ -12,6 +12,9 @@
 #define SOUNDIMPLEMENTATION_H_INCLUDED
 
 #include <forward_list>
+#ifndef NDEBUG
+#include <thread>
+#endif
 #include "../classes.hpp"
 #include "sound.hpp"
 #include "../dsp/buffer.hpp"
@@ -335,6 +338,16 @@ namespace YSE {
       std::atomic<sound*> head; // < The interface connected to this object
       std::atomic<OBJECT_IMPLEMENTATION_STATE> objectStatus; // < the status of this object
       lfQueue<messageObject> messages;
+
+#ifndef NDEBUG
+      // Debug-only guard for the single-producer contract of `messages`
+      // (issue #193). The queue is SPSC, so every sendMessage() must run on
+      // the same control thread. sendMessage() records the first producer here
+      // and asserts subsequent pushes match. Debug-build only, so it never
+      // changes the release ABI/layout.
+      std::thread::id _producerThread;
+      bool _producerThreadKnown = false;
+#endif
 
       enum PLAYER_TYPE {
         PT_FILE,


### PR DESCRIPTION
## Summary

Per-implementation `lfQueue<messageObject>` message queues are single-producer/single-consumer, but `NamedBus::publish()` dispatched **every** `T_GUI` publish synchronously on the *calling* thread. When the **gMetro timer thread** (or a script thread) propagated a bang through a `gSend`, that synchronous dispatch invoked a subscribed sound's setter → `messages.push` from the timer thread, concurrent with app-thread setters on the same queue. Two producers racing `inner_enqueue` on the `CanAlloc` path can both see "block full", both allocate, and cross-link the block list → permanent structural corruption (the audit's high-severity finding).

The fix restores the single-producer invariant those queues require, without touching the lock-free audio path.

## Linked issue
Closes #193

## Changes
- **`NamedBus`** captures the *control thread* (the thread that constructs the bus — `System::init` runs on it — and that runs `drainPending()`) at construction.
- On the `T_GUI` path, only the control thread dispatches inline. A publish arriving on any other thread is parked in a **mutex-guarded inbox** and drained on the control thread in `drainPending()`, so every subscriber setter runs on one thread and the per-sound SPSC queues keep a single producer. The inbox holds a full `BusValue`, so string/list payloads survive the deferral intact.
- The **audio-thread `T_DSP` path is untouched** (lock-free, per-thread queues). The new mutex is only ever taken by control-rate threads (timer / script), never the audio callback — real-time discipline preserved.
- Debug-build single-producer **assertion** in `implementationObject::sendMessage()` that trips if the sound message queue is pushed from more than one thread, encoding the contract (the issue's second, "separately" item).

## Test plan
- [x] `clang-format --dry-run --Werror` clean on all six changed files
- [x] `python yse.py analyze` clean for modified code (namedBus.cpp/.h and the new test cases produce no new findings; the 3 pre-existing soundImplementation.cpp findings at lines 172/559/659 and the test-helper `SilentSource` finding are untouched baseline)
- [x] Unit tests — `python yse.py test`: **17/17 suites pass**
- [x] Regression tests added and verified to **fail on the un-patched `publish()` and pass with the fix** (reverted the gate, rebuilt: 3 of the 4 new cases fail; restored: all pass):
  - `named bus: off-control-thread T_GUI publish is deferred to drainPending`
  - `named bus: control-thread T_GUI publish still dispatches synchronously`
  - `named bus: deferred publish preserves string/list payloads`
  - `sound bus: off-thread volume publish is deferred, never raced onto the SPSC queue`

Integration note: no full-app integration test was added because the behavior is engine-internal threading — there is no rendered/navigated UI surface. The end-to-end path (bus publish from a worker thread → real `YSE::sound` → `drainPending`) is exercised by the sound-level regression above, which drives the actual reported bug path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)