### PR TITLE
ENGINE: pad mpmcQueue cells against false sharing; correct the wait-free claim (#288)

### DIFF
--- a/Bench/CMakeLists.txt
+++ b/Bench/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(yse_benchmarks
   dsp/bench_delay.cpp
   dsp/bench_math.cpp
   dsp/bench_reverb.cpp
+  internal/bench_mpmcqueue.cpp
   patcher/bench_patcher.cpp
   integration/bench_mixing.cpp
   integration/bench_yse_dsl.cpp

--- a/Bench/internal/bench_mpmcqueue.cpp
+++ b/Bench/internal/bench_mpmcqueue.cpp
@@ -1,0 +1,92 @@
+// Tier 1 microbenchmark for YSE::mpmcQueue (utils/mpmcQueue.hpp) under
+// producer/consumer contention.
+//
+// This is the workload that cell false sharing degrades (issue #288): several
+// worker producers and consumers hammer sequential ring cells, so cells that
+// share a 64-byte line ping-pong between cores. The multi-producer /
+// multi-consumer cases mirror the render-pool fan-out — the audio callback and
+// nested worker dispatch pushing DSP jobs while the workers pop them. It is the
+// benchmark that justifies (or refutes) padding cells to a cache line.
+
+#include "utils/mpmcQueue.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+namespace {
+
+  // Spawn `producers` threads that each push `kPerProducer` items and `consumers`
+  // threads that drain until every item is consumed. Item count is kept high so
+  // thread spawn/join cost is amortised away and the timing reflects queue ops.
+  void runContention(benchmark::State& state, int producers, int consumers) {
+    constexpr int kPerProducer = 100000;
+    const std::int64_t total = static_cast<std::int64_t>(producers) * kPerProducer;
+
+    for (auto _ : state) {
+      YSE::mpmcQueue<void*> q(1024);
+      std::atomic<int> consumed{0};
+      std::atomic<bool> producersDone{false};
+
+      std::vector<std::thread> threads;
+      threads.reserve(static_cast<std::size_t>(producers) + consumers);
+
+      for (int p = 0; p < producers; ++p) {
+        threads.emplace_back([&] {
+          void* v = reinterpret_cast<void*>(static_cast<std::uintptr_t>(1));
+          for (int i = 0; i < kPerProducer; ++i) {
+            while (!q.try_push(v))
+              std::this_thread::yield();
+          }
+        });
+      }
+      for (int c = 0; c < consumers; ++c) {
+        threads.emplace_back([&] {
+          void* v = nullptr;
+          for (;;) {
+            if (q.try_pop(v)) {
+              consumed.fetch_add(1, std::memory_order_relaxed);
+            } else if (producersDone.load(std::memory_order_acquire)) {
+              if (!q.try_pop(v)) break;
+              consumed.fetch_add(1, std::memory_order_relaxed);
+            } else {
+              std::this_thread::yield();
+            }
+          }
+        });
+      }
+
+      for (int p = 0; p < producers; ++p)
+        threads[static_cast<std::size_t>(p)].join();
+      producersDone.store(true, std::memory_order_release);
+      for (int c = producers; c < producers + consumers; ++c)
+        threads[static_cast<std::size_t>(c)].join();
+
+      benchmark::DoNotOptimize(consumed.load());
+    }
+
+    state.SetItemsProcessed(state.iterations() * total);
+  }
+
+} // namespace
+
+// Single producer / single consumer — low contention baseline.
+static void BM_MpmcQueue_1P1C(benchmark::State& state) {
+  runContention(state, 1, 1);
+}
+BENCHMARK(BM_MpmcQueue_1P1C)->UseRealTime();
+
+// Render fan-out: multiple worker producers and consumers on adjacent cells.
+static void BM_MpmcQueue_4P4C(benchmark::State& state) {
+  runContention(state, 4, 4);
+}
+BENCHMARK(BM_MpmcQueue_4P4C)->UseRealTime();
+
+// Heavy contention — stresses the false-sharing path hardest.
+static void BM_MpmcQueue_8P8C(benchmark::State& state) {
+  runContention(state, 8, 8);
+}
+BENCHMARK(BM_MpmcQueue_8P8C)->UseRealTime();

--- a/YseEngine/utils/mpmcQueue.hpp
+++ b/YseEngine/utils/mpmcQueue.hpp
@@ -21,8 +21,16 @@ namespace YSE {
 
   // Bounded lock-free multi-producer / multi-consumer queue — Dmitry Vyukov's
   // array-of-cells algorithm. Fixed capacity, allocated once at construction;
-  // try_push / try_pop never lock, never allocate, and are wait-free bar the
-  // bounded CAS retry loop under producer/consumer contention.
+  // try_push / try_pop never lock and never allocate.
+  //
+  // The algorithm is lock-free, not wait-free. It guarantees system-wide
+  // progress, not per-operation progress: the CAS claim loop can retry under
+  // contention (bounded only by the number of concurrent claimers, not by a
+  // constant), and a producer preempted after claiming a cell but before
+  // publishing its sequence stalls consumers of that cell until it is
+  // rescheduled. This is safe on the audio callback — the operations are still
+  // non-blocking and allocation-free — but the callback is not guaranteed a
+  // wait-free hand-off if a peer worker is descheduled mid-claim (issue #284).
   //
   // Introduced for INTERNAL::threadPool (issue #188): the audio callback hands
   // DSP fan-out jobs (render pool) and manager/setup jobs (background pool) to
@@ -96,10 +104,22 @@ namespace YSE {
     }
 
   private:
-    struct cell {
+    // Producer and consumer cursors — and each ring cell — live on separate
+    // cache lines so the two cursors never share a line, and concurrent
+    // producers/consumers working adjacent cells don't ping-pong a shared line
+    // under render fan-out (issue #288). Padding the cell trades memory (the
+    // 4096-slot render ring grows to ~256 KB) for the removed false sharing.
+    static constexpr std::size_t CACHE_LINE = 64;
+
+    struct alignas(CACHE_LINE) cell {
       std::atomic<std::size_t> sequence;
       T data;
     };
+
+    // No two cells share a cache line: each occupies a whole line (or a whole
+    // number of lines once T pushes the payload past 64 bytes).
+    static_assert(alignof(cell) >= CACHE_LINE, "cell must be cache-line aligned");
+    static_assert(sizeof(cell) % CACHE_LINE == 0, "cell must span whole cache lines");
 
     static std::size_t roundUpPow2(std::size_t x) {
       if (x < 2) return 2;
@@ -112,10 +132,6 @@ namespace YSE {
       if (sizeof(std::size_t) > 4) x |= x >> 32;
       return x + 1;
     }
-
-    // Producer and consumer cursors live on separate cache lines so the two
-    // sides don't ping-pong a shared line under contention.
-    static constexpr std::size_t CACHE_LINE = 64;
 
     std::unique_ptr<cell[]> buffer_;
     const std::size_t capacityMask_;


### PR DESCRIPTION
## Summary

Two items from the 2026-07 follow-up lock-free audit on the #188 Vyukov
`mpmcQueue`:

1. **Cell false sharing.** The `{sequence, data}` cells packed ~4 per
   64-byte line, so concurrent producers/consumers on adjacent ring cells
   ping-ponged cache lines under render fan-out. Each cell is now aligned
   to a cache line (`alignas(64)`) so no two cells share a line, with
   `static_assert`s pinning the invariant. Trades memory (the 4096-slot
   render ring grows from ~64 KB to ~256 KB) for the removed contention.
2. **Comment accuracy.** The header claimed the ops were "wait-free bar
   the bounded CAS retry loop". They are lock-free, not wait-free — the
   CAS claim loop is bounded only by concurrent-claimer count, and a
   producer preempted mid-claim stalls consumers of that cell. The comment
   now states the real progress guarantee (system-wide, not per-op).

## Measurement (issue asked to measure item 1 first)

Added `Bench/internal/bench_mpmcqueue.cpp` — an MPMC producer/consumer
contention benchmark, the workload false sharing degrades. 3 reps,
MSYS2 Clang64, 24-core host:

| Case | Unpadded | Padded | Delta |
|------|----------|--------|-------|
| 1P1C | 65.8 M items/s | 68.9 M items/s | +4.7% |
| 4P4C | 6.76 M items/s | 7.25 M items/s | +7.2% |
| 8P8C | 6.07 M items/s | 7.37 M items/s | +21% |

The win scales with contention — largest in the render fan-out case the
queue exists for — so the padding is justified. The benchmark stays as a
regression guard.

## Linked issue
Closes #288

## Changes
- `YseEngine/utils/mpmcQueue.hpp` — `alignas(64)` cell + `static_assert`s; rewritten progress-guarantee comment.
- `Bench/internal/bench_mpmcqueue.cpp` — new MPMC contention microbenchmark (1P1C / 4P4C / 8P8C).
- `Bench/CMakeLists.txt` — add the new bench file to `yse_benchmarks`.

## Test plan
- [x] `python yse.py format` clean (touched files; Bench file formatted with repo `.clang-format`).
- [x] `python yse.py analyze` clean on the header's consumers (`threadPool.cpp`, `test_mpmcqueue.cpp`) — no new findings in modified code.
- [x] `python yse.py test` — all 17 doctest targets pass (incl. `utils` mpmcQueue suite and the concurrency suite).
- [x] Linux gcc 13.3 compile+run check of the header (over-aligned `new` + `static_assert` path) via the `yse-ci` Docker image — passes, matching the CI toolchain.
- [x] Bench suite rebuilds and runs (`cmake --build --preset bench`).

Pure RT-path-safe change: cell alignment is layout-only, no allocation/locking/blocking added to `try_push`/`try_pop`. No behavior change to the queue's semantics — existing conservation/FIFO/wrap tests still pass.
