### PR TITLE
AUDIO-IO: stop writing _length from render threads on shared buffer-backed soundFiles (#286)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(YSE_TEST_SOURCES
   channel/test_channel_layout.cpp
   sound/test_sound_state.cpp
   sound/test_sound_streaming.cpp
+  sound/test_sound_bufferrace.cpp
   sound/test_sound_impl.cpp
   sound/test_sound_concurrency.cpp
   sound/test_sound_bufferIO.cpp
@@ -128,6 +129,12 @@ target_link_libraries(yse_tests
 # gated behind LIBSOUNDFILE_BACKEND (defined PRIVATE on yse_objects). Enable the
 # gate for just this one TU so the rest of the suite is unaffected (issue #185).
 set_source_files_properties(sound/test_sound_streaming.cpp PROPERTIES
+  COMPILE_DEFINITIONS LIBSOUNDFILE_BACKEND
+)
+
+# test_sound_bufferrace.cpp also drives INTERNAL::soundFile directly (the
+# DSP::buffer-backed read path, issue #286), so it needs the same gate enabled.
+set_source_files_properties(sound/test_sound_bufferrace.cpp PROPERTIES
   COMPILE_DEFINITIONS LIBSOUNDFILE_BACKEND
 )
 

--- a/Tests/sound/test_sound_bufferrace.cpp
+++ b/Tests/sound/test_sound_bufferrace.cpp
@@ -1,0 +1,106 @@
+// Regression coverage for issue #286: `_length` must not be written from the
+// render threads on a shared, buffer-backed soundFile.
+//
+// A DSP::buffer-backed soundFile is deliberately shared across sounds
+// (SOUND::Manager::addFile dedups by buffer pointer), so two sounds in
+// different channels can call read() concurrently on two render workers. The
+// old code re-assigned `file->_length = _audioBuffer->getLength()` inside every
+// read(), which is a concurrent non-atomic write of the plain `int _length` —
+// formal UB and TSan-visible. The fix publishes `_length` once on the
+// single-threaded create() path and reads a local inside read().
+//
+// White-box access (INTERNAL::soundFile) mirrors test_sound_streaming.cpp; this
+// TU is compiled with LIBSOUNDFILE_BACKEND (set for just this file in
+// Tests/CMakeLists.txt). The DSP::buffer path never touches libsndfile, but the
+// concrete soundFile type lives behind that gate.
+//
+// The two-thread read below is the exact scenario the issue predicts. Under
+// ThreadSanitizer it flags the old `_length` write and is clean after the fix;
+// under a normal build the written value was always identical, so the race is
+// benign there — hence the primary normal-build regression assertion is that
+// length() reports the source length straight after create() (the old code left
+// _length unwritten at that point).
+
+#if LIBSOUNDFILE_BACKEND
+
+#include <doctest/doctest.h>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "internal/lsfSoundfile.h"
+#include "dsp/buffer.hpp"
+#include "support/null_device.hpp"
+
+using YSE::SOUND_STATUS;
+using YSE::INTERNAL::soundFile;
+// Flt / UInt / Int / Bool are global typedefs (headers/types.hpp).
+
+TEST_SUITE("sound") {
+
+  TEST_CASE("soundFile: shared DSP::buffer read is race-free on _length (issue #286)") {
+    if (!TestHelpers::engineInit()) return;
+
+    // A distinct value per frame so a mis-read produces obviously wrong output.
+    const UInt N = 1000;
+    YSE::DSP::buffer src(N);
+    {
+      Flt* p = src.getPtr();
+      for (UInt n = 0; n < N; ++n)
+        p[n] = static_cast<Flt>(n) * 0.001f;
+    }
+
+    // One buffer-backed soundFile, played from two render threads below — the
+    // shared-file situation addFile() produces in production.
+    soundFile sf(&src);
+    REQUIRE(sf.create(false));
+    bool ready = (sf.getState() == YSE::INTERNAL::FILESTATE::READY);
+    CHECK(ready);
+
+    // _length is published on the create() path now, not lazily in read().
+    bool lengthMatches = (sf.length() == N);
+    CHECK(lengthMatches);
+
+    // Render the shared file from two threads with independent play state.
+    const UInt blockSize = 128;
+    const int blocks = 60;
+    auto render = [&](std::vector<Flt>& outSamples) {
+      std::vector<YSE::DSP::buffer> fb(1);
+      fb[0].resize(blockSize);
+      Flt pos = 0.f;
+      Flt volume = 1.f;
+      SOUND_STATUS intent = YSE::SS_PLAYING_FULL_VOLUME;
+      outSamples.reserve(static_cast<size_t>(blocks) * blockSize);
+      for (int b = 0; b < blocks; ++b) {
+        REQUIRE(sf.read(fb, pos, blockSize, 1.0f, /*loop=*/true, intent, volume));
+        const Flt* o = fb[0].getPtr();
+        for (UInt k = 0; k < blockSize; ++k)
+          outSamples.push_back(o[k]);
+      }
+    };
+
+    std::vector<Flt> a;
+    std::vector<Flt> b;
+    std::thread t1([&] { render(a); });
+    std::thread t2([&] { render(b); });
+    t1.join();
+    t2.join();
+
+    // Deterministic, identical output from both render passes: the hoist to a
+    // local preserves the exact loop behaviour, and nothing is corrupted by the
+    // concurrent access.
+    bool sameSize = (a.size() == b.size());
+    REQUIRE(sameSize);
+    bool identical = (a == b);
+    CHECK(identical);
+
+    // Sanity: the first frame of the first block is the start of the source
+    // ramp, so the read actually produced the source data.
+    bool firstSampleOk = a.empty() ? false : (a[0] == doctest::Approx(0.0f));
+    CHECK(firstSampleOk);
+  }
+
+} // TEST_SUITE("sound")
+
+#endif // LIBSOUNDFILE_BACKEND

--- a/YseEngine/internal/abstractSoundFile.cpp
+++ b/YseEngine/internal/abstractSoundFile.cpp
@@ -26,6 +26,7 @@ YSE::INTERNAL::abstractSoundFile::abstractSoundFile(bool interleaved)
     _multiChannelBuffer(nullptr),
     state(NEW),
     _sampleRateAdjustment(1.f),
+    _length(0),
     _channels(0),
     _needsReset(false),
     _frontBufferBase(0),
@@ -59,6 +60,12 @@ Bool YSE::INTERNAL::abstractSoundFile::create(Bool stream) {
     _streaming = false;
     _endReached = false;
     _needsReset = false;
+    // Publish the source length once, here on the (single-threaded) create path.
+    // The audio-thread read() no longer writes _length, so a buffer-backed file
+    // shared across sounds (addFile dedups by buffer pointer) is free of the
+    // formal data race that concurrent render-thread writes would create
+    // (issue #286).
+    _length = (Int)_audioBuffer->getLength();
     state = READY;
     return true;
   }
@@ -168,14 +175,20 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
     Flt* out = filebuffer[i].getPtr();
     const Flt* in;
 
+    // Read the source length into a local; never write the shared member from
+    // this render-thread path (issue #286). _length is published once at
+    // create/load time. The multichannel source length is per-channel, so it is
+    // resolved inside this FOREACH iteration.
+    Int len;
     if (file->_audioBuffer) {
       in = file->_audioBuffer->getPtr();
-      file->_length = file->_audioBuffer->getLength();
+      len = (Int)file->_audioBuffer->getLength();
     } else if (file->_multiChannelBuffer) {
       in = file->_multiChannelBuffer->at(i).getPtr();
-      file->_length = file->_multiChannelBuffer->at(i).getLength();
+      len = (Int)file->_multiChannelBuffer->at(i).getLength();
     } else {
       in = file->_buffer[i];
+      len = file->_length;
     }
 
     UInt l = length;
@@ -227,12 +240,12 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
         // if playing forward and we're past the end of the soundFile in
         // less than 16 steps, move one by one
         else if ((speed > 0) &&
-                 ((pos + speed * 16) >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length))) {
+                 ((pos + speed * 16) >= (file->_streaming ? STREAM_BUFFERSIZE : len))) {
           while (l--) {
             *out++ = in[(UInt)pos];
             pos += speed;
             // check if we're past the end and readjust position if so
-            if (pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length)) goto calibrate;
+            if (pos >= (file->_streaming ? STREAM_BUFFERSIZE : len)) goto calibrate;
           }
           goto nextBuffer; // this output channel buffer is full if we get here
         }
@@ -279,7 +292,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
             out += 16;
 
             // check if we're past the end and readjust position if so
-            if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length))
+            if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
               goto calibrate;
 
             // since l > 15, the output buffer is not full yet
@@ -293,7 +306,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
               pos += speed;
 
               // check if we're past the end and readjust position if so
-              if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length))
+              if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
                 goto calibrate;
             }
           }
@@ -307,7 +320,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
           *out++ = in[(UInt)pos] * volume;
           pos += speed;
           volume += 0.005f;
-          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length))
+          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
             goto calibrate;
           if ((volume >= 1.f)) {
             // full volume is reached. Move to the optimized version
@@ -325,7 +338,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
           *out++ = in[(UInt)pos] * volume;
           pos += speed;
           volume -= 0.005f;
-          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length))
+          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
             goto calibrate;
           if ((volume <= 0.f)) {
             // fade out complete, switch intent to paused and restart
@@ -344,7 +357,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
           *out++ = in[(UInt)pos] * volume;
           pos += speed;
           volume -= 0.005f;
-          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : file->_length))
+          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
             goto calibrate;
           if ((volume <= 0.f)) {
             // fade out complete, switch intent to stopped and restart
@@ -362,11 +375,11 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
       // recalibrate position now. We can't simply set it to the end
       // or the beginning because this won't work with speed <> 1
       while (pos < 0)
-        pos += file->_length; // looping backwards
-      if (pos >= file->_length) {
+        pos += len; // looping backwards
+      if (pos >= len) {
         if (loop)
-          while (pos >= file->_length)
-            pos -= file->_length;
+          while (pos >= len)
+            pos -= len;
         else {
           // if no loop, fill the rest of the buffer with zero's
           pos = 0;
@@ -457,7 +470,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
 
   // For streaming, `pos` is buffer-local in [0, streamEnd) where streamEnd is the
   // count of real frames in the current front buffer (issue #185). For other
-  // sources the per-sample checks below use file->_length directly.
+  // sources the per-sample checks below use the local `len` (issue #286).
   Flt streamEnd = (Flt)file->_frontValidFrames;
 
   if (file->_streaming) {
@@ -502,11 +515,16 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
 
     const Flt* in;
 
+    // Read the source length into a local; never write the shared member from
+    // this render-thread path (issue #286). _length is published once at
+    // create/load time.
+    Int len;
     if (file->_audioBuffer) {
       in = file->_audioBuffer->getPtr();
-      file->_length = file->_audioBuffer->getLength();
+      len = (Int)file->_audioBuffer->getLength();
     } else {
       in = file->_iBuffer;
+      len = file->_length;
     }
 
   startAgain:
@@ -535,7 +553,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
         if (pos < 0 ||
             pos >= (file->_streaming
                         ? streamEnd
-                        : file->_length)) { // NOSONAR S134: nesting follows the state-machine
+                        : len)) { // NOSONAR S134: nesting follows the state-machine
                                             // structure documented at function level
           goto calibrate;
         }
@@ -551,7 +569,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
         volume += 0.005f;
         x++;
 
-        if (pos < 0 || pos >= (file->_streaming ? streamEnd : file->_length)) goto calibrate;
+        if (pos < 0 || pos >= (file->_streaming ? streamEnd : len)) goto calibrate;
 
         if ((volume >= 1.f)) {
           // full volume is reached. Move to the optimized version
@@ -571,7 +589,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
         volume -= 0.005f;
         x++;
 
-        if (pos < 0 || pos >= (file->_streaming ? streamEnd : file->_length)) goto calibrate;
+        if (pos < 0 || pos >= (file->_streaming ? streamEnd : len)) goto calibrate;
 
         if ((volume <= 0.f)) {
           // fade out complete, switch intent to paused and restart
@@ -592,7 +610,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
         volume -= 0.005f;
         x++;
 
-        if (pos < 0 || pos >= (file->_streaming ? streamEnd : file->_length)) goto calibrate;
+        if (pos < 0 || pos >= (file->_streaming ? streamEnd : len)) goto calibrate;
 
         if ((volume <= 0.f)) {
           // fade out complete, switch intent to paused and restart
@@ -636,11 +654,11 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
       // recalibrate position now. We can't simply set it to the end
       // or the beginning because this won't work with speed <> 1
       while (pos < 0)
-        pos += file->_length; // looping backwards
-      if (pos >= file->_length) {
+        pos += len; // looping backwards
+      if (pos >= len) {
         if (loop)
-          while (pos >= file->_length)
-            pos -= file->_length;
+          while (pos >= len)
+            pos -= len;
         else {
           // if no loop, fill the rest of the buffer with zero's
           pos = 0;

--- a/YseEngine/internal/abstractSoundFile.cpp
+++ b/YseEngine/internal/abstractSoundFile.cpp
@@ -292,8 +292,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
             out += 16;
 
             // check if we're past the end and readjust position if so
-            if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
-              goto calibrate;
+            if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len)) goto calibrate;
 
             // since l > 15, the output buffer is not full yet
             goto mainLoop;
@@ -306,8 +305,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
               pos += speed;
 
               // check if we're past the end and readjust position if so
-              if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
-                goto calibrate;
+              if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len)) goto calibrate;
             }
           }
           goto nextBuffer; // this output channel buffer is full if we get here
@@ -320,8 +318,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
           *out++ = in[(UInt)pos] * volume;
           pos += speed;
           volume += 0.005f;
-          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
-            goto calibrate;
+          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len)) goto calibrate;
           if ((volume >= 1.f)) {
             // full volume is reached. Move to the optimized version
             volume = 1.f;
@@ -338,8 +335,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
           *out++ = in[(UInt)pos] * volume;
           pos += speed;
           volume -= 0.005f;
-          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
-            goto calibrate;
+          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len)) goto calibrate;
           if ((volume <= 0.f)) {
             // fade out complete, switch intent to paused and restart
             // The rest of the buffer will be filled with zeroes
@@ -357,8 +353,7 @@ Bool YSE::INTERNAL::abstractSoundFile::readNonInterleaved(abstractSoundFile* fil
           *out++ = in[(UInt)pos] * volume;
           pos += speed;
           volume -= 0.005f;
-          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len))
-            goto calibrate;
+          if (pos < 0 || pos >= (file->_streaming ? STREAM_BUFFERSIZE : len)) goto calibrate;
           if ((volume <= 0.f)) {
             // fade out complete, switch intent to stopped and restart
             // The rest of the buffer will be filled with zeroes
@@ -551,10 +546,9 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
         x++;
 
         if (pos < 0 ||
-            pos >= (file->_streaming
-                        ? streamEnd
-                        : len)) { // NOSONAR S134: nesting follows the state-machine
-                                            // structure documented at function level
+            pos >= (file->_streaming ? streamEnd
+                                     : len)) { // NOSONAR S134: nesting follows the state-machine
+                                               // structure documented at function level
           goto calibrate;
         }
       }


### PR DESCRIPTION
## Summary

`readNonInterleaved` and `readInterleaved` re-assigned `file->_length = _audioBuffer->getLength()` on every call. Buffer-backed soundFiles are deliberately shared across sounds (`addFile` dedups by buffer pointer), so two sounds in different channels can call `read()` concurrently on two render workers — a concurrent non-atomic write (plus concurrent reads) of the plain `int _length`. The written value is always identical, so there is no real-world misbehaviour, but it is formal UB and TSan-visible.

## Linked issue

Closes #286

## Changes

- `abstractSoundFile::readNonInterleaved` / `readInterleaved`: hoist the source length into a local `len` used for the loop bounds; the render path no longer writes the shared member. The multichannel length stays per-channel (resolved inside the `FOREACH` iteration).
- `abstractSoundFile::create`: publish `_length` once, on the single-threaded create path, for a buffer-backed file.
- `abstractSoundFile` ctor: initialise `_length` to 0 so a buffer-backed file has a defined length before `create()` runs.
- New `Tests/sound/test_sound_bufferrace.cpp` (compiled with `LIBSOUNDFILE_BACKEND` like the streaming test): plays one shared `DSP::buffer`-backed soundFile from two threads.

## Test plan

- [x] `python yse.py test` — 17/17 ctest groups pass (full doctest suite), incl. the new case (126 assertions).
- [x] New test is a real regression test: reverting the create-time `_length` write makes `length() == N` fail on a normal build (verified).
- [x] TSan verification via the Linux sanitizer Docker repro (`tools/ci-linux/Dockerfile.sanitizers`, `setarch -R`): the new two-thread read is **clean** under ThreadSanitizer with the fix (exit 0); temporarily reintroducing the old `_length` write makes TSan report a data race (exit 66). The benign-value race is invisible on a normal build, so no unit-only assertion can catch it — hence the normal-build assertion is the create-time length and the two-thread read is the TSan-facing scenario the audit predicted.
- [x] `python yse.py analyze` on the modified source and new test file — no new findings (all warnings pre-existing/non-user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
