### PR TITLE
FIX: remove unsynchronized cross-thread reads in device/sound managers (#200)

### DIFF
--- a/Tests/sound/test_sound_manager.cpp
+++ b/Tests/sound/test_sound_manager.cpp
@@ -38,14 +38,47 @@ namespace {
 
 TEST_SUITE("sound") {
 
-  TEST_CASE("SOUND::Manager: empty() reports state of implementations list") {
+  TEST_CASE("SOUND::Manager: empty() reflects active (toLoad/inUse) impls, not the raw list") {
     if (!TestHelpers::engineInit()) return;
-    // The manager is a singleton that has been touched by every prior test
-    // in this process, so empty() may already be false; assert only that the
-    // call itself is safe and returns a bool — covers the empty() definition.
-    bool e = YSE::SOUND::Manager().empty();
-    (void)e;
-    CHECK(true);
+    // empty() is the audio thread's "nothing to render" signal. After #200 it
+    // reads only the audio-thread-owned toLoad/inUse lists, never the
+    // mutex-guarded `implementations` list. A live DSP sound must make it
+    // report non-empty.
+    {
+      YSE::sound s;
+      s.create(g_src);
+      drain(); // let the impl reach inUse
+      CHECK(YSE::SOUND::Manager().empty() == false);
+      s.stop();
+    }
+    drain(); // release + delete the impl
+  }
+
+  TEST_CASE("SOUND::Manager: a failed file-create never flips empty() to non-empty (#200)") {
+    if (!TestHelpers::engineInit()) return;
+    // Regression for #200: sound::create(fileName) adds an implementationObject
+    // to `implementations` BEFORE it validates the file, then on a missing file
+    // fails without ever handing the impl to setup() — so it lingers in
+    // `implementations` but never enters toLoad/inUse. The pre-fix empty()
+    // read `implementations.empty()`, so this stuck impl made it report
+    // non-empty forever (and, worse, read that list lock-free from the audio
+    // callback). The fixed empty() ignores it.
+    //
+    // Assert the invariant rather than an absolute empty() value: the SOUND
+    // manager is a process-wide singleton other tests have touched, so the
+    // baseline may already be non-empty. `after == before` holds on the fixed
+    // code regardless; on the pre-fix code it breaks whenever the baseline is
+    // empty (true -> false), so the test can only ever fail on a regression.
+    drain(); // settle any pending lifecycle work first
+    const bool before = YSE::SOUND::Manager().empty();
+    {
+      YSE::sound s;
+      s.create("/no/such/file.wav"); // FileExists() fails -> create() returns false
+      CHECK(s.isValid() == false); // confirm we hit the failure path
+    }
+    drain();
+    const bool after = YSE::SOUND::Manager().empty();
+    CHECK(after == before);
   }
 
   TEST_CASE("SOUND::Manager: addFile by filename returns a valid soundFile pointer or null") {

--- a/YseEngine/device/androidDeviceManager.cpp
+++ b/YseEngine/device/androidDeviceManager.cpp
@@ -13,7 +13,7 @@ YSE::DEVICE::managerObject& YSE::DEVICE::Manager() {
   return d;
 }
 
-YSE::DEVICE::managerObject::managerObject() : initDone(false), open(false) {}
+YSE::DEVICE::managerObject::managerObject() {}
 
 YSE::DEVICE::managerObject::~managerObject() {}
 
@@ -71,6 +71,13 @@ unsigned int YSE::DEVICE::managerObject::GetCallbacksSinceLastUpdate() {
   return implementation.GetCallbacksSinceLastUpdate();
 }
 
+void YSE::DEVICE::managerObject::serviceReconnect() {
+  // Runs on the control thread (system::update). Hands the pending reopen to the
+  // Oboe implementation, which rebuilds a disconnected stream off the error
+  // thread (issue #200).
+  implementation.serviceReconnect();
+}
+
 void YSE::DEVICE::managerObject::openDevice(const YSE::deviceSetup& object) {
   // android only has one device for now
   return;
@@ -85,7 +92,8 @@ void YSE::DEVICE::managerObject::close() {
   // close() after pause() — which now clears `open` but leaves the Oboe stream
   // suspended — still tears the stream down on the engine-shutdown path.
   implementation.Stop();
-  initDone = open = false;
+  initDone = false;
+  open = false;
   // YSE::Log().sendMessage("androidDeviceManager: Close done");
 }
 

--- a/YseEngine/device/androidDeviceManager.h
+++ b/YseEngine/device/androidDeviceManager.h
@@ -2,6 +2,8 @@
 
 #if YSE_ANDROID
 
+#include <atomic>
+
 #include "../classes.hpp"
 #include "../headers/types.hpp"
 #include "deviceManager.h"
@@ -30,6 +32,7 @@ namespace YSE {
       virtual void updateDeviceList();
       virtual void openDevice(const YSE::deviceSetup& object);
       virtual void addCallback();
+      virtual void serviceReconnect();
 
       // Live device-state getters (see deviceManager.h for contract).
       virtual double getActiveSampleRate() const;
@@ -38,7 +41,10 @@ namespace YSE {
 
     private:
       OboeImplementation implementation;
-      bool initDone, open;
+      // Written on the main thread (init/pause/resume/close), read cross-thread
+      // by the getActive* getters. Atomic to make those reads race-free (#200).
+      std::atomic<bool> initDone{false};
+      std::atomic<bool> open{false};
     };
 
     managerObject& Manager();

--- a/YseEngine/device/deviceManager.h
+++ b/YseEngine/device/deviceManager.h
@@ -77,6 +77,13 @@ namespace YSE {
       virtual void openDevice(const YSE::deviceSetup&) {};
       virtual void addCallback() {};
 
+      /* Service a device rebuild requested from a backend error thread (e.g.
+         Oboe's onErrorAfterClose flags a disconnect). Called once per
+         control-thread tick from system::update() so the actual reopen runs on
+         the main thread rather than the backend's error thread. No-op for
+         backends without deferred reconnect. (issue #200) */
+      virtual void serviceReconnect() {};
+
       bool doOnCallback(int numSamples);
 
       /* Render one STANDARD_BUFFERSIZE-sample block through the channel

--- a/YseEngine/device/oboeImplementation.cpp
+++ b/YseEngine/device/oboeImplementation.cpp
@@ -182,11 +182,26 @@ void OboeImplementation::updateCpuLoadEma(std::chrono::steady_clock::time_point 
 void OboeImplementation::onErrorAfterClose(oboe::AudioStream* /*stream*/, oboe::Result error) {
   // Oboe has already closed the stream by the time this fires (vs. onErrorBeforeClose).
   // Headphone unplug / USB device removal trips Disconnected; transparently rebuild.
-  YSE::INTERNAL::LogImpl().emit(YSE::E_DEBUG, "Oboe: stream disconnected, restarting");
+  //
+  // This runs on Oboe's error thread. It must NOT touch mStream, allocate
+  // (openStream does `new float*[]`), or write the plain members the audio
+  // callback reads — doing so raced a concurrent close()/pause() from the main
+  // thread (issue #200). Only flag the request; serviceReconnect() performs the
+  // reopen from the main-thread update path.
   if (error == oboe::Result::ErrorDisconnected) {
-    mStream.reset();
-    openStream(numChannels);
+    YSE::INTERNAL::LogImpl().emit(YSE::E_DEBUG, "Oboe: stream disconnected, reconnect requested");
+    reconnectRequested = true;
   }
+}
+
+void OboeImplementation::serviceReconnect() {
+  // Runs on the main-thread update path (system::update via the device manager),
+  // never the Oboe error thread. Because close()/pause()/resume() are also
+  // driven from that thread, rebuilding here serialises the reopen with them —
+  // closing the cross-thread race the error-thread reopen had (issue #200).
+  if (!reconnectRequested.exchange(false)) return;
+  mStream.reset();
+  openStream(numChannels);
 }
 
 #endif

--- a/YseEngine/device/oboeImplementation.h
+++ b/YseEngine/device/oboeImplementation.h
@@ -42,8 +42,17 @@ public:
                                         int32_t numFrames) override;
 
   // Stream disconnected (headphone unplug, USB removed, etc.). Oboe has already
-  // closed the stream; we rebuild it on a non-realtime thread.
+  // closed the stream. Runs on Oboe's error thread: it only records that a
+  // rebuild is due and returns — the actual reopen happens in serviceReconnect()
+  // on the main thread (issue #200).
   void onErrorAfterClose(oboe::AudioStream* stream, oboe::Result error) override;
+
+  // Perform a pending stream rebuild requested by onErrorAfterClose. Must be
+  // called from the main-thread update path (never the audio or error thread)
+  // so the reopen — which allocates and rewrites members the audio callback
+  // reads — is serialised with close()/pause()/resume() (issue #200). No-op
+  // when no reconnect has been requested.
+  void serviceReconnect();
 
 private:
   bool openStream(int channels);
@@ -61,6 +70,11 @@ private:
 
   std::atomic<unsigned int> callbacksSinceLastUpdate{0};
   std::atomic<float> cpuLoadEma{0.f};
+
+  // Set by onErrorAfterClose (Oboe error thread), consumed by serviceReconnect
+  // (main thread). Decouples the disconnect notification from the actual stream
+  // rebuild so the reopen never runs on the error thread (issue #200).
+  std::atomic<bool> reconnectRequested{false};
 };
 
 #endif

--- a/YseEngine/sound/soundManager.cpp
+++ b/YseEngine/sound/soundManager.cpp
@@ -274,7 +274,16 @@ void YSE::SOUND::managerObject::garbageCollectFiles() {
 }
 
 Bool YSE::SOUND::managerObject::empty() {
-  return implementations.empty();
+  // Called only from the audio callback (deviceManager::doOnCallback). It must
+  // read ONLY audio-thread-owned state: `toLoad` and `inUse` are single-thread
+  // (audio) by design, whereas `implementations` is mutated by the main thread
+  // (addImplementation) and the slow-pool (deleteJob) under implementationsMutex.
+  // Reading `implementations`' head from the callback without that lock was a
+  // data race (issue #200). An impl becomes audible only once it has been
+  // drained from the inbox into `toLoad` and promoted into `inUse`, so the
+  // combined emptiness of those two lists is the audio thread's authoritative
+  // "nothing to render" signal.
+  return toLoad.empty() && inUse.empty();
 }
 
 /*AudioFormatReader * YSE::SOUND::managerObject::getReader(const File & f) {

--- a/YseEngine/sound/soundManager.h
+++ b/YseEngine/sound/soundManager.h
@@ -69,6 +69,9 @@ namespace YSE {
       */
       void update();
 
+      // Audio-thread-only: reports whether there is anything to render. Reads
+      // the audio-thread-owned toLoad/inUse lists, never the mutex-guarded
+      // `implementations` list. Call only from the audio callback. (issue #200)
       Bool empty();
 
       /** Sets the maximum amount of sounds to be processed. The soundmanager

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -105,6 +105,10 @@ void YSE::system::update() {
   // #125). Drains on the main thread, so the callback fires here — never on
   // the script thread. No-op unless built with YSE_ENABLE_PYTHON.
   INTERNAL::Global().drainScriptResults();
+  // Rebuild a disconnected audio device on this control thread rather than the
+  // backend's error thread (e.g. Oboe's onErrorAfterClose). No-op on backends
+  // that reconnect synchronously (issue #200).
+  DEVICE::Manager().serviceReconnect();
   unsigned int callbacks = DEVICE::Manager().GetCallbacksSinceLastUpdate();
   if (callbacks == 0) {
     currentlyMissedCallbacks++;


### PR DESCRIPTION
## Summary

Closes the three unsynchronized cross-thread reads bundled in the 2026-07-02
lock-free architecture audit (issue #200).

1. **`SOUND::Manager().empty()` read the mutex-guarded `implementations` list
   lock-free from the audio callback.** `implementations` is mutated by the main
   thread (`addImplementation`) and the slow pool (`deleteJob`) under
   `implementationsMutex`; reading its head from `doOnCallback` was a data race.
   `empty()` now reads only the audio-thread-owned `toLoad`/`inUse` lists — the
   authoritative "nothing to render" signal — so the callback never touches
   `implementations`.

2. **Oboe `onErrorAfterClose` rebuilt the stream on Oboe's error thread.** It
   allocated (`new float*[]`) and wrote plain members the audio callback reads,
   with no guard against a concurrent main-thread `close()`/`pause()`. It now
   only sets an atomic `reconnectRequested` flag; the actual reopen happens in a
   new `OboeImplementation::serviceReconnect()` driven from `system::update()`
   on the control thread, serialised with `close()/pause()/resume()`. Wired
   through a no-op `deviceManager::serviceReconnect()` virtual (Android
   overrides it).

3. **`androidDeviceManager` `open`/`initDone`** are now `std::atomic<bool>` so
   the cross-thread `getActive*` getters read them race-free.

## Linked issue
Closes #200

## Changes
- `sound/soundManager.{h,cpp}` — `empty()` reads `toLoad`/`inUse`, not `implementations`.
- `device/oboeImplementation.{h,cpp}` — atomic reconnect flag + `serviceReconnect()`; error thread only flags.
- `device/androidDeviceManager.{h,cpp}` — atomic `open`/`initDone`; `serviceReconnect()` override.
- `device/deviceManager.h` — no-op `serviceReconnect()` virtual.
- `system.cpp` — call `DEVICE::Manager().serviceReconnect()` once per control tick.
- `Tests/sound/test_sound_manager.cpp` — regression + behavioral tests.

## Test plan
- [x] `yse.py format` clean (no diff outside the touched files)
- [x] `yse.py analyze` clean on the modified cross-platform sources (`soundManager.cpp`, `system.cpp`); the one test-file finding is on pre-existing unmodified `SilentSource`.
- [x] `yse.py test` — full ctest suite green (17/17 executables, incl. the live-audio `integration` and `concurrency` suites).
- [x] Added regression test **verified to fail on the pre-fix `empty()`** (`CHECK(after == before)` → `false == true`) and pass with the fix.
- [x] Android arm64 build (`cmake --build build-android-arm64`) compiles + links `libyse.so` under the NDK — Parts 2 & 3 are `#if YSE_ANDROID` and not reachable by the desktop unit suite or clang-tidy, so they are covered by the NDK compile + on-device runs rather than a desktop integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
