### PR TITLE
MUSIC: preallocate player note-generation pools so update() never allocates (#195)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -65,6 +65,7 @@ set(YSE_TEST_SOURCES
   music/test_scale.cpp
   music/test_note.cpp
   music/test_motif.cpp
+  music/test_player_alloc.cpp
   listener/test_listener.cpp
   io/test_bufferIO.cpp
   system/test_named_bus.cpp

--- a/Tests/music/test_player_alloc.cpp
+++ b/Tests/music/test_player_alloc.cpp
@@ -1,0 +1,165 @@
+// RT-allocation test for the generative player note generator (issue #195).
+//
+// PLAYER::Manager().update() runs on the audio callback every block, and it
+// calls implementationObject::update() for each live player. Before #195 that
+// path did heap traffic proportional to musical activity: std::deque erase /
+// insert of notes, voices.emplace_back when polyphony grew, whole-motif copies
+// into each voice, and motifs.emplace_back / erase in parseMessage. This test
+// drives the exact function Manager().update() invokes and asserts the steady
+// state generates notes without allocating.
+//
+// The player subsystem has no live create() path yet (it was designed to hand
+// notes to the not-yet-exposed synth), so the test constructs the
+// implementation object directly with a player head — the same object the
+// manager holds — and pumps update() from the test thread. This mirrors how the
+// motif / scale impl tests in test_motif.cpp / test_scale.cpp drive their
+// implementation objects, and needs no audio device (RandomF, the interpolators
+// and the scale / motif lookups have no PortAudio dependency).
+//
+// The probe covers generation from a cold start (no warm-up), so the growth
+// allocations the fix eliminates are in scope: the deque growing from empty,
+// the per-voice motif buffers filling for the first time, and the motif pool
+// growing in parseMessage. All config messages are sent before the probe opens
+// so the message-queue traffic is excluded; the probed region is pure
+// generation. Pre-#195 this fails (unbounded deque / vector growth allocates);
+// after the preallocated-pool conversion the probed region sees zero
+// allocations.
+
+#include <doctest/doctest.h>
+
+// Message headers must precede the impl headers: the inline sendMessage() in
+// each impl calls lfQueue<messageObject>::push, which needs the complete
+// messageObject type to size its storage.
+#include "music/scale/scaleMessage.h"
+#include "music/motif/motifMessage.h"
+#include "music/scale/scaleInterface.hpp"
+#include "music/scale/scaleImplementation.h"
+#include "music/scale/scaleManager.h"
+#include "music/motif/motifInterface.hpp"
+#include "music/motif/motifImplementation.h"
+#include "music/motif/motifManager.h"
+#include "music/pNote.hpp"
+#include "player/playerMessage.h"
+#include "player/playerImplementation.h"
+#include "player/playerInterface.hpp"
+
+#include "support/alloc_probe.hpp"
+
+namespace {
+
+  // One audio block at the standard rate — the delta the manager feeds update().
+  // SAMPLERATE is a runtime global, so this is a plain (non-constexpr) helper.
+  Flt blockDelta() {
+    return static_cast<Flt>(YSE::STANDARD_BUFFERSIZE) / static_cast<Flt>(YSE::SAMPLERATE);
+  }
+
+  // Build a small, populated motif via the real interface + manager path.
+  void fillMotif(YSE::motif& m) {
+    m.add(YSE::MUSIC::pNote(0.00f, 60.f, 0.8f, 0.05f));
+    m.add(YSE::MUSIC::pNote(0.05f, 64.f, 0.8f, 0.05f));
+    m.add(YSE::MUSIC::pNote(0.10f, 67.f, 0.8f, 0.05f));
+    m.add(YSE::MUSIC::pNote(0.15f, 72.f, 0.8f, 0.05f));
+    m.setLength();
+    YSE::MOTIF::Manager().update(); // drain the ADD / LENGTH messages into the impl
+  }
+
+} // namespace
+
+TEST_SUITE("music") {
+
+  TEST_CASE("player: pure-random note generation does not allocate on the audio path (#195)") {
+    YSE::player head;
+    YSE::PLAYER::implementationObject impl(&head);
+
+    // Aggressive, allocation-hungry configuration: full polyphony, wide pitch
+    // range, and very short notes with no gaps so the generator churns the note
+    // pool as fast as possible.
+    head.setVoices(YSE::PLAYER::MAX_VOICES);
+    head.setMinimumPitch(24.f);
+    head.setMaximumPitch(96.f);
+    head.setMinimumVelocity(0.2f);
+    head.setMaximumVelocity(0.9f);
+    head.setMinimumGap(0.f);
+    head.setMaximumGap(0.f);
+    head.setMinimumLength(0.01f);
+    head.setMaximumLength(0.05f);
+    head.play();
+
+    // Probe from a cold start: every config message is already queued, so the
+    // probed region is pure generation — the exact path that used to grow the
+    // note pool from empty. update() drains the queue (try_pop never allocates)
+    // and then generates into the ctor-reserved pools.
+    const Flt delta = blockDelta();
+    bool generated = false;
+    UInt peakNotes = 0;
+    {
+      TestHelpers::ProbeScope probe;
+      for (int i = 0; i < 4000; ++i) {
+        impl.update(delta);
+        UInt n = impl.noteCount();
+        if (n > 0u) generated = true;
+        if (n > peakNotes) peakNotes = n;
+      }
+    }
+    CHECK(TestHelpers::g_alloc_count.load() == 0);
+    CHECK(generated); // the generator actually produced notes
+    CHECK(peakNotes <= YSE::PLAYER::MAX_NOTES); // the fixed ceiling held throughout
+  }
+
+  TEST_CASE("player: motif + scale note generation does not allocate on the audio path (#195)") {
+    // A scale to constrain / quantise pitches, populated through the real path.
+    YSE::scale sc;
+    sc.add(60.f, 12.f);
+    sc.add(62.f, 12.f);
+    sc.add(64.f, 12.f);
+    sc.add(67.f, 12.f);
+    sc.add(69.f, 12.f);
+    YSE::SCALE::Manager().update();
+
+    // Two weighted motifs the player draws from.
+    YSE::motif m1;
+    YSE::motif m2;
+    fillMotif(m1);
+    fillMotif(m2);
+
+    YSE::player head;
+    YSE::PLAYER::implementationObject impl(&head);
+
+    head.setVoices(YSE::PLAYER::MAX_VOICES);
+    head.setMinimumPitch(36.f);
+    head.setMaximumPitch(84.f);
+    head.setMinimumVelocity(0.2f);
+    head.setMaximumVelocity(0.9f);
+    head.setMinimumGap(0.f);
+    head.setMaximumGap(0.01f);
+    head.setMinimumLength(0.01f);
+    head.setMaximumLength(0.05f);
+    head.setScale(sc);
+    head.addMotif(m1, 2);
+    head.addMotif(m2, 1);
+    head.playMotifs(1.f); // always draw from motifs when a note starts
+    head.playPartialMotifs(0.5f); // mix full and partial motif copies
+    head.fitMotifsToScale(1.f); // quantise every motif note to the scale
+    head.play();
+
+    // Probe from cold: the first motif selection copies a whole motif into each
+    // voice's buffer and parseMessage appends to the motif pool — both grew the
+    // heap before #195. The ctor-reserved buffers must absorb all of it.
+    const Flt delta = blockDelta();
+    bool generated = false;
+    UInt peakNotes = 0;
+    {
+      TestHelpers::ProbeScope probe;
+      for (int i = 0; i < 4000; ++i) {
+        impl.update(delta);
+        UInt n = impl.noteCount();
+        if (n > 0u) generated = true;
+        if (n > peakNotes) peakNotes = n;
+      }
+    }
+    CHECK(TestHelpers::g_alloc_count.load() == 0);
+    CHECK(generated);
+    CHECK(peakNotes <= YSE::PLAYER::MAX_NOTES);
+  }
+
+} // TEST_SUITE("music")

--- a/YseEngine/player/playerImplementation.cpp
+++ b/YseEngine/player/playerImplementation.cpp
@@ -13,8 +13,8 @@
 #include "../music/note.hpp"
 // #include "../synth/synthInterface.hpp"
 
-/*YSE::PLAYER::implementationObject::implementationObject(player* head, synth * s)
-  : head(head), instrument(s), waitTime(0.f), playing(false) {
+YSE::PLAYER::implementationObject::implementationObject(player* head)
+  : head(head), waitTime(0.f), activeVoices(1), playing(false) {
   minimumPitch.set(0.f);
   maximumPitch.set(128.f);
   minimumVelocity.set(0.f);
@@ -24,10 +24,22 @@
   minLength.set(0.1f);
   maxLength.set(1.f);
   numVoices.set(1.f);
-  activeVoices = 1;
-  voices.reserve(32);
-  voices.emplace_back(true);
-}*/
+
+  // Preallocate every audio-thread pool up to its fixed ceiling so the note
+  // generator in update() never allocates (issue #195). All the voices exist
+  // up front; activeVoices selects how many are live. Each voice's motif buffer
+  // and the shared note / motif pools are reserved once here.
+  notes.reserve(MAX_NOTES);
+  motifs.reserve(MAX_MOTIFS);
+  voices.reserve(MAX_VOICES);
+  for (UInt i = 0; i < MAX_VOICES; i++) {
+    voices.emplace_back(false);
+    voices.back().motif.reserve(MAX_MOTIF_NOTES);
+  }
+  voices[0].isActive = true;
+
+  if (head != nullptr) head->pimpl = this;
+}
 
 YSE::PLAYER::implementationObject::~implementationObject() {
   if (head.load() != nullptr) {
@@ -47,13 +59,15 @@ bool YSE::PLAYER::implementationObject::update(Flt delta) {
     parseMessage(message);
   }
 
-  // update notes and delete on note off
+  // update notes and delete on note off. Swap-and-pop keeps this allocation-free
+  // (pop_back never releases the reserved buffer) on the audio thread (#195).
   {
-    std::deque<MUSIC::note>::iterator i = notes.begin();
-    while (i != notes.end()) {
-      if (!i->update(delta)) {
-        // instrument->noteOff(*i);
-        i = notes.erase(i);
+    UInt i = 0;
+    while (i < notes.size()) {
+      if (!notes[i].update(delta)) {
+        // instrument->noteOff(notes[i]);
+        notes[i] = notes.back();
+        notes.pop_back();
       } else
         i++;
     }
@@ -77,17 +91,15 @@ bool YSE::PLAYER::implementationObject::update(Flt delta) {
   // don't play new notes if we're stopped
   if (!playing) return true;
 
-  // adjust number of active voices if needed
-  while ((UInt)numVoices() > activeVoices) {
-    if (voices.size() > activeVoices) {
-      voices[activeVoices].isActive = true;
-    } else {
-      voices.emplace_back(true);
-    }
+  // adjust number of active voices if needed. All MAX_VOICES voices are
+  // preallocated, so growing just flips isActive — never allocates — and the
+  // fixed polyphony ceiling caps activeVoices at voices.size() (#195).
+  while ((UInt)numVoices() > activeVoices && activeVoices < voices.size()) {
+    voices[activeVoices].isActive = true;
     activeVoices++;
   }
 
-  while ((UInt)numVoices() < activeVoices) {
+  while ((UInt)numVoices() < activeVoices && activeVoices > 0) {
     voices[activeVoices - 1].isActive = false;
     activeVoices--;
   }
@@ -120,9 +132,13 @@ bool YSE::PLAYER::implementationObject::update(Flt delta) {
           Flt pitch = static_cast<Flt>(
               Random(static_cast<Int>(minimumPitch()), static_cast<Int>(maximumPitch())));
           if (scale.isSet()) pitch = scale()->getNearest(pitch);
-          notes.emplace_back(MUSIC::note(pitch, RandomF(minimumVelocity(), maximumVelocity()),
-                                         voices[i].duration));
-          // instrument->noteOn(notes.back());
+          // Drop the note rather than grow the pool if the note ceiling is hit,
+          // keeping generation allocation-free on the audio thread (#195).
+          if (notes.size() < notes.capacity()) {
+            notes.emplace_back(pitch, RandomF(minimumVelocity(), maximumVelocity()),
+                               voices[i].duration);
+            // instrument->noteOn(notes.back());
+          }
         }
       }
     }
@@ -157,6 +173,8 @@ void YSE::PLAYER::implementationObject::setVoiceFromMotif(voice& v, Flt delta) {
       UInt start = Random(m->size() - 1);
       UInt count = 1 + Random(m->size() - start - 1);
       UInt end = start + count;
+      // Never copy past the voice's reserved motif buffer (#195).
+      if (end - start > v.motif.capacity()) end = start + static_cast<UInt>(v.motif.capacity());
 
       Flt offset = m->getNote(start).getPosition();
       for (; start < end; start++) {
@@ -166,7 +184,10 @@ void YSE::PLAYER::implementationObject::setVoiceFromMotif(voice& v, Flt delta) {
 
       v.duration = v.motif.back().getPosition() + v.motif.back().getLength();
     } else {
-      for (UInt i = 0; i < m->size(); i++) {
+      UInt count = m->size();
+      // Never copy past the voice's reserved motif buffer (#195).
+      if (count > v.motif.capacity()) count = static_cast<UInt>(v.motif.capacity());
+      for (UInt i = 0; i < count; i++) {
         v.motif.emplace_back(m->getNote(i));
       }
       v.duration = m->getLength();
@@ -205,8 +226,11 @@ void YSE::PLAYER::implementationObject::setVoiceFromMotif(voice& v, Flt delta) {
     if (RandomF() < motifToScale()) {
       note.setPitch(scale()->getNearest(note.getPitch()));
     }
-    notes.push_back(note);
-    // instrument->noteOn(note);
+    // Drop rather than grow the pool if the note ceiling is hit (#195).
+    if (notes.size() < notes.capacity()) {
+      notes.push_back(note);
+      // instrument->noteOn(note);
+    }
     v.motifPos++;
   }
 
@@ -272,7 +296,9 @@ void YSE::PLAYER::implementationObject::parseMessage(const messageObject& messag
       // no doubles!
       if (motifs[i].motif == m.motif) assert(false);
     }
-    motifs.emplace_back(m);
+    // Bounded by MAX_MOTIFS so the motif pool never reallocates on the audio
+    // thread; extra motifs past the ceiling are ignored (#195).
+    if (motifs.size() < motifs.capacity()) motifs.emplace_back(m);
     break;
   case REM_MOTIF:
     FOREACH(motifs) {

--- a/YseEngine/player/playerImplementation.h
+++ b/YseEngine/player/playerImplementation.h
@@ -16,15 +16,29 @@
 #include "../utils/lfQueue.hpp"
 #include "../utils/interpolators.hpp"
 #include "../music/note.hpp"
+#include "../music/pNote.hpp"
 #include "../dsp/ramp.hpp"
-#include <deque>
+#include <vector>
 
 namespace YSE {
   namespace PLAYER {
 
+    // Fixed ceilings for the preallocated audio-thread pools (issue #195). The
+    // note generator runs on the audio callback and must not allocate, so every
+    // container it touches is reserved to these bounds at construction time and
+    // never grows past them: generation above the ceiling is dropped rather than
+    // triggering a heap reallocation.
+    static constexpr UInt MAX_VOICES = 32; // polyphony ceiling
+    static constexpr UInt MAX_MOTIF_NOTES = 256; // notes copied per voice motif
+    static constexpr UInt MAX_MOTIFS = 64; // weighted motifs in the pool
+    static constexpr UInt MAX_NOTES = 512; // concurrently sounding notes
+
     class implementationObject {
     public:
-      // implementationObject(player * head, synth * s);
+      // Constructing an implementation preallocates every pool it uses on the
+      // audio thread. `head` may be null (used by tests that drive update()
+      // directly); when non-null the interface's pimpl is wired back here.
+      explicit implementationObject(player* head);
       ~implementationObject();
 
       bool update(Flt delta);
@@ -35,6 +49,12 @@ namespace YSE {
       }
 
       void removeInterface();
+
+      // Read-only inspection of the sounding-note pool. Lets the RT-allocation
+      // test assert the pool stays within its fixed ceiling (#195).
+      UInt noteCount() const {
+        return static_cast<UInt>(notes.size());
+      }
 
     private:
       std::atomic<player*> head;
@@ -58,7 +78,7 @@ namespace YSE {
 
       void setVoiceFromMotif(voice& v, Flt delta);
 
-      std::deque<MUSIC::note> notes;
+      std::vector<MUSIC::note> notes;
       std::vector<voice> voices;
       UInt activeVoices;
 


### PR DESCRIPTION
## Summary

`PLAYER::Manager().update()` runs on the audio callback every block and drove `implementationObject::update()`, which did heap traffic proportional to musical activity — the exact RT-discipline violation flagged in the 2026-07-02 lock-free audit. This converts the note generator to fixed-ceiling pools reserved once at construction, so the audio-thread path allocates nothing.

## Linked issue
Closes #195

## Changes
- **notes**: `std::deque` → `std::vector` reserved to `MAX_NOTES`, with swap-and-pop removal (`pop_back` never frees the buffer) instead of mid-container iterator `erase`.
- **voices**: all `MAX_VOICES` preallocated up front (each with its motif buffer reserved to `MAX_MOTIF_NOTES`); growing polyphony only flips `isActive` and is capped at the ceiling — no more `emplace_back` on the RT path.
- **motif copies**: clamped to the voice buffer's reserved capacity.
- **motifs pool**: reserved to `MAX_MOTIFS` in `parseMessage`.
- Generation past any ceiling is **dropped** rather than reallocating.
- Restores a real (synth-free) constructor for the implementation object (it had no usable ctor since the synth path is commented out) that performs all the preallocation and initialises state.
- Adds a read-only `noteCount()` inspector so the RT test can assert the pool stays bounded.

The public user-facing `player::create()` path is still absent (the player was designed to feed the not-yet-exposed synth); that latent null-`pimpl` crash is **out of scope** and filed separately as **#268**.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on all changed files
- [x] `clang-tidy` (`yse.py analyze`) — no new findings in modified code (the single `DivideZero` report is in the vendored `misc.hpp` `Random()` helper reached through the **pre-existing, untouched** motif weight-selection block; part of the baseline)
- [x] Unit/regression test `Tests/music/test_player_alloc.cpp` (new): drives the exact `update()` the manager invokes, **from a cold start**, under the shared heap-allocation probe (`support/alloc_probe.hpp`, same probe used by #194), for both pure-random and motif+scale generation. **Confirmed to fail on the pre-fix `std::deque`/unreserved code (2 cold-start growth allocations) and pass after the fix.**
- [x] Full unit suite: **1008 cases / 313488 assertions pass** (`yse_tests --test-suite-exclude=integration,lifecycle`)

### Integration test note
The change is **not user-visible**: the player subsystem is dormant (no live `create()` path — it was built to hand notes to the unexposed synth, all output calls are commented out), so there is no audible end-to-end flow to drive. The test therefore exercises the real note-generation flow (full polyphony, weighted motifs, partial-motif copies, scale quantisation, note lifetimes) by constructing the implementation object directly and pumping `update()` — the exact function `Manager().update()` calls on the audio thread — which is the meaningful integration of this subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)