### PR TITLE
FIX: make occlusion callback pointer atomic (#199)

### DIFF
--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -18,6 +18,7 @@
 // give it a few milliseconds + several update calls to settle.
 
 #include <doctest/doctest.h>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <thread>
@@ -85,6 +86,10 @@ namespace {
   float occlusionStub(const YSE::Pos&, const YSE::Pos&) {
     ++g_occlusionCallCount;
     return 0.25f;
+  }
+  // Second, distinct callback so the round-trip test can tell the two apart.
+  float occlusionStub2(const YSE::Pos&, const YSE::Pos&) {
+    return 0.5f;
   }
 
 } // namespace
@@ -421,6 +426,78 @@ TEST_SUITE("sound") {
     YSE::System().occlusionCallback(occlusionStub);
     YSE::SOUND::updateOcclusion();
     CHECK(g_occlusionCallCount == 0);
+    YSE::System().occlusionCallback(nullptr);
+  }
+
+  // ─── Occlusion callback pointer is atomic (issue #199) ───────────────────────
+  //
+  // occlusionPtr is written by System().occlusionCallback(func) on the
+  // application thread and read by SOUND::updateOcclusion() on the control
+  // thread. It must be a std::atomic with release-store / acquire-load ordering
+  // (matching the C API callback-bridge convention) — a plain function pointer
+  // is a data race and lets the compiler cache the load. These tests pin the
+  // observable contract; the concurrency test is the one ThreadSanitizer flags
+  // on the pre-#199 plain-pointer version.
+
+  TEST_CASE("system: occlusionCallback install/read round-trips through the atomic (#199)") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::System().occlusionCallback(nullptr);
+    CHECK(YSE::System().occlusionCallback() == nullptr);
+
+    YSE::System().occlusionCallback(occlusionStub);
+    CHECK(YSE::System().occlusionCallback() == occlusionStub);
+
+    // Overwrite with a distinct callback — the getter must observe the new one.
+    YSE::System().occlusionCallback(occlusionStub2);
+    CHECK(YSE::System().occlusionCallback() == occlusionStub2);
+
+    YSE::System().occlusionCallback(nullptr);
+    CHECK(YSE::System().occlusionCallback() == nullptr);
+  }
+
+  TEST_CASE("system: occlusion callback atomic is lock-free (RT-safe) (#199)") {
+    // The control-thread read must never take a lock; guarantee it at compile
+    // time. Function pointers are pointer-sized, so this holds on every target.
+    CHECK(std::atomic<YSE::occlusionFunc>::is_always_lock_free);
+  }
+
+  TEST_CASE("system: concurrent install + read of the occlusion callback is race-free (#199)") {
+    if (!TestHelpers::engineInit()) return;
+    // A writer thread swaps the callback while a reader thread repeatedly loads
+    // it. On the fixed (atomic) code this is well-defined; on the pre-#199 plain
+    // pointer it is a data race that ThreadSanitizer reports. The reader only
+    // ever sees one of the installed values (or null) — never a torn pointer.
+    //
+    // Both threads spin on a start gate and then run for a fixed wall-clock
+    // window so their accesses genuinely overlap — otherwise the writer can
+    // finish before the reader is even scheduled and the race never manifests.
+    std::atomic<bool> go{false};
+    std::atomic<bool> readerFault{false};
+    auto deadline = [] {
+      return std::chrono::steady_clock::now() + std::chrono::milliseconds(150);
+    };
+    std::thread writer([&] {
+      while (!go.load(std::memory_order_acquire)) {}
+      const auto end = deadline();
+      int i = 0;
+      while (std::chrono::steady_clock::now() < end) {
+        YSE::System().occlusionCallback((i++ & 1) ? occlusionStub : occlusionStub2);
+      }
+    });
+    std::thread reader([&] {
+      while (!go.load(std::memory_order_acquire)) {}
+      const auto end = deadline();
+      while (std::chrono::steady_clock::now() < end) {
+        YSE::occlusionFunc cb = YSE::System().occlusionCallback();
+        if (!(cb == nullptr || cb == occlusionStub || cb == occlusionStub2)) {
+          readerFault.store(true, std::memory_order_relaxed);
+        }
+      }
+    });
+    go.store(true, std::memory_order_release);
+    writer.join();
+    reader.join();
+    CHECK(readerFault.load(std::memory_order_relaxed) == false);
     YSE::System().occlusionCallback(nullptr);
   }
 

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -163,12 +163,12 @@ YSE::system& YSE::system::autoReconnect(bool on, int delay) {
 }
 
 YSE::system& YSE::system::occlusionCallback(float (*func)(const YSE::Pos&, const YSE::Pos&)) {
-  occlusionPtr = func;
+  occlusionPtr.store(func, std::memory_order_release);
   return *this;
 }
 
 YSE::occlusionFunc YSE::system::occlusionCallback() {
-  return occlusionPtr;
+  return occlusionPtr.load(std::memory_order_acquire);
 }
 
 YSE::system::system() : occlusionPtr(nullptr) {}

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -15,6 +15,7 @@
 #include "headers/enums.hpp"
 #include "utils/vector.hpp"
 #include "classes.hpp"
+#include <atomic>
 #include <string>
 
 namespace YSE {
@@ -298,7 +299,13 @@ namespace YSE {
     bool initShared(bool openDevice);
     /// @endcond
 
-    float (*occlusionPtr)(const Pos& source, const Pos& listener);
+    // Written by occlusionCallback(func) on the application thread, read by
+    // SOUND::updateOcclusion() (also the control thread, but a different caller
+    // may install the callback than the one driving update()). Atomic with
+    // release/acquire ordering per the C API callback-bridge convention
+    // (c_api/yse_c_internal.hpp §callback bridge rules) — a plain pointer here
+    // is a data race and licenses the compiler to cache the load (issue #199).
+    std::atomic<occlusionFunc> occlusionPtr;
     int currentlyMissedCallbacks;
     bool doAutoReconnect;
     int reconnectDelay;


### PR DESCRIPTION
## Summary
`YSE::system::occlusionPtr` was a plain function pointer, written on the application thread by `occlusionCallback(func)` and read on the control thread by `SOUND::updateOcclusion()`. Concurrent non-atomic access is a data race (UB) that also licenses the compiler to cache the load. This makes it a `std::atomic<occlusionFunc>` with release-store / acquire-load, matching the C API callback-bridge convention in `yse_c_internal.hpp`.

Note: the issue's stale line reference (`soundImplementation.cpp:534-535`, "read on the audio thread") predates #209, which already moved the callback invocation off the audio callback onto the control thread. The memory-model defect it describes remained, and is what this PR fixes. The atomic is lock-free on all targets, so the control-thread read stays allocation- and lock-free.

## Linked issue
Closes #199

## Changes
- `system.hpp`: `occlusionPtr` is now `std::atomic<occlusionFunc>` (add `<atomic>`), with a comment explaining the threading contract and convention.
- `system.cpp`: setter uses `store(..., release)`, getter uses `load(acquire)`.
- `Tests/sound/test_sound_impl.cpp`: install/read round-trip test, a compile-time `is_always_lock_free` guarantee, and a concurrent install+read test.

## Test plan
- [x] `yse.py format` clean (no reformatting of changed files)
- [x] `yse.py analyze` clean — no new findings in modified code (system.cpp/hpp clean; the two test-file warnings are pre-existing lines, not this change)
- [x] Unit tests pass — `yse.py test`, 17/17 ctest suites green (Windows debug)
- [x] Concurrency/TSan regression verified in the Linux Docker container: the new concurrent install+read test **reports a ThreadSanitizer data race at `system.cpp:166/171` on the unpatched plain-pointer code** and runs **clean on the atomic fix**. The threads use a start gate + wall-clock window so their accesses genuinely overlap.

No dedicated end-to-end integration test: the change has no new user-visible behavior (a data-race / memory-ordering fix); its observable contract is the callback round-trip and thread-safety, both covered above, with TSan as the true regression gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)