### PR TITLE
FIX: re-arm streaming reset consumed by a stale-generation fill (#283)

### DIFF
--- a/Tests/sound/test_sound_streaming.cpp
+++ b/Tests/sound/test_sound_streaming.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -99,6 +100,61 @@ namespace {
   }
 
   const long S = static_cast<long>(YSE::STREAM_BUFFERSIZE); // 44100
+
+  // Minimal in-memory backend for abstractSoundFile so the stale-generation
+  // race of issue #283 can be reproduced deterministically. The production
+  // publication protocol (abstractSoundFile::fillBackBuffer) is exercised
+  // unchanged; only the blocking disk fill is replaced by an emulated file
+  // handle, with a hook at the exact interleaving point: after fillBackBuffer()
+  // captured the fill generation, before the fill consumes the reset flag —
+  // where the audio thread's reset()/seek() races in.
+  class staleGenFile : public YSE::INTERNAL::abstractSoundFile {
+  public:
+    staleGenFile() : abstractSoundFile("stale-gen-probe", true) {
+      _length = 10 * static_cast<int>(S); // so seek() targets aren't clamped
+    }
+    void loadStreaming() override {}
+    void loadNonStreaming() override {}
+
+    std::function<void()> onFillStart; // runs once, at the race point
+    Long handlePos = S; // emulated handle position (front buffer 0 already read)
+    Long lastFillStart = -1; // where the most recent fill read from
+    int seeks = 0;
+
+    UInt fillBuffer(Flt* /*dest*/, Bool /*loop*/) override {
+      if (onFillStart) {
+        auto hook = std::move(onFillStart);
+        onFillStart = nullptr;
+        hook();
+      }
+      // Mirror the production backend's reset handling (lsfSoundfile.cpp).
+      if (_needsReset.exchange(false, std::memory_order_relaxed)) {
+        handlePos = _seekTarget.load(std::memory_order_relaxed);
+        ++seeks;
+      }
+      lastFillStart = handlePos;
+      handlePos += S;
+      return YSE::STREAM_BUFFERSIZE;
+    }
+
+    // Drive one back-buffer fill the way the slow pool does: requestRefill()
+    // marks the refill in flight before the job runs fillBackBuffer().
+    void runFill() {
+      _refillInFlight.store(true, std::memory_order_relaxed);
+      fillBackBuffer();
+    }
+
+    bool needsReset() {
+      return _needsReset.load(std::memory_order_relaxed);
+    }
+    bool backIsStale() {
+      return _backGen.load(std::memory_order_relaxed) != _fillGen.load(std::memory_order_relaxed);
+    }
+    // What streamSwap does with a stale-generation back buffer: discard it.
+    void discardStaleBack() {
+      _backReady.store(false, std::memory_order_relaxed);
+    }
+  };
 
 } // namespace
 
@@ -394,6 +450,49 @@ TEST_SUITE("sound") {
     }
 
     CHECK(soundFile::liveInstances() == baseline);
+  }
+
+  // 9. Issue #283 regression: a stop (reset) that lands after an in-flight fill
+  //    captured its generation but before that fill consumed the reset flag must
+  //    not be swallowed. The stale fill's output is (rightly) discarded, so the
+  //    reset must be re-armed for the accepted fill — otherwise the restart
+  //    resumes STREAM_BUFFERSIZE frames late. Reproduced deterministically with
+  //    an in-memory backend; no engine or slow pool involved.
+  TEST_CASE("streaming: reset consumed by a stale-generation fill is re-armed (issue #283)") {
+    staleGenFile f;
+
+    // F1 starts; the audio thread's stop lands at the race point.
+    f.onFillStart = [&f] { f.reset(); };
+    f.runFill(); // F1
+    CHECK(f.seeks == 1); // F1 consumed the reset and seeked to 0...
+    CHECK(f.lastFillStart == 0);
+    REQUIRE(f.backIsStale()); // ...but its output is stale-tagged
+    f.discardStaleBack(); // and streamSwap discards it
+
+    // The reset must have been re-armed so the accepted fill F2 seeks again.
+    CHECK(f.needsReset()); // without the fix: false (F1 swallowed the reset)
+    f.runFill(); // F2 — the fill whose output is accepted
+    CHECK(f.lastFillStart == 0); // without the fix: S (wrong file position)
+    CHECK_FALSE(f.backIsStale());
+  }
+
+  // 10. Same interleaving with a non-zero seek target (the issue-#217 path):
+  //     the re-armed reset must land the accepted fill on the requested frame,
+  //     since _seekTarget is not consumed by the reset exchange.
+  TEST_CASE("streaming: seek consumed by a stale-generation fill is re-armed (issue #283)") {
+    staleGenFile f;
+
+    const Long target = 4321;
+    f.onFillStart = [&f, target] { f.seek(target, false); };
+    f.runFill(); // F1 — consumes the seek, output stale-tagged
+    CHECK(f.lastFillStart == target);
+    REQUIRE(f.backIsStale());
+    f.discardStaleBack();
+
+    CHECK(f.needsReset()); // re-armed; _seekTarget still holds `target`
+    f.runFill(); // F2
+    CHECK(f.lastFillStart == target); // without the fix: target + S
+    CHECK_FALSE(f.backIsStale());
   }
 
 } // TEST_SUITE("sound")

--- a/YseEngine/internal/abstractSoundFile.cpp
+++ b/YseEngine/internal/abstractSoundFile.cpp
@@ -98,6 +98,32 @@ void YSE::INTERNAL::abstractSoundFile::requestRefill(Bool loop) {
   }
 }
 
+void YSE::INTERNAL::abstractSoundFile::fillBackBuffer() {
+  Bool loop = _streamLoop.load(std::memory_order_relaxed);
+  // Tag this fill with the generation observed at the start. reset() (on stop)
+  // and seek() bump _fillGen, so the audio thread discards a fill that began
+  // before the stop/seek instead of playing its stale position (issue #185).
+  uint32_t gen = _fillGen.load(std::memory_order_acquire);
+  UInt valid = fillBuffer(_iBufferBack, loop);
+  // If a reset()/seek() landed while this fill ran, the fill may have consumed
+  // the reset flag (seeked the handle and filled from the target) even though
+  // its output is tagged with the old generation and will be discarded by
+  // streamSwap. Re-arm the reset so the *accepted* fill seeks to the latest
+  // _seekTarget instead of resuming at this fill's end position (issue #283).
+  // Re-arming is idempotent: the exchange in fillBuffer does not consume
+  // _seekTarget, so the worst case is an extra seek to the already-armed target.
+  if (_fillGen.load(std::memory_order_acquire) != gen) {
+    _needsReset.store(true, std::memory_order_relaxed);
+  }
+  // Publish: these are read by the audio thread after its acquire load of
+  // _backReady, so the release store below makes them visible.
+  _backValidFrames.store((Long)valid, std::memory_order_relaxed);
+  _backTerminal.store(valid < STREAM_BUFFERSIZE, std::memory_order_relaxed);
+  _backGen.store(gen, std::memory_order_relaxed);
+  _backReady.store(true, std::memory_order_release);
+  _refillInFlight.store(false, std::memory_order_relaxed);
+}
+
 Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* file,
                                                           std::vector<DSP::buffer>& filebuffer,
                                                           Flt& pos, UInt length, Flt speed,

--- a/YseEngine/internal/abstractSoundFile.h
+++ b/YseEngine/internal/abstractSoundFile.h
@@ -113,9 +113,18 @@ namespace YSE {
       // helper (called from the audio thread's read()) makes sure exactly one
       // refill of the back buffer is scheduled on the slow pool.
       void requestRefill(Bool loop);
-      // Fill the back buffer from disk. Runs on the slow pool via _refillJob;
-      // must never be called on the audio thread. Implemented by the backend.
-      virtual void fillBackBuffer() = 0;
+      // Fill the back buffer from disk and publish it to the audio thread. Runs
+      // on the slow pool via _refillJob; must never be called on the audio
+      // thread. The generation-tagged publication protocol (issue #185) and the
+      // reset re-arm (issue #283) live here in the base; the actual disk fill is
+      // the backend's fillBuffer().
+      void fillBackBuffer();
+      // Backend disk fill: write up to STREAM_BUFFERSIZE frames into `dest` from
+      // the current stream position, honoring _needsReset/_seekTarget and the
+      // loop flag, zero-padding the tail at non-loop EOF. Returns the number of
+      // real (non-padded) frames written. Does blocking disk I/O — slow pool /
+      // load only, never the audio thread (issue #185).
+      virtual UInt fillBuffer(Flt* dest, Bool loop) = 0;
 
       // Slow-pool job that drives fillBackBuffer() for this file. A dedicated job
       // (rather than reusing the abstractSoundFile load job) is required: the load

--- a/YseEngine/internal/lsfSoundfile.cpp
+++ b/YseEngine/internal/lsfSoundfile.cpp
@@ -155,20 +155,4 @@ UInt YSE::INTERNAL::soundFile::fillBuffer(Flt* dest, Bool loop) {
   return STREAM_BUFFERSIZE;
 }
 
-void YSE::INTERNAL::soundFile::fillBackBuffer() {
-  Bool loop = _streamLoop.load(std::memory_order_relaxed);
-  // Tag this fill with the generation observed at the start. reset() (on stop)
-  // bumps _fillGen, so the audio thread discards a fill that began before the
-  // stop instead of playing its stale position on restart (issue #185).
-  uint32_t gen = _fillGen.load(std::memory_order_acquire);
-  UInt valid = fillBuffer(_iBufferBack, loop);
-  // Publish: these are read by the audio thread after its acquire load of
-  // _backReady, so the release store below makes them visible.
-  _backValidFrames.store((Long)valid, std::memory_order_relaxed);
-  _backTerminal.store(valid < STREAM_BUFFERSIZE, std::memory_order_relaxed);
-  _backGen.store(gen, std::memory_order_relaxed);
-  _backReady.store(true, std::memory_order_release);
-  _refillInFlight.store(false, std::memory_order_relaxed);
-}
-
 #endif // LIBSOUNDFILE_BACKEND

--- a/YseEngine/internal/lsfSoundfile.h
+++ b/YseEngine/internal/lsfSoundfile.h
@@ -42,12 +42,9 @@ namespace YSE {
       // position, zero-padding the tail at non-loop EOF. Returns the number of
       // real (non-padded) frames written (== STREAM_BUFFERSIZE unless EOF was hit
       // without looping). Does blocking disk I/O — slow pool / load only, never
-      // the audio thread (issue #185).
-      UInt fillBuffer(Flt* dest, Bool loop);
-
-      // Slow-pool entry point: refill the back buffer and publish it. Overrides
-      // the base hook driven by _refillJob.
-      void fillBackBuffer() override;
+      // the audio thread (issue #185). Called by the base's fillBackBuffer(),
+      // which owns the generation-tagged publication (issues #185/#283).
+      UInt fillBuffer(Flt* dest, Bool loop) override;
 
       SndfileHandle* handle;
     };


### PR DESCRIPTION
## Summary
Fixes the #283 flag-consumption race in streaming playback: a `reset()`/`seek()` that lands after an in-flight slow-pool fill has captured its generation but before it consumes `_needsReset` was swallowed by that fill. The stale fill's output is correctly discarded by `streamSwap` (gen mismatch), but the next accepted fill found `_needsReset == false`, skipped the seek, and resumed playback `STREAM_BUFFERSIZE` frames past the requested position.

`fillBackBuffer` now re-checks `_fillGen` after the disk fill and re-arms `_needsReset` when the generation moved, so the accepted fill still seeks to the (unconsumed) `_seekTarget`. Re-arming is idempotent — worst case is an extra seek to the already-armed target, on the slow pool. No audio-thread path changes: the audio thread's `reset()`/`seek()`/`streamSwap` are untouched.

To make the exact interleaving deterministically testable, the generation-tagged publish protocol (previously `soundFile::fillBackBuffer`) moved verbatim into `abstractSoundFile::fillBackBuffer` — every atomic it touches already lived in the base. The backend now only implements the virtual blocking disk fill `fillBuffer()`. This lets the regression tests drive the production publish/re-arm code with an in-memory backend that injects the reset at the precise race point.

## Linked issue
Closes #283

## Changes
- `YseEngine/internal/abstractSoundFile.{h,cpp}`: hoist `fillBackBuffer()` publish protocol into the base; add the generation re-check + `_needsReset` re-arm (the fix); `fillBuffer()` becomes the pure-virtual backend seam.
- `YseEngine/internal/lsfSoundfile.{h,cpp}`: `soundFile::fillBackBuffer` removed; `fillBuffer` now overrides the base seam (body unchanged).
- `Tests/sound/test_sound_streaming.cpp`: two deterministic regression tests (stop/reset shape and the #217 seek shape) using a minimal in-memory `abstractSoundFile` backend with a hook at the race point. Both verified to fail on the unpatched code (resume at frame 44100 / target+44100) and pass with the fix.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on all five touched files (clang-format 22.1.4)
- [x] `python yse.py analyze` clean on `abstractSoundFile.cpp`, `lsfSoundfile.cpp`, `test_sound_streaming.cpp` — no new findings
- [x] `python yse.py test`: 17/17 ctest groups pass (includes the two new #283 regression cases)
- [x] Regression tests confirmed to fail without the fix: `needsReset == false`, resume at 44100 instead of 0 / 48421 instead of 4321
- No end-to-end test added: the race window is a few instructions wide on the slow pool between two adjacent atomic operations — it cannot be reliably driven through the public API/real device. The deterministic tests exercise the production fill/publish code at the exact interleaving instead; the existing streaming suite (tests 1–8) covers the user-visible stop/restart and seek flows end-to-end against the real slow pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)