### PR TITLE
PERF: fuse toChannels() mix loop into a single MAC pass (#213)

### DIFF
--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -817,6 +817,128 @@ TEST_SUITE("sound") {
     }
   }
 
+  // ─── Fused gain multiply-accumulate: bit-identical to the old passes (#213) ──
+  //
+  // toChannels() used to mix each (source channel, speaker) pair with four full
+  // buffer passes: copy the source into scratch, ramp-multiply the scratch by the
+  // per-speaker gain (dspFunc_calculateGain), multiply the scratch by the
+  // per-sample fader block, then accumulate into the output. Issue #213 fuses
+  // those into one scaled multiply-accumulate pass, gainAccumulate():
+  //
+  //     dest[i] += (src[i] * gainRamp[i]) * fader[i]
+  //
+  // This is a pure performance change — the mixed output and the latched lastGain
+  // must be bit-for-bit what the old four-pass sequence produced. The operation
+  // tree (which products round in which order) is preserved deliberately, so the
+  // equality below is exact (`==`), not an epsilon Approx. `oldPasses` below is a
+  // faithful transcription of the removed code path; each case pins one property
+  // the fusion could have broken: the no-change fast path, a rising ramp, a
+  // falling ramp to silence (the #206 farewell block), a buffer shorter than the
+  // 50-sample ramp (the Clamp branch), and accumulation on top of existing
+  // output (the mix is additive, not a store).
+  TEST_CASE("gainAccumulate: fused MAC is bit-identical to the old four-pass mix (#213)") {
+    using Impl = YSE::SOUND::implementationObject;
+
+    // Faithful transcription of the pre-#213 path: copy -> dspFunc_calculateGain
+    // ramp -> *fader -> += out. Returns the resulting lastGain via reference.
+    auto oldPasses = [](const std::vector<float>& src, const std::vector<float>& fader,
+                        std::vector<float>& out, float& lastGain, float finalGain) {
+      const UInt len = static_cast<UInt>(src.size());
+      std::vector<float> tmp = src; // pass 1: copy
+      if (lastGain == finalGain) { // dspFunc_calculateGain fast path
+        for (UInt i = 0; i < len; i++)
+          tmp[i] *= finalGain; // pass 2 (flat)
+      } else {
+        float length = 50.f;
+        if (length < 1.f) length = 1.f;
+        if (length > static_cast<float>(len)) length = static_cast<float>(len);
+        const float step = (finalGain - lastGain) / length;
+        float mult = lastGain;
+        UInt i = 0;
+        const UInt ramp = static_cast<UInt>(length);
+        for (; i < ramp; i++) { // pass 2: ramp
+          tmp[i] *= mult;
+          mult += step;
+        }
+        for (; i < len; i++)
+          tmp[i] *= finalGain; // pass 2: tail
+        lastGain = finalGain;
+      }
+      for (UInt i = 0; i < len; i++)
+        tmp[i] *= fader[i]; // pass 3: fader block
+      for (UInt i = 0; i < len; i++)
+        out[i] += tmp[i]; // pass 4: accumulate
+    };
+
+    // A source block, a non-trivial per-sample fader ramp, and a non-zero output
+    // preload (so the additive accumulate is actually exercised).
+    const UInt len = 128;
+    std::vector<float> src(len), fader(len), outSeed(len);
+    for (UInt i = 0; i < len; i++) {
+      src[i] = std::sin(0.13f * i) * 0.7f - 0.2f;
+      fader[i] = 0.3f + 0.5f * (static_cast<float>(i) / len); // fade-in style ramp
+      outSeed[i] = std::cos(0.07f * i) * 0.4f; // pre-existing mix content
+    }
+
+    struct Scenario {
+      const char* name;
+      float lastGain;
+      float finalGain;
+    };
+    const Scenario scenarios[] = {
+        {"unchanged gain (fast path)", 0.6f, 0.6f},
+        {"rising ramp", 0.2f, 0.9f},
+        {"falling ramp to silence (#206 farewell)", 0.8f, 0.0f},
+        {"tiny step", 0.5f, 0.5000001f},
+    };
+
+    for (const auto& sc : scenarios) {
+      CAPTURE(sc.name);
+      std::vector<float> outNew = outSeed, outOld = outSeed;
+      float lastNew = sc.lastGain, lastOld = sc.lastGain;
+
+      Impl::gainAccumulate(src.data(), fader.data(), outNew.data(), len, lastNew, sc.finalGain);
+      oldPasses(src, fader, outOld, lastOld, sc.finalGain);
+
+      for (UInt i = 0; i < len; i++) {
+        CAPTURE(i);
+        CHECK(outNew[i] == outOld[i]); // bit-for-bit, not Approx
+      }
+      CHECK(lastNew == lastOld); // latched gain state matches exactly
+    }
+
+    // Buffer shorter than the 50-sample ramp: exercises the Clamp(length, 1, len)
+    // branch so the whole block ramps and none of it holds finalGain.
+    {
+      const UInt shortLen = 16;
+      std::vector<float> ssrc(shortLen), sfad(shortLen), oNew(shortLen, 0.f), oOld(shortLen, 0.f);
+      for (UInt i = 0; i < shortLen; i++) {
+        ssrc[i] = 0.5f - 0.03f * i;
+        sfad[i] = 1.0f;
+      }
+      float lNew = 0.1f, lOld = 0.1f;
+      Impl::gainAccumulate(ssrc.data(), sfad.data(), oNew.data(), shortLen, lNew, 0.9f);
+      oldPasses(ssrc, sfad, oOld, lOld, 0.9f);
+      for (UInt i = 0; i < shortLen; i++) {
+        CAPTURE(i);
+        CHECK(oNew[i] == oOld[i]);
+      }
+      CHECK(lNew == lOld);
+    }
+
+    // The fast path must NOT advance lastGain (it is already equal); the ramp path
+    // must latch it to finalGain. Pin both so a future edit can't silently drop
+    // the state write the smoothing ramp depends on across blocks.
+    {
+      std::vector<float> s(4, 1.f), f(4, 1.f), o(4, 0.f);
+      float latched = 0.42f;
+      Impl::gainAccumulate(s.data(), f.data(), o.data(), 4, latched, 0.42f);
+      CHECK(latched == 0.42f); // unchanged
+      Impl::gainAccumulate(s.data(), f.data(), o.data(), 4, latched, 0.77f);
+      CHECK(latched == 0.77f); // advanced by the ramp path
+    }
+  }
+
   // ─── Source-angle mapping: relative vs world frame (#204) ───────────────────
   //
   // Regression tests for the left↔right mirror in the relative / pan2D pan path.

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -803,37 +803,43 @@ void YSE::SOUND::implementationObject::dspFunc_parseIntent() {
   headIntent = SI_NONE;
 }
 
-void YSE::SOUND::implementationObject::dspFunc_calculateGain(Int channel, Int source,
-                                                             Flt finalGain) {
-  if (lastGain[channel][source] == finalGain) {
-    channelBuffer *= (finalGain);
+void YSE::SOUND::implementationObject::gainAccumulate(const Flt* src, const Flt* fader, Flt* dest,
+                                                      UInt length, Flt& lastGain, Flt finalGain) {
+  // Fast path: gain unchanged since the last block -> flat multiply, no ramp and
+  // no state write (mirrors the old dspFunc_calculateGain early-out). Per sample:
+  // dest[i] += (src[i] * finalGain) * fader[i] — the exact operation tree the old
+  // copy -> *gain -> *fader -> += sequence produced, so the result is bit-identical.
+  if (lastGain == finalGain) {
+    for (UInt i = 0; i < length; i++) {
+      Flt v = src[i] * finalGain;
+      v *= fader[i];
+      dest[i] += v;
+    }
     return;
   }
 
-  Flt length = 50;
-  Clamp(length, 1.f, static_cast<Flt>(channelBuffer.getLength()));
-  Flt step = (finalGain - lastGain[channel][source]) / length;
-  Flt multiplier = lastGain[channel][source];
-  Flt* ptr = channelBuffer.getPtr();
-  for (UInt i = 0; i < length; i++) {
-    *ptr++ *= (multiplier);
+  // Ramp the gain from lastGain to finalGain over the first `rampLen` samples,
+  // then hold finalGain. The multiplier sequence (start, step, running +=) is
+  // identical to the old ramp, so every g[i] is bit-identical; folding the fader
+  // multiply and the accumulate into the same pass keeps the rounding order.
+  Flt rampLen = 50;
+  Clamp(rampLen, 1.f, static_cast<Flt>(length));
+  Flt step = (finalGain - lastGain) / rampLen;
+  Flt multiplier = lastGain;
+  UInt i = 0;
+  UInt ramp = static_cast<UInt>(rampLen);
+  for (; i < ramp; i++) {
+    Flt v = src[i] * multiplier;
+    v *= fader[i];
+    dest[i] += v;
     multiplier += step;
   }
-  UInt leftOvers = channelBuffer.getLength() - (UInt)length;
-  for (; leftOvers > 7; leftOvers -= 8, ptr += 8) {
-    ptr[0] *= finalGain;
-    ptr[1] *= finalGain;
-    ptr[2] *= finalGain;
-    ptr[3] *= finalGain;
-    ptr[4] *= finalGain;
-    ptr[5] *= finalGain;
-    ptr[6] *= finalGain;
-    ptr[7] *= finalGain;
+  for (; i < length; i++) {
+    Flt v = src[i] * finalGain;
+    v *= fader[i];
+    dest[i] += v;
   }
-
-  while (leftOvers--)
-    *ptr++ *= finalGain;
-  lastGain[channel][source] = finalGain;
+  lastGain = finalGain;
 }
 
 void YSE::SOUND::implementationObject::computeFinalGains() {
@@ -912,20 +918,30 @@ void YSE::SOUND::implementationObject::toChannels() {
     gainDirty = false;
   }
 
+  // The fader is a per-sample ramp block shared by every speaker and every
+  // source channel this block, so its pointer is fetched once. Previously the
+  // fader was applied as its own full-buffer pass per (source, speaker); it is
+  // now folded into the single MAC pass below (issue #213).
+  const Flt* faderPtr = fader().getPtr();
+
   for (UInt x = 0; x < buffer->size(); x++) {
+    // Read the source channel in place — no per-speaker copy. The old loop
+    // copied (*buffer)[x] into a scratch buffer for every speaker just so the
+    // in-place gain multiply had somewhere to write; the fused MAC reads the
+    // pristine source and accumulates straight into each output (issue #213).
+    const Flt* src = (*buffer)[x].getPtr();
+    UInt length = (*buffer)[x].getLength();
     for (UInt j = 0; j < parent->out.size(); ++j) {
       if (parent->outConf[j].isLFE) continue; // leave the LFE buffer silent
       Flt finalGain = finalGainCache[j][x];
-      // Farewell block for a sound going virtual (#206): target gain 0 so
-      // dspFunc_calculateGain() ramps from lastGain down to silence instead of
-      // the sound simply vanishing on the next (skipped) block. This is a
-      // per-block override, so it is applied on the cached value here rather
-      // than folded into computeFinalGains().
+      // Farewell block for a sound going virtual (#206): target gain 0 so the
+      // smoothing ramp glides from lastGain down to silence instead of the sound
+      // simply vanishing on the next (skipped) block. This is a per-block
+      // override, so it is applied on the cached value here rather than folded
+      // into computeFinalGains().
       if (virtualFadeOut) finalGain = 0.f;
-      channelBuffer = (*buffer)[x];
-      dspFunc_calculateGain(j, x, finalGain);
-      channelBuffer *= fader();
-      parent->out[j] += channelBuffer;
+      // Single fused pass: out[j][i] += (src[i] * gainRamp[i]) * fader[i].
+      gainAccumulate(src, faderPtr, parent->out[j].getPtr(), length, lastGain[j][x], finalGain);
     }
   }
 }

--- a/YseEngine/sound/soundImplementation.h
+++ b/YseEngine/sound/soundImplementation.h
@@ -237,6 +237,22 @@ namespace YSE {
       */
       static Flt computeHorizontalFraction(const Pos& dir);
 
+      /** Fused scaled multiply-accumulate with the 50-sample smoothing ramp.
+          Replaces the old per-speaker sequence copy -> calculateGain -> *fader
+          -> += (four full-buffer passes) with a single MAC pass (issue #213):
+
+              dest[i] += (src[i] * g[i]) * fader[i]
+
+          where g[i] slews linearly from `lastGain` toward `finalGain` over the
+          first min(50,length) samples and then holds `finalGain`, and `lastGain`
+          is advanced to `finalGain`. When `lastGain` already equals `finalGain`
+          a flat gain is applied (no ramp), matching the old fast path. The
+          multiply/accumulate order reproduces the old code sample-for-sample, so
+          the mix is bit-identical. RT-safe: no allocation, no lock. Static + pure
+          (state passed by reference) so it stays unit-testable in isolation. */
+      static void gainAccumulate(const Flt* src, const Flt* fader, Flt* dest, UInt length,
+                                 Flt& lastGain, Flt finalGain);
+
       void removeInterface();
 
       OBJECT_IMPLEMENTATION_STATE getStatus();
@@ -292,7 +308,6 @@ namespace YSE {
       implementationObject* _channelNext = nullptr;
 
       void dspFunc_parseIntent();
-      void dspFunc_calculateGain(Int channel, Int source, Flt finalGain);
 
       /** Recompute the cached per-speaker gain vectors (finalGainCache) from the
           current pan inputs (angle / distance / spread / horizFraction / size /
@@ -311,7 +326,6 @@ namespace YSE {
       // buffers
       std::vector<DSP::buffer> filebuffer;
       std::vector<DSP::buffer>* buffer;
-      DSP::buffer channelBuffer; // temporary buffer to adjust channel gain
       std::vector<std::vector<Flt>> lastGain; // needed for each channel to smooth gain changes
       // Cached per-speaker gain vectors, indexed [output channel][source channel]
       // — same shape as lastGain. Filled by computeFinalGains() and read by


### PR DESCRIPTION
## Summary

Fuse the `toChannels()` mix loop. Each (source channel × speaker) pair previously ran **four full-buffer passes**: copy source → scratch, ramp-multiply scratch by per-speaker gain (`dspFunc_calculateGain`), multiply by the per-sample fader block, then accumulate into the output. This is the dominant per-sample cost of the spatializer at hundreds of concurrent sources.

They collapse into **one** fused scaled multiply-accumulate, `gainAccumulate()`:

```
out[j][i] += (src[i] * gainRamp[i]) * fader[i]
```

reading the pristine source in place (no per-speaker copy) and folding the fader multiply and the accumulate into the same pass. Passes drop from `4N` to `N` per source channel — better than the `N+2` the issue targeted, because the copy and the separate fader pass are eliminated entirely (`N` is the irreducible floor of one MAC per speaker).

Behaviour-preserving: the multiply/accumulate order and the 50-sample smoothing-ramp math are kept sample-for-sample, so the mixed output and the latched `lastGain` are **bit-identical** to the old sequence. Note `fader()` returns a per-sample ramp *block* (not a scalar), so the fused pass multiplies by `fader[i]` per sample — preserving the exact rounding tree the old two separate multiplies produced.

RT discipline: no allocation, no lock on the audio path; the MAC loop is the shape the compiler's SIMD/FMA autovectorizer handles best. The now-dead `dspFunc_calculateGain` and its `channelBuffer` scratch member are removed.

## Linked issue

Closes #213

## Changes

- `YseEngine/sound/soundImplementation.{h,cpp}` — replace `dspFunc_calculateGain` + the 4-pass `toChannels()` inner loop with a single pure static `gainAccumulate()` MAC; drop the `channelBuffer` member.
- `Tests/sound/test_sound_impl.cpp` — new unit test pinning the fused MAC bit-for-bit against a faithful transcription of the old four-pass path.

## Test plan

- [x] `python yse.py format` clean (no reformatting of changed files)
- [x] `python yse.py analyze` clean on changed files — no new findings in modified code (remaining warnings are pre-existing: `soundImplementation.cpp:174/675`, `test_sound_impl.cpp:52/72/620`)
- [x] Unit tests pass — new `gainAccumulate` case: **535 assertions, all bit-for-bit `==`** across the fast path, rising/falling ramps, the #206 farewell fade, a sub-ramp-length buffer (Clamp branch), and additive accumulation; also pins the `lastGain` latch semantics.
- [x] Full suite passes: `python yse.py test` → **17/17 ctest binaries pass** (incl. `yse_tests_sound` and `yse_tests_integration`).
- [x] Integration/behavioural coverage: the existing #212 gain-cache test drives `toChannels()` end-to-end through `System().update()` + `renderOffline()` and asserts stable, correctly-panned output — it continues to pass, confirming the real mix path is unchanged. No new user-visible behaviour is introduced (pure performance refactor with bit-identical output), so no new integration test is warranted beyond this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)