### PR TITLE
ENGINE: help-run (work-steal) in audio-callback join() and surface denied render-worker priority (#284)

### DIFF
--- a/Tests/internal/test_threadpool.cpp
+++ b/Tests/internal/test_threadpool.cpp
@@ -8,6 +8,7 @@
 
 #include <doctest/doctest.h>
 #include "internal/threadPool.h"
+#include "internal/thread.h"
 #include <atomic>
 #include <chrono>
 #include <new>
@@ -29,6 +30,20 @@ namespace {
     void run() override {
       if (ranOn) ranOn->store(std::this_thread::get_id());
       counter->fetch_add(1, std::memory_order_relaxed);
+    }
+  };
+
+  // A job that signals when it starts running and then pins its worker thread
+  // until released.
+  struct BlockJob : threadPoolJob {
+    std::atomic<bool>* release;
+    std::atomic<bool>* started;
+    explicit BlockJob(std::atomic<bool>* r, std::atomic<bool>* s = nullptr)
+      : release(r), started(s) {}
+    void run() override {
+      if (started) started->store(true, std::memory_order_release);
+      while (!release->load(std::memory_order_acquire))
+        std::this_thread::yield();
     }
   };
 } // namespace
@@ -105,15 +120,6 @@ TEST_SUITE("internal") {
 
     // A blocking job pins a worker until released, so the ring can actually
     // fill instead of being drained as fast as we push.
-    struct BlockJob : threadPoolJob {
-      std::atomic<bool>* release;
-      explicit BlockJob(std::atomic<bool>* r) : release(r) {}
-      void run() override {
-        while (!release->load(std::memory_order_acquire))
-          std::this_thread::yield();
-      }
-    };
-
     std::atomic<bool> release{false};
     std::vector<std::unique_ptr<BlockJob>> blockers;
     for (int i = 0; i < 2; ++i) { // one per worker
@@ -168,6 +174,76 @@ TEST_SUITE("internal") {
     }
 
     CHECK(counter.load() == N);
+  }
+
+  TEST_CASE("threadPool: join() help-runs queued render jobs while it waits (issue #284)") {
+    // Regression for issue #284. The spin-only join() made the audio
+    // callback's completion depend on another thread's progress: with every
+    // worker preempted (or otherwise stalled), join() on a still-queued job
+    // spun/yielded until a worker came back. With help-running, join() pops
+    // runnable jobs from the same render ring and runs them on the calling
+    // thread, so it completes even when no worker makes any progress.
+    //
+    // Model the worst case exactly: a single-worker pool whose only worker is
+    // pinned by a blocking job. Every job queued behind it can then only run
+    // if join() helps. Without the fix this test never terminates.
+    threadPool pool(1, poolClass::render);
+
+    std::atomic<bool> release{false};
+    std::atomic<bool> started{false};
+    BlockJob blocker(&release, &started);
+    pool.addJob(&blocker);
+
+    // Wait until the worker has actually popped the blocker, so the ring
+    // holds only the jobs below and the worker is provably out of play.
+    while (!started.load(std::memory_order_acquire))
+      std::this_thread::yield();
+
+    constexpr int N = 32;
+    std::atomic<int> counter{0};
+    std::vector<std::atomic<std::thread::id>> ranOn(N);
+    std::vector<std::unique_ptr<CountJob>> jobs;
+    jobs.reserve(N);
+    for (int i = 0; i < N; ++i) {
+      jobs.emplace_back(std::make_unique<CountJob>(&counter, &ranOn[i]));
+      pool.addJob(jobs.back().get());
+    }
+
+    // The worker is pinned, so these joins can only return via help-running.
+    for (auto& j : jobs)
+      j->join();
+
+    CHECK(counter.load() == N);
+    // And the help must have happened on this (the joining) thread.
+    for (int i = 0; i < N; ++i)
+      CHECK(ranOn[i].load() == std::this_thread::get_id());
+
+    release.store(true, std::memory_order_release);
+    blocker.join();
+  }
+
+  TEST_CASE("thread: setPriority reports whether the request took effect (issue #284)") {
+    // setPriority used to swallow denial silently; threadPool::startup() now
+    // logs the degraded mode, which needs an observable result. Elevation
+    // (`high == true`) is genuinely platform/privilege dependent, so only its
+    // invariants are asserted here: false before start(), and a plain
+    // normal-priority request on a running thread must succeed everywhere.
+    struct NapThread : YSE::INTERNAL::thread {
+      void run() override {
+        while (!threadShouldExit())
+          std::this_thread::yield();
+      }
+    };
+
+    NapThread t;
+    CHECK(t.setPriority(true) == false); // no underlying handle yet
+    t.start();
+    CHECK(t.setPriority(false) == true); // normal priority is always grantable
+    // Best-effort elevation: result depends on OS privileges, must not crash
+    // and must leave the thread joinable either way.
+    (void)t.setPriority(true);
+    t.stop();
+    CHECK(t.isRunning() == false);
   }
 
   TEST_CASE("threadPool: survives shutdown()/startup() cycling") {

--- a/Tests/internal/test_threadpool.cpp
+++ b/Tests/internal/test_threadpool.cpp
@@ -214,9 +214,14 @@ TEST_SUITE("internal") {
       j->join();
 
     CHECK(counter.load() == N);
-    // And the help must have happened on this (the joining) thread.
-    for (int i = 0; i < N; ++i)
-      CHECK(ranOn[i].load() == std::this_thread::get_id());
+    // And the help must have happened on this (the joining) thread. Compare
+    // outside CHECK: doctest would otherwise try to stringify the
+    // std::thread::id operands, which fails to compile on libstdc++
+    // (gcc 13/14 headers).
+    for (int i = 0; i < N; ++i) {
+      const bool ranOnJoiningThread = ranOn[i].load() == std::this_thread::get_id();
+      CHECK(ranOnJoiningThread);
+    }
 
     release.store(true, std::memory_order_release);
     blocker.join();

--- a/YseEngine/internal/thread.cpp
+++ b/YseEngine/internal/thread.cpp
@@ -52,16 +52,17 @@ void YSE::INTERNAL::thread::stop() {
   }
 }
 
-void YSE::INTERNAL::thread::setPriority(bool high) {
-  if (!handle) return;
+bool YSE::INTERNAL::thread::setPriority(bool high) {
+  if (!handle) return false;
 #if defined(_WIN32)
-  ::SetThreadPriority(static_cast<HANDLE>(handle->native_handle()),
-                      high ? THREAD_PRIORITY_HIGHEST : THREAD_PRIORITY_NORMAL);
+  return ::SetThreadPriority(static_cast<HANDLE>(handle->native_handle()),
+                             high ? THREAD_PRIORITY_HIGHEST : THREAD_PRIORITY_NORMAL) != 0;
 #else
   // Best-effort: raising to SCHED_FIFO needs privileges (CAP_SYS_NICE / RT
   // limits). If pthread_setschedparam fails we leave the thread at its default
   // policy — the spin-based join() still bounds the callback stall, priority is
-  // only an optimisation against preemption.
+  // only an optimisation against preemption. The result is reported so the
+  // caller can log the degraded mode once (issue #284).
   int policy = high ? SCHED_FIFO : SCHED_OTHER;
   sched_param param{};
   if (high) {
@@ -69,7 +70,7 @@ void YSE::INTERNAL::thread::setPriority(bool high) {
     int hi = ::sched_get_priority_max(SCHED_FIFO);
     param.sched_priority = (lo >= 0 && hi >= 0) ? lo + (hi - lo) / 2 : 0;
   }
-  ::pthread_setschedparam(handle->native_handle(), policy, &param);
+  return ::pthread_setschedparam(handle->native_handle(), policy, &param) == 0;
 #endif
 }
 

--- a/YseEngine/internal/thread.h
+++ b/YseEngine/internal/thread.h
@@ -34,11 +34,14 @@ namespace YSE {
       // audio-callback priority band (SCHED_FIFO on POSIX / THREAD_PRIORITY_-
       // HIGHEST on Windows) so a render worker can't be preempted by ordinary
       // work while the callback spins in threadPoolJob::join() waiting for it
-      // (issue #188). Must be called after start(); a no-op if the underlying
-      // handle isn't running yet. Failure (e.g. POSIX RT scheduling denied to
-      // an unprivileged process) is silently ignored — correctness never
-      // depends on the priority actually taking effect.
-      void setPriority(bool high);
+      // (issue #188). Must be called after start(); a no-op (returning false)
+      // if the underlying handle isn't running yet. Failure (e.g. POSIX RT
+      // scheduling denied to an unprivileged process) leaves the thread at its
+      // default priority — correctness never depends on the priority actually
+      // taking effect, but the caller can observe denial through the return
+      // value and surface the degraded mode (issue #284). Returns true when
+      // the OS accepted the request.
+      bool setPriority(bool high);
 
       bool isRunning() const;
       bool threadShouldExit() const;

--- a/YseEngine/internal/threadPool.cpp
+++ b/YseEngine/internal/threadPool.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <thread>
 #include "../system.hpp"
+#include "../implementations/logImplementation.h"
 #include "denormalGuard.h"
 
 #if defined(_MSC_VER)
@@ -37,19 +38,34 @@ namespace {
   }
 } // namespace
 
-YSE::INTERNAL::threadPoolJob::threadPoolJob() : shouldStop(false), inQueue(false), isDone(false) {}
+YSE::INTERNAL::threadPoolJob::threadPoolJob()
+  : shouldStop(false), inQueue(false), isDone(false), pool(nullptr) {}
 
 YSE::INTERNAL::threadPoolJob::~threadPoolJob() {
   join();
 }
 
 void YSE::INTERNAL::threadPoolJob::join() {
-  // Bounded-spin wait, called from the audio callback (buffersToParent) — it
+  // Help-running wait, called from the audio callback (buffersToParent) — it
   // must never sleep or lock. The old implementation slept in 2 ms quanta,
-  // burning ~70% of a 2.9 ms render block waiting on a worker (issue #188).
-  // Instead spin on a flag, relaxing the CPU for a while and then yielding so a
-  // not-yet-scheduled worker can run. Render workers run at raised priority, so
-  // the yield path is rarely reached.
+  // burning ~70% of a 2.9 ms render block waiting on a worker (issue #188);
+  // its spin-only successor still made the callback's completion depend on
+  // another thread's progress (issue #284). Instead, while this job isn't
+  // finished, pop and run sibling jobs from the same render ring on this
+  // thread: "wait for a possibly-preempted worker" becomes "do the remaining
+  // render work yourself". The joined job itself may be the one popped, in
+  // which case it simply runs inline here. Only when the ring is empty (the
+  // job is mid-run on a worker) do we fall back to spinning, relaxing the CPU
+  // for a while and then yielding so a not-yet-scheduled worker can run.
+  // Render workers run at raised priority, so with helping the yield path is
+  // effectively unreachable — even when priority elevation was denied by the
+  // OS (see threadPool::startup), the callback keeps making progress instead
+  // of burning its budget on a preempted worker.
+  //
+  // Background-pool jobs never help (their `pool` stays nullptr — see
+  // threadPool::addJob): running disk-touching work on the joining thread
+  // would be wrong; they use the pure spin/yield path, and are never joined
+  // from the audio callback.
   //
   // Wait on inQueue, not isDone (issue #239). activate() (and shutdown()) write
   // inQueue=false *after* isDone=true, so inQueue is the worker's genuinely last
@@ -63,6 +79,13 @@ void YSE::INTERNAL::threadPoolJob::join() {
   constexpr int YIELD_AFTER = 8192;
   int spins = 0;
   while (inQueue) {
+    threadPool* p = pool.load(std::memory_order_relaxed);
+    if (p != nullptr && p->tryRunOne()) {
+      // Made progress on the render pass; re-check immediately and restart
+      // the backoff ladder.
+      spins = 0;
+      continue;
+    }
     if (spins < YIELD_AFTER) {
       cpuRelax();
       ++spins;
@@ -125,11 +148,20 @@ void YSE::INTERNAL::threadPool::startup() {
     threads.emplace_front(this);
     threads.front().start();
     // Render workers race the audio-callback deadline: raise them so ordinary
-    // threads can't preempt one while the callback spins in join() (issue
+    // threads can't preempt one while the callback waits in join() (issue
     // #188). Best-effort — a denied request just leaves the worker at default
-    // priority. Background workers stay at normal priority.
-    if (classOf == poolClass::render) {
-      threads.front().setPriority(true);
+    // priority (join()'s help-running keeps the callback making progress
+    // regardless), but log the denial once per process so deployments know
+    // they run in the degraded mode (issue #284): without elevation, a
+    // CPU-saturated box can preempt a worker mid-job and render latency
+    // depends on the OS scheduler. Typical on Linux/Android without rtprio
+    // privileges. Background workers stay at normal priority.
+    if (classOf == poolClass::render && !threads.front().setPriority(true)) {
+      static aBool priorityDenialLogged{false};
+      if (!priorityDenialLogged.exchange(true)) {
+        LogImpl().emit(E_WARNING, "render worker priority elevation denied by the OS; running "
+                                  "at default priority (degraded real-time scheduling)");
+      }
     }
   }
 }
@@ -140,8 +172,11 @@ void YSE::INTERNAL::threadPool::shutdown() {
 
   // Release any queued jobs so a pending join() returns instead of spinning
   // forever. Marking inQueue=false is enough (join() exits on !inQueue); we do
-  // not run them. No lock: getJob() stops popping once active is false, so this
-  // thread is the only consumer of the ring now.
+  // not run them. No lock: getJob() stops popping once active is false, so the
+  // only other possible consumer is a still-spinning join() help-running via
+  // tryRunOne() (issue #284) — the MPMC ring handles that concurrency, and a
+  // job it steals simply runs instead of being released here. Either way every
+  // queued job ends with inQueue == false.
   threadPoolJob* job = nullptr;
   while (jobs.try_pop(job)) {
     // inQueue must be the last store, matching activate() and join()'s wait
@@ -164,6 +199,13 @@ void YSE::INTERNAL::threadPool::shutdown() {
 void YSE::INTERNAL::threadPool::addJob(threadPoolJob* job) {
   if (!active) return;
 
+  // Publish which ring this job lives on before it becomes joinable, so
+  // join() can help-run sibling jobs while it waits (issue #284). Render
+  // pools only: a background job must never pull disk-touching work onto the
+  // thread that joins it. The store is ordered before start()'s inQueue=true
+  // (seq_cst), so any join() that observes the job as queued also sees the
+  // pool pointer.
+  job->pool.store(classOf == poolClass::render ? this : nullptr, std::memory_order_relaxed);
   job->start();
   if (jobs.try_push(job)) return;
 
@@ -179,6 +221,18 @@ void YSE::INTERNAL::threadPool::addJob(threadPoolJob* job) {
     assert(false && "background threadPool ring overflow");
     job->inQueue = false;
   }
+}
+
+bool YSE::INTERNAL::threadPool::tryRunOne() {
+  // One non-blocking pop + inline run, for join()'s help-running (issue
+  // #284). No allocation, no lock, no syscall — RT-safe on the audio
+  // callback, exactly like the ring-full inline fallback in addJob(). No
+  // `active` check: a job popped here would otherwise have been released
+  // unrun by shutdown()'s drain, and running it is just as correct.
+  threadPoolJob* job = nullptr;
+  if (!jobs.try_pop(job)) return false;
+  job->activate();
+  return true;
 }
 
 YSE::INTERNAL::threadPoolJob* YSE::INTERNAL::threadPool::getJob() {

--- a/YseEngine/internal/threadPool.h
+++ b/YseEngine/internal/threadPool.h
@@ -13,6 +13,7 @@
 
 #include "../headers/types.hpp"
 #include "../utils/mpmcQueue.hpp"
+#include <atomic>
 #include <forward_list>
 #include "thread.h"
 
@@ -57,6 +58,14 @@ namespace YSE {
       aBool shouldStop;
       aBool inQueue;
       aBool isDone;
+      // The render pool this job was last queued on, set by threadPool::addJob
+      // so join() can help-run sibling jobs from the same ring instead of
+      // spinning while it waits (issue #284). Stays nullptr for background
+      // pools: help-running there would put disk-touching work on the joining
+      // thread. Atomic only to keep the cross-thread publish TSan-clean; the
+      // pool (a process-lifetime singleton in engine use) always outlives any
+      // join() that observes inQueue == true.
+      std::atomic<threadPool*> pool;
       friend class threadPool;
     };
 
@@ -84,6 +93,14 @@ namespace YSE {
 
       // only used by threadPoolThread, returns nullptr when the pool shuts down
       threadPoolJob* getJob();
+
+      // Pop one queued job and run it on the calling thread; returns whether a
+      // job was run. Used by threadPoolJob::join() to help-run sibling jobs
+      // while it waits (issue #284): instead of burning its budget spinning on
+      // a possibly-preempted worker, the audio callback drains runnable work
+      // from the same render ring itself. Never locks, allocates, or blocks —
+      // safe on the audio callback, same as the inline fallback in addJob().
+      bool tryRunOne();
 
       // (Re)spawn the worker threads and mark the pool active. Called by the
       // constructor and, after a shutdown(), by global::init() to revive the


### PR DESCRIPTION
## Summary

`threadPoolJob::join()` on the audio callback was blocking-by-construction: its completion was bounded by another thread's progress, and after 8192 spins it escalated to `std::this_thread::yield()` — a syscall on the callback. The safety of that design rested entirely on render workers actually being granted elevated priority, which `thread::setPriority` requested best-effort and silently ignored on denial (Linux/Android without rtprio privileges). With un-elevated workers, a CPU-saturating load could preempt a worker mid-job while the callback burned its whole budget spinning: a classic priority inversion.

This PR implements both parts of the proposed fix:

1. **Help-running (work-stealing) in `join()`** — while the joined job is still queued/running, the waiting thread pops sibling jobs from the same render ring and runs them itself, converting "wait for a possibly-preempted worker" into "do the remaining render work yourself". The joined job itself may be the one popped, in which case it runs inline. Only when the ring is empty (the job is mid-run on a worker) does `join()` fall back to the spin/relax ladder, so the `yield()` path becomes effectively unreachable in the common case. Background pools are excluded (`pool` back-pointer stays `nullptr`): help-running there would pull disk-touching work onto the joining thread.
2. **Observable priority acquisition** — `thread::setPriority` now returns whether the OS accepted the request (`SetThreadPriority != 0` / `pthread_setschedparam == 0`), and `threadPool::startup()` logs a once-per-process `E_WARNING` when render-worker elevation is denied, so deployments know they are running in the degraded scheduling mode.

RT discipline: the new `threadPool::tryRunOne()` is a non-blocking `try_pop` + inline `activate()` — no allocation, no lock, no syscall — the same execution mode as the pre-existing ring-full inline fallback in `addJob()`. The `pool` back-pointer is a relaxed atomic published before `start()`'s seq-cst `inQueue = true`, so any `join()` that observes the job as queued also sees the pool pointer; the #239 teardown contract (`inQueue` is the worker's last store) is unchanged.

## Linked issue

Closes #284

## Changes

- `YseEngine/internal/threadPool.cpp` / `.h` — help-running `join()` loop, `threadPool::tryRunOne()`, `pool` back-pointer published in `addJob()` (render pools only), once-per-process denial warning in `startup()`, shutdown-drain comment updated for the new second consumer.
- `YseEngine/internal/thread.cpp` / `.h` — `setPriority(bool)` now returns `bool` (request accepted or not) on both Windows and POSIX paths.
- `Tests/internal/test_threadpool.cpp` — regression test for #284 (single-worker pool with the worker pinned by a blocking job: every queued job can only complete via help-running, and the test asserts they ran on the joining thread; verified to hang without the fix) plus a `thread::setPriority` result-invariant test; shared `BlockJob` helper deduplicated from the overflow test.

## Test plan

- [x] `python yse.py format` — clean (no drift outside the touched files)
- [x] `python yse.py analyze` on `threadPool.cpp`, `thread.cpp`, `Tests/internal/test_threadpool.cpp` — 0 new findings (all remaining warnings suppressed non-user code)
- [x] `python yse.py test` — full doctest suite, 17/17 ctest binaries pass (unit + concurrency + lifecycle + integration on a real device)
- [x] Negative regression check: with help-running disabled (`if (false && ...)`) the new "join() help-runs queued render jobs" test hangs indefinitely (killed after 20 s); with the fix it passes in milliseconds
- [x] New doctest cases run directly: 2/2 pass, 36 assertions

No separate end-to-end test beyond the suite: the change is not user-visible (identical audio output; it removes a scheduling stall), and the existing integration suite already drives the real device through the modified `join()` path on every callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
