### PR TITLE
SYNTH: keyboard state, pedals, controllers and onNoteEvent (#154)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(YSE_TEST_SOURCES
   sound/test_virtual_finder.cpp
   sound/test_manager_alloc.cpp
   synth/test_synth.cpp
+  synth/test_synth_keyboard.cpp
   synth/test_synth_close.cpp
   reverb/test_reverb_dsp.cpp
   reverb/test_reverb_concurrency.cpp

--- a/Tests/synth/test_synth_keyboard.cpp
+++ b/Tests/synth/test_synth_keyboard.cpp
@@ -1,0 +1,589 @@
+// Tests for the YSE::synth keyboard / pedal state machine, the controller and
+// pitch-wheel / aftertouch op-set, and the onNoteEvent hook — issue #154,
+// implementing §5 / §6 / §7 of docs/design/synth_core.md.
+//
+// These drive a SYNTH::implementationObject directly (no engine, no audio
+// device): pushing control messages and calling the aggregate outputSource's
+// process() renders real audio through the real voice + allocator, which is the
+// end-to-end audio verification for these paths (same approach as the #153
+// allocator tests in test_synth.cpp). A couple of cases also exercise the
+// public YSE::synth interface through the live managers, gated on engineInit().
+
+#include <doctest/doctest.h>
+#include <chrono>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "synth/dspVoice.hpp"
+#include "synth/sineVoice.hpp"
+#include "synth/synthImplementation.h"
+#include "synth/synthInterface.hpp"
+#include "synth/synthManager.h"
+#include "synth/synthMessage.h"
+#include "sound/soundInterface.hpp"
+#include "sound/soundManager.h"
+#include "dsp/fourier/fft.hpp"
+#include "internal/time.h"
+#include "support/audio_helpers.hpp"
+#include "support/alloc_probe.hpp"
+#include "support/null_device.hpp"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+  using YSE::SOUND_STATUS;
+  using YSE::SYNTH::dspVoice;
+  using YSE::SYNTH::implementationObject;
+  using YSE::SYNTH::messageObject;
+  using YSE::SYNTH::sineVoice;
+
+  messageObject noteOnMsg(int channel, int note, float velocity) {
+    messageObject m;
+    m.ID = YSE::SYNTH::NOTE_ON;
+    m.noteOn.channel = channel;
+    m.noteOn.note = note;
+    m.noteOn.velocity = velocity;
+    return m;
+  }
+
+  messageObject noteOffMsg(int channel, int note) {
+    messageObject m;
+    m.ID = YSE::SYNTH::NOTE_OFF;
+    m.noteOff.channel = channel;
+    m.noteOff.note = note;
+    m.noteOff.velocity = 0.f;
+    return m;
+  }
+
+  messageObject wheelMsg(int channel, float value) {
+    messageObject m;
+    m.ID = YSE::SYNTH::PITCH_WHEEL;
+    m.wheel.channel = channel;
+    m.wheel.value = value;
+    return m;
+  }
+
+  messageObject ccMsg(int channel, int number, float value) {
+    messageObject m;
+    m.ID = YSE::SYNTH::CONTROLLER;
+    m.cc.channel = channel;
+    m.cc.number = number;
+    m.cc.value = value;
+    return m;
+  }
+
+  messageObject aftertouchMsg(int channel, int note, float value) {
+    messageObject m;
+    m.ID = YSE::SYNTH::AFTERTOUCH;
+    m.touch.channel = channel;
+    m.touch.note = note;
+    m.touch.value = value;
+    return m;
+  }
+
+  messageObject sustainMsg(int channel, bool down) {
+    messageObject m;
+    m.ID = YSE::SYNTH::SUSTAIN;
+    m.pedal.channel = channel;
+    m.pedal.down = down;
+    return m;
+  }
+
+  messageObject sostenutoMsg(int channel, bool down) {
+    messageObject m;
+    m.ID = YSE::SYNTH::SOSTENUTO;
+    m.pedal.channel = channel;
+    m.pedal.down = down;
+    return m;
+  }
+
+  messageObject softPedalMsg(int channel, bool down) {
+    messageObject m;
+    m.ID = YSE::SYNTH::SOFTPEDAL;
+    m.pedal.channel = channel;
+    m.pedal.down = down;
+    return m;
+  }
+
+  YSE::DSP::buffer& renderBlock(implementationObject& impl, SOUND_STATUS& intent) {
+    impl.getOutputSource().process(intent);
+    return impl.getOutputSource().samples[0];
+  }
+
+  // Render `blocks` blocks in the steady PLAYING state.
+  void render(implementationObject& impl, int blocks) {
+    SOUND_STATUS intent = YSE::SS_PLAYING;
+    for (int i = 0; i < blocks; ++i)
+      renderBlock(impl, intent);
+  }
+
+  float magAtHz(YSE::DSP::fft& f, unsigned N, float hz) {
+    const float binHz = static_cast<float>(YSE::SAMPLERATE) / static_cast<float>(N);
+    unsigned bin = static_cast<unsigned>(std::lround(hz / binHz));
+    if (bin > N / 2) bin = N / 2;
+    float re = f.getReal().getPtr()[bin];
+    float im = f.getImaginary().getPtr()[bin];
+    return re * re + im * im;
+  }
+
+  void captureSpectrum(implementationObject& impl, YSE::DSP::buffer& re, unsigned N) {
+    re = 0.f;
+    const unsigned block = YSE::STANDARD_BUFFERSIZE;
+    unsigned filled = 0;
+    SOUND_STATUS intent = YSE::SS_PLAYING;
+    while (filled + block <= N) {
+      YSE::DSP::buffer& out = renderBlock(impl, intent);
+      re.copyFrom(out, 0, filled, block);
+      filled += block;
+    }
+  }
+
+  // A minimal voice that renders a DC level equal to whatever expressive input
+  // is under test — lets a test read back per-voice atomic delivery as RMS.
+  enum class ProbeInput { Aftertouch };
+
+  class probeVoice : public dspVoice {
+  public:
+    explicit probeVoice(ProbeInput in = ProbeInput::Aftertouch) : dspVoice(1), input(in) {}
+    dspVoice* clone() override {
+      return new probeVoice(*this);
+    }
+    void process(SOUND_STATUS& intent) override {
+      if (intent == YSE::SS_WANTSTOPLAY || intent == YSE::SS_WANTSTORESTART)
+        intent = YSE::SS_PLAYING;
+      else if (intent == YSE::SS_WANTSTOSTOP)
+        intent = YSE::SS_STOPPED;
+
+      float value = 0.f;
+      if (intent == YSE::SS_PLAYING || intent == YSE::SS_PLAYING_FULL_VOLUME) {
+        value = (input == ProbeInput::Aftertouch) ? getAftertouch() : 0.f;
+      }
+      for (UInt i = 0; i < samples.size(); i++)
+        samples[i] = value;
+    }
+
+  protected:
+    probeVoice(const probeVoice& o) : dspVoice(o), input(o.input) {}
+
+  private:
+    ProbeInput input;
+  };
+
+} // namespace
+
+TEST_SUITE("synth") {
+
+  // ─── sustain pedal ────────────────────────────────────────────────────────
+
+  TEST_CASE("synth keyboard: sustain defers note-off until the pedal lifts") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    impl.addVoiceGroup(&proto, 4, 0, 0, 127);
+    impl.setup();
+
+    impl.sendMessage(sustainMsg(1, true)); // pedal down
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 6);
+    CHECK(impl.getSustain(1));
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) > 0.05f);
+
+    // Key up while the pedal is down: the note must keep sounding.
+    impl.sendMessage(noteOffMsg(1, 60));
+    render(impl, 100);
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) > 0.05f);
+
+    // Pedal up: now it releases.
+    impl.sendMessage(sustainMsg(1, false));
+    render(impl, 400);
+    CHECK_FALSE(impl.getSustain(1));
+    CHECK(TestHelpers::decaysToSilence(impl.getOutputSource().samples[0], 1e-4f));
+  }
+
+  // ─── sostenuto pedal: captures only currently-held notes ──────────────────
+
+  TEST_CASE("synth keyboard: sostenuto sustains only the notes held when it engaged") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    impl.addVoiceGroup(&proto, 4, 0, 0, 127);
+    impl.setup();
+
+    // Hold note 60, then press sostenuto (captures 60), then play note 67.
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 6);
+    impl.sendMessage(sostenutoMsg(1, true)); // captures the held 60
+    impl.sendMessage(noteOnMsg(1, 67, 1.f)); // played AFTER — not captured
+    render(impl, 8);
+    CHECK(impl.getSostenuto(1));
+
+    // Release both keys: 60 is captured (sustains), 67 is not (releases).
+    impl.sendMessage(noteOffMsg(1, 60));
+    impl.sendMessage(noteOffMsg(1, 67));
+    render(impl, 120);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    im = 0.f;
+    captureSpectrum(impl, re, N);
+    YSE::DSP::fft f;
+    f(re, im);
+    const float m60 = magAtHz(f, N, YSE::DSP::MidiToFreq(60.f));
+    const float m67 = magAtHz(f, N, YSE::DSP::MidiToFreq(67.f));
+    CHECK(m60 > 25.f * m67); // 60 still sounding, 67 gone
+
+    // Sostenuto up: the captured note now releases.
+    impl.sendMessage(sostenutoMsg(1, false));
+    render(impl, 400);
+    CHECK_FALSE(impl.getSostenuto(1));
+    CHECK(TestHelpers::decaysToSilence(impl.getOutputSource().samples[0], 1e-4f));
+  }
+
+  // ─── sustain + sostenuto interaction ──────────────────────────────────────
+
+  TEST_CASE("synth keyboard: a note held by both pedals releases only when both lift") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    impl.addVoiceGroup(&proto, 2, 0, 0, 127);
+    impl.setup();
+
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 6);
+    impl.sendMessage(sustainMsg(1, true));
+    impl.sendMessage(sostenutoMsg(1, true)); // 60 now claimed by BOTH
+    impl.sendMessage(noteOffMsg(1, 60));
+    render(impl, 60);
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) > 0.05f);
+
+    // Lift sustain only — sostenuto still claims 60, so it keeps sounding.
+    impl.sendMessage(sustainMsg(1, false));
+    render(impl, 60);
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) > 0.05f);
+
+    // Lift sostenuto — now nothing holds it, it releases.
+    impl.sendMessage(sostenutoMsg(1, false));
+    render(impl, 400);
+    CHECK(TestHelpers::decaysToSilence(impl.getOutputSource().samples[0], 1e-4f));
+  }
+
+  // ─── soft pedal scales the velocity of new notes only ─────────────────────
+
+  TEST_CASE("synth keyboard: the soft pedal lowers the level of notes started under it") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    impl.addVoiceGroup(&proto, 2, 0, 0, 127);
+    impl.setup();
+
+    // Baseline: full-velocity note.
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 8);
+    const float loud = TestHelpers::measureRms(impl.getOutputSource().samples[0]);
+    impl.sendMessage(noteOffMsg(1, 60));
+    render(impl, 400);
+
+    // Same note, same velocity, but with the soft pedal down.
+    impl.sendMessage(softPedalMsg(1, true));
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    render(impl, 8);
+    const float soft = TestHelpers::measureRms(impl.getOutputSource().samples[0]);
+
+    CHECK(impl.getSoftPedal(1));
+    CHECK(soft < loud); // quieter…
+    CHECK(soft > 0.5f * loud); // …but not silenced (≈0.7×)
+  }
+
+  // ─── pitch wheel bends a sounding voice (FFT) ─────────────────────────────
+
+  TEST_CASE("synth keyboard: the pitch wheel measurably bends a sounding sine voice") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.05f);
+    impl.addVoiceGroup(&proto, 1, 0, 0, 127);
+    impl.setup();
+
+    impl.sendMessage(noteOnMsg(1, 69, 1.f)); // A4, 440 Hz
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 8);
+
+    const unsigned N = 4096;
+    const float a4 = YSE::DSP::MidiToFreq(69.f);
+    const float bent = YSE::DSP::MidiToFreq(71.f); // +1.0 wheel → +2 semitones
+
+    // Unbent: energy sits at A4, not at the +2-semitone target.
+    {
+      YSE::DSP::buffer re(N), im(N);
+      im = 0.f;
+      captureSpectrum(impl, re, N);
+      YSE::DSP::fft f;
+      f(re, im);
+      CHECK(magAtHz(f, N, a4) > 25.f * magAtHz(f, N, bent));
+    }
+
+    // Bend the wheel fully up and let the new pitch settle.
+    impl.sendMessage(wheelMsg(1, 1.f));
+    render(impl, 8);
+    CHECK(impl.getChannelPitchWheel(1) == doctest::Approx(1.f));
+
+    // Bent: the peak has moved up to the +2-semitone frequency.
+    {
+      YSE::DSP::buffer re(N), im(N);
+      im = 0.f;
+      captureSpectrum(impl, re, N);
+      YSE::DSP::fft f;
+      f(re, im);
+      CHECK(magAtHz(f, N, bent) > 25.f * magAtHz(f, N, a4));
+    }
+  }
+
+  // ─── pitch wheel primes newly-started notes ───────────────────────────────
+
+  TEST_CASE("synth keyboard: a note started while the wheel is bent begins in tune with it") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.05f);
+    impl.addVoiceGroup(&proto, 1, 0, 0, 127);
+    impl.setup();
+
+    impl.sendMessage(wheelMsg(1, 1.f)); // wheel up BEFORE any note
+    impl.sendMessage(noteOnMsg(1, 69, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 8);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    im = 0.f;
+    captureSpectrum(impl, re, N);
+    YSE::DSP::fft f;
+    f(re, im);
+    const float a4 = YSE::DSP::MidiToFreq(69.f);
+    const float bent = YSE::DSP::MidiToFreq(71.f);
+    CHECK(magAtHz(f, N, bent) > 25.f * magAtHz(f, N, a4));
+  }
+
+  // ─── onNoteEvent rewrites the note before it sounds ───────────────────────
+
+  namespace {
+    // Captureless: transpose every note up an octave before it is allocated.
+    void transposeUpOctave(bool /*noteOn*/, float* note, float* /*velocity*/) {
+      *note += 12.f;
+    }
+  } // namespace
+
+  TEST_CASE("synth keyboard: onNoteEvent transposes a note before it sounds") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.05f);
+    impl.addVoiceGroup(&proto, 1, 0, 0, 127);
+    impl.setup();
+
+    impl.setNoteCallback(&transposeUpOctave);
+    impl.sendMessage(noteOnMsg(1, 60, 1.f)); // C4 → rewritten to C5
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 8);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    im = 0.f;
+    captureSpectrum(impl, re, N);
+    YSE::DSP::fft f;
+    f(re, im);
+    const float c4 = YSE::DSP::MidiToFreq(60.f);
+    const float c5 = YSE::DSP::MidiToFreq(72.f);
+    CHECK(magAtHz(f, N, c5) > 25.f * magAtHz(f, N, c4)); // sounds an octave up
+
+    // The rewrite is symmetric: a note-off rewritten the same way releases it.
+    impl.sendMessage(noteOffMsg(1, 60)); // → 72, matches the sounding voice
+    render(impl, 400);
+    CHECK(TestHelpers::decaysToSilence(impl.getOutputSource().samples[0], 1e-4f));
+  }
+
+  TEST_CASE("synth keyboard: clearing onNoteEvent restores pass-through") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.05f);
+    impl.addVoiceGroup(&proto, 1, 0, 0, 127);
+    impl.setup();
+
+    impl.setNoteCallback(&transposeUpOctave);
+    impl.setNoteCallback(nullptr); // cleared → note passes through unmodified
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 8);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    im = 0.f;
+    captureSpectrum(impl, re, N);
+    YSE::DSP::fft f;
+    f(re, im);
+    const float c4 = YSE::DSP::MidiToFreq(60.f);
+    const float c5 = YSE::DSP::MidiToFreq(72.f);
+    CHECK(magAtHz(f, N, c4) > 25.f * magAtHz(f, N, c5)); // sounds at C4
+  }
+
+  // ─── aftertouch reaches the sounding voice ────────────────────────────────
+
+  TEST_CASE("synth keyboard: aftertouch is delivered per-note and channel-wide") {
+    implementationObject impl(nullptr);
+    probeVoice proto(ProbeInput::Aftertouch);
+    impl.addVoiceGroup(&proto, 2, 0, 0, 127);
+    impl.setup();
+
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 2);
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) < 1e-3f); // no pressure yet
+
+    // Per-note pressure reaches the voice sounding note 60.
+    impl.sendMessage(aftertouchMsg(1, 60, 0.8f));
+    render(impl, 2);
+    CHECK(impl.getChannelAftertouch(1) == doctest::Approx(0.8f));
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) ==
+          doctest::Approx(0.8f).epsilon(0.02));
+
+    // A wrong-note message does not touch it.
+    impl.sendMessage(aftertouchMsg(1, 61, 0.2f));
+    render(impl, 2);
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) ==
+          doctest::Approx(0.8f).epsilon(0.02));
+
+    // Channel-wide (note -1) reaches it.
+    impl.sendMessage(aftertouchMsg(1, -1, 0.4f));
+    render(impl, 2);
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) ==
+          doctest::Approx(0.4f).epsilon(0.02));
+  }
+
+  // ─── controllers: pedal CCs intercepted, others stored ────────────────────
+
+  TEST_CASE("synth keyboard: CC 64 acts as sustain; other CCs are stored per channel") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.001f).decay(0.001f).sustain(1.f).release(0.02f);
+    impl.addVoiceGroup(&proto, 2, 0, 0, 127);
+    impl.setup();
+
+    // A non-pedal CC is stored as the channel's last value.
+    impl.sendMessage(ccMsg(1, 20, 0.6f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    CHECK(impl.getChannelController(1, 20) == doctest::Approx(0.6f));
+
+    // CC 64 IS the sustain pedal — routed, not stored as a plain controller.
+    impl.sendMessage(ccMsg(1, 64, 1.f));
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    renderBlock(impl, intent);
+    render(impl, 6);
+    CHECK(impl.getSustain(1));
+    impl.sendMessage(noteOffMsg(1, 60));
+    render(impl, 80);
+    CHECK(TestHelpers::measureRms(impl.getOutputSource().samples[0]) > 0.05f); // sustained
+
+    impl.sendMessage(ccMsg(1, 64, 0.f)); // pedal up
+    render(impl, 400);
+    CHECK_FALSE(impl.getSustain(1));
+    CHECK(TestHelpers::decaysToSilence(impl.getOutputSource().samples[0], 1e-4f));
+  }
+
+  // ─── real-time discipline on the keyboard paths ───────────────────────────
+
+  TEST_CASE("synth keyboard: control ops do not allocate on the audio thread") {
+    implementationObject impl(nullptr);
+    sineVoice proto;
+    proto.attack(0.002f).decay(0.002f).sustain(0.8f).release(0.05f);
+    impl.addVoiceGroup(&proto, 8, 0, 0, 127);
+    impl.setup();
+
+    // Warm up.
+    impl.sendMessage(noteOnMsg(1, 60, 1.f));
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    renderBlock(impl, intent);
+    render(impl, 8);
+
+    {
+      TestHelpers::ProbeScope probe;
+      impl.sendMessage(wheelMsg(1, 0.5f));
+      impl.sendMessage(aftertouchMsg(1, 60, 0.7f));
+      impl.sendMessage(aftertouchMsg(1, -1, 0.3f));
+      impl.sendMessage(ccMsg(1, 21, 0.9f));
+      impl.sendMessage(sustainMsg(1, true));
+      impl.sendMessage(noteOnMsg(1, 64, 1.f));
+      impl.sendMessage(noteOffMsg(1, 64));
+      impl.sendMessage(sostenutoMsg(1, true));
+      impl.sendMessage(noteOnMsg(1, 67, 1.f));
+      impl.sendMessage(softPedalMsg(1, true));
+      impl.sendMessage(noteOnMsg(1, 72, 1.f));
+      impl.sendMessage(sustainMsg(1, false));
+      impl.sendMessage(sostenutoMsg(1, false));
+      impl.sendMessage(softPedalMsg(1, false));
+      render(impl, 40);
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+  }
+
+  // ─── public interface smoke test (needs a live engine) ────────────────────
+
+  namespace {
+    void drainSynth(int n = 16) {
+      for (int i = 0; i < n; ++i) {
+        YSE::INTERNAL::Time().update();
+        YSE::SOUND::Manager().update();
+        YSE::SYNTH::Manager().update();
+        std::this_thread::sleep_for(5ms);
+      }
+    }
+  } // namespace
+
+  TEST_CASE("synth keyboard: the public interface routes pedals, wheel and onNoteEvent") {
+    if (!TestHelpers::engineInit()) return;
+    {
+      sineVoice proto;
+      proto.attack(0.005f).release(0.1f);
+      YSE::synth syn;
+      syn.create().addVoices(proto, 8);
+      YSE::sound snd;
+      snd.create(syn);
+      drainSynth();
+      CHECK(syn.getNumVoices() == 8);
+      snd.play();
+
+      // Exercise the whole control surface; the point is that none of these
+      // crash or block and the chain returns *this.
+      syn.onNoteEvent(&transposeUpOctave);
+      syn.sustain(1, true).softPedal(1, true);
+      syn.noteOn(1, 60, 0.9f);
+      syn.pitchWheel(1, 0.5f);
+      syn.aftertouch(1, 72, 0.6f); // note is transposed to 72 by the hook
+      syn.controller(1, 20, 0.5f);
+      drainSynth();
+      syn.noteOff(1, 60);
+      syn.sustain(1, false);
+      syn.sostenuto(1, true).sostenuto(1, false);
+      syn.allNotesOff();
+      syn.onNoteEvent(nullptr);
+      snd.stop();
+      drainSynth();
+    }
+    drainSynth();
+    CHECK(true);
+  }
+
+} // TEST_SUITE("synth")

--- a/YseEngine/synth/dspVoice.hpp
+++ b/YseEngine/synth/dspVoice.hpp
@@ -107,6 +107,20 @@ namespace YSE {
         return _aftertouch.load(std::memory_order_relaxed);
       }
 
+      /**
+       *  @brief Current pitch-wheel position in [-1, 1] for this voice's channel.
+       *
+       *  The keyboard state machine forwards the channel's pitch-wheel value to
+       *  every voice sounding on that channel (and primes a new voice with the
+       *  current value on note start). How far a voice bends for a given wheel
+       *  position — the bend range in semitones — is the voice's concern; the
+       *  core only delivers the normalised position. See
+       *  docs/design/synth_core.md §5.
+       */
+      Flt getPitchWheel() const {
+        return _pitchWheel.load(std::memory_order_relaxed);
+      }
+
     protected:
       /**
        *  @brief Copy the note atomics (and base output buffers) into a fresh,
@@ -121,13 +135,15 @@ namespace YSE {
         _frequency.store(o._frequency.load(std::memory_order_relaxed), std::memory_order_relaxed);
         _velocity.store(o._velocity.load(std::memory_order_relaxed), std::memory_order_relaxed);
         _aftertouch.store(o._aftertouch.load(std::memory_order_relaxed), std::memory_order_relaxed);
+        _pitchWheel.store(o._pitchWheel.load(std::memory_order_relaxed), std::memory_order_relaxed);
       }
 
     private:
       aFlt _frequency{440.f};
       aFlt _velocity{0.f};
       aFlt _aftertouch{0.f};
-      friend class implementationObject; // sets _aftertouch, drives intent
+      aFlt _pitchWheel{0.f};
+      friend class implementationObject; // sets _aftertouch / _pitchWheel, drives intent
     };
 
   } // namespace SYNTH

--- a/YseEngine/synth/sineVoice.cpp
+++ b/YseEngine/synth/sineVoice.cpp
@@ -10,8 +10,15 @@
 
 #include "sineVoice.hpp"
 
+#include <cmath>
+
 namespace YSE {
   namespace SYNTH {
+
+    // Pitch-wheel bend range for the reference voice, in semitones per unit of
+    // wheel deflection. ±1.0 wheel → ±2 semitones — the conventional default
+    // (§5 recommends this for built-in voices; the core does not enforce it).
+    static const Flt kBendRangeSemitones = 2.f;
 
     // Length of the flat sustain plateau built into the envelope, in seconds.
     // The ADSRenvelope holds sustain by looping this constant-value region
@@ -111,6 +118,17 @@ namespace YSE {
         phase = PLAYING;
         intent = SS_PLAYING;
       } else if (intent == SS_WANTSTOSTOP || intent == SS_WANTSTOPAUSE) {
+        if (phase == IDLE) {
+          // Released before it ever attacked — the note-on and note-off drained
+          // in the same audio block, or a pedal / all-notes-off release landed
+          // before the first render. Nothing is sounding, so settle at once:
+          // driving the envelope's RELEASE here would read its phase pointer
+          // before ATTACK ever primed it.
+          intent = (intent == SS_WANTSTOPAUSE) ? SS_PAUSED : SS_STOPPED;
+          for (UInt i = 0; i < samples.size(); i++)
+            samples[i] = 0.f;
+          return;
+        }
         // Note off: take the release transition once, then let it tail out.
         if (phase != RELEASING) {
           estate = DSP::ADSRenvelope::RELEASE;
@@ -128,8 +146,17 @@ namespace YSE {
         return;
       }
 
-      const Flt freq = getFrequency();
       const Flt vel = getVelocity();
+
+      // Apply the channel pitch wheel (delivered by the keyboard state machine,
+      // §5) as an exponential frequency ratio: value 0 leaves the note in tune,
+      // ±1 shifts it ±kBendRangeSemitones. Read once per block — cheap and
+      // allocation-free.
+      const Flt wheel = getPitchWheel();
+      Flt freq = getFrequency();
+      if (wheel != 0.f) {
+        freq *= std::exp2(wheel * kBendRangeSemitones / 12.f);
+      }
 
       DSP::buffer& sig = osc(freq);
       DSP::buffer& amp = (*env)(estate);

--- a/YseEngine/synth/synthImplementation.cpp
+++ b/YseEngine/synth/synthImplementation.cpp
@@ -13,6 +13,7 @@
 #include "../internalHeaders.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 
 namespace YSE {
@@ -22,6 +23,14 @@ namespace YSE {
     // tail is force-faded over this window so stealing never clicks, regardless
     // of the user voice's own (possibly seconds-long) release. See §4.
     static const Flt kStealFadeSec = 0.005f;
+
+    // Velocity scaling applied to notes that START while the soft pedal (CC 67)
+    // is held (§5). Fixed; affects only new notes, never sounding voices.
+    static const Flt kSoftPedalGain = 0.7f;
+
+    // A controller value at or above this counts as a pedal "down" when a pedal
+    // arrives as a raw CC (64/66/67) rather than via the typed pedal setters.
+    static const Flt kPedalThreshold = 0.5f;
 
     implementationObject::implementationObject(interfaceObject* head)
       : head(head), objectStatus(OBJECT_CONSTRUCTED), messages(1024), output(*this, 1) {}
@@ -62,8 +71,39 @@ namespace YSE {
       pendingGroups.push_back({prototype, numVoices, channel, lowestNote, highestNote});
     }
 
+    void implementationObject::setNoteCallback(NoteCallback func) {
+      // Release-store so the audio thread's acquire-load sees a fully-published
+      // function pointer. nullptr simply disables the hook.
+      noteCallback.store(func, std::memory_order_release);
+    }
+
     int implementationObject::getNumVoices() const {
       return numVoicesTotal.load(std::memory_order_relaxed);
+    }
+
+    Flt implementationObject::getChannelPitchWheel(int channel) const {
+      return channels[channelIndex(channel)].pitchWheel;
+    }
+
+    Flt implementationObject::getChannelController(int channel, int number) const {
+      if (number < 0 || number > 127) return 0.f;
+      return channels[channelIndex(channel)].controller[static_cast<size_t>(number)];
+    }
+
+    Flt implementationObject::getChannelAftertouch(int channel) const {
+      return channels[channelIndex(channel)].aftertouch;
+    }
+
+    bool implementationObject::getSustain(int channel) const {
+      return channels[channelIndex(channel)].sustain;
+    }
+
+    bool implementationObject::getSostenuto(int channel) const {
+      return channels[channelIndex(channel)].sostenuto;
+    }
+
+    bool implementationObject::getSoftPedal(int channel) const {
+      return channels[channelIndex(channel)].softPedal;
     }
 
     DSP::dspSourceObject& implementationObject::getOutputSource() {
@@ -199,8 +239,12 @@ namespace YSE {
               slot.note = slot.pendNote;
               slot.channel = slot.pendChannel;
               slot.age = slot.pendAge;
+              slot.keyDown = true; // the new note's key is down
+              slot.heldBySustain = false;
+              slot.heldBySostenuto = false;
               v->frequency(static_cast<Flt>(slot.pendNote));
               v->velocity(slot.pendVelocity);
+              primeVoicePitchWheel(*v, slot.pendChannel); // start in tune (§5)
               slot.intent = SS_WANTSTOPLAY;
             }
           } else if (slot.intent != SS_STOPPED) {
@@ -247,6 +291,9 @@ namespace YSE {
           slot.note = -1;
           slot.stealing = false;
           slot.stealPos = 0;
+          slot.keyDown = false;
+          slot.heldBySustain = false;
+          slot.heldBySostenuto = false;
         }
       }
     }
@@ -264,14 +311,44 @@ namespace YSE {
       case ALL_NOTES_OFF:
         handleAllNotesOff(message.allOff.channel);
         break;
-      default:
-        // PITCH_WHEEL / CONTROLLER / AFTERTOUCH / pedals are handled by the
-        // keyboard-state issue (#154); ignored here.
+      case PITCH_WHEEL:
+        handlePitchWheel(message.wheel.channel, message.wheel.value);
+        break;
+      case CONTROLLER:
+        handleController(message.cc.channel, message.cc.number, message.cc.value);
+        break;
+      case AFTERTOUCH:
+        handleAftertouch(message.touch.channel, message.touch.note, message.touch.value);
+        break;
+      case SUSTAIN:
+        handleSustain(message.pedal.channel, message.pedal.down);
+        break;
+      case SOSTENUTO:
+        handleSostenuto(message.pedal.channel, message.pedal.down);
+        break;
+      case SOFTPEDAL:
+        handleSoftPedal(message.pedal.channel, message.pedal.down);
         break;
       }
     }
 
     void implementationObject::handleNoteOn(int channel, int note, Flt velocity) {
+      // §5 step 1: let the onNoteEvent hook rewrite note/velocity in flight,
+      // before any keyboard bookkeeping or allocation. The rewritten values are
+      // what the held-note state and allocator use.
+      float n = static_cast<float>(note);
+      float v = velocity;
+      NoteCallback cb = noteCallback.load(std::memory_order_acquire);
+      if (cb != nullptr) cb(true, &n, &v);
+      note = static_cast<int>(std::lround(n));
+      velocity = v;
+
+      // §5 step 2: soft pedal scales the velocity of notes started while it is
+      // held (it never retroactively changes sounding voices).
+      if (channelFor(channel).softPedal) velocity *= kSoftPedalGain;
+
+      // §5 steps 3-4: allocate into every matching group; each allocation primes
+      // the new voice with the channel's current pitch-wheel value.
       for (auto& g : groups) {
         if (groupMatches(g, channel, note)) {
           allocateInGroup(g, channel, note, velocity);
@@ -280,27 +357,158 @@ namespace YSE {
     }
 
     void implementationObject::handleNoteOff(int channel, int note) {
-      // Release every voice sounding this (channel, note). #153 releases
-      // immediately; pedal-deferred release is #154.
+      // §5 step 1: the hook may rewrite the note to the same value a matching
+      // NOTE_ON produced, so the release finds the right voice.
+      float n = static_cast<float>(note);
+      float v = 0.f;
+      NoteCallback cb = noteCallback.load(std::memory_order_acquire);
+      if (cb != nullptr) cb(false, &n, &v);
+      note = static_cast<int>(std::lround(n));
+
+      // The key is up now. Whether the voice actually releases depends on the
+      // pedals (§5): sustain defers all releases; sostenuto defers only notes it
+      // captured. A deferred voice keeps sounding until the pedal lets go.
+      channelState& cs = channelFor(channel);
       for (auto& g : groups) {
         for (auto& slot : g.slots) {
-          if (!slot.stealing && slot.note == note && slot.channel == channel &&
-              slot.intent != SS_STOPPED && slot.intent != SS_WANTSTOSTOP) {
+          if (slot.stealing || slot.note != note || slot.channel != channel || !slot.keyDown)
+            continue;
+          slot.keyDown = false;
+          if (cs.sustain) slot.heldBySustain = true;
+          // heldBySostenuto is already set (or not) from when the pedal went
+          // down; a note played after sostenuto engaged is not captured.
+          releaseIfUnheld(slot);
+        }
+      }
+    }
+
+    void implementationObject::handleAllNotesOff(int channel) {
+      // A bulk, unconditional release of every sounding voice on the channel(s)
+      // (§4): voices enter their normal release tail rather than being cut. Any
+      // pedal claim is dropped so nothing lingers.
+      for (auto& g : groups) {
+        for (auto& slot : g.slots) {
+          if (slot.stealing || slot.intent == SS_STOPPED || slot.intent == SS_WANTSTOSTOP) continue;
+          if (channel == 0 || slot.channel == channel) {
+            slot.keyDown = false;
+            slot.heldBySustain = false;
+            slot.heldBySostenuto = false;
             slot.intent = SS_WANTSTOSTOP;
           }
         }
       }
     }
 
-    void implementationObject::handleAllNotesOff(int channel) {
+    void implementationObject::releaseIfUnheld(voiceSlot& slot) {
+      // A voice releases only once its key is up and no pedal still claims it.
+      if (!slot.keyDown && !slot.heldBySustain && !slot.heldBySostenuto && !slot.stealing &&
+          slot.intent != SS_STOPPED && slot.intent != SS_WANTSTOSTOP) {
+        slot.intent = SS_WANTSTOSTOP;
+      }
+    }
+
+    // ---- keyboard: pitch wheel / controllers / aftertouch / pedals --------
+
+    void implementationObject::primeVoicePitchWheel(dspVoice& voice, int channel) {
+      voice._pitchWheel.store(channelFor(channel).pitchWheel, std::memory_order_relaxed);
+    }
+
+    void implementationObject::handlePitchWheel(int channel, Flt value) {
+      channelFor(channel).pitchWheel = value;
+      // Forward to every voice currently sounding on this channel so a bend
+      // moves the notes already down, not just future ones (§5).
       for (auto& g : groups) {
-        for (auto& slot : g.slots) {
-          if (!slot.stealing && slot.intent != SS_STOPPED && slot.intent != SS_WANTSTOSTOP &&
-              (channel == 0 || slot.channel == channel)) {
-            slot.intent = SS_WANTSTOSTOP;
+        for (size_t i = 0; i < g.slots.size(); ++i) {
+          voiceSlot& s = g.slots[i];
+          if (s.channel == channel && s.intent != SS_STOPPED) {
+            g.voices[i]->_pitchWheel.store(value, std::memory_order_relaxed);
           }
         }
       }
+    }
+
+    void implementationObject::handleController(int channel, int number, Flt value) {
+      // CC 64/66/67 ARE the pedals — intercept them (§5/§6). A raw CC crosses
+      // the same threshold the typed pedal setters use.
+      switch (number) {
+      case 64:
+        handleSustain(channel, value >= kPedalThreshold);
+        return;
+      case 66:
+        handleSostenuto(channel, value >= kPedalThreshold);
+        return;
+      case 67:
+        handleSoftPedal(channel, value >= kPedalThreshold);
+        return;
+      default:
+        break;
+      }
+      // Every other CC is stored as the channel's last value for that number.
+      // The core does not itself map CCs to synthesis parameters (that is the
+      // instrument/modulation-matrix concern, #148); it only records them.
+      if (number >= 0 && number <= 127) {
+        channelFor(channel).controller[static_cast<size_t>(number)] = value;
+      }
+    }
+
+    void implementationObject::handleAftertouch(int channel, int note, Flt value) {
+      channelFor(channel).aftertouch = value; // last channel pressure
+      // note == -1 broadcasts to every voice on the channel; otherwise it
+      // reaches only the voice(s) sounding that note (§5).
+      for (auto& g : groups) {
+        for (size_t i = 0; i < g.slots.size(); ++i) {
+          voiceSlot& s = g.slots[i];
+          if (s.channel != channel || s.intent == SS_STOPPED) continue;
+          if (note == -1 || s.note == note) {
+            g.voices[i]->_aftertouch.store(value, std::memory_order_relaxed);
+          }
+        }
+      }
+    }
+
+    void implementationObject::handleSustain(int channel, bool down) {
+      channelState& cs = channelFor(channel);
+      cs.sustain = down;
+      if (down) return; // pedal down: future NOTE_OFFs defer — nothing to do now
+      // Pedal up: drop the sustain claim on every voice on this channel; any
+      // whose key is up (and not still held by sostenuto) releases now.
+      for (auto& g : groups) {
+        for (auto& slot : g.slots) {
+          if (slot.channel == channel && slot.heldBySustain) {
+            slot.heldBySustain = false;
+            releaseIfUnheld(slot);
+          }
+        }
+      }
+    }
+
+    void implementationObject::handleSostenuto(int channel, bool down) {
+      channelState& cs = channelFor(channel);
+      cs.sostenuto = down;
+      if (down) {
+        // Snapshot the currently-held keys: only these voices are captured.
+        for (auto& g : groups) {
+          for (auto& slot : g.slots) {
+            if (slot.channel == channel && slot.keyDown) slot.heldBySostenuto = true;
+          }
+        }
+        return;
+      }
+      // Pedal up: release any captured voice whose key is no longer held (unless
+      // sustain still holds it); clear the capture.
+      for (auto& g : groups) {
+        for (auto& slot : g.slots) {
+          if (slot.channel == channel && slot.heldBySostenuto) {
+            slot.heldBySostenuto = false;
+            releaseIfUnheld(slot);
+          }
+        }
+      }
+    }
+
+    void implementationObject::handleSoftPedal(int channel, bool down) {
+      // Only affects the velocity of FUTURE notes — no effect on sounding voices.
+      channelFor(channel).softPedal = down;
     }
 
     void implementationObject::allocateInGroup(voiceGroup& group, int channel, int note,
@@ -312,8 +520,12 @@ namespace YSE {
           s.note = note;
           s.channel = channel;
           s.age = ++ageCounter;
+          s.keyDown = true;
+          s.heldBySustain = false;
+          s.heldBySostenuto = false;
           group.voices[i]->frequency(static_cast<Flt>(note));
           group.voices[i]->velocity(velocity);
+          primeVoicePitchWheel(*group.voices[i], channel); // start in tune (§5)
           s.intent = SS_WANTSTOPLAY;
           return;
         }

--- a/YseEngine/synth/synthImplementation.h
+++ b/YseEngine/synth/synthImplementation.h
@@ -24,6 +24,7 @@
 #ifndef YSE_SYNTH_SYNTHIMPLEMENTATION_H
 #define YSE_SYNTH_SYNTHIMPLEMENTATION_H
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <memory>
@@ -48,6 +49,13 @@ namespace YSE {
 
   namespace SYNTH {
 
+    /** Audio-thread note-rewrite hook (§7). A free function / captureless
+        lambda that may rewrite note number and velocity in place before the
+        keyboard state and allocator see the event. Deliberately a plain
+        function pointer so it carries no heap closure the audio thread would
+        have to reason about. */
+    using NoteCallback = void (*)(bool noteOn, float* noteNumber, float* velocity);
+
     /**
         Internal counterpart of a ``YSE::synth``. Created and destroyed by the
         SYNTH::managerObject; the user never touches one directly.
@@ -62,6 +70,11 @@ namespace YSE {
       /** Push a note/control message onto the SPSC inbox (control thread). */
       void sendMessage(const messageObject& message);
 
+      /** Install (or clear, with nullptr) the audio-thread onNoteEvent hook.
+          Set directly via an atomic pointer — it never crosses the inbox (§7).
+          Called on the control thread; acquire-loaded on the audio thread. */
+      void setNoteCallback(NoteCallback func);
+
       /** Record a pending voice-group request. The clones themselves are built
           later, on the setup pool, in setup(). Called on the control thread;
           guarded by buildMutex against the setup pool. */
@@ -70,6 +83,17 @@ namespace YSE {
 
       /** Total allocated voices across every group. Thread-safe. */
       int getNumVoices() const;
+
+      // ---- keyboard-state introspection -----------------------------------
+      // Read the last-seen per-channel keyboard values. Intended for tests and
+      // future C-API/metering readback; all audio-thread state, read here
+      // without synchronisation is a best-effort snapshot. channel is 1..16.
+      Flt getChannelPitchWheel(int channel) const;
+      Flt getChannelController(int channel, int number) const;
+      Flt getChannelAftertouch(int channel) const;
+      bool getSustain(int channel) const;
+      bool getSostenuto(int channel) const;
+      bool getSoftPedal(int channel) const;
 
       // ---- attachment -----------------------------------------------------
 
@@ -132,6 +156,13 @@ namespace YSE {
         int note = -1; // MIDI note sounding here (-1 = free)
         int channel = 0; // channel that triggered it
         uint64_t age = 0; // allocation stamp; smaller = older
+        // ---- keyboard / pedal bookkeeping (§5) ----
+        // A sounding voice is released (intent -> SS_WANTSTOSTOP) only once its
+        // key is up AND no pedal still claims it. keyDown tracks the physical
+        // key; heldBySustain / heldBySostenuto track a pedal deferring release.
+        bool keyDown = false; // physical key is down (NOTE_ON..NOTE_OFF)
+        bool heldBySustain = false; // sustain pedal is deferring this release
+        bool heldBySostenuto = false; // captured + deferred by the sostenuto pedal
         // engine-owned declick for click-free stealing
         bool stealing = false; // fading the OLD note out before re-arming
         int stealPos = 0; // samples elapsed into the steal fade
@@ -161,12 +192,47 @@ namespace YSE {
         int highNote;
       };
 
+      // ---- per-channel keyboard state (§5) -------------------------------
+      // One entry per MIDI channel (1..16). Owned and mutated only on the audio
+      // thread (written in parseMessage, read while allocating / delivering).
+      // Fixed-size — no allocation on any control path.
+      struct channelState {
+        bool sustain = false; // CC 64 held
+        bool sostenuto = false; // CC 66 held
+        bool softPedal = false; // CC 67 held
+        Flt pitchWheel = 0.f; // last wheel value, [-1, 1]
+        Flt aftertouch = 0.f; // last channel-wide pressure, [0, 1]
+        std::array<Flt, 128> controller{}; // last value of each CC, [0, 1]
+      };
+      static constexpr int kNumChannels = 16;
+      // Map a MIDI channel (1..16) to a channels[] index, clamped so a stray
+      // channel value can never index out of bounds on the audio thread.
+      static int channelIndex(int channel) {
+        if (channel < 1) return 0;
+        if (channel > kNumChannels) return kNumChannels - 1;
+        return channel - 1;
+      }
+      channelState& channelFor(int channel) {
+        return channels[channelIndex(channel)];
+      }
+
       // ---- audio-thread render path --------------------------------------
       void renderBlock(SOUND_STATUS& masterIntent);
       void parseMessage(const messageObject& message);
       void handleNoteOn(int channel, int note, Flt velocity);
       void handleNoteOff(int channel, int note);
       void handleAllNotesOff(int channel);
+      // keyboard / controller ops (§5 / §6)
+      void handlePitchWheel(int channel, Flt value);
+      void handleController(int channel, int number, Flt value);
+      void handleAftertouch(int channel, int note, Flt value);
+      void handleSustain(int channel, bool down);
+      void handleSostenuto(int channel, bool down);
+      void handleSoftPedal(int channel, bool down);
+      // release a slot only if its key is up and no pedal still claims it
+      void releaseIfUnheld(voiceSlot& slot);
+      // forward the channel's current wheel value to one voice / all its voices
+      void primeVoicePitchWheel(dspVoice& voice, int channel);
       void allocateInGroup(voiceGroup& group, int channel, int note, Flt velocity);
       void freeAllVoices();
       void mixVoice(dspVoice& voice, Flt gain);
@@ -198,6 +264,13 @@ namespace YSE {
       std::atomic<int> numVoicesTotal{0};
       uint64_t ageCounter = 0; // audio thread only
       int stealFadeSamples = 1; // computed in setup()
+
+      // Per-channel keyboard state (§5). Audio thread only.
+      std::array<channelState, kNumChannels> channels;
+
+      // onNoteEvent hook (§7): release-store from the control thread,
+      // acquire-load on the audio thread; never crosses the message inbox.
+      std::atomic<NoteCallback> noteCallback{nullptr};
 
       friend class SYNTH::managerObject;
       friend class INTERNAL::managerSetupJob<managerObject>;

--- a/YseEngine/synth/synthInterface.cpp
+++ b/YseEngine/synth/synthInterface.cpp
@@ -83,6 +83,77 @@ namespace YSE {
       return *this;
     }
 
+    interfaceObject& interfaceObject::pitchWheel(int channel, float value) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = PITCH_WHEEL;
+      m.wheel.channel = channel;
+      m.wheel.value = value;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::controller(int channel, int number, float value) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = CONTROLLER;
+      m.cc.channel = channel;
+      m.cc.number = number;
+      m.cc.value = value;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::aftertouch(int channel, int noteNumber, float value) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = AFTERTOUCH;
+      m.touch.channel = channel;
+      m.touch.note = noteNumber;
+      m.touch.value = value;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::sustain(int channel, bool down) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = SUSTAIN;
+      m.pedal.channel = channel;
+      m.pedal.down = down;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::sostenuto(int channel, bool down) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = SOSTENUTO;
+      m.pedal.channel = channel;
+      m.pedal.down = down;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::softPedal(int channel, bool down) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = SOFTPEDAL;
+      m.pedal.channel = channel;
+      m.pedal.down = down;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::onNoteEvent(void (*func)(bool, float*, float*)) {
+      // The hook is set directly on the impl via an atomic pointer — it never
+      // crosses the message inbox (there is no CALLBACK op). See §7. Safe to
+      // call before create(): with no impl there is nothing to drive yet.
+      if (pimpl == nullptr) return *this;
+      pimpl->setNoteCallback(func);
+      return *this;
+    }
+
     int interfaceObject::getNumVoices() const {
       return pimpl != nullptr ? pimpl->getNumVoices() : 0;
     }

--- a/YseEngine/synth/synthInterface.hpp
+++ b/YseEngine/synth/synthInterface.hpp
@@ -90,6 +90,48 @@ namespace YSE {
        *  A bulk note-off: voices enter their normal release, they are not cut. */
       interfaceObject& allNotesOff(int channel = 0);
 
+      // ---- keyboard state, pedals and controllers (§5) ----------------------
+
+      /** @brief Bend every voice on ``channel``. ``value`` is normalised to
+       *  [-1, 1] (0 = centre). How far a voice bends is the voice's concern. */
+      interfaceObject& pitchWheel(int channel, float value);
+
+      /** @brief Send a control-change. ``value`` is normalised to [0, 1].
+       *
+       *  CC 64 / 66 / 67 act as the sustain / sostenuto / soft pedals; every
+       *  other CC number is stored as the channel's last controller value. */
+      interfaceObject& controller(int channel, int number, float value);
+
+      /** @brief Apply aftertouch pressure, normalised to [0, 1].
+       *
+       *  ``noteNumber == -1`` is channel-wide (every voice on the channel);
+       *  otherwise only the voice(s) sounding that note receive it. */
+      interfaceObject& aftertouch(int channel, int noteNumber, float value);
+
+      /** @brief Sustain pedal (CC 64). Down defers NOTE_OFF releases on the
+       *  channel; up releases every note that was waiting on it. */
+      interfaceObject& sustain(int channel, bool down);
+
+      /** @brief Sostenuto pedal (CC 66). Down captures the currently-held notes
+       *  and sustains only those; up releases them. */
+      interfaceObject& sostenuto(int channel, bool down);
+
+      /** @brief Soft pedal (CC 67). While down, notes that START scale their
+       *  velocity down; sounding voices are unaffected. */
+      interfaceObject& softPedal(int channel, bool down);
+
+      /** @brief Install an audio-thread note-rewrite hook, or clear it with
+       *  ``nullptr``.
+       *
+       *  ``func`` runs on the audio thread for every NOTE_ON / NOTE_OFF, before
+       *  keyboard bookkeeping and allocation, and may rewrite ``*noteNumber``
+       *  and ``*velocity`` in place — the classic use is transposition,
+       *  retuning, velocity curves or note filtering. Only a free function or
+       *  captureless lambda is accepted (it carries no heap closure). It must
+       *  obey the same real-time rules as a voice ``process()``: no allocation,
+       *  no locks, no blocking. See docs/design/synth_core.md §7. */
+      interfaceObject& onNoteEvent(void (*func)(bool noteOn, float* noteNumber, float* velocity));
+
       /** @brief Total number of allocated voices across all groups. */
       int getNumVoices() const;
 

--- a/docs/design/synth_core.md
+++ b/docs/design/synth_core.md
@@ -247,12 +247,17 @@ public:
   void velocity(Flt v)      { _velocity.store(v, std::memory_order_relaxed); }
   Flt  getVelocity() const  { return _velocity.load(std::memory_order_relaxed); }
   Flt  getAftertouch() const{ return _aftertouch.load(std::memory_order_relaxed); }
+  // Channel pitch-wheel position in [-1,1], forwarded by the keyboard state
+  // machine (§5). A voice reads this alongside getFrequency() and chooses its
+  // own bend range; the core only delivers the normalised position.
+  Flt  getPitchWheel() const{ return _pitchWheel.load(std::memory_order_relaxed); }
 
 private:
   aFlt _frequency{440.f};
   aFlt _velocity{0.f};
   aFlt _aftertouch{0.f};
-  friend class implementationObject;   // sets _aftertouch, drives intent
+  aFlt _pitchWheel{0.f};
+  friend class implementationObject;   // sets _aftertouch / _pitchWheel, drives intent
 };
 
 }} // namespace YSE::SYNTH
@@ -298,6 +303,7 @@ in `process()`:
 | frequency (Hz) | allocator on NOTE_ON | voice `process()` | `aFlt _frequency` via `frequency(midiNote)` |
 | velocity [0,1] | allocator on NOTE_ON | voice `process()` | `aFlt _velocity` |
 | aftertouch [0,1] | allocator on AFTERTOUCH | voice `process()` | `aFlt _aftertouch` |
+| pitch wheel [-1,1] | keyboard on PITCH_WHEEL + primed on NOTE_ON | voice `process()` | `aFlt _pitchWheel` |
 | gate / phase | allocator | voice `process()` | the `SOUND_STATUS& intent` argument |
 
 The `intent` argument is the gate. The allocator holds one


### PR DESCRIPTION
## Summary

Implements the control half of the synth core — the keyboard/pedal state machine (§5), the full MESSAGE op-set (§6) and the `onNoteEvent` audio-thread hook (§7) of `docs/design/synth_core.md` — on top of the object/manager/allocator (#153) and the `dspVoice` base + sine voice (#152) already on `dev`. #153 declared the full `MESSAGE` enum as the fixed contract and handled only the note ops; this PR fills in the rest.

All keyboard/controller state and the `onNoteEvent` callback run on the audio callback path and are allocation-, lock- and block-free: per-channel state is fixed-size and audio-thread-only, per-voice pitch-bend/aftertouch are delivered through relaxed atomics, and the callback is a plain atomic function pointer (no heap closure), never routed through the inbox.

## Linked issue

Closes #154.

## Changes

- **Keyboard/pedal state machine** (`synthImplementation.*`): per-channel state for 16 MIDI channels — held-note bookkeeping tracked on the voice slots (`keyDown` / `heldBySustain` / `heldBySostenuto`), sustain/sostenuto/soft-pedal flags, pitch wheel, per-CC and channel-aftertouch last values.
  - Sustain defers note-off; sostenuto captures **only** the notes held when it engaged; a note claimed by both pedals releases only when both lift; soft pedal scales the velocity of **new** notes (0.7) without touching sounding voices.
- **Op-set** (`synthMessage` was already declared by #153): `PITCH_WHEEL`, `CONTROLLER` (CC 64/66/67 route to the pedal logic, others stored per channel), `AFTERTOUCH` (per-note or channel-wide via `note == -1`), `SUSTAIN`/`SOSTENUTO`/`SOFTPEDAL`, and `ALL_NOTES_OFF`.
- **Per-voice forwarding**: new `aFlt _pitchWheel` on `dspVoice` (primed on note-on, updated live on every sounding voice), aftertouch via the existing `_aftertouch` atomic. `sineVoice` bends ±2 semitones from the wheel.
- **`onNoteEvent`**: atomic `void(*)(bool,float*,float*)` set on the impl, run on the audio thread before bookkeeping/allocation, may rewrite note/velocity in place; `nullptr` clears it.
- **Interface** (`synthInterface.*`): chainable `pitchWheel` / `controller` / `aftertouch` / `sustain` / `sostenuto` / `softPedal` / `onNoteEvent`.
- **Crash fix in the reference voice**: a voice released *before it ever rendered a block* (note-on+off draining in one block, or a pedal/all-notes-off release before the first render) previously drove `ADSRenvelope`'s RELEASE from an un-primed `phase` pointer — a segfault. `sineVoice` now settles straight to `SS_STOPPED` in that case. The underlying envelope hazard (which affects any user voice) is filed as **#300**.
- **Doc**: adds the per-voice pitch-wheel delivery row/atomic to §3 of `synth_core.md` (implementation detail the design required in §5 but had not shown in §3).

Out of scope (separate downstream issues, untouched): MIDI routing (#155), player reconnection (#156), C API (#157), and per-CC modulation matrices (#148).

## Test plan

New `Tests/synth/test_synth_keyboard.cpp` (12 cases) drives a `SYNTH::implementationObject` directly — pushing control messages and rendering the aggregate `outputSource` produces **real audio through the real voice + allocator**, the end-to-end audio verification for these paths (same approach #153 established), plus one live-engine case through the public `YSE::synth` interface:

- sustain defers note-off until the pedal lifts;
- sostenuto sustains only the notes held when it engaged;
- a note held by both pedals releases only when both lift;
- soft pedal lowers the level of notes started under it;
- **pitch wheel measurably bends a sounding sine voice (FFT)** and primes a note started while bent;
- **onNoteEvent transposes a note before it sounds (FFT)**, and clearing it restores pass-through;
- per-note and channel-wide aftertouch delivery;
- CC 64 acts as sustain, other CCs stored per channel;
- a no-allocation probe over wheel/aftertouch/CC/all three pedals/notes.

Results (MSYS2 clang64, Windows):
- [x] `clang-format` clean (`python yse.py format` — only the touched files)
- [x] `clang-tidy` clean on changed files (`python yse.py analyze YseEngine/synth/`, `… Tests/synth/test_synth_keyboard.cpp`) — no new findings
- [x] Full unit suite green: `python yse.py test` → **19/19 ctest processes pass, 100%**, incl. `yse_unit_tests`, `yse_tests_synth` (22 cases: 12 new + 10 existing), `yse_tests_synthlifecycle`, and the `dsp` suite (#152 voice tests)
- [x] Real-audio end-to-end covered by the FFT/RMS render tests above (no separate app to drive for an engine library); the crash fix is verified by the pedal/all-notes-off cases that previously segfaulted

🤖 Generated with [Claude Code](https://claude.com/claude-code)