### PR TITLE
PERF: precompute per-speaker 'effective' density term off the audio thread (#211)

### DIFF
--- a/Tests/channel/test_channel_layout.cpp
+++ b/Tests/channel/test_channel_layout.cpp
@@ -18,8 +18,11 @@
 
 #include <doctest/doctest.h>
 #include <cmath>
+#include <vector>
 #include "channel/channelInterface.hpp"
+#include "channel/channelImplementation.h"
 #include "channel/channelManager.h"
+#include "sound/soundImplementation.h"
 #include "headers/enums.hpp"
 #include "support/null_device.hpp"
 
@@ -41,6 +44,27 @@ namespace {
   void applyLayout(YSE::CHANNEL_TYPE type, int outputs) {
     YSE::CHANNEL::Manager().setChannelConf(type, outputs);
     YSE::CHANNEL::Manager().changeChannelConf();
+  }
+
+  // Build a CHANNEL::output for a speaker at a given angle (radians).
+  YSE::CHANNEL::output speaker(float angleRad, bool lfe = false) {
+    YSE::CHANNEL::output o;
+    o.angle = angleRad;
+    o.isLFE = lfe;
+    return o;
+  }
+
+  // Reference implementation of effective[i]: the exact inline loop
+  // toChannels() ran before issue #211 — Σ over non-LFE speakers j of the
+  // cardioid overlap weight. Independent of the code under test so the
+  // equivalence check is meaningful.
+  float refEffective(const std::vector<YSE::CHANNEL::output>& conf, std::size_t i) {
+    float sum = 0.f;
+    for (std::size_t j = 0; j < conf.size(); ++j) {
+      if (conf[j].isLFE) continue;
+      sum += YSE::SOUND::implementationObject::computeSpeakerOverlap(conf[i].angle, conf[j].angle);
+    }
+    return sum;
   }
 
 } // namespace
@@ -180,6 +204,80 @@ TEST_SUITE("channel") {
     CHECK(m.getOutputAngle(999) == doctest::Approx(0.f));
 
     restoreStereo();
+  }
+
+  // ─── Precomputed speaker-density weights (#211) ──────────────────────────────
+  //
+  // effective[i] = Σ_j overlap(angle_i, angle_j) over the non-LFE speakers is
+  // now precomputed once per layout change in
+  // CHANNEL::implementationObject::computeEffectiveSpeakerWeights() instead of
+  // being recomputed per source channel per block inside toChannels(). These
+  // drive the pure static directly (no engine needed) and pin the two
+  // properties that make the refactor safe: (1) it produces exactly the value
+  // the old inline loop did, and (2) it is a no-op on symmetric layouts — the
+  // whole reason the per-block recompute was pure waste there.
+
+  TEST_CASE("effective weights: match the old inline loop on an asymmetric ring (#211)") {
+    // A strongly asymmetric CT_CUSTOM ring (three speakers clustered left, one
+    // right) — exactly where the density term is non-trivial and must be right.
+    std::vector<YSE::CHANNEL::output> conf = {speaker(rad(-150.f)), speaker(rad(-120.f)),
+                                              speaker(rad(-90.f)), speaker(rad(90.f))};
+    // Compute the reference from the untouched geometry BEFORE the code under
+    // test overwrites effective.
+    std::vector<float> expected(conf.size());
+    for (std::size_t i = 0; i < conf.size(); ++i)
+      expected[i] = refEffective(conf, i);
+
+    YSE::CHANNEL::implementationObject::computeEffectiveSpeakerWeights(conf);
+
+    for (std::size_t i = 0; i < conf.size(); ++i)
+      CHECK(conf[i].effective == doctest::Approx(expected[i]));
+    // The whole point of the asymmetric case: the weights are genuinely
+    // non-uniform (otherwise the term would cancel and there'd be nothing to
+    // get wrong). The clustered-left speakers overlap more, so score higher
+    // than the lone right speaker.
+    CHECK(conf[0].effective > conf[3].effective);
+  }
+
+  TEST_CASE("effective weights: uniform on a symmetric layout — the no-op case (#211)") {
+    // Stereo (±90°): both speakers see the same neighbourhood, so effective is
+    // identical across them and cancels in the power normalisation. This is the
+    // symmetric-layout no-op the issue calls out.
+    std::vector<YSE::CHANNEL::output> stereo = {speaker(rad(-90.f)), speaker(rad(90.f))};
+    YSE::CHANNEL::implementationObject::computeEffectiveSpeakerWeights(stereo);
+    CHECK(stereo[0].effective == doctest::Approx(stereo[1].effective));
+
+    // Quad (±45°, ±135°): a regular ring — every speaker's weight is equal too.
+    std::vector<YSE::CHANNEL::output> quad = {speaker(rad(-45.f)), speaker(rad(45.f)),
+                                              speaker(rad(-135.f)), speaker(rad(135.f))};
+    YSE::CHANNEL::implementationObject::computeEffectiveSpeakerWeights(quad);
+    for (std::size_t i = 1; i < quad.size(); ++i)
+      CHECK(quad[i].effective == doctest::Approx(quad[0].effective));
+  }
+
+  TEST_CASE("effective weights: LFE outputs are excluded and left untouched (#211)") {
+    // 5.1-style ordering with the LFE at index 3. The LFE must neither
+    // contribute to any positional speaker's sum nor receive a computed weight —
+    // matching toChannels(), which skips it in both loops (issue #203).
+    std::vector<YSE::CHANNEL::output> conf = {speaker(rad(-45.f)),  speaker(rad(45.f)),
+                                              speaker(rad(0.f)),    speaker(rad(0.f), /*lfe=*/true),
+                                              speaker(rad(-135.f)), speaker(rad(135.f))};
+
+    // Reference computed with the LFE excluded from the j-sum.
+    std::vector<float> expected(conf.size());
+    for (std::size_t i = 0; i < conf.size(); ++i)
+      expected[i] = refEffective(conf, i);
+
+    // The LFE's effective must stay at its default (never written).
+    const float lfeDefault = conf[3].effective;
+
+    YSE::CHANNEL::implementationObject::computeEffectiveSpeakerWeights(conf);
+
+    for (std::size_t i = 0; i < conf.size(); ++i) {
+      if (conf[i].isLFE) continue;
+      CHECK(conf[i].effective == doctest::Approx(expected[i]));
+    }
+    CHECK(conf[3].effective == doctest::Approx(lfeDefault)); // LFE untouched
   }
 
 } // TEST_SUITE("channel")

--- a/YseEngine/channel/channelImplementation.cpp
+++ b/YseEngine/channel/channelImplementation.cpp
@@ -176,6 +176,7 @@ void YSE::CHANNEL::implementationObject::setup() {
       outConf[i].angle = CHANNEL::Manager().getOutputAngle(i);
       outConf[i].isLFE = CHANNEL::Manager().getOutputIsLFE(i);
     }
+    computeEffectiveSpeakerWeights(outConf);
     objectStatus = OBJECT_SETUP;
   }
 }
@@ -190,6 +191,7 @@ void YSE::CHANNEL::implementationObject::resize(bool deep) {
     outConf[i].angle = CHANNEL::Manager().getOutputAngle(i);
     outConf[i].isLFE = CHANNEL::Manager().getOutputIsLFE(i);
   }
+  computeEffectiveSpeakerWeights(outConf);
   if (deep) {
     for (auto i = children.begin(); i != children.end(); ++i) {
       (*i)->resize(true);
@@ -198,6 +200,27 @@ void YSE::CHANNEL::implementationObject::resize(bool deep) {
     for (auto i = sounds.begin(); i != sounds.end(); ++i) {
       (*i)->resize();
     }
+  }
+}
+
+void YSE::CHANNEL::implementationObject::computeEffectiveSpeakerWeights(
+    std::vector<output>& outConf) {
+  // The density-compensation term effective[i] = Σ_j overlap(angle_i, angle_j)
+  // depends only on the speaker geometry, not on the source or the audio block.
+  // Precompute it here (layout-change time) so toChannels() can read it instead
+  // of paying the O(N^2) cos cost per source channel per block (issue #211).
+  // LFE outputs are excluded from the azimuth pan, matching toChannels() which
+  // skips them in both the i and j loops (issue #203); their effective is left
+  // at the default and never read. The summation order over non-LFE speakers is
+  // kept identical to the old inline loop so the result is bit-for-bit the same.
+  for (UInt i = 0; i < outConf.size(); i++) {
+    if (outConf[i].isLFE) continue;
+    Flt sum = 0;
+    for (UInt j = 0; j < outConf.size(); j++) {
+      if (outConf[j].isLFE) continue;
+      sum += SOUND::implementationObject::computeSpeakerOverlap(outConf[i].angle, outConf[j].angle);
+    }
+    outConf[i].effective = sum;
   }
 }
 

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -74,6 +74,22 @@ namespace YSE {
       */
       void resize(bool deep = false);
 
+      /** Precompute the per-speaker density-compensation weights
+          (output::effective) from the current speaker geometry.
+
+          effective[i] = Σ_j computeSpeakerOverlap(angle_i, angle_j) over every
+          non-LFE output j. It depends only on the speaker angles / LFE flags,
+          never on the source or the audio block, so it is computed once on a
+          layout change (setup()/resize(), off the audio thread) rather than
+          being recomputed per source channel per block inside toChannels() —
+          the term is the entire O(N^2)-transcendental cost of the panner and is
+          a no-op on symmetric layouts. LFE outputs are skipped in both the i and
+          j sums, matching toChannels() (issue #203); their effective is left
+          untouched and never read. Kept as a pure static so the weighting stays
+          unit-testable in isolation. See issue #211.
+      */
+      static void computeEffectiveSpeakerWeights(std::vector<output>& outConf);
+
       /** This function is called by channelManager::update (from dsp callback) and verifies
       if the channel is ready to be played. It will then be moved from toCreate
       to inUse.

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -847,13 +847,10 @@ void YSE::SOUND::implementationObject::toChannels() {
       // for every speaker — an equal-power omni spread instead of a wild sweep.
       parent->outConf[i].initPan =
           (1 + horizFraction * cos(parent->outConf[i].angle - (angle + spreadAdjust))) * 0.5f;
-      parent->outConf[i].effective = 0;
-      // effective speakers
-      for (UInt j = 0; j < parent->outConf.size(); j++) {
-        if (parent->outConf[j].isLFE) continue;
-        parent->outConf[i].effective +=
-            computeSpeakerOverlap(parent->outConf[i].angle, parent->outConf[j].angle);
-      }
+      // The speaker-density term effective[i] depends only on the speaker
+      // geometry, so it is precomputed once on layout change in
+      // CHANNEL::implementationObject::computeEffectiveSpeakerWeights() instead
+      // of being recomputed here per source channel per block (issue #211).
       // initial gain
       parent->outConf[i].initGain = parent->outConf[i].initPan / parent->outConf[i].effective;
     }


### PR DESCRIPTION
## Summary

The spatializer's speaker-density compensation term `effective[i] = Σ_j overlap(angle_i, angle_j)` depends **only on the speaker geometry**, yet `toChannels()` recomputed it per output × per source channel × per sound × per block — the entire O(N²)-transcendental cost of the panner, paid on the audio callback path every block for a value that never changes between device reconfigurations. On symmetric layouts (stereo/quad/…) it also cancels in the power normalisation, so the cost was pure waste there; it only matters on irregular `CT_CUSTOM` rings.

This precomputes `effective[i]` once per layout change and has `toChannels()` read the stored value. Panner complexity drops from O(N²) to O(N) transcendentals per source channel, and the remaining trig is moved **off** the audio thread.

## Linked issue

Closes #211

## Changes

- Add `CHANNEL::implementationObject::computeEffectiveSpeakerWeights(std::vector<output>&)` — a pure static that fills `output::effective` from the current speaker angles/LFE flags. Kept static so the weighting stays unit-testable in isolation (same convention as #202/#206/#207/#208).
- Call it from `setup()` and `resize()` right after the speaker angles are populated — the only two places `outConf[i].angle` is ever written, so `effective` can never go stale relative to the angles. These run on layout change (off the per-block hot path).
- `toChannels()` drops the inner O(N) `effective` loop and reads `outConf[i].effective`.

## RT-safety

The precompute runs on the layout-change path (`setup()`/`resize()`), the same off-callback context that already resizes the `outConf`/`out` vectors. No new work is added to the per-block audio path; the change only removes work from it. No allocation/lock introduced on the callback path.

## Behaviour preservation

The summation order over non-LFE speakers is kept identical to the old inline loop, so the stored `effective` is bit-for-bit what `toChannels()` used to compute. LFE outputs are excluded from both the i and j sums, matching the prior code (#203).

## Test plan

- [x] `yse.py format` clean (ran repo formatter)
- [x] `yse.py analyze` clean on changed code — no new findings in modified regions (the two pre-existing `soundImplementation.cpp` findings at lines 173/656 are outside the changed region and part of the tracked backlog)
- [x] Full suite green: `python yse.py test` → 100% (17/17 ctest targets pass)
- [x] New unit tests in `Tests/channel/test_channel_layout.cpp` (3 cases, 15 assertions, verified passing via the channel suite):
  - **equivalence to the old inline loop** on an asymmetric `CT_CUSTOM` ring (independent reference computed from the untouched geometry) — the behaviour-preservation guard
  - **symmetric-layout no-op property**: uniform weights across stereo (±90°) and quad speakers
  - **LFE exclusion**: LFE outputs neither contribute to any speaker's sum nor receive a computed weight

Behavioural note: this is a behaviour-preserving performance refactor — audio output is unchanged. Coverage is at the unit layer against the pure static that owns the new logic, plus the pre-existing `toChannels()` reconstruction tests in `test_sound_impl.cpp` that validate the composed panner math still holds; a bespoke end-to-end audio-render harness would not exercise anything the equivalence test doesn't already pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)