### PR TITLE
PERF: cache per-sound gain vectors; recompute only on update-tick changes (#212)

### DIFF
--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -64,12 +64,31 @@ namespace {
     void process(std::vector<YSE::DSP::buffer>&) override {}
   };
 
+  // DSP source that emits a constant DC level on every channel. Used by the
+  // gain-cache behavioural test (#212): a constant source makes the per-output
+  // channel peak a direct, block-stable readout of the pan gain, so we can watch
+  // the panner track the source across update ticks. File-scope for the same
+  // lifetime reason as the sources above.
+  struct DcSource : YSE::DSP::dspSourceObject {
+    void process(YSE::SOUND_STATUS& intent) override {
+      for (UInt c = 0; c < samples.size(); ++c) {
+        float* p = samples[c].getPtr();
+        UInt len = samples[c].getLength();
+        for (UInt i = 0; i < len; i++)
+          p[i] = 0.5f;
+      }
+      intent = YSE::SS_PLAYING;
+    }
+    void frequency(float) override {}
+  };
+
   // Shared file-scope instances reused across tests.  These are stateless, so
   // sharing is safe; each test sets the position / volume / etc. it needs.
   SilentSource g_src;
   SilentSource g_srcs[8]; // size = max N used in multi-sound tests below
   NopDsp g_dsp;
   NopDsp g_dsp2;
+  DcSource g_dc;
 
   // Drive SOUND::Manager().update() several times, with short sleeps so the
   // async setupJob has a chance to call setup() on freshly created sounds and
@@ -1153,6 +1172,88 @@ TEST_SUITE("sound") {
     drainSoundManager(20);
     YSE::System().maxSounds(64);
     CHECK(true);
+  }
+
+  // ─── Cached per-sound gain vectors (#212) ────────────────────────────────────
+  //
+  // toChannels() now reads its per-speaker gains from a per-sound cache
+  // (finalGainCache) that computeFinalGains() refills only when an update() tick
+  // sets gainDirty — instead of rerunning the cos/pow/sqrt derivation every
+  // 128-sample block. This is a pure performance change: the output must be
+  // bit-for-bit what the per-block recompute produced. The pure pan math is
+  // pinned by the #202/#210/#211 cases above; this end-to-end case pins the two
+  // properties the caching layer adds, which those pure tests cannot reach:
+  //
+  //   1. The cache is REUSED across blocks within one update tick (a second
+  //      rendered block with no intervening update() must give the identical
+  //      panned level — the cache is neither dropped nor recomputed to garbage).
+  //   2. The cache is INVALIDATED when the source moves (a new update() tick must
+  //      re-pan; a stuck dirty flag would freeze the pan and is exactly the
+  //      regression this optimisation risks).
+  //
+  // A constant-DC source makes each output's per-block peak a direct readout of
+  // its pan gain. Driven device-independently: System().update() flags exactly
+  // one update tick, renderOffline() then runs N blocks against that one tick —
+  // the very 1-tick-per-many-blocks cadence the caching targets. Audio is paused
+  // (engineInit), so the test thread is the sole driver of the render path.
+  TEST_CASE("gain cache: panning is stable per tick and re-pans when the source moves (#212)") {
+    if (!TestHelpers::engineInit()) return;
+
+    // Dedicated child channel so its per-output peak reflects only this sound.
+    YSE::channel ch;
+    ch.create("gaincache212", YSE::ChannelMaster());
+
+    YSE::sound s;
+    s.create(g_dc, &ch);
+    if (!s.isValid()) return;
+    s.relative(true); // angle taken directly from position, listener ignored
+    s.size(10.f); // near field: rolloff clamps to 1, so gains are a clean pan
+    s.pos(YSE::Pos(-5.f, 0.f, 0.f)); // hard left -> output 0 dominates
+    s.play();
+
+    auto leftPeak = [&]() { return ch.getPeakLinearPre(0); };
+    auto rightPeak = [&]() { return ch.getPeakLinearPre(1); };
+    auto audible = [&]() { return leftPeak() > 1e-4f || rightPeak() > 1e-4f; };
+
+    // Pump update+render until the async slow-pool setup promotes the sound and
+    // it mixes real signal. Best-effort with a deadline; if the host never
+    // delivers audio (e.g. no slow pool), there is nothing to assert.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < deadline && !audible()) {
+      YSE::System().update();
+      YSE::System().renderOffline(2);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    if (!audible()) return;
+
+    // Settled hard-left: left output carries the signal, right is ~silent.
+    const float leftL = leftPeak();
+    const float leftR = rightPeak();
+    CHECK(leftL > 0.05f);
+    CHECK(leftR < leftL * 0.1f);
+
+    // (1) Cache REUSE across blocks within one tick. renderOffline(1) twice with
+    // a single update() in between: the second block serves gains from the cache
+    // and must match the first bit-for-bit.
+    YSE::System().update();
+    YSE::System().renderOffline(1);
+    const float blockA = leftPeak();
+    YSE::System().renderOffline(1); // no update() -> cached gains
+    const float blockB = leftPeak();
+    CHECK(blockB == doctest::Approx(blockA));
+    CHECK(blockB > 0.05f);
+
+    // (2) Cache INVALIDATION on movement. Move hard-right and run a fresh tick;
+    // the pan must flip. A stuck gainDirty would leave it panned left.
+    s.pos(YSE::Pos(5.f, 0.f, 0.f));
+    YSE::System().update();
+    YSE::System().renderOffline(2); // >50 samples: smoothing ramp fully settles
+    const float rightL = leftPeak();
+    const float rightR = rightPeak();
+    CHECK(rightR > 0.05f);
+    CHECK(rightL < rightR * 0.1f);
+
+    s.stop();
   }
 
 } // TEST_SUITE("sound")

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -311,24 +311,21 @@ namespace YSE {
     class output {
     public:
       Flt angle;
-      Flt initPan;
-      Flt initGain;
+      // Speaker-density normalisation term, precomputed on layout change in
+      // computeEffectiveSpeakerWeights() (issue #211). Read by the sound
+      // panner's computeFinalGains().
       Flt effective;
-      Flt ratio;
-      Flt finalGain;
       // True for the low-frequency-effects (.1) output. Such an output is kept
       // out of azimuth panning: positional sounds are never panned into it
       // (issue #203).
       Bool isLFE;
 
-      output()
-        : angle(0.f),
-          initPan(0.f),
-          initGain(1.f),
-          effective(1.f),
-          ratio(1.f),
-          finalGain(1.f),
-          isLFE(false) {}
+      // NB: the per-source pan scratch (initPan/initGain/ratio/finalGain) that
+      // used to live here was removed in issue #212. It was shared per-channel
+      // state written as per-sound scratch, which is exactly what forbade
+      // caching a sound's gain vector; each sound now owns its own scratch and
+      // cache (SOUND::implementationObject::finalGainCache / initGainScratch).
+      output() : angle(0.f), effective(1.f), isLFE(false) {}
     };
 
   } // namespace CHANNEL

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -26,6 +26,7 @@ YSE::SOUND::implementationObject::implementationObject(sound* head)
     _head_time(0.f),
     _head_status(SS_STOPPED),
     file(nullptr),
+    gainDirty(true),
     bufferVolume(0),
     filePtr(0.f),
     newFilePos(0),
@@ -327,10 +328,22 @@ void YSE::SOUND::implementationObject::setup() {
 }
 
 void YSE::SOUND::implementationObject::resize() {
-  lastGain.resize(CHANNEL::Manager().getNumberOfOutputs());
+  const UInt numOutputs = CHANNEL::Manager().getNumberOfOutputs();
+  lastGain.resize(numOutputs);
   for (UInt i = 0; i < lastGain.size(); i++) {
     lastGain[i].resize(buffer->size(), 0.0f);
   }
+  // Pre-size the gain cache and pan scratch off the audio thread (issue #212):
+  // the callback path only reads/cheap-writes these, never resizes them. Same
+  // [output][source] shape as lastGain.
+  finalGainCache.resize(numOutputs);
+  for (UInt i = 0; i < finalGainCache.size(); i++) {
+    finalGainCache[i].resize(buffer->size(), 0.0f);
+  }
+  initGainScratch.resize(numOutputs, 0.0f);
+  // The speaker layout / channel count just changed, so any cached gains are
+  // stale — force a recompute on the next toChannels().
+  gainDirty = true;
 }
 
 Bool YSE::SOUND::implementationObject::readyCheck() {
@@ -566,6 +579,12 @@ void YSE::SOUND::implementationObject::update() {
   // equal-power omni instead of sweeping (issue #210).
   horizFraction = computeHorizontalFraction(dir);
 
+  // The pan inputs (angle / distance / spread / size / occlusion / horizFraction)
+  // are only written here, once per update() tick. Mark the cached per-speaker
+  // gain vectors stale so toChannels() recomputes them once for this tick rather
+  // than every 128-sample block (issue #212).
+  gainDirty = true;
+
   ///////////////////////////////////////////
   // sound occlusion (optional)
   ///////////////////////////////////////////
@@ -784,8 +803,8 @@ void YSE::SOUND::implementationObject::dspFunc_parseIntent() {
   headIntent = SI_NONE;
 }
 
-void YSE::SOUND::implementationObject::dspFunc_calculateGain(Int channel, Int source) {
-  Flt finalGain = parent->outConf[channel].finalGain;
+void YSE::SOUND::implementationObject::dspFunc_calculateGain(Int channel, Int source,
+                                                             Flt finalGain) {
   if (lastGain[channel][source] == finalGain) {
     channelBuffer *= (finalGain);
     return;
@@ -817,7 +836,7 @@ void YSE::SOUND::implementationObject::dspFunc_calculateGain(Int channel, Int so
   lastGain[channel][source] = finalGain;
 }
 
-void YSE::SOUND::implementationObject::toChannels() {
+void YSE::SOUND::implementationObject::computeFinalGains() {
 #ifdef _MSC_VER
 #pragma warning(disable : 4258)
 #endif
@@ -832,6 +851,14 @@ void YSE::SOUND::implementationObject::toChannels() {
                                 ? static_cast<UInt>(parent->out.size()) - lfeCount
                                 : static_cast<UInt>(parent->out.size());
 
+  // The rolloff attenuation depends only on distance/size/rolloffScale, none of
+  // which vary across source channels, so it is hoisted out of the x loop. This
+  // yields the same value the old per-x computation did, bit-for-bit.
+  Flt dist = distance - size;
+  if (dist < 0) dist = 0;
+  Flt correctPower = 1 / pow(dist, (2 * INTERNAL::Settings().rolloffScale));
+  if (correctPower > 1) correctPower = 1;
+
   for (UInt x = 0; x < buffer->size(); x++) {
     // calculate spread value for multichannel sounds
     Flt spreadAdjust = 0;
@@ -845,41 +872,58 @@ void YSE::SOUND::implementationObject::toChannels() {
       // source on the horizon (== 1) keeps the full (1 + cos)/2 pan, while a
       // near-zenith source (-> 0) collapses the cosine term, leaving a flat 0.5
       // for every speaker — an equal-power omni spread instead of a wild sweep.
-      parent->outConf[i].initPan =
+      Flt initPan =
           (1 + horizFraction * cos(parent->outConf[i].angle - (angle + spreadAdjust))) * 0.5f;
       // The speaker-density term effective[i] depends only on the speaker
       // geometry, so it is precomputed once on layout change in
       // CHANNEL::implementationObject::computeEffectiveSpeakerWeights() instead
       // of being recomputed here per source channel per block (issue #211).
-      // initial gain
-      parent->outConf[i].initGain = parent->outConf[i].initPan / parent->outConf[i].effective;
+      // initial gain — kept in per-sound scratch, not the shared outConf (#212).
+      initGainScratch[i] = initPan / parent->outConf[i].effective;
     }
     // emitted power
     Flt power = 0;
     for (UInt i = 0; i < parent->outConf.size(); i++) {
       if (parent->outConf[i].isLFE) continue;
-      power += static_cast<Flt>(pow(parent->outConf[i].initGain, 2));
+      power += static_cast<Flt>(pow(initGainScratch[i], 2));
     }
-    // calculated power
-    Flt dist = distance - size;
-    if (dist < 0) dist = 0;
-    Flt correctPower = 1 / pow(dist, (2 * INTERNAL::Settings().rolloffScale));
-    if (correctPower > 1) correctPower = 1;
 
     // final gain assignment
     for (UInt j = 0; j < parent->out.size(); ++j) {
       if (parent->outConf[j].isLFE) continue; // leave the LFE buffer silent
-      parent->outConf[j].ratio = computePanRatio(parent->outConf[j].initGain, power, realSpeakers);
-      channelBuffer = (*buffer)[x];
-      parent->outConf[j].finalGain = sqrt(correctPower * parent->outConf[j].ratio);
+      Flt ratio = computePanRatio(initGainScratch[j], power, realSpeakers);
+      Flt finalGain = sqrt(correctPower * ratio);
 
       // add volume control now
-      if (occlusionActive) parent->outConf[j].finalGain *= 1 - occlusion_dsp;
+      if (occlusionActive) finalGain *= 1 - occlusion_dsp;
+      finalGainCache[j][x] = finalGain;
+    }
+  }
+}
+
+void YSE::SOUND::implementationObject::toChannels() {
+  // Recompute the per-speaker gain vectors only when an update() tick changed
+  // one of their inputs (angle / distance / spread / size / occlusion /
+  // horizFraction / speaker layout). Between ticks those inputs are constant,
+  // so the old per-block derivation produced bit-identical gains every block —
+  // here they are read straight from finalGainCache instead (issue #212).
+  if (gainDirty) {
+    computeFinalGains();
+    gainDirty = false;
+  }
+
+  for (UInt x = 0; x < buffer->size(); x++) {
+    for (UInt j = 0; j < parent->out.size(); ++j) {
+      if (parent->outConf[j].isLFE) continue; // leave the LFE buffer silent
+      Flt finalGain = finalGainCache[j][x];
       // Farewell block for a sound going virtual (#206): target gain 0 so
       // dspFunc_calculateGain() ramps from lastGain down to silence instead of
-      // the sound simply vanishing on the next (skipped) block.
-      if (virtualFadeOut) parent->outConf[j].finalGain = 0.f;
-      dspFunc_calculateGain(j, x);
+      // the sound simply vanishing on the next (skipped) block. This is a
+      // per-block override, so it is applied on the cached value here rather
+      // than folded into computeFinalGains().
+      if (virtualFadeOut) finalGain = 0.f;
+      channelBuffer = (*buffer)[x];
+      dspFunc_calculateGain(j, x, finalGain);
       channelBuffer *= fader();
       parent->out[j] += channelBuffer;
     }

--- a/YseEngine/sound/soundImplementation.h
+++ b/YseEngine/sound/soundImplementation.h
@@ -292,7 +292,18 @@ namespace YSE {
       implementationObject* _channelNext = nullptr;
 
       void dspFunc_parseIntent();
-      void dspFunc_calculateGain(Int channel, Int source);
+      void dspFunc_calculateGain(Int channel, Int source, Flt finalGain);
+
+      /** Recompute the cached per-speaker gain vectors (finalGainCache) from the
+          current pan inputs (angle / distance / spread / horizFraction / size /
+          occlusion + speaker geometry). The full cardioid-pan + normalisation +
+          rolloff derivation (cos/pow/sqrt per speaker) only depends on values
+          that change once per update() tick, so it is run behind the gainDirty
+          flag instead of every 128-sample block — for a stationary source that
+          removes ~5 of every 6 recomputations while staying bit-identical
+          (issue #212). virtualFadeOut (#206) is a per-block override and is NOT
+          folded in here; toChannels() applies it on the cached value. */
+      void computeFinalGains();
 
       // for streaming sounds
       INTERNAL::soundFile* file;
@@ -302,6 +313,20 @@ namespace YSE {
       std::vector<DSP::buffer>* buffer;
       DSP::buffer channelBuffer; // temporary buffer to adjust channel gain
       std::vector<std::vector<Flt>> lastGain; // needed for each channel to smooth gain changes
+      // Cached per-speaker gain vectors, indexed [output channel][source channel]
+      // — same shape as lastGain. Filled by computeFinalGains() and read by
+      // toChannels(), which only does the smoothing ramp + mix on top. Recomputed
+      // (behind gainDirty) only when an update() tick changes a pan input, not
+      // every block (issue #212). Sized off the audio thread in resize().
+      std::vector<std::vector<Flt>> finalGainCache;
+      // Per-output transient scratch for the initial pan gains, presized in
+      // resize(). Replaces the old use of the shared, per-channel
+      // parent->outConf scratch fields (initPan/initGain/ratio) as per-sound
+      // scratch space — that sharing is what previously forbade caching (#212).
+      std::vector<Flt> initGainScratch;
+      // Set by update()/resize() when a pan input may have changed; consumed
+      // (and cleared) by toChannels() to trigger a finalGainCache recompute.
+      Bool gainDirty;
       Flt bufferVolume; // keep track of actual volume in buffer (may vary all the time, not used
                         // elsewhere)
 


### PR DESCRIPTION
## Summary

Caches each sound's per-speaker gain vector and recomputes it only when an `update()` tick actually changes an input, instead of rerunning the full cardioid-pan + normalisation + rolloff derivation (cos/pow/sqrt per speaker) every 128-sample block. Those inputs (`angle` / `distance` / `spread` / `size` / `occlusion` / `horizFraction` + speaker geometry) are written once per `update()` tick, so with a ~60 Hz app tick against ~344 blocks/s roughly 5 of every 6 recomputations previously produced bit-identical gains.

## Linked issue

Closes #212

## Changes

- Split the pan derivation into `computeFinalGains()`, which fills a per-sound `finalGainCache[output][source]` behind a `gainDirty` flag set by `update()`/`resize()`. `toChannels()` now only does the smoothing ramp + mix, reading gains from the cache between ticks.
- Cache and pan scratch (`initGainScratch`) are sized **off the audio thread** in `resize()`; the block loop never allocates, locks, or resizes (RT-safe).
- Removed the per-source pan scratch (`initPan`/`initGain`/`ratio`/`finalGain`) from the shared per-channel `CHANNEL::output` — that shared-as-scratch use is exactly what forbade caching. Each sound now owns its scratch and cache.
- `virtualFadeOut` (#206) stays a per-block override applied on the cached value; the distance-rolloff term is hoisted out of the source-channel loop (bit-identical).

Behaviour-preserving: pan output is bit-for-bit what the per-block recompute produced. Part of the panner efficiency series (#211, #213, #215), building on the just-merged #210/#211.

## Test plan

- [x] `yse.py format` clean (no diff on changed files)
- [x] `yse.py analyze` clean — no new clang-tidy findings in modified code (the 2 remaining, lines 174/675, are pre-existing backlog in untouched functions)
- [x] Unit/DSP/lifecycle suite passes — `yse.py test`, 17/17 ctest targets, 0 failed
- [x] Integration/end-to-end test added and passing — new `gain cache: panning is stable per tick and re-pans when the source moves (#212)` drives the real render path device-independently (constant-DC source, `System().update()` + `renderOffline()`), asserting (1) cache reuse across blocks within one tick and (2) invalidation when the source moves. 6/6 assertions pass. **Negative-verified**: temporarily breaking the `gainDirty` invalidation makes the re-pan assertions fail, confirming the test guards the caching layer.