### PR TITLE
DSP: enforce one-patcher-per-sound at sound creation (#287)

### DIFF
--- a/Tests/sound/test_sound_state.cpp
+++ b/Tests/sound/test_sound_state.cpp
@@ -19,6 +19,7 @@
 #include "sound/soundInterface.hpp"
 #include "sound/soundManager.h"
 #include "sound/soundMessage.h"
+#include "patcher/patcher.hpp"
 #include "dsp/dspObject.hpp"
 #include "internal/time.h"
 #include "support/null_device.hpp"
@@ -462,6 +463,38 @@ TEST_SUITE("sound") {
       std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
     CHECK(s.isReady());
+  }
+
+  // ─── one-patcher-per-sound enforcement (issue #287) ──────────────────────────
+
+  // Two sounds must never share a patcher: they would call Calculate() on the
+  // same graph concurrently from two render threads (heap corruption / UAF).
+  // create() must refuse the second sound and leave it invalid, while the first
+  // keeps ownership.
+  TEST_CASE("sound: second sound from the same patcher is refused (#287)") {
+    if (!TestHelpers::engineInit()) return;
+
+    YSE::patcher p;
+    p.create(1);
+
+    YSE::sound first;
+    first.create(p);
+    CHECK(first.isValid());
+
+    YSE::sound second;
+    second.create(p);
+    CHECK_FALSE(second.isValid());
+  }
+
+  // A patcher that was never create()-d has a null impl; building a sound from
+  // it must be refused rather than dereference null.
+  TEST_CASE("sound: sound from an uncreated patcher is refused (#287)") {
+    if (!TestHelpers::engineInit()) return;
+
+    YSE::patcher p; // no p.create()
+    YSE::sound s;
+    s.create(p);
+    CHECK_FALSE(s.isValid());
   }
 
 } // TEST_SUITE("sound")

--- a/YseEngine/c_api/yse_sound.cpp
+++ b/YseEngine/c_api/yse_sound.cpp
@@ -100,8 +100,12 @@ YSE_C_API YseStatus yse_sound_load_patcher(YseSound* s, YsePatcher* patch, YseCh
   try {
     auto& cpp_patch = *reinterpret_cast<YSE::patcher*>(patch);
     to_cpp(s)->create(cpp_patch, to_cpp_chan(ch), volume);
+    // create() refuses when the patcher is already controlled by another sound
+    // (one patcher per sound — issue #287) or was never created; on refusal the
+    // sound is left invalid. Mirror that as an error status for C consumers.
     if (!to_cpp(s)->isValid()) {
-      yse_c::set_last_error("sound is not valid after patcher-source create");
+      yse_c::set_last_error(
+          "sound not created: patcher is invalid or already controlled by another sound");
       return YSE_ERR_GENERIC;
     }
     return YSE_OK;

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -262,6 +262,19 @@ bool YSE::SOUND::implementationObject::create(DSP::dspSourceObject& ptr, channel
 
 bool YSE::SOUND::implementationObject::create(PATCHER::patcherImplementation* ptr, channel* ch,
                                               float volume) {
+  // Enforce one-patcher-per-sound (issue #287). A patcher already owned by a
+  // sound must not back a second one: two sounds sharing a patcher would call
+  // Calculate() concurrently on two render threads, corrupting the graph state
+  // and breaking the #227 epoch-reclaim proof (use-after-free / heap
+  // corruption). Refuse rather than let user API misuse become a crash. A null
+  // impl (patcher never create()-d) is rejected here too, before the
+  // controlledBySound read that would otherwise dereference it.
+  if (ptr == nullptr || ptr->controlledBySound) {
+    INTERNAL::LogImpl().emit(
+        E_ERROR, "sound: patcher is already controlled by another sound (one patcher per sound)");
+    return false;
+  }
+
   parent = ch->pimpl;
   looping = false;
   fader.set(volume);

--- a/YseEngine/sound/soundInterface.cpp
+++ b/YseEngine/sound/soundInterface.cpp
@@ -219,8 +219,14 @@ void YSE::sound::create(YSE::patcher& patch, channel* ch, float volume) {
 
   pimpl = SOUND::Manager().addImplementation(this);
   if (ch == nullptr) ch = &CHANNEL::Manager().master();
-  pimpl->create(patch.pimpl, ch, volume);
-  SOUND::Manager().setup(pimpl);
+  // create() refuses when the patcher is already owned by another sound
+  // (issue #287); on refusal the impl is released and the sound stays invalid.
+  if (pimpl->create(patch.pimpl, ch, volume)) {
+    SOUND::Manager().setup(pimpl);
+  } else {
+    pimpl->setStatus(OBJECT_RELEASE);
+    pimpl = nullptr;
+  }
 }
 
 /*YSE::sound& YSE::sound::create(SYNTH::interfaceObject & synth, channel *ch, Flt volume) {


### PR DESCRIPTION
## Summary

`implementationObject::create(patcher…)` blindly set `controlledBySound = true`, so nothing stopped a user from creating two `YSE::sound`s from the same `YSE::patcher`. Two such sounds render on separate fast-pool workers and call `patcher->Calculate()` on the shared graph concurrently in the same block — clobbering `currentBlockGraph_`, double-bumping `audioBlock_` (which breaks the #227 epoch-reclaim "+2 grace" proof → UAF), and double-draining the value/param queues. Low likelihood (API misuse), high blast radius (heap corruption).

This enforces the ownership invariant at creation time — the minimal fix the issue describes.

## Linked issue
Closes #287

## Changes
- `soundImplementation.cpp` — `create(patcher…)` now refuses when the patcher is already `controlledBySound` (or its impl pointer is null, which the guard rejects before the flag read to avoid a null deref), logging `E_ERROR` and returning `false`.
- `soundInterface.cpp` — `sound::create(patcher&)` mirrors the established file-create failure path: on refusal the impl is released (`OBJECT_RELEASE`) and `pimpl` is nulled, so the sound stays invalid.
- `yse_sound.cpp` — the C API's existing `isValid()` guard now correctly surfaces the refusal, with a specific error message.
- `test_sound_state.cpp` — two regression cases (second-sound-from-same-patcher refused; uncreated-patcher refused).

RT discipline: the guard runs on the control thread (`create` is not on the audio callback path) and uses the same `LogImpl().emit()` the sibling file-create path already uses — no allocation/lock/blocking added to any audio-thread path.

## Test plan
- [x] `python yse.py format` clean (idempotent; only the 4 touched files differ)
- [x] `python yse.py analyze` on the 3 touched .cpp files — no new findings (2 pre-existing backlog warnings in `soundImplementation.cpp` at lines 174/688, outside the modified region)
- [x] `python yse.py test` — 17/17 ctest executables pass (full doctest suite incl. patcher/sound/concurrency/integration)
- [x] New regression tests confirmed to **fail on unpatched code**: `CHECK_FALSE` failure for the second-sound case, segfault (exit 139) for the uncreated-patcher case; both pass with the fix (3 assertions).
