### PR TITLE
DSP: dspVoice base class + reference sine voice (#152)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(YSE_TEST_SOURCES
   dsp/test_modules.cpp
   dsp/test_module_filters.cpp
   dsp/test_module_delays.cpp
+  dsp/test_synth_voice.cpp
   patcher/test_graph.cpp
   patcher/test_nodes.cpp
   patcher/test_patcher_math.cpp

--- a/Tests/dsp/test_synth_voice.cpp
+++ b/Tests/dsp/test_synth_voice.cpp
@@ -1,0 +1,263 @@
+// Tests for YSE::SYNTH::dspVoice (voice base) and YSE::SYNTH::sineVoice
+// (reference sine + ADSR voice) — issue #152, implementing §3 of
+// docs/design/synth_core.md.
+//
+// Coverage:
+//   - intent-driven lifecycle transitions (WANTSTOPLAY -> PLAYING -> release
+//     -> STOPPED, and retrigger),
+//   - ADSR envelope shape (silent attack onset, sustained body, decaying
+//     release tail),
+//   - correct rendered frequency (FFT peak-bin check),
+//   - clone() independence (distinct instances, distinct note state),
+//   - no heap allocation in process() after warm-up.
+//
+// No audio device required; SAMPLERATE is initialised to 44100 by the
+// portaudioDeviceManager translation unit at static-initialisation time.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include <memory>
+#include "synth/sineVoice.hpp"
+#include "dsp/fourier/fft.hpp"
+#include "support/audio_helpers.hpp"
+#include "support/alloc_probe.hpp"
+
+TEST_SUITE("dsp") {
+
+  using YSE::SOUND_STATUS;
+  using YSE::SYNTH::dspVoice;
+  using YSE::SYNTH::sineVoice;
+
+  // ─── lifecycle ────────────────────────────────────────────────────────────
+
+  TEST_CASE("sineVoice: WANTSTOPLAY settles the intent to PLAYING") {
+    sineVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    CHECK(intent == YSE::SS_PLAYING);
+  }
+
+  TEST_CASE("sineVoice: sustains indefinitely while intent stays PLAYING") {
+    sineVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent); // -> PLAYING
+    for (int i = 0; i < 200; ++i)
+      v.process(intent);
+    CHECK(intent == YSE::SS_PLAYING);
+    CHECK(TestHelpers::measureRms(v.samples[0]) > 0.05f);
+  }
+
+  TEST_CASE("sineVoice: WANTSTOSTOP releases and settles to STOPPED") {
+    sineVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    v.attack(0.005f).decay(0.01f).sustain(0.8f).release(0.05f);
+
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent); // -> PLAYING
+    for (int i = 0; i < 20; ++i)
+      v.process(intent); // reach sustain
+
+    intent = YSE::SS_WANTSTOSTOP;
+    int blocks = 0;
+    const int kMaxBlocks = 500;
+    while (intent != YSE::SS_STOPPED && blocks < kMaxBlocks) {
+      v.process(intent);
+      ++blocks;
+    }
+    CHECK(intent == YSE::SS_STOPPED);
+    CHECK(blocks < kMaxBlocks);
+    // Tail is silent once stopped.
+    v.process(intent);
+    CHECK(TestHelpers::decaysToSilence(v.samples[0], 1e-5f));
+  }
+
+  TEST_CASE("sineVoice: retriggers after a completed release") {
+    sineVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    v.attack(0.005f).decay(0.01f).sustain(0.8f).release(0.02f);
+
+    // Play then fully release.
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 10; ++i)
+      v.process(intent);
+    intent = YSE::SS_WANTSTOSTOP;
+    for (int i = 0; i < 500 && intent != YSE::SS_STOPPED; ++i)
+      v.process(intent);
+    REQUIRE(intent == YSE::SS_STOPPED);
+
+    // Retrigger.
+    intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    CHECK(intent == YSE::SS_PLAYING);
+    for (int i = 0; i < 20; ++i)
+      v.process(intent);
+    CHECK(TestHelpers::measureRms(v.samples[0]) > 0.05f);
+  }
+
+  // ─── envelope shape ───────────────────────────────────────────────────────
+
+  TEST_CASE("sineVoice: attack onset starts from silence") {
+    sineVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    v.attack(0.05f); // long attack so the block-0 onset is unambiguously near 0
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    CHECK(std::abs(v.samples[0].getPtr()[0]) < 1e-3f);
+  }
+
+  TEST_CASE("sineVoice: release tail decays monotonically toward silence") {
+    sineVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    v.attack(0.005f).decay(0.01f).sustain(0.9f).release(0.2f);
+
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 30; ++i)
+      v.process(intent); // sustain
+    float sustainRms = TestHelpers::measureRms(v.samples[0]);
+
+    intent = YSE::SS_WANTSTOSTOP;
+    v.process(intent); // first release block
+    float earlyRelease = TestHelpers::measureRms(v.samples[0]);
+    for (int i = 0; i < 20; ++i)
+      v.process(intent);
+    float lateRelease = TestHelpers::measureRms(v.samples[0]);
+
+    CHECK(sustainRms > 0.1f);
+    CHECK(lateRelease < earlyRelease);
+    CHECK(lateRelease < sustainRms);
+  }
+
+  // ─── rendered frequency ───────────────────────────────────────────────────
+
+  TEST_CASE("sineVoice: rendered pitch matches the requested note (FFT bin)") {
+    // Short attack/decay so the voice is at steady sustain during capture.
+    sineVoice v;
+    v.attack(0.001f).decay(0.001f).sustain(1.f).release(0.05f);
+    const float noteNumber = 69.f; // A4
+    v.frequency(noteNumber);
+    v.velocity(1.f);
+
+    const float noteHz = YSE::DSP::MidiToFreq(noteNumber);
+
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 8; ++i)
+      v.process(intent); // settle into sustain
+
+    const unsigned N = 2048;
+    const unsigned block = YSE::STANDARD_BUFFERSIZE;
+    YSE::DSP::buffer re(N), im(N);
+    re = 0.f;
+    im = 0.f;
+    unsigned filled = 0;
+    while (filled + block <= N) {
+      v.process(intent); // stays PLAYING
+      re.copyFrom(v.samples[0], 0, filled, block);
+      filled += block;
+    }
+
+    YSE::DSP::fft f;
+    f(re, im);
+    unsigned peak = TestHelpers::peakBinIndex(f.getReal().getPtr(), f.getImaginary().getPtr(), N);
+
+    const float binHz = static_cast<float>(YSE::SAMPLERATE) / static_cast<float>(N);
+    const float peakHz = static_cast<float>(peak) * binHz;
+    // Within one bin of the note frequency (rectangular-window leakage can
+    // shift the peak to the nearest bin, never further for a bin-adjacent tone).
+    CHECK(std::abs(peakHz - noteHz) < binHz);
+  }
+
+  // ─── clone() independence ─────────────────────────────────────────────────
+
+  TEST_CASE("sineVoice: clone() yields a distinct, same-typed voice") {
+    sineVoice proto;
+    proto.attack(0.02f).release(0.3f).sustain(0.6f);
+
+    std::unique_ptr<dspVoice> a(proto.clone());
+    std::unique_ptr<dspVoice> b(proto.clone());
+
+    CHECK(a.get() != nullptr);
+    CHECK(b.get() != nullptr);
+    CHECK(a.get() != b.get());
+    CHECK(a.get() != static_cast<dspVoice*>(&proto));
+
+    auto* as = dynamic_cast<sineVoice*>(a.get());
+    REQUIRE(as != nullptr);
+    // Envelope parameters carried across the clone.
+    CHECK(as->attack() == doctest::Approx(0.02f));
+    CHECK(as->release() == doctest::Approx(0.3f));
+    CHECK(as->sustain() == doctest::Approx(0.6f));
+  }
+
+  TEST_CASE("sineVoice: clones hold independent note state") {
+    sineVoice proto;
+    std::unique_ptr<dspVoice> a(proto.clone());
+    std::unique_ptr<dspVoice> b(proto.clone());
+
+    a->frequency(60.f);
+    a->velocity(0.25f);
+    b->frequency(72.f);
+    b->velocity(0.9f);
+
+    CHECK(a->getFrequency() == doctest::Approx(YSE::DSP::MidiToFreq(60.f)));
+    CHECK(b->getFrequency() == doctest::Approx(YSE::DSP::MidiToFreq(72.f)));
+    CHECK(a->getVelocity() == doctest::Approx(0.25f));
+    CHECK(b->getVelocity() == doctest::Approx(0.9f));
+
+    // Rendering one clone must not touch the other's output.
+    SOUND_STATUS ia = YSE::SS_WANTSTOPLAY;
+    for (int i = 0; i < 5; ++i)
+      a->process(ia);
+    CHECK(b->samples[0].isSilent());
+  }
+
+  // ─── real-time discipline ─────────────────────────────────────────────────
+
+  TEST_CASE("sineVoice: process() does not allocate after warm-up") {
+    sineVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+
+    // Warm-up: exercise every code path once (attack, sustain, release,
+    // stop, retrigger) so any first-use lazy sizing is done before probing.
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 30; ++i)
+      v.process(intent);
+    intent = YSE::SS_WANTSTOSTOP;
+    for (int i = 0; i < 500 && intent != YSE::SS_STOPPED; ++i)
+      v.process(intent);
+    intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 5; ++i)
+      v.process(intent);
+
+    {
+      TestHelpers::ProbeScope probe;
+      // Steady sustain.
+      for (int i = 0; i < 40; ++i)
+        v.process(intent);
+      // A full release cycle.
+      intent = YSE::SS_WANTSTOSTOP;
+      for (int i = 0; i < 500 && intent != YSE::SS_STOPPED; ++i)
+        v.process(intent);
+      // Silence and another retrigger.
+      v.process(intent);
+      intent = YSE::SS_WANTSTOPLAY;
+      for (int i = 0; i < 10; ++i)
+        v.process(intent);
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -127,6 +127,7 @@ set(YSE_SRCS
   sound/soundImplementation.cpp
   sound/soundInterface.cpp
   sound/soundManager.cpp
+  synth/sineVoice.cpp
   utils/fileFunctions.cpp
   utils/interpolators.cpp
   utils/vector.cpp

--- a/YseEngine/synth/dspVoice.hpp
+++ b/YseEngine/synth/dspVoice.hpp
@@ -1,0 +1,136 @@
+/*
+  ==============================================================================
+
+    dspVoice.hpp
+    Voice base class for the YSE::synth subsystem.
+
+    Implements §3 ("The voice model") of docs/design/synth_core.md. A dspVoice
+    is a DSP::dspSourceObject the user derives from: the engine owns polyphony,
+    allocation and lifecycle; the subclass owns only what one voice sounds like.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_DSPVOICE_HPP
+#define YSE_SYNTH_DSPVOICE_HPP
+
+#include "../dsp/dspObject.hpp"
+#include "../dsp/math.hpp"
+#include "../headers/types.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /// @cond INTERNAL
+    // Forward declaration only — the audio-thread implementation object that
+    // owns and drives voices arrives with the synth subsystem (#153). It is
+    // named here purely so voices can grant it friendship (it writes
+    // _aftertouch and drives the per-voice intent). Declaring a friend that is
+    // never defined in this translation unit is well-formed C++.
+    class implementationObject;
+    /// @endcond
+
+    /**
+     *  @brief Base class for user-subclassable synthesiser voices.
+     *
+     *  Derive from ``dspVoice`` to define what a single note sounds like. The
+     *  base is a ``DSP::dspSourceObject`` — it already provides the
+     *  ``samples`` output buffers and the ``process(SOUND_STATUS&)`` entry
+     *  point the sound renderer needs — extended with the pieces the voice
+     *  allocator relies on: a ``clone()`` prototype hook, atomic
+     *  frequency / velocity / aftertouch inputs, and a default atomic
+     *  ``frequency()`` that stores the note as Hz.
+     *
+     *  The reference implementation is ``SYNTH::sineVoice`` (a sine shaped by an
+     *  ADSR envelope). See docs/design/synth_core.md §3 for the full contract.
+     */
+    class API dspVoice : public DSP::dspSourceObject {
+    public:
+      /** @brief Construct a voice with ``outputChannels`` output buffers. */
+      dspVoice(int outputChannels = 1) : dspSourceObject(outputChannels) {}
+      virtual ~dspVoice() {}
+
+      /**
+       *  @brief Fill ``samples`` for one block. **You must implement this.**
+       *
+       *  ``intent`` is this voice's own ``SOUND_STATUS``: ``SS_WANTSTOPLAY`` on
+       *  note start, ``SS_WANTSTOSTOP`` on note release, etc. Honour it to
+       *  drive your amplitude envelope, and settle it to ``SS_STOPPED`` once
+       *  your release tail has finished so the allocator can free the slot.
+       *
+       *  Runs on the audio thread. Must be allocation-free, lock-free and
+       *  non-blocking.
+       */
+      void process(SOUND_STATUS& intent) override = 0;
+
+      /**
+       *  @brief Return a new, fully-allocated heap instance of your derived
+       *         type. **You must implement this.**
+       *
+       *  The typical body is ``return new MyVoice(*this);`` — a copy-construct.
+       *  Every buffer, table and filter state the returned voice will touch in
+       *  ``process()`` must already exist, so ``process()`` is thereafter
+       *  allocation-free. Called only on the setup thread (never the audio
+       *  thread); allocation here is fine.
+       */
+      virtual dspVoice* clone() = 0;
+
+      // ---- delivered by the allocator (audio thread) ---------------------
+
+      /**
+       *  @brief Set the note frequency from a MIDI note number.
+       *
+       *  Stored internally as Hz. Called by the allocator on NOTE_ON; a voice
+       *  reads the result with ``getFrequency()`` in ``process()``.
+       */
+      void frequency(Flt midiNote) override {
+        _frequency.store(DSP::MidiToFreq(midiNote), std::memory_order_relaxed);
+      }
+
+      /** @brief Current note frequency in Hz. */
+      Flt getFrequency() const {
+        return _frequency.load(std::memory_order_relaxed);
+      }
+
+      /** @brief Set the note velocity, normalised to [0, 1]. */
+      void velocity(Flt v) {
+        _velocity.store(v, std::memory_order_relaxed);
+      }
+
+      /** @brief Current note velocity in [0, 1]. */
+      Flt getVelocity() const {
+        return _velocity.load(std::memory_order_relaxed);
+      }
+
+      /** @brief Current aftertouch pressure in [0, 1]. */
+      Flt getAftertouch() const {
+        return _aftertouch.load(std::memory_order_relaxed);
+      }
+
+    protected:
+      /**
+       *  @brief Copy the note atomics (and base output buffers) into a fresh,
+       *         independently-owned voice.
+       *
+       *  Provided so a derived ``clone()`` can be a plain copy-construct
+       *  (``new MyVoice(*this)``): ``std::atomic`` members are not implicitly
+       *  copyable, so the base supplies this. Each instance keeps its own
+       *  atomics, so a clone shares no mutable note state with its prototype.
+       */
+      dspVoice(const dspVoice& o) : dspSourceObject(o) {
+        _frequency.store(o._frequency.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        _velocity.store(o._velocity.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        _aftertouch.store(o._aftertouch.load(std::memory_order_relaxed), std::memory_order_relaxed);
+      }
+
+    private:
+      aFlt _frequency{440.f};
+      aFlt _velocity{0.f};
+      aFlt _aftertouch{0.f};
+      friend class implementationObject; // sets _aftertouch, drives intent
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_DSPVOICE_HPP

--- a/YseEngine/synth/sineVoice.cpp
+++ b/YseEngine/synth/sineVoice.cpp
@@ -1,0 +1,151 @@
+/*
+  ==============================================================================
+
+    sineVoice.cpp
+    Reference sine + ADSR voice — see sineVoice.hpp and
+    docs/design/synth_core.md §3.
+
+  ==============================================================================
+*/
+
+#include "sineVoice.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    // Length of the flat sustain plateau built into the envelope, in seconds.
+    // The ADSRenvelope holds sustain by looping this constant-value region
+    // (ADSRenvelope::RESUME), so it only needs to be long enough to contain a
+    // handful of samples; the exact value is inaudible.
+    static const Flt kSustainHold = 0.05f;
+
+    // Smallest legal segment duration. Two envelope breakpoints sharing the
+    // same time would make ADSRenvelope::generate() divide by a zero-length
+    // segment, so every duration is clamped to this floor.
+    static const Flt kMinSegment = 1e-4f;
+
+    static inline Flt clampMin(Flt v, Flt lo) {
+      return v < lo ? lo : v;
+    }
+
+    sineVoice::sineVoice(int outputChannels)
+      : dspVoice(outputChannels),
+        _attack(0.01f),
+        _decay(0.05f),
+        _sustainLevel(0.7f),
+        _release(0.1f),
+        phase(IDLE) {
+      buildEnvelope();
+    }
+
+    sineVoice::sineVoice(const sineVoice& other)
+      : dspVoice(other),
+        _attack(other._attack),
+        _decay(other._decay),
+        _sustainLevel(other._sustainLevel),
+        _release(other._release),
+        phase(IDLE) {
+      // Build a fresh envelope rather than copy the prototype's: ADSRenvelope
+      // holds raw pointers into its own storage, so a copy would alias the
+      // original. Rebuilding keeps a clone's state fully independent.
+      buildEnvelope();
+    }
+
+    void sineVoice::buildEnvelope() {
+      const Flt a = clampMin(_attack, kMinSegment);
+      const Flt d = clampMin(_decay, kMinSegment);
+      const Flt r = clampMin(_release, kMinSegment);
+      Flt s = _sustainLevel;
+      if (s < 0.f) s = 0.f;
+      if (s > 1.f) s = 1.f;
+
+      // Fresh envelope on the heap: each rebuild replaces the previous one, so
+      // breakpoints never accumulate and the raw pointers ADSRenvelope keeps
+      // stay valid for exactly this instance's lifetime. Off the audio thread.
+      auto fresh = std::make_unique<DSP::ADSRenvelope>();
+      fresh->addPoint({0.f, 0.f, 1.f}); // start silent
+      fresh->addPoint({a, 1.f, 1.f}); // attack -> peak
+      fresh->addPoint({a + d, s, 1.f, /*loopStart*/ true}); // decay -> sustain
+      fresh->addPoint({a + d + kSustainHold, s, 1.f, // sustain plateau
+                       /*loopStart*/ false, /*loopEnd*/ true});
+      fresh->addPoint({a + d + kSustainHold + r, 0.f, 1.f}); // release -> silent
+      fresh->generate();
+      env = std::move(fresh);
+    }
+
+    sineVoice& sineVoice::attack(Flt seconds) {
+      _attack = seconds;
+      buildEnvelope();
+      return *this;
+    }
+
+    sineVoice& sineVoice::decay(Flt seconds) {
+      _decay = seconds;
+      buildEnvelope();
+      return *this;
+    }
+
+    sineVoice& sineVoice::sustain(Flt level) {
+      _sustainLevel = level;
+      buildEnvelope();
+      return *this;
+    }
+
+    sineVoice& sineVoice::release(Flt seconds) {
+      _release = seconds;
+      buildEnvelope();
+      return *this;
+    }
+
+    dspVoice* sineVoice::clone() {
+      return new sineVoice(*this);
+    }
+
+    void sineVoice::process(SOUND_STATUS& intent) {
+      DSP::ADSRenvelope::STATE estate;
+
+      if (intent == SS_WANTSTOPLAY || intent == SS_WANTSTORESTART) {
+        // Note start (or retrigger): restart the oscillator and the envelope.
+        osc.reset();
+        estate = DSP::ADSRenvelope::ATTACK;
+        phase = PLAYING;
+        intent = SS_PLAYING;
+      } else if (intent == SS_WANTSTOSTOP || intent == SS_WANTSTOPAUSE) {
+        // Note off: take the release transition once, then let it tail out.
+        if (phase != RELEASING) {
+          estate = DSP::ADSRenvelope::RELEASE;
+          phase = RELEASING;
+        } else {
+          estate = DSP::ADSRenvelope::RESUME;
+        }
+      } else if (intent == SS_PLAYING || intent == SS_PLAYING_FULL_VOLUME) {
+        // Sustaining: RESUME loops the envelope's sustain plateau.
+        estate = DSP::ADSRenvelope::RESUME;
+      } else {
+        // SS_STOPPED / SS_PAUSED: emit silence.
+        for (UInt i = 0; i < samples.size(); i++)
+          samples[i] = 0.f;
+        return;
+      }
+
+      const Flt freq = getFrequency();
+      const Flt vel = getVelocity();
+
+      DSP::buffer& sig = osc(freq);
+      DSP::buffer& amp = (*env)(estate);
+
+      for (UInt i = 0; i < samples.size(); i++) {
+        samples[i] = sig;
+        samples[i] *= amp;
+        samples[i] *= vel;
+      }
+
+      // The release tail has fully decayed — hand the slot back to the engine.
+      if (phase == RELEASING && env->isAtEnd()) {
+        intent = SS_STOPPED;
+        phase = IDLE;
+      }
+    }
+
+  } // namespace SYNTH
+} // namespace YSE

--- a/YseEngine/synth/sineVoice.hpp
+++ b/YseEngine/synth/sineVoice.hpp
@@ -1,0 +1,111 @@
+/*
+  ==============================================================================
+
+    sineVoice.hpp
+    Reference synth voice: one sine oscillator shaped by one ADSR envelope.
+
+    The minimal legal SYNTH::dspVoice implementation from issue #152 — it proves
+    the voice contract (intent-driven lifecycle, clone() prototype, atomic
+    note inputs) and is the voice every downstream synth test builds on. See
+    docs/design/synth_core.md §3.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_SINEVOICE_HPP
+#define YSE_SYNTH_SINEVOICE_HPP
+
+#include <memory>
+#include "dspVoice.hpp"
+#include "../dsp/oscillators.hpp"
+#include "../dsp/ADSRenvelope.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /**
+     *  @brief Reference voice — a sine oscillator gated by an ADSR envelope.
+     *
+     *  Pitched from ``getFrequency()``, scaled by ``getVelocity()`` and shaped
+     *  by a classic attack / decay / sustain / release envelope keyed off the
+     *  ``SOUND_STATUS`` intent:
+     *
+     *  - ``SS_WANTSTOPLAY`` restarts the oscillator phase and the envelope
+     *    attack, then settles the intent to ``SS_PLAYING``.
+     *  - ``SS_PLAYING`` holds the sustain level.
+     *  - ``SS_WANTSTOSTOP`` enters the release tail; when the tail reaches
+     *    zero the voice settles the intent to ``SS_STOPPED``.
+     *
+     *  Everything is allocated up front (in the constructor and the envelope
+     *  setters, both off the audio thread) so ``process()`` and ``clone()``'s
+     *  copy stay allocation-clean on their respective threads.
+     */
+    class API sineVoice : public dspVoice {
+    public:
+      /** @brief Construct a mono (or ``outputChannels``-wide) sine voice with a default ADSR. */
+      sineVoice(int outputChannels = 1);
+
+      // ---- chainable envelope setters (times in seconds; sustain in [0,1]) ----
+
+      /** @brief Set the attack time in seconds. */
+      sineVoice& attack(Flt seconds);
+      /** @brief Set the decay time in seconds. */
+      sineVoice& decay(Flt seconds);
+      /** @brief Set the sustain level in [0, 1]. */
+      sineVoice& sustain(Flt level);
+      /** @brief Set the release time in seconds. */
+      sineVoice& release(Flt seconds);
+
+      /** @brief Current attack time in seconds. */
+      Flt attack() const {
+        return _attack;
+      }
+      /** @brief Current decay time in seconds. */
+      Flt decay() const {
+        return _decay;
+      }
+      /** @brief Current sustain level in [0, 1]. */
+      Flt sustain() const {
+        return _sustainLevel;
+      }
+      /** @brief Current release time in seconds. */
+      Flt release() const {
+        return _release;
+      }
+
+      // ---- dspVoice contract -------------------------------------------------
+
+      /** @brief Render one block, honouring and settling ``intent``. Audio-thread only. */
+      void process(SOUND_STATUS& intent) override;
+
+      /** @brief Return a new, independently-allocated copy of this voice. Setup-thread only. */
+      dspVoice* clone() override;
+
+    protected:
+      /** @brief Copy-construct an independent voice (rebuilds its own envelope). */
+      sineVoice(const sineVoice& other);
+
+    private:
+      // Where the voice is in its own attack/sustain/release arc. Separate from
+      // the SOUND_STATUS intent so a note-off knows whether the release
+      // transition has already been taken.
+      enum Phase { IDLE, PLAYING, RELEASING };
+
+      // (Re)build the ADSR envelope from the current scalar parameters. Called
+      // from the constructors and every setter — never from process().
+      void buildEnvelope();
+
+      Flt _attack;
+      Flt _decay;
+      Flt _sustainLevel;
+      Flt _release;
+
+      DSP::sine osc;
+      std::unique_ptr<DSP::ADSRenvelope> env;
+      Phase phase;
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_SINEVOICE_HPP


### PR DESCRIPTION
## Summary

Implements §3 ("The voice model") of `docs/design/synth_core.md` — the
user-subclassable synth voice base and its reference sine + ADSR voice.
This is the voice contract every downstream synth sub-issue (#153–#157)
and the Instruments epic (#148) build on.

Scope is strictly the voice base + reference voice + tests. Polyphony,
allocation/stealing, keyboard state, the manager and the `YSE::sound`
attachment are explicitly out of scope (deferred to #153/#154 per the
design's non-goals).

## Linked issue

Closes #152

## Changes

- **`SYNTH::dspVoice`** (`YseEngine/synth/dspVoice.hpp`) — a
  `DSP::dspSourceObject` subclass adding the pieces the allocator needs:
  a `clone()` prototype hook, atomic frequency/velocity/aftertouch
  inputs, and a default `frequency()` that stores the incoming MIDI note
  as Hz (matching the design listing exactly). A protected copy
  constructor makes a derived `clone()` a plain copy-construct; the
  `implementationObject` friend is forward-declared for the allocator
  arriving in #153.
- **`SYNTH::sineVoice`** (`YseEngine/synth/sineVoice.{hpp,cpp}`) — one
  `DSP::sine` shaped by one `DSP::ADSRenvelope`, keyed off the
  `SOUND_STATUS` intent: `WANTSTOPLAY` → attack + settle to `PLAYING`;
  `PLAYING` → sustain; `WANTSTOSTOP` → release tail, settling to
  `STOPPED` when it reaches zero. Sustain is held via the envelope's
  loop region. Chainable `attack/decay/sustain/release` setters. All
  allocation happens in the constructor and setters (setup thread only);
  `process()` is allocation-, lock- and block-free.
- CMake registration for the new source and test.

## Real-time discipline

`process()` runs on the audio callback path and does not allocate, lock
or block: the oscillator, envelope and output buffers are built up front,
buffer ops reuse fixed-size storage (no resize when block size is
constant), and the envelope is (re)built only in the constructor /
setters. Covered by an explicit heap-allocation probe test.

## Test plan

`Tests/dsp/test_synth_voice.cpp` (10 cases, 28 assertions), in the `dsp`
suite:

- [x] `clang-format` 22.1.4 clean (`--dry-run --Werror` on all changed files)
- [x] `python yse.py analyze` clean on changed `.cpp` files (no user-code findings)
- [x] unit tests pass — full suite `100% tests passed, 0 tests failed out of 17`; the new voice cases: `10 passed, 28 assertions`
- [x] no integration test — the change is engine-internal DSP logic with no
  user-visible flow yet (voice-to-sound attachment is #153); behaviour is
  fully covered by the unit tests above, including an FFT pitch check and a
  no-allocation probe

Covered behaviours: lifecycle transitions + retrigger, ADSR envelope
shape (silent onset, sustained body, decaying release tail), rendered
pitch (FFT peak-bin), `clone()` independence (distinct instances +
independent note state), and no heap allocation in `process()` after
warm-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
