### PR TITLE
FIX: 5.1/7.1 surround — init angles, LFE handling, platform channel order (#203)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -240,7 +240,7 @@ system& occlusionCallback(float(*func)(const Pos& source, const Pos& listener));
 
 The callback runs on the **control thread** (inside `System().update()`), once per occlusion-enabled sound per tick — never on the audio callback thread. Its clamped result is handed to the audio thread over the sound message queue, so a raycast that locks or allocates cannot stall the audio callback ([#209](https://github.com/yvanvds/yse-soundengine/issues/209)).
 
-**Output channel configurations:** `CT_MONO CT_STEREO CT_QUAD CT_51 CT_51SIDE CT_61 CT_71 CT_CUSTOM`
+**Output channel configurations:** `CT_MONO CT_STEREO CT_QUAD CT_51 CT_51SIDE CT_61 CT_71 CT_CUSTOM`. The `.1` layouts follow the platform-standard channel order (`FL FR FC LFE …`) with the LFE at index 3; the LFE output is flagged and excluded from azimuth panning, so positional sounds are never panned into the subwoofer ([#203](https://github.com/yvanvds/yse-soundengine/issues/203)).
 
 ---
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(YSE_TEST_SOURCES
   channel/test_channel_concurrency.cpp
   channel/test_channel_metering.cpp
   channel/test_channel_bus.cpp
+  channel/test_channel_layout.cpp
   sound/test_sound_state.cpp
   sound/test_sound_streaming.cpp
   sound/test_sound_impl.cpp

--- a/Tests/channel/test_channel_layout.cpp
+++ b/Tests/channel/test_channel_layout.cpp
@@ -1,0 +1,185 @@
+// Tests for surround speaker-layout configuration in the channel manager
+// (issue #203). Covers the three defects the issue documents, all in
+// YseEngine/channel/channelManager.cpp:
+//
+//   1. Uninitialized speaker angle — every allocated output must read a
+//      defined angle (value-initialised array), not indeterminate memory.
+//   2. No LFE concept — the .1 output must be flagged so it is excluded from
+//      azimuth panning (getOutputIsLFE()).
+//   3. Wrong physical channel order — 5.1/6.1/7.1 must follow the platform
+//      standard order (FL FR FC LFE ...), with the LFE at index 3.
+//
+// These drive the real CHANNEL::Manager() through its public
+// setChannelConf()/changeChannelConf() API and read back the per-output angle
+// and LFE flag. Like the sibling channel tests they guard on engineInit()
+// (which pauses the audio stream, so the test thread is the sole caller) and
+// each case restores the default stereo layout so later tests see the engine
+// in its initial state.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include "channel/channelInterface.hpp"
+#include "channel/channelManager.h"
+#include "headers/enums.hpp"
+#include "support/null_device.hpp"
+
+namespace {
+
+  // Same conversion the manager uses (utils/misc.hpp Pi = 3.14159265f).
+  constexpr float kPi = 3.14159265f;
+  float rad(float degrees) {
+    return kPi / 180.0f * degrees;
+  }
+
+  // Restore the layout System().init() leaves behind so the shared engine
+  // singleton looks untouched to subsequent test cases.
+  void restoreStereo() {
+    YSE::CHANNEL::Manager().setChannelConf(YSE::CT_STEREO, 2);
+    YSE::CHANNEL::Manager().changeChannelConf();
+  }
+
+  void applyLayout(YSE::CHANNEL_TYPE type, int outputs) {
+    YSE::CHANNEL::Manager().setChannelConf(type, outputs);
+    YSE::CHANNEL::Manager().changeChannelConf();
+  }
+
+} // namespace
+
+TEST_SUITE("channel") {
+
+  // ─── 5.1: LFE at index 3, platform channel order ─────────────────────────────
+
+  TEST_CASE("channel layout: CT_51 uses FL FR FC LFE BL BR order with LFE at index 3 (#203)") {
+    if (!TestHelpers::engineInit()) return;
+    auto& m = YSE::CHANNEL::Manager();
+    applyLayout(YSE::CT_51, 6);
+
+    CHECK(m.getNumberOfOutputs() == 6);
+
+    // Only index 3 is the LFE.
+    CHECK(m.getOutputIsLFE(3) == true);
+    CHECK(m.getOutputIsLFE(0) == false);
+    CHECK(m.getOutputIsLFE(1) == false);
+    CHECK(m.getOutputIsLFE(2) == false);
+    CHECK(m.getOutputIsLFE(4) == false);
+    CHECK(m.getOutputIsLFE(5) == false);
+
+    // Angles: FL FR FC (LFE=0) BL BR.
+    CHECK(m.getOutputAngle(0) == doctest::Approx(rad(-45.f)));
+    CHECK(m.getOutputAngle(1) == doctest::Approx(rad(45.f)));
+    CHECK(m.getOutputAngle(2) == doctest::Approx(rad(0.f)));
+    CHECK(m.getOutputAngle(3) == doctest::Approx(0.f)); // LFE is not panned
+    CHECK(m.getOutputAngle(4) == doctest::Approx(rad(-135.f)));
+    CHECK(m.getOutputAngle(5) == doctest::Approx(rad(135.f)));
+
+    restoreStereo();
+  }
+
+  // ─── 7.1: LFE at index 3, 8-channel order ────────────────────────────────────
+
+  TEST_CASE("channel layout: CT_71 uses FL FR FC LFE BL BR SL SR order (#203)") {
+    if (!TestHelpers::engineInit()) return;
+    auto& m = YSE::CHANNEL::Manager();
+    applyLayout(YSE::CT_71, 8);
+
+    CHECK(m.getNumberOfOutputs() == 8);
+
+    CHECK(m.getOutputIsLFE(3) == true);
+    for (unsigned i = 0; i < 8; ++i) {
+      if (i != 3) CHECK(m.getOutputIsLFE(i) == false);
+    }
+
+    CHECK(m.getOutputAngle(0) == doctest::Approx(rad(-45.f)));
+    CHECK(m.getOutputAngle(1) == doctest::Approx(rad(45.f)));
+    CHECK(m.getOutputAngle(2) == doctest::Approx(rad(0.f)));
+    CHECK(m.getOutputAngle(3) == doctest::Approx(0.f)); // LFE
+    CHECK(m.getOutputAngle(4) == doctest::Approx(rad(-135.f)));
+    CHECK(m.getOutputAngle(5) == doctest::Approx(rad(135.f)));
+    CHECK(m.getOutputAngle(6) == doctest::Approx(rad(-90.f)));
+    CHECK(m.getOutputAngle(7) == doctest::Approx(rad(90.f)));
+
+    restoreStereo();
+  }
+
+  // ─── 6.1: LFE at index 3, 7-channel order ────────────────────────────────────
+
+  TEST_CASE("channel layout: CT_61 uses FL FR FC LFE SL SR BC order (#203)") {
+    if (!TestHelpers::engineInit()) return;
+    auto& m = YSE::CHANNEL::Manager();
+    applyLayout(YSE::CT_61, 7);
+
+    CHECK(m.getNumberOfOutputs() == 7);
+
+    CHECK(m.getOutputIsLFE(3) == true);
+    for (unsigned i = 0; i < 7; ++i) {
+      if (i != 3) CHECK(m.getOutputIsLFE(i) == false);
+    }
+
+    CHECK(m.getOutputAngle(0) == doctest::Approx(rad(-45.f)));
+    CHECK(m.getOutputAngle(1) == doctest::Approx(rad(45.f)));
+    CHECK(m.getOutputAngle(2) == doctest::Approx(rad(0.f)));
+    CHECK(m.getOutputAngle(3) == doctest::Approx(0.f)); // LFE
+    CHECK(m.getOutputAngle(4) == doctest::Approx(rad(-90.f)));
+    CHECK(m.getOutputAngle(5) == doctest::Approx(rad(90.f)));
+    CHECK(m.getOutputAngle(6) == doctest::Approx(rad(180.f)));
+
+    restoreStereo();
+  }
+
+  // ─── CT_AUTO maps a 6-channel device to 5.1 (regression: index 5 used to be
+  //     uninitialized, and there was no LFE) ─────────────────────────────────────
+
+  TEST_CASE("channel layout: CT_AUTO on a 6-channel device yields 5.1 with LFE at 3 (#203)") {
+    if (!TestHelpers::engineInit()) return;
+    auto& m = YSE::CHANNEL::Manager();
+    applyLayout(YSE::CT_AUTO, 6);
+
+    CHECK(m.getNumberOfOutputs() == 6);
+    CHECK(m.getOutputIsLFE(3) == true);
+
+    // Every allocated output is defined — the last output (index 5) in
+    // particular used to be left indeterminate by the old setAuto/set51 path.
+    CHECK(m.getOutputAngle(4) == doctest::Approx(rad(-135.f)));
+    CHECK(m.getOutputAngle(5) == doctest::Approx(rad(135.f)));
+
+    restoreStereo();
+  }
+
+  // ─── Non-.1 layouts carry no LFE, and bounds are safe ────────────────────────
+
+  TEST_CASE("channel layout: CT_QUAD has no LFE and correct corner angles (#203)") {
+    if (!TestHelpers::engineInit()) return;
+    auto& m = YSE::CHANNEL::Manager();
+    applyLayout(YSE::CT_QUAD, 4);
+
+    CHECK(m.getNumberOfOutputs() == 4);
+    for (unsigned i = 0; i < 4; ++i)
+      CHECK(m.getOutputIsLFE(i) == false);
+
+    CHECK(m.getOutputAngle(0) == doctest::Approx(rad(-45.f)));
+    CHECK(m.getOutputAngle(1) == doctest::Approx(rad(45.f)));
+    CHECK(m.getOutputAngle(2) == doctest::Approx(rad(-135.f)));
+    CHECK(m.getOutputAngle(3) == doctest::Approx(rad(135.f)));
+
+    restoreStereo();
+  }
+
+  TEST_CASE("channel layout: stereo has no LFE and out-of-range queries are safe (#203)") {
+    if (!TestHelpers::engineInit()) return;
+    auto& m = YSE::CHANNEL::Manager();
+    applyLayout(YSE::CT_STEREO, 2);
+
+    CHECK(m.getNumberOfOutputs() == 2);
+    CHECK(m.getOutputIsLFE(0) == false);
+    CHECK(m.getOutputIsLFE(1) == false);
+
+    // Out-of-range indices return safe defaults rather than reading past the end.
+    CHECK(m.getOutputIsLFE(2) == false);
+    CHECK(m.getOutputIsLFE(999) == false);
+    CHECK(m.getOutputAngle(2) == doctest::Approx(0.f));
+    CHECK(m.getOutputAngle(999) == doctest::Approx(0.f));
+
+    restoreStereo();
+  }
+
+} // TEST_SUITE("channel")

--- a/YseEngine/channel/channelImplementation.cpp
+++ b/YseEngine/channel/channelImplementation.cpp
@@ -174,6 +174,7 @@ void YSE::CHANNEL::implementationObject::setup() {
     lastPeakLinearPost.resize(numOutputs);
     for (UInt i = 0; i < numOutputs; i++) {
       outConf[i].angle = CHANNEL::Manager().getOutputAngle(i);
+      outConf[i].isLFE = CHANNEL::Manager().getOutputIsLFE(i);
     }
     objectStatus = OBJECT_SETUP;
   }
@@ -187,6 +188,7 @@ void YSE::CHANNEL::implementationObject::resize(bool deep) {
   lastPeakLinearPost.resize(numOutputs);
   for (UInt i = 0; i < numOutputs; i++) {
     outConf[i].angle = CHANNEL::Manager().getOutputAngle(i);
+    outConf[i].isLFE = CHANNEL::Manager().getOutputIsLFE(i);
   }
   if (deep) {
     for (auto i = children.begin(); i != children.end(); ++i) {

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -300,9 +300,19 @@ namespace YSE {
       Flt effective;
       Flt ratio;
       Flt finalGain;
+      // True for the low-frequency-effects (.1) output. Such an output is kept
+      // out of azimuth panning: positional sounds are never panned into it
+      // (issue #203).
+      Bool isLFE;
 
       output()
-        : angle(0.f), initPan(0.f), initGain(1.f), effective(1.f), ratio(1.f), finalGain(1.f) {}
+        : angle(0.f),
+          initPan(0.f),
+          initGain(1.f),
+          effective(1.f),
+          ratio(1.f),
+          finalGain(1.f),
+          isLFE(false) {}
     };
 
   } // namespace CHANNEL

--- a/YseEngine/channel/channelManager.cpp
+++ b/YseEngine/channel/channelManager.cpp
@@ -16,7 +16,11 @@ YSE::CHANNEL::managerObject& YSE::CHANNEL::Manager() {
 }
 
 YSE::CHANNEL::managerObject::managerObject()
-  : mgrSetup(this), mgrDelete(this), outputAngles(nullptr), outputChannels(0) {}
+  : mgrSetup(this),
+    mgrDelete(this),
+    outputAngles(nullptr),
+    outputIsLFE(nullptr),
+    outputChannels(0) {}
 
 YSE::CHANNEL::managerObject::~managerObject() noexcept {
   try {
@@ -36,6 +40,7 @@ YSE::CHANNEL::managerObject::~managerObject() noexcept {
     inUse.clear();
     implementations.clear();
     delete[] outputAngles;
+    delete[] outputIsLFE;
   } catch (...) {
     INTERNAL::LogImpl().emit(E_ERROR, "CHANNEL::Manager destructor swallowed exception");
   }
@@ -208,6 +213,14 @@ Flt YSE::CHANNEL::managerObject::getOutputAngle(UInt nr) {
   }
 }
 
+Bool YSE::CHANNEL::managerObject::getOutputIsLFE(UInt nr) {
+  if (nr >= outputChannels || outputIsLFE == nullptr) {
+    return false;
+  } else {
+    return outputIsLFE[nr];
+  }
+}
+
 void YSE::CHANNEL::managerObject::setMaster(CHANNEL::implementationObject* impl) {
   impl->objectStatus = OBJECT_CREATED;
   impl->setup();
@@ -220,8 +233,16 @@ void YSE::CHANNEL::managerObject::setChannelConf(CHANNEL_TYPE type, Int outputs)
 }
 
 void YSE::CHANNEL::managerObject::changeChannelConf() {
+  const UInt count = outputChannels.load();
   delete[] outputAngles;
-  outputAngles = new aFlt[outputChannels.load()];
+  delete[] outputIsLFE;
+  // Value-initialise (the trailing ()): std::atomic has no default member
+  // initialiser, so `new aFlt[n]` alone would leave every angle indeterminate.
+  // Presets below only touch the outputs their layout defines, so any output a
+  // preset skips (e.g. an LFE, or a channel beyond the layout) must already
+  // read as 0° / not-LFE rather than garbage (issue #203).
+  outputAngles = new aFlt[count]();
+  outputIsLFE = new aBool[count]();
   switch (channelType.load()) {
   case CT_AUTO:
     setAuto(outputChannels);
@@ -260,6 +281,11 @@ void YSE::CHANNEL::managerObject::changeChannelConf() {
 }
 
 void YSE::CHANNEL::managerObject::setAuto(Int count) {
+  // `count` is the device's physical channel count. Map it onto the standard
+  // layout with that many channels. The .1 layouts (6 = 5.1, 7 = 6.1, 8 = 7.1)
+  // carry an LFE at the platform-standard index 3. Counts without a defined
+  // channel order here (3, 5, >8) fall back to stereo rather than guessing a
+  // speaker order (issue #203).
   switch (count) {
   case 1:
     setMono();
@@ -269,9 +295,6 @@ void YSE::CHANNEL::managerObject::setAuto(Int count) {
     break;
   case 4:
     setQuad();
-    break;
-  case 5:
-    set51();
     break;
   case 6:
     set51();
@@ -288,53 +311,73 @@ void YSE::CHANNEL::managerObject::setAuto(Int count) {
   }
 }
 
+void YSE::CHANNEL::managerObject::setAngle(UInt idx, Flt degrees) {
+  if (idx < outputChannels.load()) {
+    outputAngles[idx] = Pi / 180.0f * degrees;
+  }
+}
+
+void YSE::CHANNEL::managerObject::setLFE(UInt idx) {
+  if (idx < outputChannels.load()) {
+    outputIsLFE[idx] = true;
+  }
+}
+
 void YSE::CHANNEL::managerObject::setMono() {
-  outputAngles[0] = 0;
+  setAngle(0, 0.0f);
 }
 
 void YSE::CHANNEL::managerObject::setStereo() {
-  outputAngles[0] = Pi / 180.0f * -90.0f;
-  outputAngles[1] = Pi / 180.0f * 90.0f;
+  setAngle(0, -90.0f);
+  setAngle(1, 90.0f);
 }
 
 void YSE::CHANNEL::managerObject::setQuad() {
-  outputAngles[0] = Pi / 180.0f * -45.0f;
-  outputAngles[1] = Pi / 180.0f * 45.0f;
-  outputAngles[2] = Pi / 180.0f * -135.0f;
-  outputAngles[3] = Pi / 180.0f * 135.0f;
+  setAngle(0, -45.0f);
+  setAngle(1, 45.0f);
+  setAngle(2, -135.0f);
+  setAngle(3, 135.0f);
 }
 
+// 5.1 — platform channel order: FL FR FC LFE BL BR.
 void YSE::CHANNEL::managerObject::set51() {
-  outputAngles[0] = Pi / 180.0f * -45.0f;
-  outputAngles[1] = Pi / 180.0f * 45.0f;
-  outputAngles[2] = Pi / 180.0f * 0.0f;
-  outputAngles[3] = Pi / 180.0f * -135.0f;
-  outputAngles[4] = Pi / 180.0f * 135.0f;
+  setAngle(0, -45.0f); // front left
+  setAngle(1, 45.0f); // front right
+  setAngle(2, 0.0f); // front center
+  setLFE(3); // low-frequency effects
+  setAngle(4, -135.0f); // back left
+  setAngle(5, 135.0f); // back right
 }
 
+// 5.1 with side surrounds — FL FR FC LFE SL SR.
 void YSE::CHANNEL::managerObject::set51Side() {
-  outputAngles[0] = Pi / 180.0f * -45.0f;
-  outputAngles[1] = Pi / 180.0f * 45.0f;
-  outputAngles[2] = Pi / 180.0f * 0.0f;
-  outputAngles[3] = Pi / 180.0f * -90.0f;
-  outputAngles[4] = Pi / 180.0f * 90.0f;
+  setAngle(0, -45.0f); // front left
+  setAngle(1, 45.0f); // front right
+  setAngle(2, 0.0f); // front center
+  setLFE(3); // low-frequency effects
+  setAngle(4, -90.0f); // side left
+  setAngle(5, 90.0f); // side right
 }
 
+// 6.1 — platform channel order: FL FR FC LFE SL SR BC.
 void YSE::CHANNEL::managerObject::set61() {
-  outputAngles[0] = Pi / 180.0f * -45.0f;
-  outputAngles[1] = Pi / 180.0f * 45.0f;
-  outputAngles[2] = Pi / 180.0f * 0.0f;
-  outputAngles[3] = Pi / 180.0f * -90.0f;
-  outputAngles[4] = Pi / 180.0f * 90.0f;
-  outputAngles[5] = Pi / 180.0f * 180.0f;
+  setAngle(0, -45.0f); // front left
+  setAngle(1, 45.0f); // front right
+  setAngle(2, 0.0f); // front center
+  setLFE(3); // low-frequency effects
+  setAngle(4, -90.0f); // side left
+  setAngle(5, 90.0f); // side right
+  setAngle(6, 180.0f); // back center
 }
 
+// 7.1 — platform channel order: FL FR FC LFE BL BR SL SR.
 void YSE::CHANNEL::managerObject::set71() {
-  outputAngles[0] = Pi / 180.0f * -45.0f;
-  outputAngles[1] = Pi / 180.0f * 45.0f;
-  outputAngles[2] = Pi / 180.0f * 0.0f;
-  outputAngles[3] = Pi / 180.0f * -90.0f;
-  outputAngles[4] = Pi / 180.0f * 90.0f;
-  outputAngles[5] = Pi / 180.0f * -135.0f;
-  outputAngles[6] = Pi / 180.0f * 135.0f;
+  setAngle(0, -45.0f); // front left
+  setAngle(1, 45.0f); // front right
+  setAngle(2, 0.0f); // front center
+  setLFE(3); // low-frequency effects
+  setAngle(4, -135.0f); // back left
+  setAngle(5, 135.0f); // back right
+  setAngle(6, -90.0f); // side left
+  setAngle(7, 90.0f); // side right
 }

--- a/YseEngine/channel/channelManager.h
+++ b/YseEngine/channel/channelManager.h
@@ -59,6 +59,12 @@ namespace YSE {
       UInt getNumberOfOutputs();
       Flt getOutputAngle(UInt nr);
 
+      /** @brief True when output @p nr is the low-frequency-effects (.1) channel.
+          The LFE output is excluded from azimuth panning; positional sounds are
+          never panned into it. Returns false when @p nr is out of range or the
+          current layout has no LFE. */
+      Bool getOutputIsLFE(UInt nr);
+
       channel& master();
       channel& FX();
       channel& music();
@@ -104,10 +110,20 @@ namespace YSE {
       channel _voice;
       channel _gui;
 
-      // channel output configuration
+      // channel output configuration. `outputAngles` holds the azimuth (radians)
+      // of each physical output; `outputIsLFE` marks the low-frequency-effects
+      // (.1) output so it is kept out of azimuth panning. Both arrays are sized
+      // to `outputChannels` and value-initialised in changeChannelConf().
       aFlt* outputAngles;
+      aBool* outputIsLFE;
       aUInt outputChannels;
       std::atomic<CHANNEL_TYPE> channelType;
+
+      // Bounds-checked writers used by the layout presets below, so a preset can
+      // never write past the allocated `outputChannels` even if it is applied to
+      // a device with fewer channels than the layout expects.
+      void setAngle(UInt idx, Flt degrees);
+      void setLFE(UInt idx);
 
       void setMono();
       void setStereo();

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -822,6 +822,17 @@ void YSE::SOUND::implementationObject::toChannels() {
 #ifdef _MSC_VER
 #pragma warning(disable : 4258)
 #endif
+  // Count the LFE outputs so the pan normalisation below runs over the real
+  // (positional) speakers only. The .1 output receives no azimuth-panned
+  // content — sounds are never panned into the subwoofer (issue #203).
+  UInt lfeCount = 0;
+  for (UInt i = 0; i < parent->outConf.size(); i++) {
+    if (parent->outConf[i].isLFE) lfeCount++;
+  }
+  const UInt realSpeakers = (parent->out.size() > lfeCount)
+                                ? static_cast<UInt>(parent->out.size()) - lfeCount
+                                : static_cast<UInt>(parent->out.size());
+
   for (UInt x = 0; x < buffer->size(); x++) {
     // calculate spread value for multichannel sounds
     Flt spreadAdjust = 0;
@@ -830,11 +841,13 @@ void YSE::SOUND::implementationObject::toChannels() {
 
     // initial panning
     for (UInt i = 0; i < parent->outConf.size(); i++) {
+      if (parent->outConf[i].isLFE) continue; // LFE is not azimuth-panned
       parent->outConf[i].initPan =
           (1 + cos(parent->outConf[i].angle - (angle + spreadAdjust))) * 0.5f;
       parent->outConf[i].effective = 0;
       // effective speakers
       for (UInt j = 0; j < parent->outConf.size(); j++) {
+        if (parent->outConf[j].isLFE) continue;
         parent->outConf[i].effective +=
             computeSpeakerOverlap(parent->outConf[i].angle, parent->outConf[j].angle);
       }
@@ -844,6 +857,7 @@ void YSE::SOUND::implementationObject::toChannels() {
     // emitted power
     Flt power = 0;
     for (UInt i = 0; i < parent->outConf.size(); i++) {
+      if (parent->outConf[i].isLFE) continue;
       power += static_cast<Flt>(pow(parent->outConf[i].initGain, 2));
     }
     // calculated power
@@ -854,8 +868,8 @@ void YSE::SOUND::implementationObject::toChannels() {
 
     // final gain assignment
     for (UInt j = 0; j < parent->out.size(); ++j) {
-      parent->outConf[j].ratio = computePanRatio(parent->outConf[j].initGain, power,
-                                                 static_cast<UInt>(parent->out.size()));
+      if (parent->outConf[j].isLFE) continue; // leave the LFE buffer silent
+      parent->outConf[j].ratio = computePanRatio(parent->outConf[j].initGain, power, realSpeakers);
       channelBuffer = (*buffer)[x];
       parent->outConf[j].finalGain = sqrt(correctPower * parent->outConf[j].ratio);
 


### PR DESCRIPTION
## Summary

Fixes the three surround-output defects in `channelManager.cpp` reported in #203:

1. **Uninitialized speaker angle** — `changeChannelConf()` now value-initialises the per-output angle array (`new aFlt[n]()`) plus a new parallel `isLFE` array, so no allocated output can ever pan by indeterminate memory.
2. **No LFE concept** — the `.1` output is flagged (`getOutputIsLFE()`), propagated to each channel's `outConf[i].isLFE`, and excluded from azimuth panning: `SOUND::toChannels()` skips LFE outputs in the pan/effective/power loops and the final-gain assignment, and normalises pan power over the real (non-LFE) speaker count. Positional sounds are never panned into the subwoofer.
3. **Wrong physical channel order** — 5.1/6.1/7.1 now follow the platform-standard order `FL FR FC LFE …` with the LFE at index 3.

The presets write through bounds-checked `setAngle()`/`setLFE()` helpers so a layout can never overrun a device with fewer channels. `setAuto()` maps a device's physical channel count onto the matching layout (6→5.1, 7→6.1, 8→7.1); counts without a defined channel order fall back to stereo.

Real-time discipline: no new allocations on the audio-callback path. The array (re)allocation in `changeChannelConf()` is pre-existing and only runs on a device-layout change (already documented as "reallocates a lot of memory ... only done when changing output channel count"). The `toChannels()` additions are branches and a small O(n≤8) LFE count — no locks, no allocation.

## Linked issue
Closes #203

## Changes
- `channel/channelManager.{h,cpp}` — value-init both arrays; `getOutputIsLFE()`; bounds-checked `setAngle()`/`setLFE()`; corrected 5.1/5.1-side/6.1/7.1 presets with LFE at index 3; `setAuto()` count→layout mapping.
- `channel/channelImplementation.{h,cpp}` — `isLFE` field on `CHANNEL::output`; populated in `setup()`/`resize()`.
- `sound/soundImplementation.cpp` — exclude LFE from panning; normalise over real speaker count.
- `Tests/channel/test_channel_layout.cpp` (new) — angle order, LFE flag placement, CT_AUTO mapping, non-.1 layouts, out-of-range safety.
- `PROJECT_OVERVIEW.md` — note the LFE policy.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on changed files (`yse.py format` applied)
- [x] `clang-tidy` (`yse.py analyze`) clean — no new findings in modified code (only pre-existing baseline warnings on untouched lines)
- [x] Unit tests pass — full suite green, `ctest` 17/17; new `channel/test_channel_layout.cpp` = 6 cases / 65 assertions
- [x] Regression confirmed: the new tests **fail** against the old `set51` ordering (4 assertions) and pass with the fix
- [ ] End-to-end multichannel render test — **not added**: exercising the LFE-silent panning end-to-end needs a real 5.1/7.1 output device (hardware); the shared single-init test binary can't drive an offline multichannel render alongside the device-based suite. The `isLFE` flag that drives the panning branch is covered by the unit tests; the panning change itself is a reviewed `if (isLFE) continue;` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)