### PR TITLE
PERF: make manager bookkeeping allocation-free on the audio thread (#194)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(YSE_TEST_SOURCES
   main.cpp
   test_sanity.cpp
+  support/alloc_probe.cpp
   dsp/test_buffer.cpp
   dsp/test_ramp.cpp
   dsp/test_math_scalars.cpp
@@ -15,6 +16,7 @@ set(YSE_TEST_SOURCES
   utils/test_lfqueue.cpp
   utils/test_mpmcqueue.cpp
   utils/test_interpolators.cpp
+  utils/test_intrusive_list.cpp
   internal/test_threadpool.cpp
   dsp/test_filters.cpp
   dsp/test_delay.cpp
@@ -52,6 +54,8 @@ set(YSE_TEST_SOURCES
   sound/test_sound_manager.cpp
   sound/test_sound_file_gc.cpp
   sound/test_sound_bus.cpp
+  sound/test_virtual_finder.cpp
+  sound/test_manager_alloc.cpp
   reverb/test_reverb_dsp.cpp
   reverb/test_reverb_concurrency.cpp
   midi/test_midifile.cpp

--- a/Tests/sound/test_manager_alloc.cpp
+++ b/Tests/sound/test_manager_alloc.cpp
@@ -1,0 +1,111 @@
+// Engine-level RT-allocation test for the manager bookkeeping (issue #194).
+//
+// This drives the *real* engine — real channels, real sound impls, the real
+// message pipe and the real SOUND/CHANNEL manager update() functions — rather
+// than a data structure in isolation, so it exercises the actual audio-thread
+// paths (promote → connect, sync → reparent, release → disconnect) that used to
+// churn std::forward_list nodes on the heap.
+//
+// Like every other engine test here it drives Manager().update() from the test
+// thread with the audio stream paused (see support/null_device.hpp), so it only
+// runs where a default audio device is present and skips gracefully otherwise
+// (headless CI). Locally it fails on the pre-#194 code (per-move push_front
+// allocations) and passes after the intrusive-list conversion.
+
+#include <doctest/doctest.h>
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "channel/channelInterface.hpp"
+#include "channel/channelManager.h"
+#include "sound/soundInterface.hpp"
+#include "sound/soundManager.h"
+#include "dsp/dspObject.hpp"
+#include "internal/time.h"
+#include "support/alloc_probe.hpp"
+#include "support/null_device.hpp"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+  struct SilentSource : YSE::DSP::dspSourceObject {
+    void process(YSE::SOUND_STATUS&) override {}
+    void frequency(float) override {}
+  };
+
+  // Outlives every sound impl created in this TU (see test_sound_impl.cpp for
+  // the source-lifetime rationale).
+  SilentSource g_src;
+
+  // One pump of the manager update()s the audio thread would normally drive.
+  void pump(int n = 1) {
+    for (int i = 0; i < n; ++i) {
+      YSE::INTERNAL::Time().update();
+      YSE::CHANNEL::Manager().update();
+      YSE::SOUND::Manager().update();
+      std::this_thread::sleep_for(2ms);
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("sound") {
+
+  TEST_CASE(
+      "managers: reparenting sounds churns the audio-thread lists without allocating (#194)") {
+    if (!TestHelpers::engineInit()) return;
+
+    // Two user channels to shuttle sounds between.
+    YSE::channel chA;
+    YSE::channel chB;
+    chA.create("allocTestA", YSE::ChannelFX());
+    chB.create("allocTestB", YSE::ChannelFX());
+
+    // A handful of DSP-source sounds, all parented to chA to start.
+    constexpr int kSounds = 6;
+    std::vector<YSE::sound> sounds(kSounds);
+    for (auto& s : sounds)
+      s.create(g_src, &chA);
+
+    // Settle everything OUTSIDE the probe: channels promote into the manager's
+    // inUse list, the slow-pool sets each sound up, and the sounds promote and
+    // connect into chA's `sounds` list. After this the slow pool is idle, so the
+    // probed region below only sees the audio-thread manager work.
+    pump(24);
+
+    {
+      TestHelpers::ProbeScope probe;
+      // Repeatedly reparent every sound between chA and chB. Each move fires a
+      // MOVE message that the manager's sync() turns into a disconnect from the
+      // old parent's `sounds` list and a push_front into the new one — the exact
+      // per-tick list churn that allocated a forward_list node before #194.
+      for (int round = 0; round < 20; ++round) {
+        YSE::channel& target = (round % 2 == 0) ? chB : chA;
+        for (auto& s : sounds)
+          s.moveTo(target);
+        pump(2);
+      }
+      // A few pure steady-state pumps with no structural change at all.
+      pump(4);
+
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+
+    // Sanity: the engine survived the churn and the sounds are still usable.
+    for (auto& s : sounds)
+      CHECK(s.isValid());
+
+    // Tear the sounds down and let the release/disconnect path run — must not
+    // crash or corrupt the lists (functional check, not an allocation one:
+    // destruction legitimately frees the canonical `implementations` nodes on
+    // the slow pool).
+    for (auto& s : sounds)
+      s.stop();
+    pump(8);
+  }
+
+} // TEST_SUITE("sound")

--- a/Tests/sound/test_virtual_finder.cpp
+++ b/Tests/sound/test_virtual_finder.cpp
@@ -1,0 +1,81 @@
+// RT-allocation regression tests for YSE::virtualFinder (issue #194).
+//
+// virtualFinder::reset()/add()/calculate() all run on the audio callback thread
+// (SOUND::Manager::update() calls reset()+calculate(); soundImplementation::dsp()
+// calls add()). The old implementation grew/shrank its `bin` vector with
+// bin.resize() inside calculate(), which reallocated on the heap — and, because
+// the resolution was unbounded, could resize on essentially every callback under
+// sustained load. The fix pins the backing buffer to a fixed maximum size and
+// only moves the logical resolution within [MIN, MAX], so the histogram never
+// touches the heap after construction.
+//
+// The functional behavior of inRange()/calculate() is covered in
+// test_sound_impl.cpp; here we lock in the zero-allocation guarantee and the
+// resolution clamp under a load pattern that reallocated (unboundedly) before.
+
+#include <doctest/doctest.h>
+
+#include "internal/virtualFinder.h"
+#include "support/alloc_probe.hpp"
+
+TEST_SUITE("sound") {
+
+  TEST_CASE("virtualFinder: sustained reset/add/calculate cycles never allocate (#194)") {
+    // Construct OUTSIDE the probe: the one-time bin allocation happens here.
+    YSE::virtualFinder vf(10);
+    vf.setLimit(10);
+
+    // Warm up one cycle so any lazy first-use state is established pre-probe.
+    vf.reset();
+    for (int k = 0; k < 100; ++k)
+      vf.add(0.5f);
+    vf.calculate();
+
+    {
+      TestHelpers::ProbeScope probe;
+      // This pattern (a big spike of entries into a single low bin, limit far
+      // below the entry count) drove the old calculate() to grow the bin vector
+      // every cycle without bound — hundreds of reallocations. With the fix the
+      // resolution saturates at its clamp and the buffer is never resized.
+      for (int cycle = 0; cycle < 400; ++cycle) {
+        vf.reset();
+        for (int k = 0; k < 100; ++k)
+          vf.add(0.5f);
+        vf.calculate();
+      }
+      // Also exercise the shrink branch: many cycles right at the limit.
+      for (int cycle = 0; cycle < 400; ++cycle) {
+        vf.reset();
+        for (int k = 0; k < 11; ++k)
+          vf.add(static_cast<float>(k));
+        vf.calculate();
+      }
+    }
+
+    CHECK(TestHelpers::g_alloc_count.load() == 0);
+  }
+
+  TEST_CASE("virtualFinder: stays functional after the resolution clamp saturates (#194)") {
+    YSE::virtualFinder vf(10);
+    vf.setLimit(4);
+
+    // Drive the same 8-entry (distances 1..8) histogram for many cycles. With a
+    // budget of 4 the count always overshoots the limit, so the old code would
+    // have grown `resolution` without bound; the fix saturates it at the clamp.
+    // Repeating the identical distribution also lets `calculatedMax` (carried
+    // reset-to-reset) settle, so the histogram scale is stable when we assert.
+    for (int cycle = 0; cycle < 200; ++cycle) {
+      vf.reset();
+      for (int k = 0; k < 8; ++k)
+        vf.add(static_cast<float>(k + 1)); // 1..8
+      vf.calculate();
+    }
+
+    // A very near sound is kept; a very far one is dropped, regardless of prior
+    // real/virtual state. (The exact cutoff is covered elsewhere; this only
+    // checks the finder didn't degenerate after the clamp.)
+    CHECK(vf.inRange(0.5f, /*wasReal=*/false) == true);
+    CHECK(vf.inRange(100.f, /*wasReal=*/true) == false);
+  }
+
+} // TEST_SUITE("sound")

--- a/Tests/support/alloc_probe.cpp
+++ b/Tests/support/alloc_probe.cpp
@@ -1,0 +1,59 @@
+// Single definition of the test-suite heap-allocation probe (see
+// support/alloc_probe.hpp). The replaceable global operator new/delete live
+// here — in exactly one TU — so including the header from many test files
+// cannot produce a multiple-definition link error.
+
+#include "support/alloc_probe.hpp"
+
+#include <cstdlib>
+#include <new>
+
+namespace TestHelpers {
+  std::atomic<int> g_alloc_count{0};
+  std::atomic<bool> g_alloc_probe_active{false};
+} // namespace TestHelpers
+
+// ThreadSanitizer ships its own replaceable operator new/delete in
+// libclang_rt.tsan_cxx, so defining ours too is a multiple-definition link
+// error (issue #229 wired a TSan build of the test binary). Skip the probe
+// under TSan: the audio-path checks assert g_alloc_count == 0, which then holds
+// trivially because the counter is never touched. ASan tolerates the override,
+// so it is kept there.
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define YSE_UNDER_TSAN 1
+#endif
+#endif
+#if defined(__SANITIZE_THREAD__)
+#define YSE_UNDER_TSAN 1
+#endif
+
+#ifndef YSE_UNDER_TSAN
+void* operator new(std::size_t n) {
+  if (TestHelpers::g_alloc_probe_active.load(std::memory_order_relaxed))
+    TestHelpers::g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+  if (void* p = std::malloc(n == 0 ? 1 : n)) return p;
+  throw std::bad_alloc{};
+}
+
+// Route the nothrow form through malloc too. libsndfile's sndfile.hh allocates
+// SNDFILE_ref with `new (std::nothrow)`; without this override that allocation
+// would go through the default (ASan-instrumented) operator new while the
+// matching delete below frees it with std::free, which AddressSanitizer flags
+// as an alloc-dealloc-mismatch (issue #219).
+void* operator new(std::size_t n, const std::nothrow_t&) noexcept {
+  if (TestHelpers::g_alloc_probe_active.load(std::memory_order_relaxed))
+    TestHelpers::g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+  return std::malloc(n == 0 ? 1 : n);
+}
+
+void operator delete(void* p) noexcept {
+  std::free(p);
+}
+void operator delete(void* p, std::size_t) noexcept {
+  std::free(p);
+}
+void operator delete(void* p, const std::nothrow_t&) noexcept {
+  std::free(p);
+}
+#endif // YSE_UNDER_TSAN

--- a/Tests/support/alloc_probe.hpp
+++ b/Tests/support/alloc_probe.hpp
@@ -1,0 +1,35 @@
+#pragma once
+// Shared heap-allocation probe for the test suite.
+//
+// The replaceable global operator new/delete are defined once in
+// alloc_probe.cpp (a single TU — defining them in a header would be an ODR /
+// multiple-definition violation the moment two TUs include it). While
+// `g_alloc_probe_active` is true the overrides count every `operator new`
+// call; the rest of the time they are transparent so doctest/STL/etc. are
+// unaffected. Wrap the region under test in a `ProbeScope` and assert
+// `g_alloc_count == 0`.
+//
+// Extracted from test_named_bus.cpp (issue #121) so the manager / virtualFinder
+// RT-allocation tests (issue #194) can share the same probe.
+
+#include <atomic>
+
+namespace TestHelpers {
+
+  // Number of `operator new` calls observed while the probe is active.
+  extern std::atomic<int> g_alloc_count;
+  // When true, the global operator-new overrides increment g_alloc_count.
+  extern std::atomic<bool> g_alloc_probe_active;
+
+  // RAII activation: zeroes the counter and arms the probe for its lifetime.
+  struct ProbeScope {
+    ProbeScope() {
+      g_alloc_count.store(0, std::memory_order_relaxed);
+      g_alloc_probe_active.store(true, std::memory_order_relaxed);
+    }
+    ~ProbeScope() {
+      g_alloc_probe_active.store(false, std::memory_order_relaxed);
+    }
+  };
+
+} // namespace TestHelpers

--- a/Tests/system/test_named_bus.cpp
+++ b/Tests/system/test_named_bus.cpp
@@ -7,17 +7,11 @@
 //   - 1000 subscribers + 1000 audio-path publishes: no heap allocations
 //   - publish() to a name with no subscribers is a no-op (no allocation)
 //
-// Allocation probe: the operator-new replacement below is a "replaceable
-// allocation function" per [basic.stc.dynamic.allocation]. It counts calls
-// only while `g_alloc_probe_active` is true so the rest of the test binary
-// (doctest, STL, std::function, ...) is unaffected. The probe lives in this
-// TU because no other test needs it; if a future TU also wants it, lift the
-// probe into a shared header.
+// The heap-allocation probe used by the no-allocation checks lives in the
+// shared support/alloc_probe.{hpp,cpp} (issue #194 lifted it out of this TU so
+// the manager / virtualFinder RT tests can reuse it).
 
 #include <array>
-#include <atomic>
-#include <cstdlib>
-#include <new>
 #include <string>
 #include <thread>
 #include <vector>
@@ -26,69 +20,13 @@
 
 #include "yse.hpp"
 #include "internal/namedBus.h"
+#include "support/alloc_probe.hpp"
 #include "support/null_device.hpp"
 
 namespace {
-
-  std::atomic<int> g_alloc_count{0};
-  std::atomic<bool> g_alloc_probe_active{false};
-
-  struct ProbeScope {
-    ProbeScope() {
-      g_alloc_count = 0;
-      g_alloc_probe_active = true;
-    }
-    ~ProbeScope() {
-      g_alloc_probe_active = false;
-    }
-  };
-
+  using TestHelpers::g_alloc_count;
+  using TestHelpers::ProbeScope;
 } // namespace
-
-// ThreadSanitizer ships its own replaceable operator new/delete in
-// libclang_rt.tsan_cxx, so defining ours too is a multiple-definition link
-// error (issue #229 wired a TSan build of this binary). Skip the allocation
-// probe under TSan: the audio-path checks below assert g_alloc_count == 0, which
-// then holds trivially because the counter is never touched. ASan tolerates the
-// override, so it is kept there.
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-#define YSE_UNDER_TSAN 1
-#endif
-#endif
-#if defined(__SANITIZE_THREAD__)
-#define YSE_UNDER_TSAN 1
-#endif
-
-#ifndef YSE_UNDER_TSAN
-void* operator new(std::size_t n) {
-  if (g_alloc_probe_active.load(std::memory_order_relaxed))
-    g_alloc_count.fetch_add(1, std::memory_order_relaxed);
-  if (void* p = std::malloc(n == 0 ? 1 : n)) return p;
-  throw std::bad_alloc{};
-}
-
-// Route the nothrow form through malloc too. libsndfile's sndfile.hh allocates
-// SNDFILE_ref with `new (std::nothrow)`; without this override that allocation
-// would go through the default (ASan-instrumented) operator new while the
-// matching delete below frees it with std::free, which AddressSanitizer flags
-// as an alloc-dealloc-mismatch (issue #219).
-void* operator new(std::size_t n, const std::nothrow_t&) noexcept {
-  if (g_alloc_probe_active.load(std::memory_order_relaxed))
-    g_alloc_count.fetch_add(1, std::memory_order_relaxed);
-  return std::malloc(n == 0 ? 1 : n);
-}
-
-void operator delete(void* p) noexcept {
-  std::free(p);
-}
-void operator delete(void* p, std::size_t) noexcept {
-  std::free(p);
-}
-void operator delete(void* p, const std::nothrow_t&) noexcept {
-  std::free(p);
-}
-#endif // YSE_UNDER_TSAN
 
 TEST_SUITE("system") {
 

--- a/Tests/utils/test_intrusive_list.cpp
+++ b/Tests/utils/test_intrusive_list.cpp
@@ -1,0 +1,184 @@
+// Unit tests for YSE::IntrusiveForwardList (issue #194).
+//
+// The list replaces the std::forward_list<T*> bookkeeping the sound/channel/
+// reverb managers walked and mutated on the audio callback thread. The key
+// guarantees exercised here:
+//   - functional parity with the forward_list idioms it replaced
+//     (head-insertion order, remove, remove_if, cursor erase-during-iteration);
+//   - one node can live in two independent lists via two link fields;
+//   - none of the mutating operations allocate (the whole point of the change).
+
+#include <doctest/doctest.h>
+
+#include <vector>
+
+#include "utils/intrusiveForwardList.hpp"
+#include "support/alloc_probe.hpp"
+
+namespace {
+
+  struct Node {
+    int id = 0;
+    // Two independent intrusive links, mirroring how a real impl belongs to a
+    // manager list (via one link) and its parent's child list (via another).
+    Node* aNext = nullptr;
+    Node* bNext = nullptr;
+  };
+
+  using ListA = YSE::IntrusiveForwardList<Node, &Node::aNext>;
+  using ListB = YSE::IntrusiveForwardList<Node, &Node::bNext>;
+
+  // Collect the ids of a list in iteration order.
+  std::vector<int> ids(const ListA& list) {
+    std::vector<int> out;
+    for (auto it = list.begin(); it != list.end(); ++it)
+      out.push_back((*it)->id);
+    return out;
+  }
+
+} // namespace
+
+TEST_SUITE("utils") {
+
+  TEST_CASE("IntrusiveForwardList: push_front prepends (head-insertion order)") {
+    Node n1{1, {}, {}}, n2{2, {}, {}}, n3{3, {}, {}};
+    ListA list;
+    CHECK(list.empty());
+    list.push_front(&n1);
+    list.push_front(&n2);
+    list.push_front(&n3);
+    CHECK_FALSE(list.empty());
+    CHECK(ids(list) == std::vector<int>{3, 2, 1});
+  }
+
+  TEST_CASE("IntrusiveForwardList: remove unlinks head, middle, and tail nodes") {
+    Node n1{1, {}, {}}, n2{2, {}, {}}, n3{3, {}, {}};
+
+    SUBCASE("middle") {
+      ListA list;
+      list.push_front(&n1);
+      list.push_front(&n2);
+      list.push_front(&n3); // 3,2,1
+      list.remove(&n2);
+      CHECK(ids(list) == std::vector<int>{3, 1});
+      CHECK(n2.aNext == nullptr); // detached link is cleared
+    }
+    SUBCASE("head") {
+      ListA list;
+      list.push_front(&n1);
+      list.push_front(&n2);
+      list.push_front(&n3); // 3,2,1
+      list.remove(&n3);
+      CHECK(ids(list) == std::vector<int>{2, 1});
+    }
+    SUBCASE("tail") {
+      ListA list;
+      list.push_front(&n1);
+      list.push_front(&n2);
+      list.push_front(&n3); // 3,2,1
+      list.remove(&n1);
+      CHECK(ids(list) == std::vector<int>{3, 2});
+    }
+    SUBCASE("absent is a no-op") {
+      Node other{99, {}, {}};
+      ListA list;
+      list.push_front(&n1);
+      list.remove(&other);
+      CHECK(ids(list) == std::vector<int>{1});
+    }
+  }
+
+  TEST_CASE("IntrusiveForwardList: remove_if drops matching nodes and keeps order") {
+    Node n1{1, {}, {}}, n2{2, {}, {}}, n3{3, {}, {}}, n4{4, {}, {}};
+    ListA list;
+    list.push_front(&n1);
+    list.push_front(&n2);
+    list.push_front(&n3);
+    list.push_front(&n4); // 4,3,2,1
+    list.remove_if([](Node* n) { return n->id % 2 == 0; }); // drop evens
+    CHECK(ids(list) == std::vector<int>{3, 1});
+    CHECK(n2.aNext == nullptr);
+    CHECK(n4.aNext == nullptr);
+  }
+
+  TEST_CASE("IntrusiveForwardList: cursor erases the current node and lands on its successor") {
+    Node n1{1, {}, {}}, n2{2, {}, {}}, n3{3, {}, {}}, n4{4, {}, {}};
+    ListA list;
+    list.push_front(&n1);
+    list.push_front(&n2);
+    list.push_front(&n3);
+    list.push_front(&n4); // 4,3,2,1
+
+    // Erase ids 3 and 1 while walking once — the same erase-during-iteration
+    // idiom the manager update() loops use.
+    for (auto c = list.front(); c.valid();) {
+      if (c.get()->id == 3 || c.get()->id == 1)
+        c.erase();
+      else
+        c.next();
+    }
+    CHECK(ids(list) == std::vector<int>{4, 2});
+  }
+
+  TEST_CASE("IntrusiveForwardList: clear detaches every node without owning them") {
+    Node n1{1, {}, {}}, n2{2, {}, {}};
+    ListA list;
+    list.push_front(&n1);
+    list.push_front(&n2);
+    list.clear();
+    CHECK(list.empty());
+    CHECK(n1.aNext == nullptr);
+    CHECK(n2.aNext == nullptr);
+    // Nodes still usable — clear only detaches. Re-link into a fresh list.
+    ListA again;
+    again.push_front(&n1);
+    CHECK(ids(again) == std::vector<int>{1});
+  }
+
+  TEST_CASE("IntrusiveForwardList: one node lives in two lists via independent links") {
+    Node n1{1, {}, {}}, n2{2, {}, {}};
+    ListA a;
+    ListB b;
+    a.push_front(&n1);
+    a.push_front(&n2); // a: 2,1
+    b.push_front(&n2); // b: 2   (uses the other link)
+
+    // Removing n2 from `a` must not disturb its membership in `b`.
+    a.remove(&n2);
+    CHECK(ids(a) == std::vector<int>{1});
+    // b still holds n2 through bNext.
+    int seen = 0;
+    for (auto it = b.begin(); it != b.end(); ++it)
+      seen += (*it)->id;
+    CHECK(seen == 2);
+  }
+
+  TEST_CASE("IntrusiveForwardList: mutating operations perform no heap allocation (#194)") {
+    // Pre-create the nodes OUTSIDE the probe so only the list operations are
+    // measured. This is the regression guard for the whole change: the old
+    // std::forward_list<T*> allocated a node per push_front / erase.
+    constexpr int kNodes = 64;
+    std::vector<Node> nodes(kNodes);
+    for (int i = 0; i < kNodes; ++i)
+      nodes[i].id = i;
+
+    ListA list;
+    {
+      TestHelpers::ProbeScope probe;
+      for (int i = 0; i < kNodes; ++i)
+        list.push_front(&nodes[i]);
+      // Walk + erase every other node via the cursor.
+      for (auto c = list.front(); c.valid();) {
+        if (c.get()->id % 2 == 0)
+          c.erase();
+        else
+          c.next();
+      }
+      list.remove(&nodes[1]);
+      list.remove_if([](Node* n) { return n->id > 40; });
+      list.clear();
+    }
+    CHECK(TestHelpers::g_alloc_count.load() == 0);
+  }
+
+} // TEST_SUITE("utils")

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -12,10 +12,16 @@
 #define CHANNELIMPLEMENTATION_H_INCLUDED
 
 #include <atomic>
-#include <forward_list>
 #include "../classes.hpp"
 #include "../utils/lfQueue.hpp"
+#include "../utils/intrusiveForwardList.hpp"
 #include "../internal/threadPool.h"
+// The `sounds` intrusive list forms a pointer-to-member into
+// SOUND::implementationObject, which requires the complete type here (a bare
+// forward declaration sufficed for the old std::forward_list<T*>). This is an
+// acyclic dependency: soundImplementation.h refers to CHANNEL only through the
+// forward declaration in classes.hpp. (issue #194)
+#include "../sound/soundImplementation.h"
 
 namespace YSE {
   namespace CHANNEL {
@@ -229,6 +235,14 @@ namespace YSE {
       }
 
     private:
+      // Intrusive forward-list links (issue #194). `_mgrNext` threads this impl
+      // through the CHANNEL manager's audio-thread toLoad/inUse lists (mutually
+      // exclusive membership). `_childNext` threads it through its parent
+      // channel's `children` list. Both are touched only on the audio thread,
+      // replacing the std::forward_list<T*> nodes without per-tick heap churn.
+      implementationObject* _mgrNext = nullptr;
+      implementationObject* _childNext = nullptr;
+
       std::atomic<channel*> head; // < The interface connected to this object
       std::atomic<OBJECT_IMPLEMENTATION_STATE> objectStatus; // < the status of this object
       lfQueue<messageObject> messages;
@@ -244,8 +258,13 @@ namespace YSE {
       // and parent->sounds traversal.
       std::atomic<bool> connectedToParent{false};
 
-      std::forward_list<CHANNEL::implementationObject*> children;
-      std::forward_list<SOUND::implementationObject*> sounds;
+      // Intrusive lists keyed on the per-impl link fields — zero heap churn on
+      // the audio-thread connect()/disconnect() paths (issue #194).
+      IntrusiveForwardList<CHANNEL::implementationObject,
+                           &CHANNEL::implementationObject::_childNext>
+          children;
+      IntrusiveForwardList<SOUND::implementationObject, &SOUND::implementationObject::_channelNext>
+          sounds;
 
       std::vector<output> outConf;
       std::vector<DSP::buffer> out;

--- a/YseEngine/channel/channelManager.cpp
+++ b/YseEngine/channel/channelManager.cpp
@@ -51,7 +51,7 @@ void YSE::CHANNEL::managerObject::update() {
   {
     implementationObject* p;
     while (toLoadInbox.try_pop(p))
-      toLoad.emplace_front(p);
+      toLoad.push_front(p);
   }
 
   ///////////////////////////////////////////
@@ -79,16 +79,16 @@ void YSE::CHANNEL::managerObject::update() {
   // the freed pointer (ASan-confirmed).
   ///////////////////////////////////////////
   {
-    auto previous = toLoad.before_begin();
-    for (auto i = toLoad.begin(); i != toLoad.end();) {
-      implementationObject* ptr = *i;
+    for (auto c = toLoad.front(); c.valid();) {
+      implementationObject* ptr = c.get();
       if (ptr->readyCheck()) {
-        inUse.emplace_front(ptr);
+        // Unlink from toLoad before linking into inUse: both share the impl's
+        // single `_mgrNext` link (issue #194).
+        c.erase();
+        inUse.push_front(ptr);
         ptr->doThisWhenReady();
-        i = toLoad.erase_after(previous);
       } else {
-        previous = i;
-        ++i;
+        c.next();
       }
     }
   }
@@ -97,12 +97,11 @@ void YSE::CHANNEL::managerObject::update() {
   // sync implementations
   ///////////////////////////////////////////
   {
-    auto previous = inUse.before_begin();
-    for (auto i = inUse.begin(); i != inUse.end();) {
-      (*i)->sync();
-      if ((*i)->getStatus() == OBJECT_RELEASE) {
-        implementationObject* ptr = (*i);
-        i = inUse.erase_after(previous);
+    for (auto c = inUse.front(); c.valid();) {
+      implementationObject* ptr = c.get();
+      ptr->sync();
+      if (ptr->getStatus() == OBJECT_RELEASE) {
+        c.erase();
         // Audio-thread-side disconnect: reparent any children to this
         // channel's parent and remove this channel from parent->children
         // BEFORE marking OBJECT_DELETE. The slow-pool's deleteJob filters
@@ -120,10 +119,9 @@ void YSE::CHANNEL::managerObject::update() {
         }
         ptr->setStatus(OBJECT_DELETE);
         runDelete = true;
-        continue;
+        continue; // c already refers to the successor after erase()
       }
-      previous = i;
-      ++i;
+      c.next();
     }
   }
 }

--- a/YseEngine/channel/channelManager.h
+++ b/YseEngine/channel/channelManager.h
@@ -21,6 +21,7 @@
 #include "../internal/threadPool.h"
 #include "../internal/managerJobs.hpp"
 #include "../utils/lfQueue.hpp"
+#include "../utils/intrusiveForwardList.hpp"
 
 namespace YSE {
   namespace CHANNEL {
@@ -68,9 +69,10 @@ namespace YSE {
       void setMaster(implementationObject* impl);
 
     private:
-      // Once an object is ready for use, a pointer is placed in this container. The manager will
-      // update and sync all these objects during the dsp callback function
-      std::forward_list<implementationObject*> inUse;
+      // Once an object is ready for use, it is linked into this container. The
+      // manager updates and syncs all these objects during the dsp callback.
+      // Intrusive (link embedded via `_mgrNext`) — allocation-free (issue #194).
+      IntrusiveForwardList<implementationObject, &implementationObject::_mgrNext> inUse;
 
       INTERNAL::managerSetupJob<managerObject> mgrSetup;
       INTERNAL::managerDeleteJob<managerObject> mgrDelete;
@@ -79,8 +81,9 @@ namespace YSE {
       // thread drains it into `toLoad` at the top of update().
       lfQueue<implementationObject*> toLoadInbox;
 
-      // Audio-thread-owned working list of impls awaiting OBJECT_READY.
-      std::forward_list<implementationObject*> toLoad;
+      // Audio-thread-owned working list of impls awaiting OBJECT_READY. Shares
+      // the `_mgrNext` link with `inUse` (an impl is only ever in one of them).
+      IntrusiveForwardList<implementationObject, &implementationObject::_mgrNext> toLoad;
 
       // Canonical list of all implementationObjects. Touched by main thread
       // (addImplementation emplace_front) and the slow-pool worker (setupJob

--- a/YseEngine/classes.hpp
+++ b/YseEngine/classes.hpp
@@ -102,6 +102,10 @@ namespace YSE {
     class midiMessage;
     class midiNote;
   } // namespace MIDI
+
+  namespace PATCHER {
+    class patcherImplementation;
+  } // namespace PATCHER
 } // namespace YSE
 
 #endif // CLASSES_HPP_INCLUDED

--- a/YseEngine/internal/virtualFinder.cpp
+++ b/YseEngine/internal/virtualFinder.cpp
@@ -18,7 +18,12 @@ YSE::virtualFinder& YSE::VirtualSoundFinder() {
 
 YSE::virtualFinder::virtualFinder(Int resolution)
   : resolution(resolution), limit(50), maximum(0.f), calculatedMax(10.f) {
-  bin.resize(resolution, 0);
+  // Clamp the requested initial resolution into the valid band and allocate the
+  // backing histogram once at its maximum size. It is never resized afterwards
+  // (issue #194): calculate() only adjusts the logical `resolution`.
+  if (this->resolution < RESOLUTION_MIN) this->resolution = RESOLUTION_MIN;
+  if (this->resolution > RESOLUTION_MAX) this->resolution = RESOLUTION_MAX;
+  bin.resize(RESOLUTION_MAX, 0);
 }
 
 void YSE::virtualFinder::setLimit(Int value) {
@@ -35,7 +40,7 @@ void YSE::virtualFinder::reset() {
   else
     calculatedMax = 10;
 
-  for (UInt i = 0; i < bin.size(); i++)
+  for (Int i = 0; i < resolution; i++)
     bin[i] = 0;
   maximum = 0;
   entries = 0;
@@ -50,8 +55,11 @@ void YSE::virtualFinder::add(Flt value) {
     sort = 0;
   else
     sort = static_cast<Int>(value / (calculatedMax / resolution));
-  if ((UInt)sort > bin.size() - 1) {
-    sort = bin.size() - 1;
+  if (sort > resolution - 1) {
+    sort = resolution - 1;
+  }
+  if (sort < 0) {
+    sort = 0;
   }
   bin[sort]++;
 }
@@ -70,8 +78,8 @@ void YSE::virtualFinder::calculate() {
   // add up bins until we have enough entries
   Int count = 0;
   currentLimit = limit.load();
-  UInt i;
-  for (i = 0; i < bin.size(); i++) {
+  Int i;
+  for (i = 0; i < resolution; i++) {
     count += bin[i];
     if (count > currentLimit) {
       break;
@@ -83,13 +91,12 @@ void YSE::virtualFinder::calculate() {
     range -= calculatedMax / resolution * (1 - (count - currentLimit) / bin[i]);
 
     // if the difference between the count and the limit is more than 10%, we have to enlarge our
-    // resolution
+    // resolution; if it is very small we can shrink it. The backing buffer is never resized — we
+    // only move the logical `resolution` within [RESOLUTION_MIN, RESOLUTION_MAX] (issue #194).
     if (abs(count - currentLimit) > currentLimit / 10.f) {
-      resolution++;
-      bin.resize(resolution);
+      if (resolution < RESOLUTION_MAX) resolution++;
     } else if (abs(count - currentLimit) < currentLimit / 50.f) {
-      resolution--;
-      bin.resize(resolution);
+      if (resolution > RESOLUTION_MIN) resolution--;
     }
   } else {
     range = maximum;

--- a/YseEngine/internal/virtualFinder.h
+++ b/YseEngine/internal/virtualFinder.h
@@ -33,6 +33,15 @@ namespace YSE {
                                    // internally when needed.
 
   private:
+    // The histogram resolution adapts at runtime, but the backing `bin` buffer
+    // is allocated once at construction to RESOLUTION_MAX and never resized —
+    // reset()/add()/calculate() all run on the audio thread and must not touch
+    // the heap (issue #194). `resolution` is the logical bin count in use and
+    // is clamped to [RESOLUTION_MIN, RESOLUTION_MAX]; only bins [0, resolution)
+    // are ever read or written.
+    static constexpr Int RESOLUTION_MIN = 2;
+    static constexpr Int RESOLUTION_MAX = 128;
+
     Int resolution;
     aInt limit; // the number of entries that should be in range
     Int currentLimit;
@@ -41,7 +50,7 @@ namespace YSE {
     Flt calculatedMax; // the biggest value before last reset (we can assume this is about the same
                        // as the new value will be)
     Int entries; // how many entries are added since reset
-    std::vector<Int> bin;
+    std::vector<Int> bin; // fixed size RESOLUTION_MAX; logical size is `resolution`
   };
 
   virtualFinder& VirtualSoundFinder();

--- a/YseEngine/reverb/reverbImplementation.h
+++ b/YseEngine/reverb/reverbImplementation.h
@@ -72,6 +72,12 @@ namespace YSE {
       }
 
     private:
+      // Intrusive forward-list link (issue #194). Threads this impl through the
+      // REVERB manager's audio-thread toLoad/inUse lists (mutually exclusive
+      // membership, so one link suffices). Touched only on the audio thread,
+      // replacing the std::forward_list<T*> node without per-tick heap churn.
+      implementationObject* _mgrNext = nullptr;
+
       std::atomic<reverb*> head; // < The interface connected to this object
       std::atomic<OBJECT_IMPLEMENTATION_STATE> objectStatus; // < the status of this object
       lfQueue<messageObject> messages;

--- a/YseEngine/reverb/reverbManager.cpp
+++ b/YseEngine/reverb/reverbManager.cpp
@@ -105,7 +105,7 @@ void YSE::REVERB::managerObject::update() {
   {
     implementationObject* p;
     while (toLoadInbox.try_pop(p))
-      toLoad.emplace_front(p);
+      toLoad.push_front(p);
   }
 
   toLoad.remove_if(implementationObject::canBeRemovedFromLoading);
@@ -122,15 +122,15 @@ void YSE::REVERB::managerObject::update() {
   // manager update() for the use-after-free rationale this avoids.
   ///////////////////////////////////////////
   {
-    auto previous = toLoad.before_begin();
-    for (auto i = toLoad.begin(); i != toLoad.end();) {
-      implementationObject* ptr = *i;
+    for (auto c = toLoad.front(); c.valid();) {
+      implementationObject* ptr = c.get();
       if (ptr->readyCheck()) {
-        inUse.emplace_front(ptr);
-        i = toLoad.erase_after(previous);
+        // Unlink from toLoad before linking into inUse: both share the impl's
+        // single `_mgrNext` link (issue #194).
+        c.erase();
+        inUse.push_front(ptr);
       } else {
-        previous = i;
-        ++i;
+        c.next();
       }
     }
   }
@@ -139,18 +139,16 @@ void YSE::REVERB::managerObject::update() {
   // sync and update implementations
   ///////////////////////////////////////////
   {
-    auto previous = inUse.before_begin();
-    for (auto i = inUse.begin(); i != inUse.end();) {
-      (*i)->sync();
-      if ((*i)->getStatus() == OBJECT_RELEASE) {
-        implementationObject* ptr = (*i);
-        i = inUse.erase_after(previous);
+    for (auto c = inUse.front(); c.valid();) {
+      implementationObject* ptr = c.get();
+      ptr->sync();
+      if (ptr->getStatus() == OBJECT_RELEASE) {
+        c.erase();
         ptr->setStatus(OBJECT_DELETE);
         runDelete = true;
-        continue;
+        continue; // c already refers to the successor after erase()
       }
-      previous = i;
-      ++i;
+      c.next();
     }
   }
 

--- a/YseEngine/reverb/reverbManager.h
+++ b/YseEngine/reverb/reverbManager.h
@@ -20,6 +20,7 @@
 #include "../internal/threadPool.h"
 #include "../internal/managerJobs.hpp"
 #include "../utils/lfQueue.hpp"
+#include "../utils/intrusiveForwardList.hpp"
 
 namespace YSE {
   namespace REVERB {
@@ -104,9 +105,10 @@ namespace YSE {
 
       INTERNAL::managerDeleteJob<managerObject> mgrDelete;
 
-      // Once an object is ready for use, a pointer is placed in this container. The manager will
-      // update and sync all these objects during the dsp callback function
-      std::forward_list<implementationObject*> inUse;
+      // Once an object is ready for use, it is linked into this container. The
+      // manager updates and syncs all these objects during the dsp callback.
+      // Intrusive (link embedded via `_mgrNext`) — allocation-free (issue #194).
+      IntrusiveForwardList<implementationObject, &implementationObject::_mgrNext> inUse;
 
       // Lock-free SPSC inbox: main thread pushes here from setup(); audio
       // thread drains it into `toLoad` at the top of update(). Reverb impls
@@ -114,8 +116,9 @@ namespace YSE {
       // OBJECT_SETUP in setup()) — the inbox is purely a main→audio handoff.
       lfQueue<implementationObject*> toLoadInbox;
 
-      // Audio-thread-owned working list of impls awaiting OBJECT_READY.
-      std::forward_list<implementationObject*> toLoad;
+      // Audio-thread-owned working list of impls awaiting OBJECT_READY. Shares
+      // the `_mgrNext` link with `inUse` (an impl is only ever in one of them).
+      IntrusiveForwardList<implementationObject, &implementationObject::_mgrNext> toLoad;
 
       // Canonical list of all implementationObjects. Touched by main thread
       // (addImplementation emplace_front) and the slow-pool worker

--- a/YseEngine/sound/soundImplementation.h
+++ b/YseEngine/sound/soundImplementation.h
@@ -227,6 +227,15 @@ namespace YSE {
       std::atomic<SOUND_STATUS> _head_status; // what it is currently doing
 
     private:
+      // Intrusive forward-list links (issue #194). `_mgrNext` threads this impl
+      // through the SOUND manager's audio-thread toLoad/inUse lists (membership
+      // in those two is mutually exclusive, so one link suffices).
+      // `_channelNext` threads it through its parent channel's `sounds` list.
+      // Both are touched only on the audio thread, exactly like the
+      // std::forward_list<T*> nodes they replace — but without heap churn.
+      implementationObject* _mgrNext = nullptr;
+      implementationObject* _channelNext = nullptr;
+
       void dspFunc_parseIntent();
       void dspFunc_calculateGain(Int channel, Int source);
 

--- a/YseEngine/sound/soundManager.cpp
+++ b/YseEngine/sound/soundManager.cpp
@@ -128,7 +128,7 @@ void YSE::SOUND::managerObject::setup(YSE::SOUND::implementationObject* impl) {
 void YSE::SOUND::managerObject::drainInbox() {
   implementationObject* p;
   while (toLoadInbox.try_pop(p))
-    toLoad.emplace_front(p);
+    toLoad.push_front(p);
 }
 
 void YSE::SOUND::managerObject::scrubToLoadAndScheduleSetup() {
@@ -138,9 +138,8 @@ void YSE::SOUND::managerObject::scrubToLoadAndScheduleSetup() {
   // the slow-pool delete job — but only AFTER erasing them from toLoad,
   // so the slow-pool can't free a pointer that's still in the
   // audio-thread-iterated list. See enums.hpp for the PENDING rationale.
-  auto previous = toLoad.before_begin();
-  for (auto it = toLoad.begin(); it != toLoad.end();) {
-    implementationObject* p = *it;
+  for (auto c = toLoad.front(); c.valid();) {
+    implementationObject* p = c.get();
     OBJECT_IMPLEMENTATION_STATE s = p->objectStatus.load(
         std::memory_order_acquire); // NOSONAR S8417: intentional acquire — read impl state
                                     // published by setup-failure path
@@ -150,12 +149,11 @@ void YSE::SOUND::managerObject::scrubToLoadAndScheduleSetup() {
           std::memory_order_release); // NOSONAR S8417: intentional release — publish DELETE state
                                       // to slow-pool deleteJob's acquire load
       runDelete = true;
-      it = toLoad.erase_after(previous);
+      c.erase();
     } else if (s == OBJECT_READY || s == OBJECT_RELEASE || s == OBJECT_DELETE) {
-      it = toLoad.erase_after(previous);
+      c.erase();
     } else {
-      previous = it;
-      ++it;
+      c.next();
     }
   }
   INTERNAL::Global().addSlowJob(&mgrSetup);
@@ -169,27 +167,27 @@ void YSE::SOUND::managerObject::promoteReadyImpls() {
   // in the inUse iteration below, runDelete is set, deleteJob is enqueued,
   // the slow-pool frees the impl, and the next remove_if call dereferences
   // the freed pointer (ASan-confirmed).
-  auto previous = toLoad.before_begin();
-  for (auto i = toLoad.begin(); i != toLoad.end();) {
-    implementationObject* ptr = *i;
+  for (auto c = toLoad.front(); c.valid();) {
+    implementationObject* ptr = c.get();
     if (ptr->readyCheck()) {
-      inUse.emplace_front(ptr);
+      // Unlink from toLoad BEFORE linking into inUse: both lists share the
+      // impl's single `_mgrNext` link, so the erase (which reads _mgrNext to
+      // stitch toLoad) must happen before push_front overwrites it (issue #194).
+      c.erase();
+      inUse.push_front(ptr);
       ptr->doThisWhenReady();
-      i = toLoad.erase_after(previous);
     } else {
-      previous = i;
-      ++i;
+      c.next();
     }
   }
 }
 
 void YSE::SOUND::managerObject::syncAndReleaseInUse() {
-  auto previous = inUse.before_begin();
-  for (auto i = inUse.begin(); i != inUse.end();) {
-    (*i)->sync();
-    if ((*i)->getStatus() == OBJECT_RELEASE) {
-      implementationObject* ptr = (*i);
-      i = inUse.erase_after(previous);
+  for (auto c = inUse.front(); c.valid();) {
+    implementationObject* ptr = c.get();
+    ptr->sync();
+    if (ptr->getStatus() == OBJECT_RELEASE) {
+      c.erase();
       // Audio-thread-side disconnect: remove this impl from parent->sounds
       // BEFORE marking it OBJECT_DELETE. The slow-pool's deleteJob filters
       // on OBJECT_DELETE, so any impl visible to it has already been pulled
@@ -213,11 +211,10 @@ void YSE::SOUND::managerObject::syncAndReleaseInUse() {
                                                // nulled dsp source to audio thread's acquire load
       ptr->setStatus(OBJECT_DELETE);
       runDelete = true;
-      continue;
+      continue; // c already refers to the successor after erase()
     }
-    (*i)->update();
-    previous = i;
-    ++i;
+    ptr->update();
+    c.next();
   }
 }
 

--- a/YseEngine/sound/soundManager.h
+++ b/YseEngine/sound/soundManager.h
@@ -23,6 +23,7 @@
 #include "../internal/threadPool.h"
 #include "../internal/managerJobs.hpp"
 #include "../utils/lfQueue.hpp"
+#include "../utils/intrusiveForwardList.hpp"
 
 // global object for file loading
 // used in system.cpp, soundimpl.cpp and soundfile.cpp
@@ -157,9 +158,11 @@ namespace YSE {
       // This value is calculated on every update
       // aFlt maxDistance;
 
-      // Once an object is ready for use, a pointer is placed in this container. The manager will
-      // update and sync all these objects during the dsp callback function
-      std::forward_list<implementationObject*> inUse;
+      // Once an object is ready for use, it is linked into this container. The
+      // manager updates and syncs all these objects during the dsp callback.
+      // Intrusive (link embedded in the impl via `_mgrNext`) so linking on the
+      // audio thread never allocates (issue #194).
+      IntrusiveForwardList<implementationObject, &implementationObject::_mgrNext> inUse;
 
       // Lock-free SPSC inbox: main thread pushes here from setup(); audio thread
       // drains it into `toLoad` at the top of update(). This is the only
@@ -168,9 +171,11 @@ namespace YSE {
 
       // Audio-thread-owned working list of impls awaiting OBJECT_READY. The
       // audio thread drains the inbox into it, iterates it to detect readiness,
-      // and remove_ifs ready/released/deleted impls out of it. No other thread
-      // touches this list.
-      std::forward_list<implementationObject*> toLoad;
+      // and removes ready/released/deleted impls out of it. No other thread
+      // touches this list. Intrusive on the same `_mgrNext` link as `inUse` —
+      // an impl is only ever in one of the two (it moves from toLoad to inUse),
+      // so a single embedded link is sufficient and allocation-free.
+      IntrusiveForwardList<implementationObject, &implementationObject::_mgrNext> toLoad;
 
       // Canonical list of all implementationObjects for this subsystem. Touched
       // by the main thread (emplace_front in addImplementation) and the

--- a/YseEngine/utils/intrusiveForwardList.hpp
+++ b/YseEngine/utils/intrusiveForwardList.hpp
@@ -1,0 +1,166 @@
+/*
+  ==============================================================================
+
+    intrusiveForwardList.hpp
+    Created: for issue #194 — zero-allocation manager bookkeeping.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_UTILS_INTRUSIVEFORWARDLIST_HPP_INCLUDED
+#define YSE_UTILS_INTRUSIVEFORWARDLIST_HPP_INCLUDED
+
+namespace YSE {
+
+  // A singly-linked forward list whose link pointer lives *inside* the element
+  // type `T` (an "intrusive" list). Because the node storage is embedded in the
+  // element — which is already owned/allocated elsewhere — none of the mutating
+  // operations here touch the heap. This replaces the `std::forward_list<T*>`
+  // bookkeeping in the sound/channel/reverb managers and in
+  // channelImplementation, all of which are walked and mutated on the audio
+  // callback thread and were the source of per-tick malloc/free node churn
+  // (issue #194).
+  //
+  // `NextField` is a pointer-to-member naming the `T*` link inside `T`. An
+  // element may belong to at most one list per link field at a time — e.g. a
+  // sound impl uses one link for the manager's toLoad/inUse list (mutually
+  // exclusive membership) and a second link for its parent channel's `sounds`
+  // list. The list does NOT own its elements: clear() only detaches nodes; it
+  // never destroys them.
+  //
+  // The list is intentionally non-copyable (a link is a single embedded slot,
+  // so a node cannot live in two copies of a list at once).
+  template <typename T, T* T::* NextField> class IntrusiveForwardList {
+  public:
+    IntrusiveForwardList() = default;
+    IntrusiveForwardList(const IntrusiveForwardList&) = delete;
+    IntrusiveForwardList& operator=(const IntrusiveForwardList&) = delete;
+
+    bool empty() const noexcept {
+      return head_ == nullptr;
+    }
+
+    // Prepend `node`. Matches std::forward_list::push_front ordering so the
+    // head-insertion semantics the managers relied on are preserved.
+    void push_front(T* node) noexcept {
+      node->*NextField = head_;
+      head_ = node;
+    }
+
+    // Detach every node without destroying it. Elements are owned by the
+    // canonical `implementations` list (or equivalent), not by this list.
+    void clear() noexcept {
+      T* node = head_;
+      while (node != nullptr) {
+        T* next = node->*NextField;
+        node->*NextField = nullptr;
+        node = next;
+      }
+      head_ = nullptr;
+    }
+
+    // Unlink the first node equal to `value`. No-op if it is not present.
+    void remove(T* value) noexcept {
+      for (T** link = &head_; *link != nullptr; link = &((*link)->*NextField)) {
+        if (*link == value) {
+          T* node = *link;
+          *link = node->*NextField;
+          node->*NextField = nullptr;
+          return;
+        }
+      }
+    }
+
+    // Unlink every node for which pred(node) is true. `Pred` is invoked with a
+    // `T*`, matching the old std::forward_list<T*>::remove_if predicates.
+    template <typename Pred> void remove_if(Pred pred) {
+      T** link = &head_;
+      while (*link != nullptr) {
+        T* node = *link;
+        if (pred(node)) {
+          *link = node->*NextField;
+          node->*NextField = nullptr;
+        } else {
+          link = &(node->*NextField);
+        }
+      }
+    }
+
+    // Read-only forward iterator. Dereferences to `T*` so existing `(*it)->foo()`
+    // call sites that used `std::forward_list<T*>` compile unchanged.
+    class iterator {
+    public:
+      explicit iterator(T* node) noexcept : node_(node) {}
+      T* operator*() const noexcept {
+        return node_;
+      }
+      iterator& operator++() noexcept {
+        node_ = node_->*NextField;
+        return *this;
+      }
+      iterator operator++(int) noexcept {
+        iterator prev(*this);
+        node_ = node_->*NextField;
+        return prev;
+      }
+      bool operator==(const iterator& other) const noexcept {
+        return node_ == other.node_;
+      }
+      bool operator!=(const iterator& other) const noexcept {
+        return node_ != other.node_;
+      }
+
+    private:
+      T* node_;
+    };
+
+    iterator begin() const noexcept {
+      return iterator(head_);
+    }
+    iterator end() const noexcept {
+      return iterator(nullptr);
+    }
+
+    // Mutating traversal that supports erase-during-iteration, replacing the
+    // std::forward_list before_begin()/erase_after(previous) idiom. Ordering is
+    // preserved: get() yields the current node, next() advances, and erase()
+    // unlinks the current node and leaves the cursor referring to its
+    // successor (so the caller must NOT also call next() after an erase).
+    //
+    //   for (auto c = list.cursor(); c.valid();) {
+    //     T* p = c.get();
+    //     if (drop) c.erase(); else c.next();
+    //   }
+    class cursor {
+    public:
+      explicit cursor(T** link) noexcept : link_(link) {}
+      bool valid() const noexcept {
+        return *link_ != nullptr;
+      }
+      T* get() const noexcept {
+        return *link_;
+      }
+      void next() noexcept {
+        link_ = &((*link_)->*NextField);
+      }
+      void erase() noexcept {
+        T* node = *link_;
+        *link_ = node->*NextField;
+        node->*NextField = nullptr;
+      }
+
+    private:
+      T** link_;
+    };
+
+    cursor front() noexcept {
+      return cursor(&head_);
+    }
+
+  private:
+    T* head_ = nullptr;
+  };
+
+} // namespace YSE
+
+#endif // YSE_UTILS_INTRUSIVEFORWARDLIST_HPP_INCLUDED


### PR DESCRIPTION
## Summary

The sound/channel/reverb managers and `channelImplementation` walked and mutated `std::forward_list<T*>` containers (`toLoad`, `inUse`, channel `children`/`sounds`) **on the audio callback thread**. Every sound/channel promote, connect, or reparent churned a list node through `malloc`/`free`, and `virtualFinder::calculate()` resized its histogram vector — **unbounded** — on essentially every callback under load. This breaks the project's real-time discipline (no heap traffic on the callback path) and the glitch-free-live-editing bar.

This converts that bookkeeping to zero-allocation intrusive lists and pins the virtualFinder histogram to a fixed buffer.

## Linked issue
Closes #194

## Changes
- **New `YSE::IntrusiveForwardList<T, &T::Next>`** (`YseEngine/utils/intrusiveForwardList.hpp`): singly-linked list whose link lives inside the element, so link/unlink never allocates. API: `push_front`, `remove`, `remove_if`, `clear`, a read-only iterator (dereferences to `T*`, so existing `(*it)->` call sites are unchanged), and a `cursor` for erase-during-iteration that replaces the `before_begin()`/`erase_after()` idiom while preserving order.
- **Embedded link fields in the impls**: SOUND/CHANNEL impls carry `_mgrNext` (manager `toLoad`/`inUse` — membership is mutually exclusive, so one link covers both) plus a second link for their parent's list (`_channelNext` / `_childNext`); REVERB carries `_mgrNext`. `toLoad`/`inUse` and channel `children`/`sounds` become intrusive lists. The manager `update()` loops are rewritten onto the cursor idiom, erasing from `toLoad` **before** relinking into `inUse` since they share the one `_mgrNext` link.
- **virtualFinder**: histogram allocated once at `RESOLUTION_MAX` and never resized; the adaptive resolution is now a logical count clamped to `[RESOLUTION_MIN, RESOLUTION_MAX]`.
- **classes.hpp**: forward-declare `PATCHER::patcherImplementation` so `soundImplementation.h` is self-contained (`channelImplementation.h` now needs the complete SOUND impl type for the `sounds` pointer-to-member).
- Lift the `operator new` allocation probe out of `test_named_bus.cpp` into shared `Tests/support/alloc_probe.{hpp,cpp}` so several TUs can share one definition.

Device-config-change reallocations (`changeChannelConf`, channel `resize`) are left as documented jitter per the issue; `adjustLastGainBuffer` is dead code (no callers) and untouched. The MIDI file manager shares the same `forward_list` pattern but was out of scope for #194 — filed as #266.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on all touched files
- [x] `python yse.py analyze` on the changed sources — no new findings (one pre-existing `bugprone-integer-division` on an unmodified virtualFinder line, part of the tracked baseline)
- [x] Unit tests: `Tests/utils/test_intrusive_list.cpp` (functional parity + zero-allocation) and `Tests/sound/test_virtual_finder.cpp` (sustained reset/add/calculate never allocates; stays functional after the resolution clamp). The virtualFinder allocation test was **confirmed to fail on the pre-fix code** and pass after.
- [x] Integration test: `Tests/sound/test_manager_alloc.cpp` drives reparenting churn through the **real** SOUND/CHANNEL managers (`engineInit` + `Manager().update()`) and asserts zero allocation on the update path; skips gracefully on headless CI (no audio device), runs locally.
- [x] Full suite: `python yse.py test` — 100% (17/17 CTest entries) pass locally on MSYS2/Clang64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)