### PR TITLE
FIX: guard listener aPos with a seqlock to stop torn multi-word reads (#196)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(YSE_TEST_SOURCES
   music/test_motif.cpp
   music/test_player_alloc.cpp
   listener/test_listener.cpp
+  listener/test_listener_concurrency.cpp
   io/test_bufferIO.cpp
   system/test_named_bus.cpp
   system/test_system_active_state.cpp

--- a/Tests/listener/test_listener_concurrency.cpp
+++ b/Tests/listener/test_listener_concurrency.cpp
@@ -1,0 +1,166 @@
+// Regression + stress tests for issue #196: the listener's spatial vectors
+// (pos / forward / up / vel) used to be three independent std::atomic<Flt>, so
+// a component-wise read on the audio thread could observe a mixed-generation
+// vector (a fresh x combined with a stale y/z) while the control thread wrote
+// component-wise. They are now seqlock-guarded (YseEngine/utils/atomicPos.h),
+// which publishes and reads all three components as one consistent snapshot.
+//
+// Each test encodes a coherence invariant that only a tear-free snapshot can
+// satisfy, then hammers the writer/reader race. On the old
+// three-independent-atomics design a reader eventually captures a torn triple
+// (verified by temporarily stripping the sequence guard); with the seqlock the
+// invariant holds for every observed snapshot.
+
+#include <doctest/doctest.h>
+#include <atomic>
+#include <thread>
+#include "listener.hpp"
+#include "implementations/listenerImplementation.h"
+#include "utils/atomicPos.h"
+#include "utils/vector.hpp"
+#include "internal/settings.h"
+#include "internal/time.h"
+#include "support/null_device.hpp"
+
+TEST_SUITE("listener") {
+
+  // ─── aPos primitive: the seqlock itself ─────────────────────────────────────
+
+  TEST_CASE("listener concurrency: aPos never yields a torn snapshot under a writer/reader race") {
+    YSE::aPos p;
+    // Seed a value that already satisfies the invariant, so the reader never
+    // observes the default-constructed (0,0,0) (which is coherent but off the
+    // (v, v+1000, v+2000) signature the writer publishes).
+    p.store(0.f, 1000.f, 2000.f);
+
+    std::atomic<bool> stop{false};
+    std::atomic<bool> torn{false};
+    long long reads = 0;
+
+    // Writer publishes coherent triples (k, k+1000, k+2000) with k in [0,1000)
+    // so every component is an exactly representable float and adjacent
+    // generations always differ — any tear mixes two generations and breaks the
+    // y == x+1000 / z == x+2000 relation.
+    std::thread writer([&]() {
+      int k = 0;
+      while (!stop.load(std::memory_order_acquire)) {
+        const float v = static_cast<float>(k % 1000);
+        p.store(v, v + 1000.f, v + 2000.f);
+        ++k;
+      }
+    });
+
+    for (int i = 0; i < 3'000'000 && !torn.load(std::memory_order_relaxed); ++i) {
+      const YSE::Pos s = p.load();
+      if (s.y != s.x + 1000.f || s.z != s.x + 2000.f) {
+        torn.store(true, std::memory_order_relaxed);
+      }
+      ++reads;
+    }
+
+    stop.store(true, std::memory_order_release);
+    writer.join();
+
+    CHECK_FALSE(torn.load(std::memory_order_relaxed));
+    CHECK(reads > 0);
+  }
+
+  // ─── Integration: real audio update path reads the control-thread position ──
+
+  TEST_CASE("listener concurrency: audio-path position stays coherent while the control thread "
+            "moves the listener") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::INTERNAL::Settings().distanceFactor = 1.f;
+
+    std::atomic<bool> stop{false};
+    std::atomic<bool> torn{false};
+
+    // Seed a coherent (k,k,k) baseline so the reader never inspects a leftover
+    // position from an earlier test (e.g. (1,2,4)) that legitimately fails the
+    // x == y == z invariant this test relies on.
+    YSE::Listener().pos(YSE::Pos(0.f, 0.f, 0.f));
+
+    // Control thread: moves the listener to coherent positions (k,k,k) via the
+    // public setter, exactly as an application would.
+    std::thread mover([&]() {
+      int k = 0;
+      while (!stop.load(std::memory_order_acquire)) {
+        const float v = static_cast<float>(k % 1000);
+        YSE::Listener().pos(YSE::Pos(v, v, v));
+        ++k;
+      }
+    });
+
+    // Audio-thread stand-in: drive the real listenerImplementation::update()
+    // (which reads the position snapshot) and inspect the scaled result the
+    // audio path consumes. With distanceFactor == 1 a coherent source position
+    // yields x == y == z; the old component-wise read could tear it here.
+    long long ticks = 0;
+    for (int i = 0; i < 300'000 && !torn.load(std::memory_order_relaxed); ++i) {
+      YSE::INTERNAL::Time().update();
+      YSE::INTERNAL::ListenerImpl().update();
+      const YSE::Pos& scaled = YSE::INTERNAL::ListenerImpl().getPos();
+      if (scaled.x != scaled.y || scaled.y != scaled.z) {
+        torn.store(true, std::memory_order_relaxed);
+      }
+      ++ticks;
+    }
+
+    stop.store(true, std::memory_order_release);
+    mover.join();
+
+    CHECK_FALSE(torn.load(std::memory_order_relaxed));
+    CHECK(ticks > 0);
+
+    // Restore the clean baseline other listener tests assume.
+    YSE::Listener().pos(YSE::Pos(0.f, 0.f, 0.f));
+  }
+
+  // ─── Integration: orientation reads race orient() through the public API ────
+
+  TEST_CASE(
+      "listener concurrency: orientation reads stay coherent while orient() runs concurrently") {
+    if (!TestHelpers::engineInit()) return;
+
+    std::atomic<bool> stop{false};
+    std::atomic<bool> torn{false};
+
+    // Seed both vectors on their invariant signatures so the reader never
+    // catches the pre-race baseline (forward zero / up +Y) as a false tear.
+    YSE::Listener().orient(YSE::Pos(0.f, 1000.f, 2000.f), YSE::Pos(0.f, 0.f, 0.f));
+
+    // Control thread rewrites both orientation vectors. forward carries the
+    // (k, k+1000, k+2000) signature; up carries the (k,k,k) signature.
+    std::thread orienter([&]() {
+      int k = 0;
+      while (!stop.load(std::memory_order_acquire)) {
+        const float v = static_cast<float>(k % 1000);
+        YSE::Listener().orient(YSE::Pos(v, v + 1000.f, v + 2000.f), YSE::Pos(v, v, v));
+        ++k;
+      }
+    });
+
+    long long reads = 0;
+    for (int i = 0; i < 1'000'000 && !torn.load(std::memory_order_relaxed); ++i) {
+      const YSE::Pos f = YSE::Listener().forward();
+      if (f.y != f.x + 1000.f || f.z != f.x + 2000.f) {
+        torn.store(true, std::memory_order_relaxed);
+      }
+      const YSE::Pos u = YSE::Listener().upward();
+      if (u.x != u.y || u.y != u.z) {
+        torn.store(true, std::memory_order_relaxed);
+      }
+      ++reads;
+    }
+
+    stop.store(true, std::memory_order_release);
+    orienter.join();
+
+    CHECK_FALSE(torn.load(std::memory_order_relaxed));
+    CHECK(reads > 0);
+
+    // Restore the clean baseline (forward zero, up = +Y) other tests assume.
+    YSE::Listener().orient(YSE::Pos(0.f, 0.f, 0.f), YSE::Pos(0.f, 1.f, 0.f));
+  }
+
+} // TEST_SUITE("listener")

--- a/YseEngine/implementations/listenerImplementation.cpp
+++ b/YseEngine/implementations/listenerImplementation.cpp
@@ -18,27 +18,21 @@ YSE::INTERNAL::listenerImplementation& YSE::INTERNAL::ListenerImpl() {
 YSE::INTERNAL::listenerImplementation::listenerImplementation() {
   newPos.zero();
   lastPos.zero();
-  vel.x.store(0.f);
-  vel.y.store(0.f);
-  vel.z.store(0.f);
-  forward.x.store(0.f);
-  forward.y.store(0.f);
-  forward.z.store(0.f);
-  up.x.store(0.f);
-  up.y.store(1.f);
-  up.z.store(0.f);
-  pos.x.store(0.f);
-  pos.y.store(0.f);
-  pos.z.store(0.f);
+  vel.store(0.f, 0.f, 0.f);
+  forward.store(0.f, 0.f, 0.f);
+  up.store(0.f, 1.f, 0.f);
+  pos.store(0.f, 0.f, 0.f);
 }
 
 void YSE::INTERNAL::listenerImplementation::update() {
-  // ugly, but the atomic version of vector isn't great right now
-  newPos.x = pos.x.load() * (Settings().distanceFactor);
-  newPos.y = pos.y.load() * (Settings().distanceFactor);
-  newPos.z = pos.z.load() * (Settings().distanceFactor);
-  vel.x.store((newPos.x - lastPos.x) * (1.f / Time().delta()));
-  vel.y.store((newPos.y - lastPos.y) * (1.f / Time().delta()));
-  vel.z.store((newPos.z - lastPos.z) * (1.f / Time().delta()));
+  // Read the control-thread-written position as one tear-free snapshot, then
+  // publish the derived velocity as one snapshot too (seqlock, issue #196).
+  const Pos p = pos.load();
+  newPos.x = p.x * (Settings().distanceFactor);
+  newPos.y = p.y * (Settings().distanceFactor);
+  newPos.z = p.z * (Settings().distanceFactor);
+  const Flt invDelta = 1.f / Time().delta();
+  vel.store((newPos.x - lastPos.x) * invDelta, (newPos.y - lastPos.y) * invDelta,
+            (newPos.z - lastPos.z) * invDelta);
   lastPos = newPos;
 }

--- a/YseEngine/listener.cpp
+++ b/YseEngine/listener.cpp
@@ -32,14 +32,12 @@ YSE::Pos YSE::listener::upward() {
 }
 
 YSE::listener& YSE::listener::pos(const Pos& pos) {
-  INTERNAL::ListenerImpl().pos.x = pos.x;
-  INTERNAL::ListenerImpl().pos.y = pos.y;
-  INTERNAL::ListenerImpl().pos.z = pos.z;
+  INTERNAL::ListenerImpl().pos.store(pos);
   return (*this);
 }
 
 YSE::listener& YSE::listener::orient(const Pos& forward, const Pos& up) {
-  INTERNAL::ListenerImpl().forward = forward;
-  INTERNAL::ListenerImpl().up = up;
+  INTERNAL::ListenerImpl().forward.store(forward);
+  INTERNAL::ListenerImpl().up.store(up);
   return (*this);
 }

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -539,10 +539,7 @@ void YSE::SOUND::implementationObject::update() {
   if (doppler) {
     velocityVec = (newPos - lastPos) * (1 / INTERNAL::Time().delta());
 
-    Pos listenerVelocity;
-    listenerVelocity.x = INTERNAL::ListenerImpl().vel.x.load();
-    listenerVelocity.y = INTERNAL::ListenerImpl().vel.y.load();
-    listenerVelocity.z = INTERNAL::ListenerImpl().vel.z.load();
+    Pos listenerVelocity = INTERNAL::ListenerImpl().vel.load();
 
     if (!(velocityVec == Pos(0) && listenerVelocity == Pos(0))) {
       Pos dist = relative ? newPos : newPos - INTERNAL::ListenerImpl().newPos;
@@ -560,9 +557,10 @@ void YSE::SOUND::implementationObject::update() {
   Pos dir = relative ? newPos : newPos - INTERNAL::ListenerImpl().newPos;
   if (relative)
     a = -atan2(dir.x, dir.z);
-  else
-    a = (atan2(dir.x, dir.z) - atan2(INTERNAL::ListenerImpl().forward.x.load(),
-                                     INTERNAL::ListenerImpl().forward.z.load()));
+  else {
+    const Pos listenerForward = INTERNAL::ListenerImpl().forward.load();
+    a = (atan2(dir.x, dir.z) - atan2(listenerForward.x, listenerForward.z));
+  }
   while (a > Pi)
     a -= Pi2;
   while (a < -Pi)

--- a/YseEngine/utils/atomicPos.h
+++ b/YseEngine/utils/atomicPos.h
@@ -1,34 +1,92 @@
 #pragma once
 #include <atomic>
+#include <cstdint>
 #include "../headers/types.hpp"
 
 namespace YSE {
+  /// @cond INTERNAL
   class Pos;
 
+  /**
+   *  @brief Seqlock-guarded 3D vector used for the listener's spatial state.
+   *
+   *  The three components are published and observed as ONE consistent
+   *  snapshot, so a reader can never see a mixed-generation vector (a fresh
+   *  ``x`` combined with a stale ``y`` / ``z``). This replaces the previous
+   *  three-independent-atomics layout, whose component-wise reads on the audio
+   *  thread could tear against component-wise writes on the control thread
+   *  (issue #196).
+   *
+   *  Threading discipline — a seqlock supports a SINGLE writer and any number
+   *  of concurrent readers:
+   *    - ``pos`` / ``forward`` / ``up`` are written only by the control thread
+   *      (the ``YSE::listener`` setters).
+   *    - ``vel`` is written only by the audio thread
+   *      (``listenerImplementation::update()``).
+   *  Two writers on the same instance would corrupt the snapshot, so never
+   *  cross those roles.
+   *
+   *  Real-time safety: the writer's critical section is just three relaxed
+   *  atomic stores bracketed by two sequence bumps, and the reader only retries
+   *  when it collides with an in-progress write. Neither side allocates, locks,
+   *  or blocks, so ``load()`` (audio thread) and the audio-thread ``vel``
+   *  ``store()`` are safe on the callback path.
+   */
   class API aPos {
   public:
-    std::atomic<Flt> x;
-    std::atomic<Flt> y;
-    std::atomic<Flt> z;
-
     aPos() {
-      x.store(0.f), y.store(0.f), z.store(0.f);
+      store(0.f, 0.f, 0.f);
     }
     aPos(Flt x, Flt y, Flt z) {
-      this->x.store(x);
-      this->y.store(y);
-      this->z.store(z);
+      store(x, y, z);
     }
-    aPos(const Pos& v) {
-      x.store(v.x);
-      y.store(v.y);
-      z.store(v.z);
+    // Pos-typed constructor / assignment are defined in vector.cpp, where Pos
+    // is a complete type.
+    aPos(const Pos& v);
+    aPos& operator=(const Pos& v);
+
+    /** @brief Publish all three components as one consistent snapshot. */
+    void store(Flt x, Flt y, Flt z) {
+      const uint32_t s = seq_.load(std::memory_order_relaxed);
+      // Odd sequence marks a write in progress; a reader that observes it (or
+      // sees the sequence change across its read) retries.
+      seq_.store(s + 1, std::memory_order_relaxed);
+      std::atomic_thread_fence(std::memory_order_release);
+      x_.store(x, std::memory_order_relaxed);
+      y_.store(y, std::memory_order_relaxed);
+      z_.store(z, std::memory_order_relaxed);
+      std::atomic_thread_fence(std::memory_order_release);
+      seq_.store(s + 2, std::memory_order_release);
     }
-    aPos& operator=(const Pos& v) {
-      x.store(v.x);
-      y.store(v.y);
-      z.store(v.z);
-      return *this;
+    void store(const Pos& v);
+
+    /** @brief Read a tear-free snapshot into three floats. */
+    void loadInto(Flt& x, Flt& y, Flt& z) const {
+      uint32_t s0, s1;
+      do {
+        s0 = seq_.load(std::memory_order_acquire);
+        x = x_.load(std::memory_order_relaxed);
+        y = y_.load(std::memory_order_relaxed);
+        z = z_.load(std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_acquire);
+        s1 = seq_.load(std::memory_order_relaxed);
+        // Retry if a write was in progress (odd) or one completed between the
+        // two sequence reads.
+      } while ((s0 & 1u) || s0 != s1);
     }
+
+    /** @brief Read a tear-free snapshot as a Pos (defined in vector.cpp). */
+    Pos load() const;
+
+  private:
+    // Payload atomics are accessed relaxed; the seqlock sequence provides both
+    // the happens-before ordering and the snapshot-consistency guarantee.
+    // Keeping them atomic (rather than plain floats read racily) makes the
+    // reader well-defined under the C++ memory model and clean under TSan.
+    std::atomic<Flt> x_{0.f};
+    std::atomic<Flt> y_{0.f};
+    std::atomic<Flt> z_{0.f};
+    std::atomic<uint32_t> seq_{0};
   };
+  /// @endcond
 } // namespace YSE

--- a/YseEngine/utils/vector.cpp
+++ b/YseEngine/utils/vector.cpp
@@ -12,5 +12,24 @@
 #include "../utils/atomicPos.h"
 
 YSE::Pos::Pos(const aPos& v) {
-  set(v.x.load(), v.y.load(), v.z.load());
+  v.loadInto(x, y, z);
+}
+
+YSE::aPos::aPos(const Pos& v) {
+  store(v.x, v.y, v.z);
+}
+
+YSE::aPos& YSE::aPos::operator=(const Pos& v) {
+  store(v.x, v.y, v.z);
+  return *this;
+}
+
+void YSE::aPos::store(const Pos& v) {
+  store(v.x, v.y, v.z);
+}
+
+YSE::Pos YSE::aPos::load() const {
+  Flt x, y, z;
+  loadInto(x, y, z);
+  return Pos(x, y, z);
 }


### PR DESCRIPTION
## Summary
The listener's spatial vectors (`pos` / `forward` / `up` / `vel`) were three independent `std::atomic<Flt>` (`aPos`). The audio thread read them **component-wise** (`listenerImplementation::update()` reads `pos`; `soundImplementation::update()` reads `vel` and `forward`) while the control thread wrote them component-wise via `listener::pos()` / `orient()`. A reader could therefore observe a **mixed-generation vector** — a fresh `x` combined with a stale `y`/`z` — producing one block of slightly wrong panning/doppler (issue #196, Medium).

This replaces the three-independent-atomics layout in `aPos` with a **seqlock**: a single writer publishes all three components as one snapshot, and readers retry on an odd/changed sequence, so every observed vector is coherent. This is the issue's proposed option 2.

## Linked issue
Closes #196

## Changes
- `YseEngine/utils/atomicPos.h` — `aPos` is now a seqlock. `store(x,y,z)` bumps the sequence odd, writes the three payload atomics (relaxed) between two release fences, then bumps it even; `loadInto()` / `load()` retry until they capture a tear-free snapshot. Payload floats stay atomic (accessed relaxed) so the reader is well-defined under the C++ memory model and clean under TSan.
- `YseEngine/utils/vector.cpp` — `Pos(const aPos&)` and the `Pos`-typed `aPos` members defined here (where `Pos` is complete).
- `YseEngine/implementations/listenerImplementation.cpp`, `YseEngine/listener.cpp`, `YseEngine/sound/soundImplementation.cpp` — updated call sites to whole-vector `store()` / `load()` instead of per-component `.x.load()` / `.x = …`.
- `Tests/listener/test_listener_concurrency.cpp` (+ CMake registration) — new concurrency/regression tests.

## Real-time safety
The writer's critical section is three relaxed atomic stores bracketed by two sequence bumps, and the reader only spins when it collides with an in-progress write (listener writes are user-driven, at most once per frame — negligible contention). Both `load()` (audio thread) and the audio-thread `vel` `store()` remain allocation/lock/block-free on the callback path. Single-writer discipline: `pos`/`forward`/`up` are written only by the control thread, `vel` only by the audio thread.

## Test plan
- [x] `clang-format` clean (`python yse.py format`)
- [x] `clang-tidy` clean on modified code (`python yse.py analyze` per file) — no new findings; the 3 pre-existing `soundImplementation.cpp` warnings are outside the edited lines and part of the tracked baseline
- [x] unit/widget tests pass — full `ctest --preset tests-debug`: **17/17 test entries, 100%**
- [x] integration/e2e tests pass — new `Tests/listener/test_listener_concurrency.cpp` (3 cases): a direct `aPos` writer/reader race plus two integration races that drive the **real** listener API + audio update path and assert snapshot coherence. Verified with teeth: all three **fail** on the pre-fix component-wise implementation and **pass** with the seqlock; the listener suite is stable across repeated runs.
