### PR TITLE
FIX: close per-object patcher races — gToggle/gButton RMW, gGate index TOCTOU (#197)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(YSE_TEST_SOURCES
   patcher/test_patcher_setparams.cpp
   patcher/test_patcher_value_queue.cpp
   patcher/test_patcher_concurrency.cpp
+  patcher/test_patcher_object_races.cpp
   patcher/test_patcher_feedback_loop.cpp
   patcher/test_timerthread.cpp
   channel/test_channel.cpp
@@ -328,6 +329,7 @@ set_source_files_properties(
   patcher/test_patcher_setparams.cpp
   patcher/test_patcher_value_queue.cpp
   patcher/test_patcher_concurrency.cpp
+  patcher/test_patcher_object_races.cpp
   patcher/test_patcher_feedback_loop.cpp
   patcher/test_timerthread.cpp
   PROPERTIES COMPILE_FLAGS "${_patcher_test_suppress}"

--- a/Tests/patcher/test_patcher_object_races.cpp
+++ b/Tests/patcher/test_patcher_object_races.cpp
@@ -1,0 +1,208 @@
+// Object-level concurrency regression tests for patcher runtime objects
+// (issue #197). These target the per-object read-modify-write / index-vs-read
+// races between a control thread (GUI / timer) and the audio thread that the
+// graph-swap epic (#189/#234) does NOT cover, because they live inside a single
+// published object rather than in the topology:
+//
+//   * gToggle::Bang  — `value = !value` was an atomic load + a separate atomic
+//                      store, not a real RMW, so two concurrent flips collapse
+//                      into one (a lost update). The parity test below fails on
+//                      that code and passes once Bang is a compare-exchange.
+//   * gButton        — GUI_VALUE() read-then-cleared `on` in two steps, so a
+//                      press landing between the load and the store was dropped.
+//                      exchange(false) closes the window.
+//   * gGate          — the value handlers read the `activeOutlet` atomic several
+//                      times (bounds check + index). A concurrent SetActiveOutlet
+//                      could satisfy the check with a small value and then have
+//                      the index sample a large one -> out-of-bounds `outputs[]`
+//                      access. Loading it once into a local removes the TOCTOU;
+//                      the churn test is an AddressSanitizer gate (tests-asan),
+//                      exactly like test_patcher_concurrency.cpp.
+//
+// The patcher handlers are public (the PATCHER_CLASS macro opens `public:`), so
+// the tests drive them directly from several threads — that is precisely the
+// real hazard: pHandle::Set* run an inlet handler synchronously on the control
+// thread while the audio thread runs the same handler during traversal.
+//
+// doctest assertion macros are not thread-safe, so worker threads never call
+// them: they only touch the object under test, and every CHECK runs on the main
+// thread after all workers have joined. No audio device required.
+
+#include <doctest/doctest.h>
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "patcher/guiObjects/gButton.h"
+#include "patcher/guiObjects/gToggle.h"
+#include "patcher/genericObjects/gGate.h"
+#include "patcher/sinks.hpp"
+
+using TestHelpers::MultiSink;
+
+TEST_SUITE("patcher") {
+
+  // ─── gToggle ────────────────────────────────────────────────────────────────
+
+  TEST_CASE("gToggle: concurrent bangs preserve toggle parity (atomic RMW)") {
+    // An even total number of flips must return the toggle to its initial
+    // "off" state. With the old load+store flip, concurrent bangs lose updates
+    // and the final parity comes out wrong on some runs; the compare-exchange
+    // RMW makes every flip count, so the result is deterministic.
+    constexpr int kThreads = 4;
+    constexpr int kFlipsPerThread = 60000; // kThreads*kFlipsPerThread is even
+    static_assert((kThreads * kFlipsPerThread) % 2 == 0, "total flips must be even");
+
+    // A few trials so a rare lucky interleaving on broken code still gets caught.
+    for (int trial = 0; trial < 5; ++trial) {
+      YSE::PATCHER::gToggle t;
+      std::atomic<bool> go{false};
+
+      std::vector<std::thread> flippers;
+      flippers.reserve(kThreads);
+      for (int i = 0; i < kThreads; ++i) {
+        flippers.emplace_back([&] {
+          while (!go.load(std::memory_order_acquire)) {}
+          for (int n = 0; n < kFlipsPerThread; ++n) {
+            t.Bang(0, YSE::T_GUI);
+          }
+        });
+      }
+      go.store(true, std::memory_order_release);
+      for (auto& th : flippers)
+        th.join();
+
+      // Even number of real toggles from "off" -> back to "off".
+      CHECK(t.GetGuiValue() == "off");
+    }
+  }
+
+  // ─── gButton ────────────────────────────────────────────────────────────────
+
+  TEST_CASE("gButton: a press is never lost across a concurrent poll (exchange)") {
+    // The producer presses the button once per round; a poller polls in a tight
+    // loop. With atomic read-and-clear (exchange), the press is always observed
+    // either by the poller or by the main-thread drain poll after the producer
+    // stops — it can never be silently cleared. Read-then-clear could drop the
+    // press that lands between its load and store.
+    constexpr int kRounds = 20000;
+    int losses = 0;
+
+    for (int round = 0; round < kRounds; ++round) {
+      YSE::PATCHER::gButton b;
+      std::atomic<bool> pressed{false};
+      std::atomic<bool> sawOn{false};
+      std::atomic<bool> stop{false};
+
+      std::thread poller([&] {
+        while (!stop.load(std::memory_order_acquire)) {
+          if (b.GetGuiValue() == "on") sawOn.store(true, std::memory_order_release);
+        }
+      });
+
+      b.Bang(0, YSE::T_GUI);
+      pressed.store(true, std::memory_order_release);
+      stop.store(true, std::memory_order_release);
+      poller.join();
+
+      // Drain: after the poller stopped, the press must be visible somewhere.
+      const bool drainOn = (b.GetGuiValue() == "on");
+      if (!sawOn.load(std::memory_order_acquire) && !drainOn) ++losses;
+    }
+
+    CHECK(losses == 0);
+  }
+
+  TEST_CASE("gButton: concurrent presses and polls keep the coalescing invariant") {
+    // High-contention smoke/ASan exercise: many presses, one poller. Every
+    // observed "on" must correspond to at least one press (never a phantom),
+    // and the object must survive the storm.
+    YSE::PATCHER::gButton b;
+    std::atomic<bool> stop{false};
+    std::atomic<long> presses{0};
+    std::atomic<long> observed{0};
+
+    std::thread poller([&] {
+      while (!stop.load(std::memory_order_acquire)) {
+        if (b.GetGuiValue() == "on") observed.fetch_add(1, std::memory_order_relaxed);
+      }
+      // Final drain so the last press is accounted for.
+      if (b.GetGuiValue() == "on") observed.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    std::vector<std::thread> pressers;
+    pressers.reserve(3);
+    for (int i = 0; i < 3; ++i) {
+      pressers.emplace_back([&] {
+        for (int n = 0; n < 100000; ++n) {
+          b.Bang(0, YSE::T_GUI);
+          presses.fetch_add(1, std::memory_order_relaxed);
+        }
+      });
+    }
+    for (auto& th : pressers)
+      th.join();
+    stop.store(true, std::memory_order_release);
+    poller.join();
+
+    // Presses coalesce, so observed <= presses, and at least one must be seen.
+    CHECK(observed.load() >= 1);
+    CHECK(observed.load() <= presses.load());
+  }
+
+  // ─── gGate ──────────────────────────────────────────────────────────────────
+
+  TEST_CASE("gGate: activeOutlet churn never indexes out of bounds (ASan gate)") {
+    // AddressSanitizer regression for the index-vs-read TOCTOU: on the old code
+    // the value handler bounds-checked `activeOutlet` and then re-read it for the
+    // index, so a concurrent SetActiveOutlet flipping it to a large value between
+    // the two reads drove `outputs[large]` out of bounds. Loading it once fixes
+    // it. Under tests-asan this trips on the broken code; it must stay clean on
+    // the fixed code. In a plain (non-ASan) build it is a liveness smoke test.
+    // Storm with no outlets connected: the OOB index happens inside the handler
+    // before any downstream send, so connections are unnecessary — and leaving
+    // them off keeps the value threads from racing on a shared sink's plain
+    // fields (which would false-positive the TSan leg rather than exercise the
+    // object under test).
+    YSE::PATCHER::gGate gate; // default: 2 value outlets, activeOutlet == 0
+    std::atomic<bool> stop{false};
+
+    // Selector thread: alternate the active outlet between a valid index (1) and
+    // a wildly out-of-range one (a large value). The out-of-range selections must
+    // simply be dropped by the handler's bounds check, never indexed.
+    std::thread selector([&] {
+      int flip = 0;
+      while (!stop.load(std::memory_order_acquire)) {
+        gate.SetActiveOutlet((flip++ & 1) ? 1 : 1000000, 0, YSE::T_GUI);
+      }
+    });
+
+    // Value threads: hammer the value inlet with every message kind.
+    auto valueBody = [&] {
+      while (!stop.load(std::memory_order_acquire)) {
+        gate.SetIntValue(7, 1, YSE::T_GUI);
+        gate.SetFloatValue(1.5f, 1, YSE::T_GUI);
+        gate.SetBangValue(1, YSE::T_GUI);
+        gate.SetListValue("x", 1, YSE::T_GUI);
+      }
+    };
+    std::thread v0(valueBody), v1(valueBody);
+
+    for (volatile int spin = 0; spin < 2000000; ++spin) {}
+    stop.store(true, std::memory_order_release);
+    selector.join();
+    v0.join();
+    v1.join();
+
+    // Survived the storm; a well-formed selection still routes correctly.
+    MultiSink sink0;
+    gate.ConnectOutlet(sink0.GetInlet(0), 0);
+    sink0.ConnectInlet(gate.GetOutlet(0), 0);
+    gate.SetActiveOutlet(1, 0, YSE::T_GUI);
+    gate.SetIntValue(42, 1, YSE::T_GUI);
+    CHECK(sink0.gotInt);
+    CHECK(sink0.intValue == 42);
+  }
+
+} // TEST_SUITE("patcher")

--- a/YseEngine/patcher/genericObjects/gGate.cpp
+++ b/YseEngine/patcher/genericObjects/gGate.cpp
@@ -52,26 +52,38 @@ PARM_PARSE() {
   }
 }
 
+// Snapshot activeOutlet once per value delivery. Reading the atomic separately
+// for the bounds check and the index is a TOCTOU: a concurrent SetActiveOutlet
+// (control thread) could satisfy the check with a valid index and then have the
+// index expression sample a larger value, driving `outputs[]` out of bounds
+// (issue #197). `outputs` itself is never resized on a published object — a
+// live SetParams that changes the outlet count goes through the graph-swap
+// rebuild path (issue #234), not an in-place PARM_PARSE — so a single load of
+// the selector is all that is needed here.
 BANG_IN(SetBangValue) {
-  if (activeOutlet > 0 && (unsigned int)activeOutlet <= outputs.size()) {
-    outputs[activeOutlet - 1].SendBang(thread);
+  const int active = activeOutlet.load(std::memory_order_relaxed);
+  if (active > 0 && (unsigned int)active <= outputs.size()) {
+    outputs[active - 1].SendBang(thread);
   }
 }
 
 INT_IN(SetIntValue) {
-  if (activeOutlet > 0 && (unsigned int)activeOutlet <= outputs.size()) {
-    outputs[activeOutlet - 1].SendInt(value, thread);
+  const int active = activeOutlet.load(std::memory_order_relaxed);
+  if (active > 0 && (unsigned int)active <= outputs.size()) {
+    outputs[active - 1].SendInt(value, thread);
   }
 }
 
 FLOAT_IN(SetFloatValue) {
-  if (activeOutlet > 0 && (unsigned int)activeOutlet <= outputs.size()) {
-    outputs[activeOutlet - 1].SendFloat(value, thread);
+  const int active = activeOutlet.load(std::memory_order_relaxed);
+  if (active > 0 && (unsigned int)active <= outputs.size()) {
+    outputs[active - 1].SendFloat(value, thread);
   }
 }
 
 LIST_IN(SetListValue) {
-  if (activeOutlet > 0 && (unsigned int)activeOutlet <= outputs.size()) {
-    outputs[activeOutlet - 1].SendList(value, thread);
+  const int active = activeOutlet.load(std::memory_order_relaxed);
+  if (active > 0 && (unsigned int)active <= outputs.size()) {
+    outputs[active - 1].SendList(value, thread);
   }
 }

--- a/YseEngine/patcher/guiObjects/gButton.cpp
+++ b/YseEngine/patcher/guiObjects/gButton.cpp
@@ -33,9 +33,12 @@ FLOAT_IN(SetFloat) {
 }
 
 GUI_VALUE() {
-  bool value = on;
-  on = false;
-  return value ? "on" : "off";
+  // Atomic read-and-clear. A plain `bool v = on; on = false;` is a load then a
+  // separate store, so a press that lands between the two (writers run on the
+  // audio thread during traversal and on the control thread) is silently
+  // cleared and never reported — a lost press (issue #197). exchange() reads
+  // and clears in one indivisible step.
+  return on.exchange(false, std::memory_order_relaxed) ? "on" : "off";
 }
 
 CALC() {

--- a/YseEngine/patcher/guiObjects/gToggle.cpp
+++ b/YseEngine/patcher/guiObjects/gToggle.cpp
@@ -30,7 +30,16 @@ INT_IN(SetValue) {
 }
 
 BANG_IN(Bang) {
-  value = !value;
+  // Atomic flip. A plain `value = !value` is an atomic load followed by a
+  // separate atomic store, so two concurrent bangs (GUI/timer thread racing
+  // the audio thread) can both read the same state and collapse into a single
+  // flip — a lost update (issue #197). compare_exchange makes it a real RMW;
+  // the retry loop is lock-free and never allocates, so it is audio-thread
+  // safe. std::atomic<bool> has no fetch_xor, hence the CAS.
+  bool current = value.load(std::memory_order_relaxed);
+  while (!value.compare_exchange_weak(current, !current, std::memory_order_relaxed)) {
+    // `current` is refreshed with the latest value on failure; retry.
+  }
 }
 
 GUI_VALUE() {


### PR DESCRIPTION
## Summary

Closes three per-object concurrency races in the patcher runtime (writer = GUI/timer thread, reader = audio thread) that the wait-free graph-swap epic (#189/#234) did not cover, because they live *inside* a single published object rather than in the topology.

## Linked issue
Closes #197

## Changes

- **gToggle::Bang** — `value = !value` was an atomic load + a separate atomic store, not an RMW, so two concurrent flips collapsed into one lost update. Now a `compare_exchange_weak` loop on the `std::atomic<bool>` (which has no `fetch_xor`); lock-free, no allocation, audio-thread safe.
- **gButton::GetGuiValue** — read-then-cleared `on` in two steps (`bool v = on; on = false;`), dropping any press that landed between the load and the store. Now `on.exchange(false)`.
- **gGate value handlers** — read the `activeOutlet` atomic several times (bounds check + index), a TOCTOU that let a concurrent `SetActiveOutlet` satisfy the check with a small index and then index `outputs[]` with a large one → out-of-bounds access. Now the selector is loaded once into a local before check + index.

### Already covered by #234/#228 (documented, not re-fixed)
The issue also listed live in-place pin-vector reallocation on gGate/gSwitch and the `std::string` SetParams UAF. Those are already closed: a live `SetParams` on an object that registers clear/parse callbacks or a string/list param takes the off-graph **rebuild + atomic swap** path (`ReplaceObjectUnlocked`), never an in-place `PARM_PARSE`/`Set` on the rendering object. gSwitch's handler already reads `activeInlet` exactly once and does not index by it, so it needs no change.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on all touched files
- [x] `clang-tidy` (`python yse.py analyze`) clean — no new findings on the three sources or the test file
- [x] Unit/regression tests pass — new `Tests/patcher/test_patcher_object_races.cpp`:
  - gToggle parity test **confirmed failing on the pre-fix code** (final state `"on"` from lost updates) and **passing after the fix** — a genuine regression gate.
  - gButton lost-press test + coalescing-invariant contention test.
  - gGate `activeOutlet`-churn test — an AddressSanitizer gate (`tests-asan`) in the style of `test_patcher_concurrency.cpp`; trips on the broken index-vs-read on the CI ASan leg, stays clean on the fix.
- [x] Full suite green: `ctest --preset tests-debug` → 17/17 groups, 100%; patcher suite 219 cases / 4382 assertions pass.

Note on integration: this is engine-internal audio-thread concurrency with no user-visible/rendered surface to drive end-to-end; the multi-threaded regression tests above (plus the ASan/TSan CI legs) are the integration-level coverage for these races. ASan/TSan are Linux-only in this toolchain, so the ASan gate is exercised in CI rather than locally on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
