### PR TITLE
FIX: clear inQueue on every threadPoolJob::activate() exit (#285)

### DIFF
--- a/Tests/internal/test_threadpool.cpp
+++ b/Tests/internal/test_threadpool.cpp
@@ -176,6 +176,27 @@ TEST_SUITE("internal") {
     CHECK(counter.load() == N);
   }
 
+  TEST_CASE("threadPool: activate() on a stopped queued job clears inQueue (issue #285)") {
+    // Regression for issue #285. activate() used to early-return when
+    // shouldStop was set WITHOUT clearing inQueue. join() waits on inQueue
+    // (issue #239), so any future caller that stops a still-queued job and then
+    // joins or destroys it (~threadPoolJob calls join()) would spin forever — on
+    // the audio thread for a channel job. No live caller stops a queued job
+    // today, but the trap was latent. activate() must clear inQueue on every
+    // exit while still not running a stopped job.
+    std::atomic<int> counter{0};
+    CountJob job(&counter);
+
+    job.start(); // inQueue = true, exactly as addJob() would set it
+    CHECK(job.isQueued() == true);
+    job.stop(); // a future stop() caller marks it shouldStop
+    job.activate(); // a worker (or the inline fallback) picks it up
+
+    CHECK(counter.load() == 0); // a stopped job must not run
+    CHECK(job.isQueued() == false); // ...but must leave the queue flag cleared
+    job.join(); // and so join() returns instead of spinning
+  }
+
   TEST_CASE("threadPool: join() help-runs queued render jobs while it waits (issue #284)") {
     // Regression for issue #284. The spin-only join() made the audio
     // callback's completion depend on another thread's progress: with every

--- a/YseEngine/internal/threadPool.cpp
+++ b/YseEngine/internal/threadPool.cpp
@@ -96,9 +96,14 @@ void YSE::INTERNAL::threadPoolJob::join() {
 }
 
 void YSE::INTERNAL::threadPoolJob::activate() {
-  if (shouldStop || isDone) return;
-
-  run();
+  // Only run when the job is live, but ALWAYS clear the queued flags on the way
+  // out — even on the stopped/already-done early-out. join() waits on inQueue
+  // (issue #239), so an activate() that returned without clearing it would leave
+  // a stopped-but-queued job spinning any future join() forever (issue #285).
+  // No live caller stops a queued job today, but the trap is latent. Preserve
+  // the #239 store order: isDone must land before inQueue so a racing join()'s
+  // trailing store can't land in freed memory.
+  if (!shouldStop && !isDone) run();
   isDone = true;
   inQueue = false;
 }


### PR DESCRIPTION
## Summary

`threadPoolJob::activate()` early-returned when `shouldStop` (or `isDone`) was set **without clearing `inQueue`**. Since the #239 fix, `join()` waits on `inQueue` — so the first future caller that stops a still-queued job and then joins or destroys it (`~threadPoolJob` calls `join()`) would spin forever, on the audio thread for a channel job.

No live caller stops a queued job today (only `thread::stop()` is used, never `threadPoolJob::stop()`), so this is a latent trap rather than a live bug — but worth closing before someone trips it.

## Linked issue
Closes #285

## Changes
- `activate()` now runs the job only when live (`!shouldStop && !isDone`) but **always** falls through to `isDone = true; inQueue = false;`, preserving the #239 store order (`isDone` before `inQueue`) so a racing `join()`'s trailing store cannot land in freed memory.
- Regression test `threadPool: activate() on a stopped queued job clears inQueue (issue #285)`: a started-then-stopped job, activated directly, must not run yet must clear `inQueue` so `join()` returns. Verified it hangs (spins forever in `join()`) on the unpatched code and passes with the fix. Assertions use only streamable types (int/bool), so libstdc++ doctest stringification stays happy.

## Real-time discipline
No new allocation, lock, or blocking on the audio path — the change only reorders two atomic stores that already ran. It removes a potential infinite spin on the audio thread.

## Test plan
- [x] `python yse.py format` clean (no diff on changed files)
- [x] `python yse.py analyze YseEngine/internal/threadPool.cpp` — no new findings (21 warnings, all suppressed non-user-code baseline)
- [x] `python yse.py test` — all 17 ctest suites pass (0 failed); new #285 case: 3/3 assertions pass
- [x] Regression confirmed: reverting the source makes the new test's `join()` spin forever (bug reproduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)