### PR TITLE
FIX: relative / pan2D sounds mirrored left-right (#204)

### DIFF
--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -797,6 +797,72 @@ TEST_SUITE("sound") {
     }
   }
 
+  // ─── Source-angle mapping: relative vs world frame (#204) ───────────────────
+  //
+  // Regression tests for the left↔right mirror in the relative / pan2D pan path.
+  // The engine's convention (CHANNEL::setStereo()) puts the right speaker at
+  // +90° (output 1) and the left at -90° (output 0). update() derives the source
+  // pan angle from atan2(dir.x, dir.z), which is +90° for a source on +x. The
+  // relative branch used to *negate* that (-90°), imaging every relative /
+  // pan2D source on the wrong speaker (#204). computeSourceAngle must take the
+  // relative angle directly so both frames agree. These call the pure helper
+  // (and, for the end-to-end case, compose it with the toChannels() pan math
+  // from the other pure helpers) so the assertions are exact and independent of
+  // any audio device.
+
+  TEST_CASE("sourceAngle: a relative source at +x images right (+90°), not left (#204)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // dir already lives in the listener's frame; listenerForward is ignored.
+    const float a = Impl::computeSourceAngle(true, YSE::Pos(1.f, 0.f, 0.f), YSE::Pos(0.f));
+    CHECK(a == doctest::Approx(static_cast<float>(YSE::Pi) / 2.f)); // pre-fix this was -π/2
+  }
+
+  TEST_CASE("sourceAngle: relative and world frames agree for a +z-facing listener (#204)") {
+    using Impl = YSE::SOUND::implementationObject;
+    const YSE::Pos src(1.f, 0.f, 0.f);
+    const YSE::Pos fwd(0.f, 0.f, 1.f); // listener looking down +z
+    const float world = Impl::computeSourceAngle(false, src, fwd);
+    const float rel = Impl::computeSourceAngle(true, src, YSE::Pos(0.f));
+    CHECK(world == doctest::Approx(static_cast<float>(YSE::Pi) / 2.f)); // right speaker
+    CHECK(rel == doctest::Approx(world)); // frames must not mirror each other
+  }
+
+  TEST_CASE("sourceAngle: world frame rotates with the listener's facing (#204)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // Listener turned 90° to face +x: a source on +x is now straight ahead (0°).
+    const float a =
+        Impl::computeSourceAngle(false, YSE::Pos(1.f, 0.f, 0.f), YSE::Pos(1.f, 0.f, 0.f));
+    CHECK(a == doctest::Approx(0.f));
+  }
+
+  TEST_CASE("sourceAngle: a relative +x source pans to the right speaker end-to-end (#204)") {
+    using Impl = YSE::SOUND::implementationObject;
+    // Compose the full update()->toChannels() mapping for a stereo layout: the
+    // source angle feeds the toChannels() pan math (computeSpeakerOverlap +
+    // computePanRatio). Output 0 = left (-90°), output 1 = right (+90°), exactly
+    // as setStereo() configures them.
+    const std::vector<float> speakers = {
+        -static_cast<float>(YSE::Pi) / 2.f, // output 0 = left
+        +static_cast<float>(YSE::Pi) / 2.f, // output 1 = right
+    };
+    const float src = Impl::computeSourceAngle(true, YSE::Pos(1.f, 0.f, 0.f), YSE::Pos(0.f));
+    std::vector<float> initGain(speakers.size());
+    float power = 0.f;
+    for (std::size_t s = 0; s < speakers.size(); ++s) {
+      const float initPan = (1.f + std::cos(speakers[s] - src)) * 0.5f;
+      float effective = 0.f;
+      for (float other : speakers)
+        effective += Impl::computeSpeakerOverlap(speakers[s], other);
+      initGain[s] = initPan / effective;
+      power += initGain[s] * initGain[s];
+    }
+    const float gainL = std::sqrt(1.f * Impl::computePanRatio(initGain[0], power, 2));
+    const float gainR = std::sqrt(1.f * Impl::computePanRatio(initGain[1], power, 2));
+    // Pre-fix the angle was -90°, which put all the gain on output 0 (left).
+    CHECK(gainR > gainL);
+    CHECK(gainL == doctest::Approx(0.f)); // fully panned to output 1 (right)
+  }
+
   // ─── Doppler ratio: multiplicative + scaled + clamped (#208) ────────────────
   //
   // Regression tests for the additive, unsmoothed doppler. computeDopplerRatio

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -553,19 +553,11 @@ void YSE::SOUND::implementationObject::update() {
   ///////////////////////////////////////////
   // calculate angle
   ///////////////////////////////////////////
-  Flt a = angle; // avoid using atomic all the time
   Pos dir = relative ? newPos : newPos - INTERNAL::ListenerImpl().newPos;
-  if (relative)
-    a = -atan2(dir.x, dir.z);
-  else {
-    const Pos listenerForward = INTERNAL::ListenerImpl().forward.load();
-    a = (atan2(dir.x, dir.z) - atan2(listenerForward.x, listenerForward.z));
-  }
-  while (a > Pi)
-    a -= Pi2;
-  while (a < -Pi)
-    a += Pi2;
-  angle = a; // back to atomic
+  // Only touch the listener's atomic forward vector in the world branch; the
+  // relative branch ignores it (dir is already in the listener's frame).
+  Pos listenerForward = relative ? Pos(0) : INTERNAL::ListenerImpl().forward.load();
+  angle = computeSourceAngle(relative, dir, listenerForward); // back to atomic
 
   ///////////////////////////////////////////
   // sound occlusion (optional)
@@ -937,6 +929,25 @@ Flt YSE::SOUND::implementationObject::computePanRatio(Flt initGain, Flt power, U
   if (speakerCount == 0) return 0.f;
   if (!(power > minPower)) return 1.f / static_cast<Flt>(speakerCount);
   return static_cast<Flt>(pow(initGain, 2) / power);
+}
+
+Flt YSE::SOUND::implementationObject::computeSourceAngle(bool relative, const Pos& dir,
+                                                         const Pos& listenerForward) {
+  // atan2(x, z) gives +90° for a source on +x, which maps to the right speaker
+  // (see CHANNEL::setStereo()). The relative branch takes this angle directly;
+  // it must NOT be negated, or relative / pan2D sounds mirror left↔right (#204).
+  Flt a = static_cast<Flt>(atan2(dir.x, dir.z));
+  if (!relative) {
+    // World frame: measure the source direction against the listener's facing.
+    a -= static_cast<Flt>(atan2(listenerForward.x, listenerForward.z));
+  }
+  // A world-frame difference of two atan2 results can leave (-2π, 2π); wrap it
+  // back into (-π, π] so downstream pan math sees a canonical angle.
+  while (a > Pi)
+    a -= Pi2;
+  while (a < -Pi)
+    a += Pi2;
+  return a;
 }
 
 Flt YSE::SOUND::implementationObject::computeDopplerRatio(const Pos& sourceVel,

--- a/YseEngine/sound/soundImplementation.h
+++ b/YseEngine/sound/soundImplementation.h
@@ -196,6 +196,24 @@ namespace YSE {
       */
       static Flt computePanRatio(Flt initGain, Flt power, UInt speakerCount);
 
+      /** Pan angle of a source relative to the listener, in radians and wrapped
+          to (-π, π]. The engine's convention (see CHANNEL::setStereo()) puts the
+          right speaker at +90° and the left at -90°, so a source at +x must map
+          to +90° on both frames.
+
+          - World frame (``relative == false``): the source direction is measured
+            against the listener's own facing, so ``dir`` is the listener→source
+            vector and ``listenerForward`` the listener's forward vector.
+          - Relative frame (``relative == true``): ``dir`` already lives in the
+            listener's frame, so the angle is taken directly and
+            ``listenerForward`` is ignored. This branch must NOT negate the angle
+            — doing so mirrored relative / pan2D sounds left↔right (issue #204).
+
+          Kept as a pure static helper so the mapping stays unit-testable in
+          isolation.
+      */
+      static Flt computeSourceAngle(bool relative, const Pos& dir, const Pos& listenerForward);
+
       void removeInterface();
 
       OBJECT_IMPLEMENTATION_STATE getStatus();


### PR DESCRIPTION
## Summary

Relative-mode sounds — and therefore all `pan2D` sounds, which are implemented as relative mode — were mirrored left↔right. The relative branch of the pan-angle math in `implementationObject::update()` negated `atan2(dir.x, dir.z)`, so a relative source at `+x` imaged on the **left** speaker, the opposite of the world-space convention (`CHANNEL::setStereo()` puts +90° on the right). The bug hid because relative sounds usually sit at the origin.

## Linked issue

Closes #204

## Changes

- Extract the pan-angle computation from `update()` into a pure static helper `computeSourceAngle(relative, dir, listenerForward)` (following the `#202`/`#205`–`#208` unit-testability pattern) and **drop the negation** on the relative branch so both frames agree.
- The helper is allocation- and lock-free — safe on the audio-thread `update()` path. The world branch still only touches the listener's atomic `forward` vector when needed.
- Add doctests in `Tests/sound/test_sound_impl.cpp`:
  - a relative `+x` source now yields `+90°` (was `-90°`);
  - relative and world frames agree for a forward-facing listener;
  - the world frame still rotates with the listener's facing;
  - an end-to-end stereo-pan composition (angle → `computeSpeakerOverlap` → `computePanRatio`) confirms the source images on **output 1 (right)**, with output 0 (left) at zero.

## Test plan

- [x] `yse.py format` clean (only the 3 touched files reformatted)
- [x] `yse.py analyze` on both changed sources — no new findings in modified code (only pre-existing backlog warnings in unrelated functions)
- [x] Unit tests pass — `yse.py test`, 17/17 suites, sound suite 147 cases / 264k assertions
- [x] Regression guard verified: the 3 relative/e2e cases **fail** on the unpatched (negated) code and pass with the fix
- [x] Integration-level coverage: the end-to-end doctest composes the full `update()`→`toChannels()` pan mapping and asserts the audible result (right speaker). A full audio-device run isn't feasible in CI (no output device / private `lastGain`), so the composition test exercises the same math path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)