### PR TITLE
FIX: lfQueue destructor leaks blocks; MSVC/ARM64 fence path (#201)

### DIFF
--- a/Tests/utils/test_lfqueue.cpp
+++ b/Tests/utils/test_lfqueue.cpp
@@ -5,6 +5,41 @@
 #include <thread>
 #include <vector>
 
+namespace {
+  // Element type that tracks how many instances are currently alive. Used to
+  // prove the queue destructor runs ~T() for every element it still holds.
+  struct LiveCounter {
+    static int live;
+    int value;
+    LiveCounter() : value(0) {
+      ++live;
+    }
+    explicit LiveCounter(int v) : value(v) {
+      ++live;
+    }
+    LiveCounter(const LiveCounter& o) : value(o.value) {
+      ++live;
+    }
+    LiveCounter(LiveCounter&& o) noexcept : value(o.value) {
+      ++live;
+    }
+    // Assignment transfers the value only — neither object is created or
+    // destroyed, so the live count is unchanged.
+    LiveCounter& operator=(const LiveCounter& o) {
+      if (this != &o) value = o.value;
+      return *this;
+    }
+    LiveCounter& operator=(LiveCounter&& o) noexcept {
+      if (this != &o) value = o.value;
+      return *this;
+    }
+    ~LiveCounter() {
+      --live;
+    }
+  };
+  int LiveCounter::live = 0;
+} // namespace
+
 TEST_SUITE("utils") {
 
   TEST_CASE("lfQueue: single element push/pop round-trip") {
@@ -102,6 +137,46 @@ TEST_SUITE("utils") {
     REQUIRE(static_cast<int>(received.size()) == N);
     for (int i = 0; i < N; ++i)
       CHECK(received[i] == i);
+  }
+
+  TEST_CASE("lfQueue: destructor destroys every element across all blocks (issue #201)") {
+    // Regression: the destructor walked frontBlock..tailBlock and stopped
+    // *before* the tail block, so any live elements still sitting in the tail
+    // block (and the tail block's memory, plus any free blocks) were leaked.
+    LiveCounter::live = 0;
+    {
+      // maxSize=1 gives a 1-slot initial block; push() then doubles the block
+      // size on each overflow, so 16 un-popped elements span several blocks and
+      // the last few land in the tail block.
+      YSE::lfQueue<LiveCounter> q(1);
+      for (int i = 0; i < 16; ++i)
+        q.push(LiveCounter(i));
+      CHECK(LiveCounter::live == 16);
+    } // queue destroyed here
+    CHECK(LiveCounter::live == 0);
+  }
+
+  TEST_CASE("lfQueue: destructor walks the full block circle when free blocks exist "
+            "(issue #201)") {
+    // After allocating several blocks and then draining the queue, the block
+    // circle contains empty "free" blocks between the tail and front. The
+    // destructor must delete those too. This also exercises the full-circle
+    // walk over empty blocks without double-free or crash.
+    LiveCounter::live = 0;
+    {
+      YSE::lfQueue<LiveCounter> q(1);
+      for (int i = 0; i < 16; ++i)
+        q.push(LiveCounter(i));
+      LiveCounter out;
+      for (int i = 0; i < 16; ++i)
+        CHECK(q.try_pop(out) == true);
+      CHECK(LiveCounter::live == 1); // only `out` remains alive
+      // Re-fill partially so the tail advances into the previously-freed blocks.
+      for (int i = 0; i < 5; ++i)
+        q.push(LiveCounter(i));
+      CHECK(LiveCounter::live == 6); // `out` + 5 queued
+    } // queue destroyed here — 5 queued elements must be destructed
+    CHECK(LiveCounter::live == 0);
   }
 
 } // TEST_SUITE("utils")

--- a/YseEngine/utils/atomicOps.hpp
+++ b/YseEngine/utils/atomicOps.hpp
@@ -85,8 +85,14 @@ namespace YSE {
 
 } // namespace YSE
 
-#if defined(AE_VCPP) || defined(AE_ICC)
-// VS2010 and ICC13 don't support std::atomic_*_fence, implement our own fences
+#if (defined(AE_VCPP) && _MSC_VER < 1700) || defined(AE_ICC)
+// VS2010 and ICC13 don't support std::atomic_*_fence, implement our own fences.
+// Only pre-VS2012 MSVC (_MSC_VER < 1700) needs this legacy intrinsic path;
+// modern MSVC falls through to the std::atomic_thread_fence path below. That
+// also avoids referencing the never-defined AeFullSync/AeLiteSync macros on
+// architectures with no intrinsic branch here (e.g. MSVC/ARM64, which lands in
+// AE_ARCH_UNKNOWN), which would otherwise fail to compile. This mirrors the
+// _MSC_VER >= 1700 gate already used for weak_atomic below.
 
 #include <intrin.h>
 

--- a/YseEngine/utils/lfQueue.hpp
+++ b/YseEngine/utils/lfQueue.hpp
@@ -102,9 +102,14 @@ namespace YSE {
       // Make sure we get the latest version of all variables from other CPUs:
       fence(memory_order_sync);
 
-      // Destroy any remaining objects in queue and free memory
-      Block* tailBlock_ = tailBlock;
-      Block* block = frontBlock;
+      // Destroy any remaining objects in queue and free memory.
+      // Blocks form a circular linked list; walk the whole circle back to the
+      // starting block so every block (including the tail block and any free
+      // blocks between the tail and front) is destroyed. Stopping at tailBlock
+      // — as an earlier version did — leaked the tail block, the free blocks,
+      // and any live elements still held in the tail block.
+      Block* frontBlock_ = frontBlock;
+      Block* block = frontBlock_;
       do {
         Block* nextBlock = block->next;
         size_t blockFront = block->front;
@@ -119,7 +124,7 @@ namespace YSE {
         delete block;
         block = nextBlock;
 
-      } while (block != tailBlock_);
+      } while (block != frontBlock_);
     }
 
     // Enqueues a copy of element if there is room in the queue.


### PR DESCRIPTION
## Summary
Fixes the two actionable issues from the lock-free audit for the in-tree
vendored `utils/lfQueue.hpp` + `utils/atomicOps.hpp` (a 2013-vintage copy of
moodycamel's ReaderWriterQueue maintained in-tree):

1. **Destructor leak** — `~lfQueue()` walked `frontBlock..tailBlock` and stopped
   *before* the tail block, leaking the tail block, any free blocks between tail
   and front, and any live elements still held in the tail block (their `~T()`
   never ran). Now walks the whole circular block list back to the starting
   block, matching upstream. Shutdown-only leak.
2. **MSVC/ARM64 fence path** — `atomicOps.hpp` selected the legacy intrinsic
   fence path for *all* MSVC, referencing the never-defined
   `AeFullSync`/`AeLiteSync` on architectures with no intrinsic branch (e.g.
   MSVC/ARM64 → `AE_ARCH_UNKNOWN`), failing to compile. Gated the legacy path on
   `_MSC_VER < 1700` so modern MSVC uses the `std::atomic_thread_fence` path,
   mirroring the existing `weak_atomic` gate. Latent portability fix (no such
   build target today; the CI toolchain is Clang, which already uses the std
   path and is unaffected).

Item 3 from the audit (benign spurious-full under bursts) is explicitly
no-action and untouched.

## Linked issue
Closes #201

## Changes
- `YseEngine/utils/lfQueue.hpp` — destructor loops the full block circle back to `frontBlock`.
- `YseEngine/utils/atomicOps.hpp` — legacy fence path gated on `(AE_VCPP && _MSC_VER < 1700) || AE_ICC`.
- `Tests/utils/test_lfqueue.cpp` — two regression tests.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on all three files
- [x] `python yse.py analyze` clean on the test TU and an engine TU including the headers (no new user-code findings)
- [x] Unit tests pass — `utils` suite 85/85 cases, 13582 assertions; full `ctest` 17/17 tests pass
- [x] Regression verified: the multi-block destructor test **fails on the unpatched code** (`live == 5`, tail-block elements leaked) and **passes with the fix** (`live == 0`)

**On the integration test:** no separate end-to-end test was added. The change is not user-visible — a shutdown-only memory-lifetime fix in an internal SPSC queue and a compile-time preprocessor gate for a build target (MSVC/ARM64) that does not exist in this project. There is no runtime flow a user can drive to observe it; the leak is exercised deterministically by the unit regression test via a live-instance counter, and the fence gate is compile-only and inactive on the Clang CI toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)