### PR TITLE
ENGINE: synth object, manager, and voice allocator (#153)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -60,6 +60,8 @@ set(YSE_TEST_SOURCES
   sound/test_sound_bus.cpp
   sound/test_virtual_finder.cpp
   sound/test_manager_alloc.cpp
+  synth/test_synth.cpp
+  synth/test_synth_close.cpp
   reverb/test_reverb_dsp.cpp
   reverb/test_reverb_concurrency.cpp
   midi/test_midifile.cpp
@@ -161,10 +163,11 @@ set_target_properties(yse_tests PROPERTIES
 if(NOT ANDROID)
 add_test(
   NAME    yse_unit_tests
-  # `lifecycle` is excluded alongside `integration`: it drives System::close(),
-  # which permanently stops the global thread pools and would break every later
-  # suite sharing this process. It runs in its own process via yse_tests_lifecycle.
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle --duration=true
+  # `lifecycle` and `synthlifecycle` are excluded alongside `integration`: they
+  # drive System::close(), which permanently stops the global thread pools and
+  # would break every later suite sharing this process. Each runs in its own
+  # process via yse_tests_lifecycle / yse_tests_synthlifecycle.
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -233,6 +236,23 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_reverb PROPERTIES LABELS reverb)
+
+add_test(
+  NAME    yse_tests_synth
+  COMMAND yse_tests --test-suite=synth
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_synth PROPERTIES LABELS synth)
+
+# Synth engine-close / offline lifecycle tests. Isolated in their own process
+# for the same reason as yse_tests_lifecycle: they drive System::close(). Kept
+# separate from the `lifecycle` process on purpose (see test_synth_close.cpp).
+add_test(
+  NAME    yse_tests_synthlifecycle
+  COMMAND yse_tests --test-suite=synthlifecycle
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_synthlifecycle PROPERTIES LABELS "synth;lifecycle")
 
 add_test(
   NAME    yse_tests_midi

--- a/Tests/synth/test_synth.cpp
+++ b/Tests/synth/test_synth.cpp
@@ -1,0 +1,424 @@
+// Tests for the YSE::synth object, voice allocator, stealing policy and
+// manager/lifecycle — issue #153, implementing §2 / §4 / §8 / §9 of
+// docs/design/synth_core.md.
+//
+// Two layers:
+//   * DSP / allocator tests drive a SYNTH::implementationObject directly (no
+//     engine, no audio device needed — SAMPLERATE is initialised to 44100 by
+//     the device translation unit at static-init time). They exercise the
+//     allocator, stealing, click-free declick and mixing by pushing note
+//     messages and calling the aggregate outputSource's process().
+//   * Manager / lifecycle tests drive the public YSE::synth + YSE::sound API
+//     through the real managers (engineInit; skipped on CI hosts without an
+//     audio device, like the sibling sound/reverb manager tests).
+
+#include <doctest/doctest.h>
+#include <chrono>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "synth/sineVoice.hpp"
+#include "synth/synthImplementation.h"
+#include "synth/synthInterface.hpp"
+#include "synth/synthManager.h"
+#include "synth/synthMessage.h"
+#include "sound/soundInterface.hpp"
+#include "sound/soundManager.h"
+#include "dsp/fourier/fft.hpp"
+#include "internal/time.h"
+#include "support/audio_helpers.hpp"
+#include "support/alloc_probe.hpp"
+#include "support/null_device.hpp"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+  using YSE::SOUND_STATUS;
+  using YSE::SYNTH::dspVoice;
+  using YSE::SYNTH::implementationObject;
+  using YSE::SYNTH::messageObject;
+  using YSE::SYNTH::sineVoice;
+
+  messageObject noteOnMsg(int channel, int note, float velocity) {
+    messageObject m;
+    m.ID = YSE::SYNTH::NOTE_ON;
+    m.noteOn.channel = channel;
+    m.noteOn.note = note;
+    m.noteOn.velocity = velocity;
+    return m;
+  }
+
+  messageObject noteOffMsg(int channel, int note) {
+    messageObject m;
+    m.ID = YSE::SYNTH::NOTE_OFF;
+    m.noteOff.channel = channel;
+    m.noteOff.note = note;
+    m.noteOff.velocity = 0.f;
+    return m;
+  }
+
+  messageObject allNotesOffMsg(int channel) {
+    messageObject m;
+    m.ID = YSE::SYNTH::ALL_NOTES_OFF;
+    m.allOff.channel = channel;
+    return m;
+  }
+
+  // Render one block of the aggregate and return its (mono) output buffer.
+  YSE::DSP::buffer& renderBlock(implementationObject& impl, SOUND_STATUS& intent) {
+    impl.getOutputSource().process(intent);
+    return impl.getOutputSource().samples[0];
+  }
+
+  // Squared FFT magnitude at the bin nearest `hz`.
+  float magAtHz(YSE::DSP::fft& f, unsigned N, float hz) {
+    const float binHz = static_cast<float>(YSE::SAMPLERATE) / static_cast<float>(N);
+    unsigned bin = static_cast<unsigned>(hz / binHz + 0.5f);
+    if (bin > N / 2) bin = N / 2;
+    float re = f.getReal().getPtr()[bin];
+    float im = f.getImaginary().getPtr()[bin];
+    return re * re + im * im;
+  }
+
+  // Capture N samples of steady output into `re`, driving the synth in PLAYING.
+  void captureSpectrum(implementationObject& impl, YSE::DSP::buffer& re, unsigned N) {
+    re = 0.f;
+    const unsigned block = YSE::STANDARD_BUFFERSIZE;
+    unsigned filled = 0;
+    SOUND_STATUS intent = YSE::SS_PLAYING;
+    while (filled + block <= N) {
+      YSE::DSP::buffer& out = renderBlock(impl, intent);
+      re.copyFrom(out, 0, filled, block);
+      filled += block;
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("synth") {
+
+  // ─── allocator: polyphonic chord ──────────────────────────────────────────
+
+  TEST_CASE("synth allocator: a chord renders N distinct FFT peaks") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.05f);
+    impl.addVoiceGroup(&proto, 8, /*omni*/ 0, 0, 127);
+    impl.setup();
+    REQUIRE(impl.getNumVoices() == 8);
+
+    // Sound a C-major triad.
+    impl.sendMessage(noteOnMsg(1, 60, 1.f)); // C4  ~261.6 Hz
+    impl.sendMessage(noteOnMsg(1, 64, 1.f)); // E4  ~329.6 Hz
+    impl.sendMessage(noteOnMsg(1, 67, 1.f)); // G4  ~392.0 Hz
+
+    // First block drains the inbox (allocates) and attacks; settle a few more.
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    CHECK(intent == YSE::SS_PLAYING);
+    for (int i = 0; i < 8; ++i)
+      renderBlock(impl, intent);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    im = 0.f;
+    captureSpectrum(impl, re, N);
+
+    YSE::DSP::fft f;
+    f(re, im);
+
+    const float c4 = YSE::DSP::MidiToFreq(60.f);
+    const float e4 = YSE::DSP::MidiToFreq(64.f);
+    const float g4 = YSE::DSP::MidiToFreq(67.f);
+    const float gap = magAtHz(f, N, 300.f); // between C4 and E4 — no note here
+
+    // Every played note is a strong peak, each far above the empty gap bin.
+    CHECK(magAtHz(f, N, c4) > 25.f * gap);
+    CHECK(magAtHz(f, N, e4) > 25.f * gap);
+    CHECK(magAtHz(f, N, g4) > 25.f * gap);
+  }
+
+  // ─── allocator: free-slot reuse ───────────────────────────────────────────
+
+  TEST_CASE("synth allocator: a released voice is reused for the next note") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    impl.addVoiceGroup(&proto, 1, 0, 0, 127); // single voice
+    impl.setup();
+
+    // Play then fully release note 60.
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    for (int i = 0; i < 5; ++i)
+      renderBlock(impl, intent);
+    impl.sendMessage(noteOffMsg(1, 60));
+    for (int i = 0; i < 400; ++i)
+      renderBlock(impl, intent);
+    CHECK(TestHelpers::decaysToSilence(impl.getOutputSource().samples[0], 1e-4f));
+
+    // The freed single voice must accept a new, different note.
+    impl.sendMessage(noteOnMsg(1, 72, 1.f)); // C5 ~523 Hz
+    renderBlock(impl, intent);
+    for (int i = 0; i < 8; ++i)
+      renderBlock(impl, intent);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    im = 0.f;
+    captureSpectrum(impl, re, N);
+    YSE::DSP::fft f;
+    f(re, im);
+    CHECK(magAtHz(f, N, YSE::DSP::MidiToFreq(72.f)) > 25.f * magAtHz(f, N, 300.f));
+  }
+
+  // ─── stealing: correctness ────────────────────────────────────────────────
+
+  TEST_CASE("synth stealing: exhausting polyphony steals the oldest voice") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.05f);
+    impl.addVoiceGroup(&proto, 2, 0, 0, 127); // only 2 voices
+    impl.setup();
+
+    // Fill both voices: 60 (oldest) then 64.
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    impl.sendMessage(noteOnMsg(1, 64, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    for (int i = 0; i < 10; ++i)
+      renderBlock(impl, intent);
+
+    // Third note with no free voice → steals the oldest overall (60).
+    impl.sendMessage(noteOnMsg(1, 67, 1.f));
+    for (int i = 0; i < 300; ++i) // let the steal fade + new attack settle
+      renderBlock(impl, intent);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    im = 0.f;
+    captureSpectrum(impl, re, N);
+    YSE::DSP::fft f;
+    f(re, im);
+
+    const float m60 = magAtHz(f, N, YSE::DSP::MidiToFreq(60.f));
+    const float m64 = magAtHz(f, N, YSE::DSP::MidiToFreq(64.f));
+    const float m67 = magAtHz(f, N, YSE::DSP::MidiToFreq(67.f));
+
+    // 64 survived, 67 replaced 60, and 60 is gone.
+    CHECK(m64 > 25.f * m60);
+    CHECK(m67 > 25.f * m60);
+  }
+
+  // ─── stealing: click-free handoff ─────────────────────────────────────────
+
+  TEST_CASE("synth stealing: the stolen-voice handoff is click-free") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.002f).decay(0.002f).sustain(1.f).release(0.2f);
+    impl.addVoiceGroup(&proto, 2, 0, 0, 127);
+    impl.setup();
+
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    impl.sendMessage(noteOnMsg(1, 64, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    for (int i = 0; i < 20; ++i)
+      renderBlock(impl, intent);
+
+    // Concatenate a stretch of output spanning the steal transition.
+    std::vector<float> stream;
+    const unsigned block = YSE::STANDARD_BUFFERSIZE;
+    auto grab = [&](int blocks) {
+      for (int b = 0; b < blocks; ++b) {
+        YSE::DSP::buffer& out = renderBlock(impl, intent);
+        float* p = out.getPtr();
+        for (unsigned s = 0; s < block; ++s)
+          stream.push_back(p[s]);
+      }
+    };
+
+    grab(4); // baseline (2 voices sounding)
+    impl.sendMessage(noteOnMsg(1, 67, 1.f)); // trigger the steal
+    grab(16); // across the ~5 ms fade + re-attack
+
+    // No abrupt discontinuity: a hard voice cut would jump by ~1 or more between
+    // adjacent samples. The engine's declick keeps every step small (the signal
+    // itself only slews a fraction of a unit per sample at these pitches).
+    float maxDelta = 0.f;
+    for (size_t i = 1; i < stream.size(); ++i)
+      maxDelta = std::max(maxDelta, std::fabs(stream[i] - stream[i - 1]));
+    CHECK(maxDelta < 0.5f);
+  }
+
+  // ─── all notes off ────────────────────────────────────────────────────────
+
+  TEST_CASE("synth: allNotesOff releases every held voice") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    impl.addVoiceGroup(&proto, 8, 0, 0, 127);
+    impl.setup();
+
+    for (int n = 60; n < 68; ++n)
+      impl.sendMessage(noteOnMsg(1, n, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    for (int i = 0; i < 5; ++i)
+      renderBlock(impl, intent);
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) > 0.05f);
+
+    impl.sendMessage(allNotesOffMsg(0)); // 0 = all channels
+    for (int i = 0; i < 400; ++i)
+      renderBlock(impl, intent);
+    CHECK(TestHelpers::decaysToSilence(impl.getOutputSource().samples[0], 1e-4f));
+  }
+
+  // ─── channel / range routing (voice groups) ───────────────────────────────
+
+  TEST_CASE("synth groups: a split keyboard routes notes to the matching group") {
+    implementationObject impl(nullptr);
+    sineVoice bass;
+    bass.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    sineVoice lead;
+    lead.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    impl.addVoiceGroup(&bass, 2, 1, 0, 47); // channel 1, low keys
+    impl.addVoiceGroup(&lead, 2, 1, 48, 127); // channel 1, high keys
+    impl.setup();
+    CHECK(impl.getNumVoices() == 4);
+
+    // A low note (40) sounds only in the bass group; a high note (72) only in
+    // the lead group. Both together must produce their two distinct pitches.
+    impl.sendMessage(noteOnMsg(1, 40, 1.f));
+    impl.sendMessage(noteOnMsg(1, 72, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    for (int i = 0; i < 8; ++i)
+      renderBlock(impl, intent);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    im = 0.f;
+    captureSpectrum(impl, re, N);
+    YSE::DSP::fft f;
+    f(re, im);
+    CHECK(magAtHz(f, N, YSE::DSP::MidiToFreq(40.f)) > 25.f * magAtHz(f, N, 1500.f));
+    CHECK(magAtHz(f, N, YSE::DSP::MidiToFreq(72.f)) > 25.f * magAtHz(f, N, 1500.f));
+  }
+
+  // ─── note routed outside every range is dropped ───────────────────────────
+
+  TEST_CASE("synth groups: a note outside every group range is silently dropped") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    impl.addVoiceGroup(&proto, 4, 1, 48, 72); // only C3..C5 on channel 1
+    impl.setup();
+
+    impl.sendMessage(noteOnMsg(1, 100, 1.f)); // above range → no voice
+    impl.sendMessage(noteOnMsg(2, 60, 1.f)); // wrong channel → no voice
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    for (int i = 0; i < 10; ++i)
+      renderBlock(impl, intent);
+    CHECK(TestHelpers::decaysToSilence(impl.getOutputSource().samples[0], 1e-4f));
+  }
+
+  // ─── real-time discipline ─────────────────────────────────────────────────
+
+  TEST_CASE("synth render: process() does not allocate after warm-up") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.002f).decay(0.002f).sustain(0.8f).release(0.05f);
+    impl.addVoiceGroup(&proto, 8, 0, 0, 127);
+    impl.setup();
+
+    // Warm up every path: allocate, steal, release, free.
+    for (int n = 60; n < 68; ++n)
+      impl.sendMessage(noteOnMsg(1, n, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    for (int i = 0; i < 20; ++i)
+      renderBlock(impl, intent);
+    impl.sendMessage(noteOnMsg(1, 70, 1.f)); // steal
+    for (int i = 0; i < 40; ++i)
+      renderBlock(impl, intent);
+
+    {
+      TestHelpers::ProbeScope probe;
+      impl.sendMessage(noteOnMsg(1, 71, 1.f)); // another steal
+      impl.sendMessage(noteOffMsg(1, 61));
+      for (int i = 0; i < 60; ++i)
+        renderBlock(impl, intent);
+      impl.sendMessage(allNotesOffMsg(0));
+      for (int i = 0; i < 400; ++i)
+        renderBlock(impl, intent);
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+  }
+
+  // ─── manager / lifecycle (needs a live engine) ────────────────────────────
+
+  namespace {
+    void drainSynth(int n = 16) {
+      for (int i = 0; i < n; ++i) {
+        YSE::INTERNAL::Time().update();
+        YSE::SOUND::Manager().update();
+        YSE::SYNTH::Manager().update();
+        std::this_thread::sleep_for(5ms);
+      }
+    }
+  } // namespace
+
+  TEST_CASE("synth lifecycle: create -> addVoices -> attach reaches READY, then releases") {
+    if (!TestHelpers::engineInit()) return;
+    {
+      sineVoice proto;
+      proto.attack(0.005f).release(0.1f);
+      YSE::synth syn;
+      syn.create().addVoices(proto, 8);
+      YSE::sound snd;
+      snd.create(syn); // attaches the synth's aggregate behind a positioned sound
+      drainSynth();
+      CHECK(syn.getNumVoices() == 8);
+      CHECK(YSE::SYNTH::Manager().empty() == false);
+      snd.play();
+      syn.noteOn(1, 60, 0.9f);
+      drainSynth();
+      syn.noteOff(1, 60);
+      snd.stop();
+      drainSynth();
+      // snd (declared last) destructs first, before syn — the required order.
+    }
+    drainSynth();
+    CHECK(true); // no crash through the full create/attach/release/delete cycle
+  }
+
+  TEST_CASE("synth lifecycle: rapid create/destroy under a note storm") {
+    if (!TestHelpers::engineInit()) return;
+    for (int round = 0; round < 3; ++round) {
+      sineVoice proto;
+      proto.attack(0.002f).release(0.05f);
+      YSE::synth syn;
+      syn.create().addVoices(proto, 16);
+      YSE::sound snd;
+      snd.create(syn);
+      drainSynth(6);
+      snd.play();
+      for (int i = 0; i < 200; ++i) {
+        syn.noteOn(1, 48 + (i % 24), 0.8f);
+        if (i % 3 == 0) syn.noteOff(1, 48 + (i % 24));
+      }
+      drainSynth(4);
+      syn.allNotesOff();
+      snd.stop();
+      drainSynth(4);
+    }
+    drainSynth(8);
+    CHECK(true);
+  }
+
+} // TEST_SUITE("synth")

--- a/Tests/synth/test_synth_close.cpp
+++ b/Tests/synth/test_synth_close.cpp
@@ -1,0 +1,112 @@
+// Engine-close / offline-render lifecycle tests for YSE::synth (issue #153,
+// §8 / §9 of docs/design/synth_core.md).
+//
+// ISOLATION: these live in their own "synthlifecycle" TEST_SUITE and run as a
+// dedicated ctest process, excluded from the combined `yse_unit_tests` run —
+// exactly like the "lifecycle" suite. They call System::close(), which
+// permanently stops the global thread pools and would break every later suite
+// sharing the process. They are ALSO kept out of the "lifecycle" process on
+// purpose: that process leaves a lingering file-backed sound impl (the #140
+// case), and merely constructing the SYNTH::Manager singleton here reorders
+// static teardown enough to expose a pre-existing SOUND/CHANNEL teardown-order
+// fragility in that lingering impl. Running the synth close tests in their own
+// fresh process sidesteps that entirely. (Tracked as a follow-up issue.)
+//
+// initOffline() needs no audio hardware, so these run in CI; if it returns
+// false on some host the case bails out and doctest counts it as a pass.
+
+#include <doctest/doctest.h>
+#include <chrono>
+#include <thread>
+#include "yse.hpp"
+#include "channel/channelInterface.hpp"
+#include "sound/soundInterface.hpp"
+#include "synth/sineVoice.hpp"
+#include "synth/synthInterface.hpp"
+#include "synth/synthManager.h"
+#include "internal/time.h"
+
+TEST_SUITE("synthlifecycle") {
+
+  // A standalone synth (no sound) survives engine close with notes still held:
+  // close() joins the pools, the interface destructs against a closed engine,
+  // and the static SYNTH::Manager frees the impl (with its cloned voices) at
+  // process exit — no crash.
+  TEST_CASE("synthlifecycle: engine close with a standalone synth and held notes") {
+    YSE::System().close(); // normalize to a closed engine
+    if (!YSE::System().initOffline()) return;
+    {
+      YSE::SYNTH::sineVoice proto;
+      proto.attack(0.005f).release(0.1f);
+      YSE::synth syn;
+      syn.create().addVoices(proto, 8);
+      // Voice cloning runs async on the slow pool; wait for it.
+      const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+      while (std::chrono::steady_clock::now() < deadline) {
+        YSE::INTERNAL::Time().update();
+        YSE::SYNTH::Manager().update();
+        if (syn.getNumVoices() == 8) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      }
+      CHECK(syn.getNumVoices() == 8);
+      for (int n = 60; n < 68; ++n)
+        syn.noteOn(1, n, 1.f); // notes queued / held
+      YSE::System().close(); // close with the synth still live
+    }
+    CHECK(true); // interface destructs against the closed engine — no crash
+  }
+
+  // A synth attached to a sound, driven to actually sound notes via the offline
+  // render loop, then torn down respecting the §9 lifetime contract (the sound
+  // is destroyed and drained before the synth). Exercises the #153 lifecycle
+  // end to end: create -> attach -> render -> release -> delete.
+  TEST_CASE("synthlifecycle: synth behind a sound renders offline then tears down") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice proto; // outlives everything below (declared first)
+    proto.attack(0.005f).decay(0.01f).sustain(0.8f).release(0.05f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(proto, 8);
+      {
+        YSE::sound snd;
+        snd.create(syn);
+        // Bring both impls to READY (voice cloning is async on the slow pool,
+        // so wait), then render blocks so voices allocate and sound.
+        const auto ready = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (std::chrono::steady_clock::now() < ready) {
+          YSE::System().update();
+          YSE::System().renderOffline(1);
+          if (syn.getNumVoices() == 8) break;
+          std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        CHECK(syn.getNumVoices() == 8);
+        snd.play();
+        for (int n = 60; n < 65; ++n)
+          syn.noteOn(1, n, 1.f);
+        YSE::System().update();
+        YSE::System().renderOffline(16); // notes sounding
+        snd.stop();
+        YSE::System().renderOffline(8);
+      } // sound destroyed (notes still held) — synth still alive (§9 order)
+      // Drain so the sound impl is fully released + deleted before the synth.
+      const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+      while (std::chrono::steady_clock::now() < deadline) {
+        YSE::System().update();
+        YSE::System().renderOffline(1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      }
+    } // synth destroyed after its sound
+    // Drain so the synth impl is released + deleted while the engine is up.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    YSE::System().close();
+    CHECK(true);
+  }
+
+} // TEST_SUITE("synthlifecycle")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -128,6 +128,9 @@ set(YSE_SRCS
   sound/soundInterface.cpp
   sound/soundManager.cpp
   synth/sineVoice.cpp
+  synth/synthImplementation.cpp
+  synth/synthInterface.cpp
+  synth/synthManager.cpp
   utils/fileFunctions.cpp
   utils/interpolators.cpp
   utils/vector.cpp

--- a/YseEngine/classes.hpp
+++ b/YseEngine/classes.hpp
@@ -14,6 +14,7 @@
 #include "utils/vector.hpp"
 #include "channel/channel.hpp"
 #include "sound/sound.hpp"
+#include "synth/synth.hpp"
 #include "reverb/reverb.hpp"
 #include "device/device.hpp"
 #include "player/player.hpp"

--- a/YseEngine/device/deviceManager.cpp
+++ b/YseEngine/device/deviceManager.cpp
@@ -30,6 +30,7 @@ bool YSE::DEVICE::deviceManager::doOnCallback(int numSamples) {
     INTERNAL::Time().update();
     INTERNAL::ListenerImpl().update();
     SOUND::Manager().update();
+    SYNTH::Manager().update();
     CHANNEL::Manager().update();
     REVERB::Manager().update();
     MIDI::Manager().update();
@@ -43,7 +44,6 @@ bool YSE::DEVICE::deviceManager::doOnCallback(int numSamples) {
   // between two buffer updates and should have the least latency possible
   INTERNAL::DeviceTime().update();
   PLAYER::Manager().update((Flt)numSamples / (Flt)SAMPLERATE);
-  // SYNTH::Manager().update();
 
   if (SOUND::Manager().empty()) return false;
 

--- a/YseEngine/internalHeaders.h
+++ b/YseEngine/internalHeaders.h
@@ -24,6 +24,11 @@
 #include "sound/soundManager.h"
 #include "sound/soundMessage.h"
 
+#include "synth/synthImplementation.h"
+#include "synth/synthInterface.hpp"
+#include "synth/synthManager.h"
+#include "synth/synthMessage.h"
+
 #include "player/playerImplementation.h"
 #include "player/playerManager.h"
 #include "player/playerMessage.h"

--- a/YseEngine/sound/soundInterface.cpp
+++ b/YseEngine/sound/soundInterface.cpp
@@ -10,7 +10,7 @@
 
 #include "../internalHeaders.h"
 #include "../patcher/patcherImplementation.h"
-// #include "../synth/synthInterface.hpp"
+#include "../synth/synthInterface.hpp"
 
 #include <mutex>
 #include <unordered_set>
@@ -229,14 +229,21 @@ void YSE::sound::create(YSE::patcher& patch, channel* ch, float volume) {
   }
 }
 
-/*YSE::sound& YSE::sound::create(SYNTH::interfaceObject & synth, channel *ch, Flt volume) {
+void YSE::sound::create(YSE::synth& synth, channel* ch, float volume) {
   assert(pimpl == nullptr);
+
+  // Ensure the synth has a live implementation, then attach its aggregate
+  // output source through the existing dspSourceObject render path. All
+  // synth-specific work (drain / allocate / mix) happens inside that source's
+  // process(), which the sound already knows how to call — no new audio-thread
+  // path is opened (docs/design/synth_core.md §9).
+  if (!synth.isValid()) synth.create();
+
   pimpl = SOUND::Manager().addImplementation(this);
   if (ch == nullptr) ch = &CHANNEL::Manager().master();
-  pimpl->create(synth.pimpl, ch, volume);
+  pimpl->create(synth.pimpl->getOutputSource(), ch, volume);
   SOUND::Manager().setup(pimpl);
-  return *this;
-}*/
+}
 
 Bool YSE::sound::isValid() {
   return pimpl != nullptr;

--- a/YseEngine/sound/soundInterface.hpp
+++ b/YseEngine/sound/soundInterface.hpp
@@ -139,6 +139,24 @@ namespace YSE {
     void create(YSE::patcher& patcher, channel* ch = nullptr, float volume = 1.0f);
 
     /**
+     *  @brief Create a sound driven by a polyphonic ``YSE::synth``.
+     *
+     *  Attaches the synth's aggregate voice pool behind this sound, which
+     *  supplies the single 3D position, channel routing, and master play/stop
+     *  intent. Calls ``synth.create()`` for you if you have not. Build the
+     *  synth's voices with ``synth.addVoices(...)`` *before* this call.
+     *
+     *  @param synth  The synth to render. Must outlive the sound (see warning).
+     *  @param ch     Channel to attach to. ``nullptr`` uses ``MainMix``.
+     *  @param volume Initial volume in the range [0.0, 1.0].
+     *
+     *  @warning **Lifetime contract.** The ``synth`` must outlive this sound —
+     *           until after the sound's destructor AND the engine's slow-pool
+     *           delete tick. Same shape as the raw ``dspSourceObject`` overload.
+     */
+    void create(YSE::synth& synth, channel* ch = nullptr, float volume = 1.0f);
+
+    /**
      *  @brief Whether this interface has a live implementation.
      *
      *  Returns ``true`` for the entire lifetime of a successfully ``create``-d

--- a/YseEngine/synth/synth.hpp
+++ b/YseEngine/synth/synth.hpp
@@ -1,0 +1,53 @@
+/*
+  ==============================================================================
+
+    synth.hpp
+    Forward-declaration hub for the YSE::synth subsystem.
+
+    Mirrors sound/sound.hpp: declares the four-part subsystem split (interface,
+    implementation, message, manager) plus the voice base, and defines the
+    MESSAGE op-set and the public `YSE::synth` typedef. Implements §2 ("Object
+    model") of docs/design/synth_core.md.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_SYNTH_HPP
+#define YSE_SYNTH_SYNTH_HPP
+
+namespace YSE {
+  /** Every subSystem consists out of several classes which are meant to work
+      together: an interface, implementation, manager, message and a message
+      enumeration. The synth subsystem mirrors the sound subsystem one-for-one.
+  */
+  namespace SYNTH {
+    class interfaceObject;
+    class implementationObject;
+    class messageObject;
+    class managerObject;
+    class dspVoice;
+
+    /** The control events the interface can push onto an implementation's
+        lock-free inbox. #153 wires up the note ops (NOTE_ON / NOTE_OFF /
+        ALL_NOTES_OFF); the pedal / controller / wheel / aftertouch ops are
+        declared here as the fixed contract but handled by #154 (keyboard
+        state). There is deliberately no CALLBACK op — onNoteEvent is a direct
+        atomic function pointer (#154), never a queued message. */
+    enum MESSAGE {
+      NOTE_ON,
+      NOTE_OFF,
+      ALL_NOTES_OFF,
+      PITCH_WHEEL,
+      CONTROLLER,
+      AFTERTOUCH,
+      SUSTAIN,
+      SOSTENUTO,
+      SOFTPEDAL,
+    };
+  } // namespace SYNTH
+
+  /** Users just write ``YSE::synth`` to get an interface object. */
+  typedef SYNTH::interfaceObject synth;
+} // namespace YSE
+
+#endif // YSE_SYNTH_SYNTH_HPP

--- a/YseEngine/synth/synthImplementation.cpp
+++ b/YseEngine/synth/synthImplementation.cpp
@@ -1,0 +1,360 @@
+/*
+  ==============================================================================
+
+    synthImplementation.cpp
+    Audio-thread synth implementation — voice allocator, stealing policy, mix,
+    and lifecycle. See synthImplementation.h and docs/design/synth_core.md
+    (§2 / §4 / §8).
+
+  ==============================================================================
+*/
+
+#include "synthImplementation.h"
+#include "../internalHeaders.h"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace YSE {
+  namespace SYNTH {
+
+    // Engine-owned steal declick length, in seconds (~5 ms). A stolen voice's
+    // tail is force-faded over this window so stealing never clicks, regardless
+    // of the user voice's own (possibly seconds-long) release. See §4.
+    static const Flt kStealFadeSec = 0.005f;
+
+    implementationObject::implementationObject(interfaceObject* head)
+      : head(head), objectStatus(OBJECT_CONSTRUCTED), messages(1024), output(*this, 1) {}
+
+    implementationObject::~implementationObject() {
+      // If the interface somehow outlives us (e.g. engine teardown clears the
+      // implementations list), null its back-pointer so it does not dereference
+      // freed storage. In the normal path the interface is already gone (that
+      // is what drove us to OBJECT_RELEASE via sync()). The unique_ptr voices
+      // free here, on the setup pool's delete job — never on the audio thread.
+      interfaceObject* h = head.load(std::memory_order_acquire);
+      if (h != nullptr) {
+        h->pimpl = nullptr;
+      }
+    }
+
+    // ---- control thread ---------------------------------------------------
+
+    void implementationObject::sendMessage(const messageObject& message) {
+      // Non-allocating push: a flood of note events drops on overflow rather
+      // than growing the queue, so no thread ever allocates for MIDI (§6).
+      if (!messages.try_push(message)) {
+        INTERNAL::LogImpl().emit(E_DEBUG, "SYNTH: note inbox full, message dropped");
+      }
+    }
+
+    void implementationObject::addVoiceGroup(dspVoice* prototype, int numVoices, int channel,
+                                             int lowestNote, int highestNote) {
+      if (prototype == nullptr || numVoices <= 0) return;
+      std::scoped_lock lk(buildMutex);
+      if (objectStatus.load(std::memory_order_acquire) >= OBJECT_SETUP) {
+        // Voice groups are immutable once built: the audio thread reads them
+        // lock-free. Growing the pool at runtime is an explicit non-goal (§1);
+        // reject rather than race the reader.
+        INTERNAL::LogImpl().emit(E_WARNING, "SYNTH: addVoices() after setup is not supported");
+        return;
+      }
+      pendingGroups.push_back({prototype, numVoices, channel, lowestNote, highestNote});
+    }
+
+    int implementationObject::getNumVoices() const {
+      return numVoicesTotal.load(std::memory_order_relaxed);
+    }
+
+    DSP::dspSourceObject& implementationObject::getOutputSource() {
+      return output;
+    }
+
+    // ---- lifecycle --------------------------------------------------------
+
+    bool implementationObject::tryClaimForSetup() {
+      OBJECT_IMPLEMENTATION_STATE expected = OBJECT_CREATED;
+      return objectStatus.compare_exchange_strong(expected, OBJECT_SETTING_UP);
+    }
+
+    void implementationObject::setup() {
+      // Runs on the single-threaded setup pool — the ONLY place voices are
+      // allocated. clone() does the user's `new`.
+      std::scoped_lock lk(buildMutex);
+      for (auto& req : pendingGroups) {
+        voiceGroup g;
+        g.channel = req.channel;
+        g.lowNote = req.lowNote;
+        g.highNote = req.highNote;
+        g.slots.resize(static_cast<size_t>(req.numVoices)); // default: free (note -1, STOPPED)
+        g.voices.reserve(static_cast<size_t>(req.numVoices));
+        for (int k = 0; k < req.numVoices; ++k) {
+          g.voices.emplace_back(req.prototype->clone());
+        }
+        groups.push_back(std::move(g));
+      }
+      pendingGroups.clear();
+
+      int total = 0;
+      for (auto& g : groups)
+        total += static_cast<int>(g.voices.size());
+      numVoicesTotal.store(total, std::memory_order_relaxed);
+
+      stealFadeSamples = std::max(1, static_cast<int>(SAMPLERATE * kStealFadeSec));
+
+      // Publish groups to the audio thread. Storing inside the lock closes the
+      // window where an addVoiceGroup() could append a request this setup will
+      // never build (it is serialised on buildMutex and now sees OBJECT_SETUP).
+      objectStatus.store(OBJECT_SETUP, std::memory_order_release);
+    }
+
+    bool implementationObject::readyCheck() {
+      if (objectStatus.load(std::memory_order_acquire) == OBJECT_SETUP) {
+        objectStatus.store(OBJECT_READY, std::memory_order_release);
+        return true;
+      }
+      return false;
+    }
+
+    void implementationObject::sync() {
+      // Audio-thread lifecycle tick. The note inbox is drained in
+      // renderBlock(), not here; sync() only watches for interface teardown.
+      if (head.load(std::memory_order_acquire) == nullptr) {
+        objectStatus.store(OBJECT_RELEASE, std::memory_order_release);
+      }
+    }
+
+    void implementationObject::removeInterface() {
+      head.store(nullptr, std::memory_order_release);
+    }
+
+    OBJECT_IMPLEMENTATION_STATE implementationObject::getStatus() {
+      return objectStatus.load(std::memory_order_acquire);
+    }
+
+    void implementationObject::setStatus(OBJECT_IMPLEMENTATION_STATE value) {
+      objectStatus.store(value, std::memory_order_release);
+    }
+
+    // ---- audio-thread render path -----------------------------------------
+
+    void implementationObject::renderBlock(SOUND_STATUS& masterIntent) {
+      const OBJECT_IMPLEMENTATION_STATE st = objectStatus.load(std::memory_order_acquire);
+      const bool ready = (st == OBJECT_SETUP || st == OBJECT_READY);
+
+      // 1. Drain the inbox so every note event for this block takes effect
+      //    before any audio is produced. Events arriving before the synth is
+      //    ready are discarded (they have no group to target yet).
+      messageObject m;
+      while (messages.try_pop(m)) {
+        if (ready) parseMessage(m);
+      }
+
+      // 2. Clear the aggregate.
+      for (auto& b : output.samples)
+        b = 0.f;
+
+      if (!ready) return;
+
+      // 3. Honour the sound-level master intent as a gate over the whole pool.
+      switch (masterIntent) {
+      case SS_WANTSTOPLAY:
+      case SS_WANTSTORESTART:
+        masterIntent = SS_PLAYING;
+        break;
+      case SS_PLAYING:
+      case SS_PLAYING_FULL_VOLUME:
+        break;
+      case SS_WANTSTOSTOP:
+        // Hard cut: the owning sound has already faded to silence via its own
+        // fader by the time it reaches WANTSTOSTOP, so freeing here is
+        // click-free. Frees the whole pool.
+        freeAllVoices();
+        masterIntent = SS_STOPPED;
+        return;
+      case SS_WANTSTOPAUSE:
+        masterIntent = SS_PAUSED;
+        return;
+      default: // SS_STOPPED / SS_PAUSED — stay silent, keep voice state.
+        return;
+      }
+
+      // 4. Render + mix every active voice.
+      const int blockLen = static_cast<int>(output.samples[0].getLength());
+      for (auto& g : groups) {
+        for (size_t i = 0; i < g.slots.size(); ++i) {
+          voiceSlot& slot = g.slots[i];
+          dspVoice* v = g.voices[i].get();
+
+          if (slot.stealing) {
+            // Keep rendering the OLD note, faded out by the engine ramp.
+            v->process(slot.intent);
+            mixVoiceRamp(*v, slot);
+            slot.stealPos += blockLen;
+            if (slot.stealPos >= stealFadeSamples) {
+              // Fade complete: re-arm this slot with the new note. It begins on
+              // the next block — the small (~5 ms) latency a stolen note pays.
+              slot.stealing = false;
+              slot.stealPos = 0;
+              slot.note = slot.pendNote;
+              slot.channel = slot.pendChannel;
+              slot.age = slot.pendAge;
+              v->frequency(static_cast<Flt>(slot.pendNote));
+              v->velocity(slot.pendVelocity);
+              slot.intent = SS_WANTSTOPLAY;
+            }
+          } else if (slot.intent != SS_STOPPED) {
+            v->process(slot.intent); // may settle the intent to SS_STOPPED
+            mixVoice(*v, 1.f);
+            if (slot.intent == SS_STOPPED) {
+              slot.note = -1; // release tail finished — slot is free again
+            }
+          }
+        }
+      }
+    }
+
+    void implementationObject::mixVoice(dspVoice& voice, Flt gain) {
+      Flt* dst = output.samples[0].getPtr();
+      const UInt len = output.samples[0].getLength();
+      for (auto& vb : voice.samples) {
+        Flt* src = vb.getPtr();
+        const UInt n = std::min(len, vb.getLength());
+        for (UInt s = 0; s < n; ++s)
+          dst[s] += src[s] * gain;
+      }
+    }
+
+    void implementationObject::mixVoiceRamp(dspVoice& voice, voiceSlot& slot) {
+      Flt* dst = output.samples[0].getPtr();
+      const UInt len = output.samples[0].getLength();
+      const Flt fade = static_cast<Flt>(stealFadeSamples);
+      for (auto& vb : voice.samples) {
+        Flt* src = vb.getPtr();
+        const UInt n = std::min(len, vb.getLength());
+        for (UInt s = 0; s < n; ++s) {
+          Flt g = 1.f - static_cast<Flt>(slot.stealPos + static_cast<int>(s)) / fade;
+          if (g < 0.f) g = 0.f;
+          dst[s] += src[s] * g;
+        }
+      }
+    }
+
+    void implementationObject::freeAllVoices() {
+      for (auto& g : groups) {
+        for (auto& slot : g.slots) {
+          slot.intent = SS_STOPPED;
+          slot.note = -1;
+          slot.stealing = false;
+          slot.stealPos = 0;
+        }
+      }
+    }
+
+    // ---- keyboard / allocator ---------------------------------------------
+
+    void implementationObject::parseMessage(const messageObject& message) {
+      switch (message.ID) {
+      case NOTE_ON:
+        handleNoteOn(message.noteOn.channel, message.noteOn.note, message.noteOn.velocity);
+        break;
+      case NOTE_OFF:
+        handleNoteOff(message.noteOff.channel, message.noteOff.note);
+        break;
+      case ALL_NOTES_OFF:
+        handleAllNotesOff(message.allOff.channel);
+        break;
+      default:
+        // PITCH_WHEEL / CONTROLLER / AFTERTOUCH / pedals are handled by the
+        // keyboard-state issue (#154); ignored here.
+        break;
+      }
+    }
+
+    void implementationObject::handleNoteOn(int channel, int note, Flt velocity) {
+      for (auto& g : groups) {
+        if (groupMatches(g, channel, note)) {
+          allocateInGroup(g, channel, note, velocity);
+        }
+      }
+    }
+
+    void implementationObject::handleNoteOff(int channel, int note) {
+      // Release every voice sounding this (channel, note). #153 releases
+      // immediately; pedal-deferred release is #154.
+      for (auto& g : groups) {
+        for (auto& slot : g.slots) {
+          if (!slot.stealing && slot.note == note && slot.channel == channel &&
+              slot.intent != SS_STOPPED && slot.intent != SS_WANTSTOSTOP) {
+            slot.intent = SS_WANTSTOSTOP;
+          }
+        }
+      }
+    }
+
+    void implementationObject::handleAllNotesOff(int channel) {
+      for (auto& g : groups) {
+        for (auto& slot : g.slots) {
+          if (!slot.stealing && slot.intent != SS_STOPPED && slot.intent != SS_WANTSTOSTOP &&
+              (channel == 0 || slot.channel == channel)) {
+            slot.intent = SS_WANTSTOSTOP;
+          }
+        }
+      }
+    }
+
+    void implementationObject::allocateInGroup(voiceGroup& group, int channel, int note,
+                                               Flt velocity) {
+      // 1. Prefer a free (STOPPED) slot.
+      for (size_t i = 0; i < group.slots.size(); ++i) {
+        voiceSlot& s = group.slots[i];
+        if (!s.stealing && s.intent == SS_STOPPED) {
+          s.note = note;
+          s.channel = channel;
+          s.age = ++ageCounter;
+          group.voices[i]->frequency(static_cast<Flt>(note));
+          group.voices[i]->velocity(velocity);
+          s.intent = SS_WANTSTOPLAY;
+          return;
+        }
+      }
+
+      // 2. No free slot — steal. Prefer the oldest voice already in release;
+      //    else the oldest voice overall. Slots mid-steal are not candidates.
+      int stealIdx = -1;
+      uint64_t bestAge = UINT64_MAX;
+      for (size_t i = 0; i < group.slots.size(); ++i) {
+        voiceSlot& s = group.slots[i];
+        if (!s.stealing && s.intent == SS_WANTSTOSTOP && s.age < bestAge) {
+          bestAge = s.age;
+          stealIdx = static_cast<int>(i);
+        }
+      }
+      if (stealIdx < 0) {
+        bestAge = UINT64_MAX;
+        for (size_t i = 0; i < group.slots.size(); ++i) {
+          voiceSlot& s = group.slots[i];
+          if (!s.stealing && s.age < bestAge) {
+            bestAge = s.age;
+            stealIdx = static_cast<int>(i);
+          }
+        }
+      }
+      if (stealIdx < 0) {
+        // Every voice is already mid-steal; drop rather than click.
+        return;
+      }
+
+      // Begin the click-free steal: keep the old note rendering, fade it out,
+      // and record the new note to arm when the fade completes.
+      voiceSlot& s = group.slots[static_cast<size_t>(stealIdx)];
+      s.stealing = true;
+      s.stealPos = 0;
+      s.pendNote = note;
+      s.pendChannel = channel;
+      s.pendVelocity = velocity;
+      s.pendAge = ++ageCounter;
+    }
+
+  } // namespace SYNTH
+} // namespace YSE

--- a/YseEngine/synth/synthImplementation.h
+++ b/YseEngine/synth/synthImplementation.h
@@ -1,0 +1,210 @@
+/*
+  ==============================================================================
+
+    synthImplementation.h
+    Audio-thread implementation object for the YSE::synth subsystem.
+
+    Owns the voice groups, the per-impl lock-free note inbox, the aggregate
+    output source, the voice allocator (with the #151 stealing policy) and the
+    OBJECT_* lifecycle. Implements §2 / §4 / §8 / §9 of
+    docs/design/synth_core.md.
+
+    Threading:
+      * control thread  — sendMessage() (push inbox), addVoiceGroup() (record
+                          a pending group request under buildMutex).
+      * setup pool      — setup() clones voices under buildMutex. The ONLY place
+                          voices are allocated.
+      * audio thread    — renderBlock() (via outputSource::process): drains the
+                          inbox, runs the keyboard/allocator, drives every voice
+                          and mixes, all allocation-free and lock-free.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_SYNTHIMPLEMENTATION_H
+#define YSE_SYNTH_SYNTHIMPLEMENTATION_H
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "../classes.hpp"
+#include "../dsp/dspObject.hpp"
+#include "../headers/enums.hpp"
+#include "../headers/types.hpp"
+#include "../utils/lfQueue.hpp"
+#include "dspVoice.hpp"
+#include "synth.hpp"
+#include "synthMessage.h"
+
+namespace YSE {
+  namespace INTERNAL {
+    // The manager job templates befriended below (defined in managerJobs.hpp).
+    template <typename Manager> class managerSetupJob;
+    template <typename Manager> class managerDeleteJob;
+  } // namespace INTERNAL
+
+  namespace SYNTH {
+
+    /**
+        Internal counterpart of a ``YSE::synth``. Created and destroyed by the
+        SYNTH::managerObject; the user never touches one directly.
+    */
+    class implementationObject {
+    public:
+      explicit implementationObject(interfaceObject* head);
+      ~implementationObject();
+
+      // ---- control thread -------------------------------------------------
+
+      /** Push a note/control message onto the SPSC inbox (control thread). */
+      void sendMessage(const messageObject& message);
+
+      /** Record a pending voice-group request. The clones themselves are built
+          later, on the setup pool, in setup(). Called on the control thread;
+          guarded by buildMutex against the setup pool. */
+      void addVoiceGroup(dspVoice* prototype, int numVoices, int channel, int lowestNote,
+                         int highestNote);
+
+      /** Total allocated voices across every group. Thread-safe. */
+      int getNumVoices() const;
+
+      // ---- attachment -----------------------------------------------------
+
+      /** The aggregate source the owning ``YSE::sound`` renders. */
+      DSP::dspSourceObject& getOutputSource();
+
+      // ---- lifecycle (manager + job templates) ----------------------------
+
+      /** Atomically claim OBJECT_CREATED -> OBJECT_SETTING_UP for the setup
+          pool (used by INTERNAL::managerSetupJob). */
+      bool tryClaimForSetup();
+
+      /** Setup-pool entry point: clone the pending voice groups. Publishes
+          OBJECT_SETUP on completion. */
+      void setup();
+
+      /** Promote OBJECT_SETUP -> OBJECT_READY (audio thread). */
+      bool readyCheck();
+
+      /** Audio-thread lifecycle tick: detects interface teardown and flags
+          the impl for release. */
+      void sync();
+
+      void removeInterface();
+      OBJECT_IMPLEMENTATION_STATE getStatus();
+      void setStatus(OBJECT_IMPLEMENTATION_STATE value);
+
+      /** Predicate for the delete job's remove_if. */
+      static bool canBeDeleted(const implementationObject& impl) {
+        return impl.objectStatus.load(std::memory_order_acquire) == OBJECT_DELETE;
+      }
+
+      /** Predicate for the audio-thread toLoad scrub: an impl that is already
+          ready/released/deleted no longer belongs in the loading list. */
+      static bool canBeRemovedFromLoading(const implementationObject* impl) {
+        OBJECT_IMPLEMENTATION_STATE s = impl->objectStatus.load(std::memory_order_acquire);
+        return s == OBJECT_READY || s == OBJECT_RELEASE || s == OBJECT_DELETE;
+      }
+
+    private:
+      // ---- aggregate output source ---------------------------------------
+      // The single dspSourceObject the owning sound renders. Its process() is
+      // the synth's per-block heartbeat; it simply forwards to renderBlock().
+      class outputSource : public DSP::dspSourceObject {
+      public:
+        outputSource(implementationObject& owner, Int channels)
+          : dspSourceObject(channels), owner(owner) {}
+        void process(SOUND_STATUS& masterIntent) override {
+          owner.renderBlock(masterIntent);
+        }
+        void frequency(Flt) override {} // no-op: notes carry pitch
+      private:
+        implementationObject& owner;
+      };
+
+      // ---- voice bookkeeping ---------------------------------------------
+      // Per-voice slot state owned and mutated only on the audio thread.
+      struct voiceSlot {
+        SOUND_STATUS intent = SS_STOPPED; // this voice's gate (passed to process)
+        int note = -1; // MIDI note sounding here (-1 = free)
+        int channel = 0; // channel that triggered it
+        uint64_t age = 0; // allocation stamp; smaller = older
+        // engine-owned declick for click-free stealing
+        bool stealing = false; // fading the OLD note out before re-arming
+        int stealPos = 0; // samples elapsed into the steal fade
+        int pendNote = 0; // the NEW note to arm once the fade completes
+        int pendChannel = 0;
+        Flt pendVelocity = 0.f;
+        uint64_t pendAge = 0;
+      };
+
+      // A group is one addVoices() call: n identical voices with a channel
+      // filter and note range. Allocation is always within a matching group.
+      struct voiceGroup {
+        std::vector<std::unique_ptr<dspVoice>> voices;
+        std::vector<voiceSlot> slots; // parallel to voices
+        int channel = 0; // 0 = omni
+        int lowNote = 0;
+        int highNote = 127;
+      };
+
+      // A not-yet-built group, recorded by addVoiceGroup() and consumed by
+      // setup(). Holds a raw prototype pointer the caller must keep alive.
+      struct groupRequest {
+        dspVoice* prototype;
+        int numVoices;
+        int channel;
+        int lowNote;
+        int highNote;
+      };
+
+      // ---- audio-thread render path --------------------------------------
+      void renderBlock(SOUND_STATUS& masterIntent);
+      void parseMessage(const messageObject& message);
+      void handleNoteOn(int channel, int note, Flt velocity);
+      void handleNoteOff(int channel, int note);
+      void handleAllNotesOff(int channel);
+      void allocateInGroup(voiceGroup& group, int channel, int note, Flt velocity);
+      void freeAllVoices();
+      void mixVoice(dspVoice& voice, Flt gain);
+      void mixVoiceRamp(dspVoice& voice, voiceSlot& slot);
+
+      static bool groupMatches(const voiceGroup& group, int channel, int note) {
+        return (group.channel == 0 || group.channel == channel) && note >= group.lowNote &&
+               note <= group.highNote;
+      }
+
+      // Intrusive manager-list link (issue #194): threads this impl through the
+      // manager's audio-thread toLoad/inUse lists (mutually exclusive).
+      implementationObject* _mgrNext = nullptr;
+
+      std::atomic<interfaceObject*> head; // owning interface (null once gone)
+      std::atomic<OBJECT_IMPLEMENTATION_STATE> objectStatus;
+      lfQueue<messageObject> messages; // SPSC note inbox
+
+      outputSource output; // aggregate source
+
+      // Built on the setup pool, read on the audio thread. Published via
+      // objectStatus (release in setup(), acquire in renderBlock()): the audio
+      // thread only touches `groups` once status >= OBJECT_SETUP, after which
+      // the container is immutable for the impl's lifetime.
+      std::vector<voiceGroup> groups;
+      std::vector<groupRequest> pendingGroups; // control -> setup pool
+      std::mutex buildMutex; // guards pendingGroups / groups build
+
+      std::atomic<int> numVoicesTotal{0};
+      uint64_t ageCounter = 0; // audio thread only
+      int stealFadeSamples = 1; // computed in setup()
+
+      friend class SYNTH::managerObject;
+      friend class INTERNAL::managerSetupJob<managerObject>;
+      friend class INTERNAL::managerDeleteJob<managerObject>;
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_SYNTHIMPLEMENTATION_H

--- a/YseEngine/synth/synthInterface.cpp
+++ b/YseEngine/synth/synthInterface.cpp
@@ -1,0 +1,95 @@
+/*
+  ==============================================================================
+
+    synthInterface.cpp
+    Public YSE::synth interface — a thin chainable pimpl over the
+    implementationObject. See synthInterface.hpp and docs/design/synth_core.md
+    §12.
+
+  ==============================================================================
+*/
+
+#include "synthInterface.hpp"
+#include "../internalHeaders.h"
+#include "../music/note.hpp"
+#include "synthManager.h"
+
+#include <cmath>
+
+namespace YSE {
+  namespace SYNTH {
+
+    interfaceObject::interfaceObject() : pimpl(nullptr) {}
+
+    interfaceObject::~interfaceObject() {
+      if (pimpl != nullptr) {
+        pimpl->removeInterface();
+        pimpl = nullptr;
+      }
+    }
+
+    interfaceObject& interfaceObject::create() {
+      if (pimpl != nullptr) return *this; // idempotent
+      pimpl = Manager().addImplementation(this);
+      Manager().setup(pimpl);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::addVoices(dspVoice& prototype, int numVoices, int channel,
+                                                int lowestNote, int highestNote) {
+      if (pimpl == nullptr) create();
+      pimpl->addVoiceGroup(&prototype, numVoices, channel, lowestNote, highestNote);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::noteOn(int channel, int noteNumber, float velocity) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = NOTE_ON;
+      m.noteOn.channel = channel;
+      m.noteOn.note = noteNumber;
+      m.noteOn.velocity = velocity;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::noteOff(int channel, int noteNumber, float velocity) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = NOTE_OFF;
+      m.noteOff.channel = channel;
+      m.noteOff.note = noteNumber;
+      m.noteOff.velocity = velocity;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::noteOn(const MUSIC::note& note) {
+      return noteOn(note.getChannel(), static_cast<int>(std::lround(note.getPitch())),
+                    note.getVolume());
+    }
+
+    interfaceObject& interfaceObject::noteOff(const MUSIC::note& note) {
+      return noteOff(note.getChannel(), static_cast<int>(std::lround(note.getPitch())),
+                     note.getVolume());
+    }
+
+    interfaceObject& interfaceObject::allNotesOff(int channel) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = ALL_NOTES_OFF;
+      m.allOff.channel = channel;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    int interfaceObject::getNumVoices() const {
+      return pimpl != nullptr ? pimpl->getNumVoices() : 0;
+    }
+
+    bool interfaceObject::isValid() const {
+      return pimpl != nullptr;
+    }
+
+  } // namespace SYNTH
+} // namespace YSE

--- a/YseEngine/synth/synthInterface.hpp
+++ b/YseEngine/synth/synthInterface.hpp
@@ -1,0 +1,109 @@
+/*
+  ==============================================================================
+
+    synthInterface.hpp
+    Public interface for the YSE::synth subsystem — a thin, chainable pimpl.
+
+    Implements the #153 slice of §12 ("Public API surface") of
+    docs/design/synth_core.md: object creation, voice-group construction, and
+    note events. Keyboard state / pedals / controllers / onNoteEvent are the
+    next issue (#154) and are intentionally absent here.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_SYNTHINTERFACE_HPP
+#define YSE_SYNTH_SYNTHINTERFACE_HPP
+
+#include "../classes.hpp"
+#include "../headers/defines.hpp"
+#include "synth.hpp"
+
+namespace YSE {
+
+  namespace SYNTH {
+
+    /**
+     *  @brief A polyphonic synthesiser voice pool rendered behind one ``YSE::sound``.
+     *
+     *  Write ``YSE::synth`` (a typedef for this class). Build the pool from a
+     *  prototype voice with ``addVoices``, attach it behind a positioned
+     *  ``YSE::sound`` with ``sound::create(synth&, ...)``, then drive it with
+     *  ``noteOn`` / ``noteOff``. The engine owns polyphony, allocation, voice
+     *  stealing and lifecycle; a ``SYNTH::dspVoice`` subclass owns only what a
+     *  single voice sounds like.
+     *
+     *  Like ``YSE::sound`` the interface is **non-copyable**: the implementation
+     *  holds this object's address, so the address must stay stable.
+     *
+     *  @see YSE::SYNTH::dspVoice   For user-subclassable voices.
+     *  @see YSE::SYNTH::sineVoice  The reference sine + ADSR voice.
+     */
+    class API interfaceObject {
+    public:
+      interfaceObject();
+      ~interfaceObject();
+
+      /** @brief Synths are non-copyable (the implementation holds our address). */
+      interfaceObject(const interfaceObject&) = delete;
+      interfaceObject& operator=(const interfaceObject&) = delete;
+
+      /** @brief Register this synth with the engine.
+       *
+       *  Must be called before ``addVoices`` / ``noteOn``. Idempotent-safe to
+       *  omit: ``sound::create(synth&, ...)`` calls it for you if you have not.
+       */
+      interfaceObject& create();
+
+      /**
+       *  @brief Clone ``prototype`` ``numVoices`` times into a voice group.
+       *
+       *  The group responds to note numbers in ``[lowestNote, highestNote]`` on
+       *  MIDI ``channel`` (0 = omni). May be called several times to build
+       *  layered or split keyboards; a note may sound in more than one matching
+       *  group. Cloning happens off the audio thread, on the engine's setup
+       *  pool, so the synth becomes playable a short moment after this returns
+       *  (when it reaches ``OBJECT_READY``) — exactly like a file-backed sound
+       *  is not playable until its buffer finishes loading.
+       *
+       *  @warning ``prototype`` must outlive the resulting setup — the engine
+       *           reads it to clone but neither copies nor owns it. Call
+       *           ``addVoices`` before the synth is attached and played.
+       */
+      interfaceObject& addVoices(dspVoice& prototype, int numVoices, int channel = 0,
+                                 int lowestNote = 0, int highestNote = 127);
+
+      /** @brief Start a note. ``velocity`` is normalised to [0, 1]. */
+      interfaceObject& noteOn(int channel, int noteNumber, float velocity);
+
+      /** @brief Release a note. */
+      interfaceObject& noteOff(int channel, int noteNumber, float velocity = 0.f);
+
+      /** @brief Start a note from a ``MUSIC::note`` (uses its pitch/volume/channel). */
+      interfaceObject& noteOn(const MUSIC::note& note);
+
+      /** @brief Release the note matching a ``MUSIC::note`` (pitch/channel). */
+      interfaceObject& noteOff(const MUSIC::note& note);
+
+      /** @brief Release every held note on ``channel`` (0 = all channels).
+       *
+       *  A bulk note-off: voices enter their normal release, they are not cut. */
+      interfaceObject& allNotesOff(int channel = 0);
+
+      /** @brief Total number of allocated voices across all groups. */
+      int getNumVoices() const;
+
+      /** @brief Whether this interface has a live implementation. */
+      bool isValid() const;
+
+    private:
+      implementationObject* pimpl = nullptr;
+
+      friend class YSE::sound; // sound::create(synth&, ...)
+      friend class SYNTH::implementationObject; // impl holds our address
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_SYNTHINTERFACE_HPP

--- a/YseEngine/synth/synthManager.cpp
+++ b/YseEngine/synth/synthManager.cpp
@@ -1,0 +1,117 @@
+/*
+  ==============================================================================
+
+    synthManager.cpp
+    Synth subsystem manager singleton. See synthManager.h and
+    docs/design/synth_core.md §8.
+
+  ==============================================================================
+*/
+
+#include "synthManager.h"
+#include "../internalHeaders.h"
+
+YSE::SYNTH::managerObject& YSE::SYNTH::Manager() {
+  static managerObject m;
+  return m;
+}
+
+YSE::SYNTH::managerObject::managerObject() : mgrSetup(this), mgrDelete(this) {}
+
+YSE::SYNTH::managerObject::~managerObject() noexcept {
+  try {
+    mgrSetup.join();
+    mgrDelete.join();
+
+    // Drain any pointers still queued by the main thread; they reference impls
+    // owned by `implementations` and are freed when that list is cleared.
+    implementationObject* drained;
+    while (toLoadInbox.try_pop(drained)) {
+      (void)drained;
+    }
+
+    toLoad.clear();
+    inUse.clear();
+    {
+      std::scoped_lock lk(implementationsMutex);
+      implementations.clear();
+    }
+  } catch (...) {
+    INTERNAL::LogImpl().emit(E_ERROR, "SYNTH::Manager destructor swallowed exception");
+  }
+}
+
+YSE::SYNTH::implementationObject*
+YSE::SYNTH::managerObject::addImplementation(YSE::SYNTH::interfaceObject* head) {
+  std::scoped_lock lk(implementationsMutex);
+  implementations.emplace_front(head);
+  return &implementations.front();
+}
+
+void YSE::SYNTH::managerObject::setup(YSE::SYNTH::implementationObject* impl) {
+  impl->setStatus(OBJECT_CREATED);
+  // Hand off to the audio thread via the lock-free inbox; update() drains it
+  // into `toLoad` and schedules the setup-pool clone job.
+  toLoadInbox.push(impl);
+}
+
+void YSE::SYNTH::managerObject::drainInbox() {
+  implementationObject* p;
+  while (toLoadInbox.try_pop(p))
+    toLoad.push_front(p);
+}
+
+void YSE::SYNTH::managerObject::promoteReadyImpls() {
+  // Move OBJECT_SETUP impls into inUse, erasing from toLoad in the same step so
+  // no freed pointer lingers in the audio-thread-iterated list (same
+  // use-after-free rationale as the SOUND/REVERB managers). toLoad and inUse
+  // share the impl's single `_mgrNext` link, so unlink before relink.
+  for (auto c = toLoad.front(); c.valid();) {
+    implementationObject* ptr = c.get();
+    if (ptr->readyCheck()) {
+      c.erase();
+      inUse.push_front(ptr);
+    } else {
+      c.next();
+    }
+  }
+}
+
+void YSE::SYNTH::managerObject::syncAndReleaseInUse() {
+  for (auto c = inUse.front(); c.valid();) {
+    implementationObject* ptr = c.get();
+    ptr->sync();
+    if (ptr->getStatus() == OBJECT_RELEASE) {
+      // The synth impl's only audio-visible reference is its outputSource,
+      // held by the owning sound. Per the §9 lifetime contract the synth
+      // outlives its sound, so by the time the interface is gone no sound
+      // still points at us. Move straight to OBJECT_DELETE for the delete pool.
+      c.erase();
+      ptr->setStatus(OBJECT_DELETE);
+      runDelete = true;
+      continue; // c already refers to the successor after erase()
+    }
+    c.next();
+  }
+}
+
+void YSE::SYNTH::managerObject::update() {
+  drainInbox();
+
+  if (!toLoad.empty() && !mgrSetup.isQueued()) {
+    toLoad.remove_if(implementationObject::canBeRemovedFromLoading);
+    INTERNAL::Global().addSlowJob(&mgrSetup);
+  }
+
+  if (runDelete && !mgrDelete.isQueued()) {
+    INTERNAL::Global().addSlowJob(&mgrDelete);
+  }
+  runDelete = false;
+
+  promoteReadyImpls();
+  syncAndReleaseInUse();
+}
+
+Bool YSE::SYNTH::managerObject::empty() {
+  return toLoad.empty() && inUse.empty();
+}

--- a/YseEngine/synth/synthManager.h
+++ b/YseEngine/synth/synthManager.h
@@ -1,0 +1,93 @@
+/*
+  ==============================================================================
+
+    synthManager.h
+    Singleton manager for the YSE::synth subsystem.
+
+    Mirrors the sound manager's modern, job-based idiom (managerSetupJob /
+    managerDeleteJob + the OBJECT_* state machine) — voice cloning happens on
+    the setup pool, deletion on the delete pool, and the audio-thread tick only
+    drives lifecycle. Implements §8 of docs/design/synth_core.md.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_SYNTHMANAGER_H
+#define YSE_SYNTH_SYNTHMANAGER_H
+
+#include <forward_list>
+#include <mutex>
+
+#include "../internal/managerJobs.hpp"
+#include "../internal/threadPool.h"
+#include "../utils/intrusiveForwardList.hpp"
+#include "../utils/lfQueue.hpp"
+#include "synth.hpp"
+#include "synthImplementation.h"
+#include "synthInterface.hpp"
+#include "synthMessage.h"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /**
+      Owns every synth implementationObject and drives their lifecycle. There is
+      one process-wide instance, reached through Manager().
+    */
+    class managerObject {
+    public:
+      using ImplementationType = implementationObject;
+
+      managerObject();
+      ~managerObject() noexcept;
+
+      /** Create and register a new implementation for `head`. */
+      implementationObject* addImplementation(interfaceObject* head);
+
+      /** Move `impl` (freshly configured) into the setup pipeline: mark it
+          OBJECT_CREATED and hand it to the audio thread via the lock-free
+          inbox, which schedules the setup-pool clone job. */
+      void setup(implementationObject* impl);
+
+      /** Audio-thread lifecycle tick — called once per callback. Never renders
+          audio (that happens inside each impl's outputSource); this only drains
+          the inbox, schedules setup/delete jobs, promotes ready impls, and
+          releases teardown impls. */
+      void update();
+
+      /** Audio-thread-only "nothing alive" signal. */
+      Bool empty();
+
+    private:
+      void drainInbox();
+      void promoteReadyImpls();
+      void syncAndReleaseInUse();
+
+      INTERNAL::managerSetupJob<managerObject> mgrSetup;
+      INTERNAL::managerDeleteJob<managerObject> mgrDelete;
+
+      // Audio-thread-owned lists (intrusive, allocation-free — issue #194).
+      IntrusiveForwardList<implementationObject, &implementationObject::_mgrNext> inUse;
+      IntrusiveForwardList<implementationObject, &implementationObject::_mgrNext> toLoad;
+
+      // Lock-free main->audio handoff of newly registered impls.
+      lfQueue<implementationObject*> toLoadInbox;
+
+      // Canonical owner of every impl. Touched by the main thread
+      // (addImplementation) and the delete pool (deleteJob); guarded by
+      // implementationsMutex. The audio thread never iterates it.
+      std::forward_list<implementationObject> implementations;
+      std::mutex implementationsMutex;
+
+      aBool runDelete;
+
+      friend class INTERNAL::managerSetupJob<managerObject>;
+      friend class INTERNAL::managerDeleteJob<managerObject>;
+    };
+
+    managerObject& Manager();
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_SYNTHMANAGER_H

--- a/YseEngine/synth/synthMessage.h
+++ b/YseEngine/synth/synthMessage.h
@@ -1,0 +1,84 @@
+/*
+  ==============================================================================
+
+    synthMessage.h
+    Tagged-union control message from the synth interface to its implementation.
+
+    Implements §6 ("Message op-set") of docs/design/synth_core.md. Unlike the
+    old loosely-typed synth message (which aliased a single Flt[3] across every
+    op and carried a latent field-aliasing bug), each op reads and writes its
+    own named struct in the union, so no field is ever read under the wrong
+    name.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_SYNTHMESSAGE_H
+#define YSE_SYNTH_SYNTHMESSAGE_H
+
+#include "synth.hpp"
+#include "../headers/types.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /*
+       Message objects carry a control event from a synth interfaceObject to its
+       implementationObject across the per-impl lock-free SPSC inbox. They are a
+       way to ensure threadsafe and lockfree communication between the two.
+    */
+    // Named per-op payloads. Each op touches exactly the fields it means — no
+    // positional aliasing. Named (rather than anonymous nested) struct types so
+    // the tagged union below is standard C++ with no -Wnested-anon-types.
+    struct NoteOnData {
+      Int channel;
+      Int note;
+      Flt velocity;
+    };
+    struct NoteOffData {
+      Int channel;
+      Int note;
+      Flt velocity;
+    };
+    struct AllOffData {
+      Int channel; // 0 = all channels
+    };
+    struct WheelData {
+      Int channel;
+      Flt value; // [-1, 1]  (handled by #154)
+    };
+    struct ControllerData {
+      Int channel;
+      Int number;
+      Flt value; // [0, 1]   (handled by #154)
+    };
+    struct AftertouchData {
+      Int channel;
+      Int note; // -1 = channel-wide  (handled by #154)
+      Flt value;
+    };
+    struct PedalData {
+      Int channel;
+      Bool down; // SUSTAIN / SOSTENUTO / SOFTPEDAL  (handled by #154)
+    };
+
+    class messageObject {
+    public:
+      /** Selects which member of the union below is live. */
+      MESSAGE ID;
+
+      union {
+        NoteOnData noteOn; // NOTE_ON
+        NoteOffData noteOff; // NOTE_OFF
+        AllOffData allOff; // ALL_NOTES_OFF
+        WheelData wheel; // PITCH_WHEEL
+        ControllerData cc; // CONTROLLER
+        AftertouchData touch; // AFTERTOUCH
+        PedalData pedal; // SUSTAIN / SOSTENUTO / SOFTPEDAL
+      };
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_SYNTHMESSAGE_H

--- a/YseEngine/yse.hpp
+++ b/YseEngine/yse.hpp
@@ -109,6 +109,10 @@
 // #include "sound/sound.hpp"
 #include "sound/soundInterface.hpp"
 
+#include "synth/dspVoice.hpp"
+#include "synth/sineVoice.hpp"
+#include "synth/synthInterface.hpp"
+
 #include "midi/midifile.hpp"
 #include "midi/midiMessage.hpp"
 #include "midi/midiNote.hpp"


### PR DESCRIPTION
## Summary

Implements the engine-native `YSE::synth` subsystem per §2 / §4 / §8 / §9 of
`docs/design/synth_core.md`, building on the merged `dspVoice` base + reference
`sineVoice` from #152. Mirrors the sound subsystem's four-part split
(interface / implementation / message / manager) plus the voice base.

- **Public `YSE::synth`** (chainable, non-copyable pimpl): `create`,
  `addVoices`, `noteOn`/`noteOff` (+ `MUSIC::note` overloads), `allNotesOff`,
  `getNumVoices`.
- **`implementationObject`**: `OBJECT_*` lifecycle, per-impl `lfQueue` SPSC note
  inbox, and an aggregate `outputSource` (a `DSP::dspSourceObject`) whose
  `process()` is the per-block heartbeat — drains the inbox, runs the allocator,
  drives every active voice and mixes, all on the audio thread, **allocation-free
  and lock-free**. Voice cloning happens on the setup pool; freeing on the delete
  pool. Never on the audio thread.
- **Voice allocator + stealing** (fixed #151 policy): within a matching group,
  take a free voice; else steal oldest-in-release, else oldest overall. Stolen
  voices get an engine-owned ~5 ms linear declick fade in the aggregate mix, so
  stealing is click-free regardless of the user voice's release length.
- **Voice groups**: each `addVoices()` builds one group (channel filter + note
  range); layered/split keyboards are supported (a note may sound in multiple
  matching groups).
- **Attachment**: revived `sound::create(synth&, channel*, volume)` attaches the
  aggregate behind a positioned sound through the existing `PT_DSP` render path —
  no new audio-thread code path.
- **Manager**: `managerObject` singleton using the shared `managerSetupJob` /
  `managerDeleteJob` templates + the `OBJECT_*` state machine; wired into the
  device callback's update tick.
- **Message**: tagged union with named per-op payloads (no field aliasing).

Out of scope (separate downstream issues, intentionally absent): keyboard
state / pedals / controllers / `onNoteEvent` (#154), MIDI routing (#155),
player (#156), C API (#157). The full `MESSAGE` enum is declared as the fixed
contract; only the note ops are handled here.

## Linked issue

Closes #153

## Notes

Filed #298 for a **pre-existing** static-teardown ordering fragility in the
SOUND/CHANNEL managers: a sound impl lingering at process exit can UAF on its
freed parent channel. Merely introducing the `SYNTH::Manager` singleton
reorders static destruction enough to expose it in the isolated `lifecycle`
process. The synth code is correct; as a workaround the synth engine-close
tests run in their own isolated `synthlifecycle` ctest process, kept out of the
`lifecycle` process.

## Test plan

- [x] `yse.py format` clean (format gate green; only touched files changed)
- [x] `yse.py analyze` clean on the new/changed sources (no user-code findings)
- [x] Unit tests pass — `yse.py test`: **19/19 ctest targets, 100%**
  - `synth` suite (DSP-level, no device): chord renders 3 distinct FFT peaks;
    voice-stealing correctness (oldest stolen, survivor intact); **click-free**
    steal handoff (max inter-sample delta < 0.5); free-slot reuse; split-keyboard
    group routing; out-of-range note dropped; `allNotesOff` releases all;
    allocation-free `process()` after warm-up.
  - `synth` manager suite (live engine): create/attach→READY→release; rapid
    create/destroy under a 200-note storm.
  - `synthlifecycle` suite (isolated process): engine close with a standalone
    synth + held notes; synth-behind-a-sound offline render + ordered teardown.
- [x] Full pre-existing suite still green; `lifecycle` suite stress-run 20× (0
  failures) after isolating the synth close tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)