### PR TITLE
MIDI: route device input and file playback into synths (#155)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -69,6 +69,8 @@ set(YSE_TEST_SOURCES
   midi/test_midifile_concurrency.cpp
   midi/test_devicemanager.cpp
   midi/test_midi_in.cpp
+  midi/test_midi_synth_routing.cpp
+  midi/test_midi_synth.cpp
   music/test_scale.cpp
   music/test_note.cpp
   music/test_motif.cpp
@@ -164,11 +166,12 @@ set_target_properties(yse_tests PROPERTIES
 if(NOT ANDROID)
 add_test(
   NAME    yse_unit_tests
-  # `lifecycle` and `synthlifecycle` are excluded alongside `integration`: they
-  # drive System::close(), which permanently stops the global thread pools and
-  # would break every later suite sharing this process. Each runs in its own
-  # process via yse_tests_lifecycle / yse_tests_synthlifecycle.
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle --duration=true
+  # `lifecycle`, `synthlifecycle` and `midisynth` are excluded alongside
+  # `integration`: they drive System::close(), which permanently stops the
+  # global thread pools and would break every later suite sharing this process.
+  # Each runs in its own process via
+  # yse_tests_lifecycle / yse_tests_synthlifecycle / yse_tests_midisynth.
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,midisynth --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -261,6 +264,17 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_midi PROPERTIES LABELS midi)
+
+# End-to-end MIDI -> synth routing (issue #155). Isolated in its own process for
+# the same reason as yse_tests_synthlifecycle: it drives System::close() and
+# constructs the synth + sound managers, whose static teardown must not leak
+# into other suites (issue #298). Uses initOffline(), so it runs in CI.
+add_test(
+  NAME    yse_tests_midisynth
+  COMMAND yse_tests --test-suite=midisynth
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_midisynth PROPERTIES LABELS "midi;synth;lifecycle")
 
 add_test(
   NAME    yse_tests_music

--- a/Tests/midi/test_midi_in.cpp
+++ b/Tests/midi/test_midi_in.cpp
@@ -27,15 +27,7 @@
 
 #include "midi/device.hpp"
 #include "yse_c/yse_midi.h"
-
-// Friend-declared in YSE::midiIn so tests can drive dispatch() directly
-// without needing a real MIDI port (RtMidi's openVirtualPort is unavailable
-// on Windows; this keeps the parser test deterministic on every platform).
-struct MidiInDispatchTester {
-  static void dispatch(YSE::midiIn& m, double ts, const unsigned char* bytes, std::size_t len) {
-    m.dispatch(ts, bytes, len);
-  }
-};
+#include "support/midi_dispatch_tester.hpp"
 
 namespace {
 

--- a/Tests/midi/test_midi_synth.cpp
+++ b/Tests/midi/test_midi_synth.cpp
@@ -1,0 +1,229 @@
+// End-to-end MIDI -> synth routing tests (issue #155).
+//
+// These drive the *whole* path: a MIDI source (file playback or device input)
+// pushes MESSAGE ops onto a real synth's inbox, the synth renders them offline,
+// and we assert the note sequence the synth actually received via an
+// onNoteEvent log. This is the acceptance-criterion "event log comparison on a
+// test synth".
+//
+// ISOLATION: like the "synthlifecycle" suite, these run as a dedicated ctest
+// process (excluded from the combined run) because they call System::close(),
+// which permanently stops the global thread pools. Keeping them in their own
+// process also contains the pre-existing SOUND/CHANNEL static-teardown
+// fragility (issue #298) that constructing the synth + sound managers can
+// expose at exit.
+//
+// initOffline() needs no audio hardware, so these run in CI; if it returns
+// false on some host the case bails out and doctest counts it as a pass.
+
+#include <doctest/doctest.h>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "headers/defines.hpp"
+#include "sound/soundInterface.hpp"
+#include "synth/sineVoice.hpp"
+#include "synth/synthInterface.hpp"
+#include "midi/midifile.hpp"
+#include "internal/time.h"
+
+#if YSE_ENABLE_MIDI_DEVICE
+#include "midi/device.hpp"
+#include "support/midi_dispatch_tester.hpp"
+#endif
+
+using namespace std::chrono_literals;
+
+namespace {
+
+  // onNoteEvent is a captureless function pointer, so it logs into this
+  // process-static buffer. The offline render loop is single-threaded (the
+  // test thread), so no synchronisation is needed.
+  struct NoteLogEntry {
+    bool on;
+    int note;
+  };
+  std::vector<NoteLogEntry> g_noteLog;
+
+  void logNote(bool on, float* noteNumber, float* /*velocity*/) {
+    g_noteLog.push_back({on, static_cast<int>(*noteNumber + 0.5f)});
+  }
+
+  // Bring a synth attached to a sound up to OBJECT_READY (voice cloning is
+  // async on the slow pool). Returns true once its voices are allocated.
+  bool bringReady(YSE::synth& syn, int expectedVoices) {
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (std::chrono::steady_clock::now() < deadline) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+      if (syn.getNumVoices() == expectedVoices) return true;
+      std::this_thread::sleep_for(5ms);
+    }
+    return syn.getNumVoices() == expectedVoices;
+  }
+
+  // Drain the engine so released impls are fully deleted before teardown.
+  void drain(std::chrono::milliseconds budget = 500ms) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+      std::this_thread::sleep_for(2ms);
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("midisynth") {
+
+  // ─── MIDI file -> synth ───────────────────────────────────────────────────
+
+  TEST_CASE("midisynth: MIDI file playback drives the note on/off sequence into a synth") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+    g_noteLog.clear();
+
+    YSE::SYNTH::sineVoice proto; // declared first: outlives the synth
+    proto.attack(0.005f).release(0.05f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(proto, 8);
+      syn.onNoteEvent(logNote);
+      {
+        YSE::sound snd;
+        snd.create(syn);
+        REQUIRE(bringReady(syn, 8));
+        snd.play();
+
+        YSE::MIDI::file mf;
+        REQUIRE(mf.create(std::string(YSE_TEST_FIXTURES_DIR) + "/test_type0.mid"));
+        mf.connect(syn);
+        mf.play();
+
+        // One update() drains the file into the MIDI manager's audio-thread
+        // list; then render blocks until both note events land (or a generous
+        // cap — the fixture's note-off is half a second in).
+        YSE::System().update();
+        for (int i = 0; i < 4000 && g_noteLog.size() < 2; ++i)
+          YSE::System().renderOffline(1);
+
+        mf.disconnect(syn);
+        snd.stop();
+        YSE::System().renderOffline(8);
+      } // sound destroyed first (§9 order)
+      drain();
+    } // synth destroyed after its sound
+    drain();
+    YSE::System().close();
+
+    REQUIRE(g_noteLog.size() == 2);
+    CHECK(g_noteLog[0].on == true);
+    CHECK(g_noteLog[0].note == 60);
+    CHECK(g_noteLog[1].on == false);
+    CHECK(g_noteLog[1].note == 60);
+  }
+
+#if YSE_ENABLE_MIDI_DEVICE
+
+  // ─── MIDI device -> synth ──────────────────────────────────────────────────
+
+  TEST_CASE("midisynth: device MIDI note on/off is routed into a connected synth") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+    g_noteLog.clear();
+
+    YSE::SYNTH::sineVoice proto;
+    proto.attack(0.005f).release(0.05f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(proto, 8);
+      syn.onNoteEvent(logNote);
+      {
+        YSE::sound snd;
+        snd.create(syn);
+        REQUIRE(bringReady(syn, 8));
+        snd.play();
+
+        YSE::midiIn in; // no real port opened — dispatch() is driven directly
+        in.connect(syn); // omni
+
+        const unsigned char noteOn[3] = {0x90, 60, 100}; // ch 1 note-on
+        MidiInDispatchTester::dispatch(in, 0.0, noteOn, 3);
+        YSE::System().update();
+        for (int i = 0; i < 8; ++i)
+          YSE::System().renderOffline(1);
+
+        const unsigned char noteOff[3] = {0x80, 60, 0}; // ch 1 note-off
+        MidiInDispatchTester::dispatch(in, 0.0, noteOff, 3);
+        for (int i = 0; i < 8; ++i)
+          YSE::System().renderOffline(1);
+
+        in.disconnect(syn);
+        snd.stop();
+        YSE::System().renderOffline(8);
+      }
+      drain();
+    }
+    drain();
+    YSE::System().close();
+
+    REQUIRE(g_noteLog.size() == 2);
+    CHECK(g_noteLog[0].on == true);
+    CHECK(g_noteLog[0].note == 60);
+    CHECK(g_noteLog[1].on == false);
+    CHECK(g_noteLog[1].note == 60);
+  }
+
+  TEST_CASE("midisynth: device channel filter drops messages on other channels") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+    g_noteLog.clear();
+
+    YSE::SYNTH::sineVoice proto;
+    proto.attack(0.005f).release(0.05f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(proto, 8);
+      syn.onNoteEvent(logNote);
+      {
+        YSE::sound snd;
+        snd.create(syn);
+        REQUIRE(bringReady(syn, 8));
+        snd.play();
+
+        YSE::midiIn in;
+        in.connect(syn, /*channelFilter*/ 2); // accept MIDI channel 2 only
+
+        // Channel 1 (status nibble channel 0) — filtered out.
+        const unsigned char ch1[3] = {0x90, 60, 100};
+        MidiInDispatchTester::dispatch(in, 0.0, ch1, 3);
+        YSE::System().update();
+        for (int i = 0; i < 8; ++i)
+          YSE::System().renderOffline(1);
+        CHECK(g_noteLog.empty());
+
+        // Channel 2 (status nibble channel 1) — accepted.
+        const unsigned char ch2[3] = {0x91, 62, 100};
+        MidiInDispatchTester::dispatch(in, 0.0, ch2, 3);
+        for (int i = 0; i < 8; ++i)
+          YSE::System().renderOffline(1);
+        REQUIRE(g_noteLog.size() == 1);
+        CHECK(g_noteLog[0].on == true);
+        CHECK(g_noteLog[0].note == 62);
+
+        in.disconnect(syn);
+        snd.stop();
+        YSE::System().renderOffline(8);
+      }
+      drain();
+    }
+    drain();
+    YSE::System().close();
+    CHECK(true);
+  }
+
+#endif // YSE_ENABLE_MIDI_DEVICE
+
+} // TEST_SUITE("midisynth")

--- a/Tests/midi/test_midi_synth_routing.cpp
+++ b/Tests/midi/test_midi_synth_routing.cpp
@@ -1,0 +1,175 @@
+// Unit tests for the raw-MIDI -> YSE::synth mapping (issue #155).
+//
+// routeChannelVoiceMessage() is the single place both MIDI input paths (device
+// input and file playback) convert a raw channel-voice MIDI message into the
+// synth's normalized note API. These tests pin the mapping precisely — channel
+// offset, 7-bit / 14-bit normalization, velocity-0 note-off — against a
+// recording sink, with no engine or audio device needed.
+
+#include <doctest/doctest.h>
+#include <vector>
+#include "midi/midiSynthRouting.hpp"
+
+namespace {
+
+  // Records every synth call the router makes, with its arguments, so a test
+  // can assert the exact mapping. Mirrors the public YSE::synth note API the
+  // router targets.
+  struct RecordingSynth {
+    enum Kind { NoteOn, NoteOff, Controller, PitchWheel, Aftertouch };
+    struct Call {
+      Kind kind;
+      int channel;
+      int arg; // note number / controller number (unused for pitch wheel)
+      float value; // velocity / cc value / bend / pressure
+    };
+    std::vector<Call> calls;
+
+    void noteOn(int ch, int note, float vel) {
+      calls.push_back({NoteOn, ch, note, vel});
+    }
+    void noteOff(int ch, int note, float vel) {
+      calls.push_back({NoteOff, ch, note, vel});
+    }
+    void controller(int ch, int num, float val) {
+      calls.push_back({Controller, ch, num, val});
+    }
+    void pitchWheel(int ch, float val) {
+      calls.push_back({PitchWheel, ch, 0, val});
+    }
+    void aftertouch(int ch, int note, float val) {
+      calls.push_back({Aftertouch, ch, note, val});
+    }
+  };
+
+  using YSE::MIDI::routeChannelVoiceMessage;
+
+} // namespace
+
+TEST_SUITE("midi") {
+
+  // ─── note on / off ────────────────────────────────────────────────────────
+
+  TEST_CASE("routing: note-on maps channel(+1), note and normalized velocity") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0x90, 0x00, 60, 127); // ch nibble 0, C4, vel 127
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].kind == RecordingSynth::NoteOn);
+    CHECK(s.calls[0].channel == 1); // MIDI channel 0 -> synth channel 1
+    CHECK(s.calls[0].arg == 60);
+    CHECK(s.calls[0].value == doctest::Approx(1.0f)); // 127/127
+  }
+
+  TEST_CASE("routing: note-on with velocity 0 is routed as a note-off") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0x90, 0x03, 64, 0);
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].kind == RecordingSynth::NoteOff);
+    CHECK(s.calls[0].channel == 4);
+    CHECK(s.calls[0].arg == 64);
+  }
+
+  TEST_CASE("routing: note-off maps channel, note and normalized release velocity") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0x80, 0x05, 48, 64); // ch nibble 5
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].kind == RecordingSynth::NoteOff);
+    CHECK(s.calls[0].channel == 6);
+    CHECK(s.calls[0].arg == 48);
+    CHECK(s.calls[0].value == doctest::Approx(64.f / 127.f));
+  }
+
+  TEST_CASE("routing: channel nibble 15 maps to synth channel 16") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0x90, 0x0F, 60, 100);
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].channel == 16);
+  }
+
+  // ─── control change ───────────────────────────────────────────────────────
+
+  TEST_CASE("routing: control change maps controller number and normalized value") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0xB0, 0x00, 7, 64); // CC 7 (volume) = 64
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].kind == RecordingSynth::Controller);
+    CHECK(s.calls[0].channel == 1);
+    CHECK(s.calls[0].arg == 7);
+    CHECK(s.calls[0].value == doctest::Approx(64.f / 127.f));
+  }
+
+  TEST_CASE("routing: sustain pedal (CC 64) is forwarded as a controller") {
+    // The synth itself intercepts CC 64/66/67 as the pedals, so the router
+    // just forwards every CC unchanged.
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0xB0, 0x00, 64, 127);
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].kind == RecordingSynth::Controller);
+    CHECK(s.calls[0].arg == 64);
+    CHECK(s.calls[0].value == doctest::Approx(1.0f));
+  }
+
+  // ─── pitch bend (14-bit) ──────────────────────────────────────────────────
+
+  TEST_CASE("routing: pitch bend centre (8192) maps to 0") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0xE0, 0x00, 0x00, 0x40); // LSB 0, MSB 64 -> 8192
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].kind == RecordingSynth::PitchWheel);
+    CHECK(s.calls[0].value == doctest::Approx(0.0f));
+  }
+
+  TEST_CASE("routing: pitch bend minimum maps to -1") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0xE0, 0x02, 0x00, 0x00); // raw 0
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].channel == 3);
+    CHECK(s.calls[0].value == doctest::Approx(-1.0f));
+  }
+
+  TEST_CASE("routing: pitch bend maximum maps to nearly +1") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0xE0, 0x00, 0x7F, 0x7F); // raw 16383
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].value == doctest::Approx(8191.f / 8192.f));
+  }
+
+  // ─── aftertouch ───────────────────────────────────────────────────────────
+
+  TEST_CASE("routing: polyphonic aftertouch maps to the per-note pressure") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0xA0, 0x02, 60, 100); // note 60, pressure 100
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].kind == RecordingSynth::Aftertouch);
+    CHECK(s.calls[0].channel == 3);
+    CHECK(s.calls[0].arg == 60);
+    CHECK(s.calls[0].value == doctest::Approx(100.f / 127.f));
+  }
+
+  TEST_CASE("routing: channel aftertouch broadcasts (note == -1)") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0xD0, 0x02, 100, 0); // pressure in data1
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].kind == RecordingSynth::Aftertouch);
+    CHECK(s.calls[0].channel == 3);
+    CHECK(s.calls[0].arg == -1);
+    CHECK(s.calls[0].value == doctest::Approx(100.f / 127.f));
+  }
+
+  // ─── unrouted messages ────────────────────────────────────────────────────
+
+  TEST_CASE("routing: program change is not routed to the synth core") {
+    RecordingSynth s;
+    routeChannelVoiceMessage(s, 0xC0, 0x00, 5, 0);
+    CHECK(s.calls.empty());
+  }
+
+  TEST_CASE("routing: isChannelVoiceStatus accepts 0x80..0xE0 only") {
+    CHECK(YSE::MIDI::isChannelVoiceStatus(0x80));
+    CHECK(YSE::MIDI::isChannelVoiceStatus(0x90));
+    CHECK(YSE::MIDI::isChannelVoiceStatus(0xE0));
+    CHECK_FALSE(YSE::MIDI::isChannelVoiceStatus(0x70));
+    CHECK_FALSE(YSE::MIDI::isChannelVoiceStatus(0xF0)); // system / meta
+  }
+
+} // TEST_SUITE("midi")

--- a/Tests/midi/test_midifile.cpp
+++ b/Tests/midi/test_midifile.cpp
@@ -3,21 +3,24 @@
 // Coverage:
 //   - midiMessage base class: getRaw() pointer validity and raw vector properties
 //   - midiNote construction, note/velocity getters/setters, raw byte layout
-//   - midifile lifecycle: construction, create (stub), destruction
+//   - midifile lifecycle: construction, create, destruction
 //   - midifileManager: singleton identity, update(), orphan removal
-//   - MIDI Type-0 fixture: verifies fixture file exists for future parsing tests
+//   - SMF parser (issue #155): decodes the Type-0 fixture into a time-sorted
+//     event list with correct note numbers, velocities and sample times
 //
-// Note: MIDI file parsing (midifileImplementation::create) is currently stubbed;
-// the fixture is committed for future use when parsing is implemented.
-// No engine initialisation is required — the MIDI classes are independent of
-// PortAudio and the audio graph.
+// No engine initialisation is required — the MIDI classes (and the SMF parser)
+// are independent of PortAudio and the audio graph. SAMPLERATE is initialised
+// to 44100 by the device translation unit at static-init time.
 
 #include <doctest/doctest.h>
+#include <cstdint>
+#include <cstdio>
 #include <fstream>
 #include <string>
 #include "midi/midiMessage.hpp"
 #include "midi/midiNote.hpp"
 #include "midi/midifile.hpp"
+#include "midi/midifileImplementation.h"
 #include "midi/midifileManager.h"
 
 TEST_SUITE("midi") {
@@ -120,17 +123,18 @@ TEST_SUITE("midi") {
     { YSE::MIDI::file f; } // ~file() calls pimpl->removeInterface()
   }
 
-  TEST_CASE("midifile: create with any filename returns true (stub)") {
+  TEST_CASE("midifile: create on a missing file returns false") {
     YSE::MIDI::file f;
     bool ok = f.create("nonexistent.mid");
-    CHECK(ok == true);
+    CHECK(ok == false);
   }
 
   TEST_CASE("midifile: multiple file objects can coexist") {
+    const std::string fixture = std::string(YSE_TEST_FIXTURES_DIR) + "/test_type0.mid";
     YSE::MIDI::file a;
     YSE::MIDI::file b;
-    bool ok1 = a.create("a.mid");
-    bool ok2 = b.create("b.mid");
+    bool ok1 = a.create(fixture);
+    bool ok2 = b.create(fixture);
     CHECK(ok1 == true);
     CHECK(ok2 == true);
   }
@@ -151,6 +155,60 @@ TEST_SUITE("midi") {
     // Manager().update() removes that implementation from the forward_list.
     { YSE::MIDI::file f; }
     YSE::MIDI::Manager().update();
+  }
+
+  // ─── SMF parser (issue #155) ─────────────────────────────────────────────────
+
+  TEST_CASE("SMF parser: missing file leaves no events and fails") {
+    YSE::MIDI::fileImpl impl(nullptr);
+    CHECK(impl.create("does-not-exist.mid") == false);
+    CHECK(impl.events().empty());
+  }
+
+  TEST_CASE("SMF parser: Type-0 fixture decodes to a note-on then note-off") {
+    // test_type0.mid: 96 PPQN, 120 BPM tempo meta, note-on C4 vel 127 at tick 0,
+    // note-off C4 at tick 96 (one quarter = 0.5 s), end-of-track.
+    YSE::MIDI::fileImpl impl(nullptr);
+    REQUIRE(impl.create(std::string(YSE_TEST_FIXTURES_DIR) + "/test_type0.mid"));
+
+    const auto& ev = impl.events();
+    REQUIRE(ev.size() == 2);
+
+    // Event 0: note-on, channel 1 (status 0x90), note 60, velocity 127, at t=0.
+    CHECK((ev[0].status & 0xF0) == 0x90);
+    CHECK((ev[0].status & 0x0F) == 0x00);
+    CHECK(ev[0].data1 == 60);
+    CHECK(ev[0].data2 == 127);
+    CHECK(ev[0].sampleTime == 0u);
+
+    // Event 1: note-off (status 0x80), note 60, half a second later.
+    CHECK((ev[1].status & 0xF0) == 0x80);
+    CHECK(ev[1].data1 == 60);
+    // 96 ticks at 96 PPQN, 120 BPM = one quarter note = 0.5 s.
+    CHECK(ev[1].sampleTime == static_cast<uint64_t>(YSE::SAMPLERATE) / 2u);
+  }
+
+  TEST_CASE("SMF parser: events come back sorted by sample time") {
+    YSE::MIDI::fileImpl impl(nullptr);
+    REQUIRE(impl.create(std::string(YSE_TEST_FIXTURES_DIR) + "/test_type0.mid"));
+    const auto& ev = impl.events();
+    for (std::size_t i = 1; i < ev.size(); ++i)
+      CHECK(ev[i - 1].sampleTime <= ev[i].sampleTime);
+  }
+
+  TEST_CASE("SMF parser: garbage data is rejected without crashing") {
+    // A file that exists but is not a valid MIDI file must fail create() (not
+    // crash) and leave the event list empty.
+    const std::string tmp = std::string(YSE_TEST_FIXTURES_DIR) + "/garbage_not_midi.tmp";
+    {
+      std::ofstream out(tmp, std::ios::binary);
+      const char junk[] = "this is definitely not a midi file";
+      out.write(junk, sizeof(junk));
+    }
+    YSE::MIDI::fileImpl impl(nullptr);
+    CHECK(impl.create(tmp) == false);
+    CHECK(impl.events().empty());
+    std::remove(tmp.c_str());
   }
 
   // ─── MIDI fixture existence ───────────────────────────────────────────────────

--- a/Tests/support/midi_dispatch_tester.hpp
+++ b/Tests/support/midi_dispatch_tester.hpp
@@ -1,0 +1,22 @@
+#pragma once
+// Test-only access to YSE::midiIn's private dispatch() path.
+//
+// RtMidi's openVirtualPort() is unavailable on Windows, so tests cannot feed a
+// real device. midiIn friend-declares this struct (device.hpp) so tests can
+// drive dispatch() directly with synthetic MIDI bytes, deterministically on
+// every platform. Shared by test_midi_in.cpp (parser fan-out) and the
+// device -> synth routing tests so the friend struct has a single definition.
+
+#include "headers/defines.hpp"
+#if YSE_ENABLE_MIDI_DEVICE
+
+#include <cstddef>
+#include "midi/device.hpp"
+
+struct MidiInDispatchTester {
+  static void dispatch(YSE::midiIn& m, double ts, const unsigned char* bytes, std::size_t len) {
+    m.dispatch(ts, bytes, len);
+  }
+};
+
+#endif // YSE_ENABLE_MIDI_DEVICE

--- a/YseEngine/device/deviceManager.cpp
+++ b/YseEngine/device/deviceManager.cpp
@@ -44,6 +44,9 @@ bool YSE::DEVICE::deviceManager::doOnCallback(int numSamples) {
   // between two buffer updates and should have the least latency possible
   INTERNAL::DeviceTime().update();
   PLAYER::Manager().update((Flt)numSamples / (Flt)SAMPLERATE);
+  // MIDI file playback is advanced every block too (issue #155) so events reach
+  // the connected synths block-accurately, before the synths render this block.
+  MIDI::Manager().updatePlayback(numSamples);
 
   if (SOUND::Manager().empty()) return false;
 

--- a/YseEngine/midi/device.cpp
+++ b/YseEngine/midi/device.cpp
@@ -3,6 +3,8 @@
 #include "device.hpp"
 #include "RtMidi.h"
 #include "midiDeviceManager.h"
+#include "synth/synthInterface.hpp"
+#include "midi/midiSynthRouting.hpp"
 
 YSE::midiOut::midiOut() : device(nullptr) {}
 
@@ -262,6 +264,37 @@ void YSE::midiIn::setParsedCallback(ParsedCallback cb, void* user_data) {
   parsedCb.store(cb, std::memory_order_release);
 }
 
+void YSE::midiIn::connect(YSE::synth& synth, int channelFilter) {
+  // Already connected? Just refresh its channel filter.
+  for (auto& sub : synthSubs) {
+    if (sub.synth.load(std::memory_order_acquire) == &synth) {
+      sub.channel.store(channelFilter, std::memory_order_relaxed);
+      return;
+    }
+  }
+  // Claim a free slot. The CAS publishes the pointer with release ordering so
+  // the RtMidi thread's acquire-load in dispatch() sees a valid synth.
+  for (auto& sub : synthSubs) {
+    SYNTH::interfaceObject* expected = nullptr;
+    if (sub.synth.compare_exchange_strong(expected, &synth, std::memory_order_acq_rel)) {
+      sub.channel.store(channelFilter, std::memory_order_relaxed);
+      return;
+    }
+  }
+  // Table full (>kMaxSynthSubs synths on one port) — a rare misconfiguration;
+  // ignore rather than grow a table the RtMidi thread reads lock-free.
+}
+
+void YSE::midiIn::disconnect(YSE::synth& synth) {
+  for (auto& sub : synthSubs) {
+    if (sub.synth.load(std::memory_order_acquire) == &synth) {
+      sub.channel.store(0, std::memory_order_relaxed); // reset filter for reuse
+      sub.synth.store(nullptr, std::memory_order_release);
+      return;
+    }
+  }
+}
+
 void YSE::midiIn::rtMidiTrampoline(double ts, std::vector<unsigned char>* msg, void* userData) {
   if (msg == nullptr || msg->empty() || userData == nullptr) return;
   auto* self = static_cast<midiIn*>(userData);
@@ -290,6 +323,26 @@ void YSE::midiIn::dispatch(double timestampSec, const unsigned char* bytes, std:
     const unsigned char data1 = len > 1 ? bytes[1] : 0;
     const unsigned char data2 = len > 2 ? bytes[2] : 0;
     pcb(timestampSec, status, channel, data1, data2, parsedUser.load(std::memory_order_acquire));
+  }
+
+  // Internal synth subscribers (issue #155). This is the additive fan-out the
+  // port hub was left open for: route every channel-voice message to each
+  // connected synth whose channel filter matches. Each routed call maps raw
+  // MIDI onto the synth's normalized note API and lock-free try_pushes onto its
+  // inbox — safe to run here on RtMidi's input thread.
+  const unsigned char statusNibble = static_cast<unsigned char>(bytes[0] & 0xF0);
+  if (MIDI::isChannelVoiceStatus(statusNibble)) {
+    const unsigned char channelNibble = static_cast<unsigned char>(bytes[0] & 0x0F);
+    const int synthChannel = static_cast<int>(channelNibble) + 1;
+    const unsigned char d1 = len > 1 ? bytes[1] : 0;
+    const unsigned char d2 = len > 2 ? bytes[2] : 0;
+    for (auto& sub : synthSubs) {
+      SYNTH::interfaceObject* s = sub.synth.load(std::memory_order_acquire);
+      if (s == nullptr) continue;
+      const int filter = sub.channel.load(std::memory_order_relaxed);
+      if (filter == 0 || filter == synthChannel)
+        MIDI::routeChannelVoiceMessage(*s, statusNibble, channelNibble, d1, d2);
+    }
   }
 }
 

--- a/YseEngine/midi/device.hpp
+++ b/YseEngine/midi/device.hpp
@@ -9,6 +9,7 @@
 
 #include "midiMessage.hpp"
 #include "../headers/enums.hpp"
+#include "../synth/synth.hpp" // YSE::synth / SYNTH::interfaceObject (device -> synth routing)
 
 /// @cond INTERNAL
 class RtMidiIn;
@@ -161,6 +162,23 @@ namespace YSE {
     /** @brief Install a parsed callback. Pass ``nullptr`` to detach. */
     void setParsedCallback(ParsedCallback cb, void* user_data);
 
+    /** @brief Route incoming device MIDI into a synth (issue #155).
+     *
+     *  Every channel-voice message received on the open port is delivered to
+     *  ``synth`` — mapped to the synth's normalized note API and pushed
+     *  lock-free onto its inbox, on RtMidi's input thread. ``channelFilter``
+     *  is a 1..16 MIDI channel to accept, or 0 for every channel. May be
+     *  called for several synths; calling it again for an already-connected
+     *  synth just updates its channel filter.
+     *
+     *  @warning ``synth`` must outlive the connection — ``disconnect`` it (or
+     *           close / destroy this port) before destroying the synth. This
+     *           is a control-thread call; do not call it from the callbacks. */
+    void connect(YSE::synth& synth, int channelFilter = 0);
+
+    /** @brief Stop routing incoming device MIDI into ``synth``. */
+    void disconnect(YSE::synth& synth);
+
   private:
     // RtMidi's setCallback entry point. Forwards to dispatch() so the
     // raw / parsed subscribers are not coupled to the trampoline; this
@@ -177,6 +195,18 @@ namespace YSE {
     std::atomic<void*> rawUser{nullptr};
     std::atomic<ParsedCallback> parsedCb{nullptr};
     std::atomic<void*> parsedUser{nullptr};
+
+    // Internal synth subscribers (issue #155). A fixed-size atomic table so
+    // connect/disconnect (control thread) never lock and dispatch() (RtMidi
+    // input thread) never allocates. `channel` is 0 (all) or a 1..16 filter.
+    // This is the "additive internal subscribers" hook the port fan-out was
+    // left open for — see the dispatch() comment and yvanvds/yse-soundengine#52.
+    static constexpr std::size_t kMaxSynthSubs = 8;
+    struct synthSub {
+      std::atomic<SYNTH::interfaceObject*> synth{nullptr};
+      std::atomic<int> channel{0};
+    };
+    synthSub synthSubs[kMaxSynthSubs];
 
     // Test-only access to the private dispatch() path. Driven by
     // Tests/midi/test_midi_in.cpp to verify the parsed-callback nibble

--- a/YseEngine/midi/midiSynthRouting.hpp
+++ b/YseEngine/midi/midiSynthRouting.hpp
@@ -1,0 +1,117 @@
+/*
+  ==============================================================================
+
+    midiSynthRouting.hpp
+    Convert a raw MIDI channel-voice message into normalized YSE::synth calls.
+
+    Shared by both MIDI input sources that feed a synth (issue #155):
+      * MIDI file playback  — midifileImplementation.cpp
+      * MIDI device input    — device.cpp (RtMidi dispatch)
+
+    The synth interface takes device-agnostic, normalized ranges (velocity /
+    controller / aftertouch in [0, 1]; pitch wheel in [-1, 1]) — see
+    docs/design/synth_core.md §12. This header is the single place that maps
+    raw 7-bit / 14-bit MIDI onto those ranges, so both input paths stay
+    consistent and the mapping is unit-testable in isolation.
+
+    Templated on the target so it can drive either the real YSE::synth (its
+    public note API) or a recording sink in tests, with zero overhead and no
+    coupling to the synth headers.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_MIDI_MIDISYNTHROUTING_HPP
+#define YSE_MIDI_MIDISYNTHROUTING_HPP
+
+namespace YSE {
+  namespace MIDI {
+
+    // MIDI status nibbles (high nibble of the status byte).
+    enum : unsigned char {
+      MSG_NOTE_OFF = 0x80,
+      MSG_NOTE_ON = 0x90,
+      MSG_POLY_AFTERTOUCH = 0xA0,
+      MSG_CONTROL_CHANGE = 0xB0,
+      MSG_PROGRAM_CHANGE = 0xC0,
+      MSG_CHANNEL_AFTERTOUCH = 0xD0,
+      MSG_PITCH_BEND = 0xE0,
+    };
+
+    /** True for the seven channel-voice status nibbles (0x80..0xE0). Everything
+        else (system / real-time / meta) is not routed to the synth core. */
+    inline bool isChannelVoiceStatus(unsigned char statusNibble) {
+      return statusNibble >= MSG_NOTE_OFF && statusNibble <= MSG_PITCH_BEND;
+    }
+
+    /**
+     *  Route one channel-voice MIDI message to a synth-like ``target``.
+     *
+     *  @param target       Anything exposing the YSE::synth note API
+     *                       (noteOn/noteOff/controller/pitchWheel/aftertouch).
+     *  @param statusNibble  High nibble of the status byte (0x80..0xE0).
+     *  @param channelNibble Low nibble of the status byte (0..15). Mapped to a
+     *                       1..16 synth channel to match the synth API.
+     *  @param data1,data2   The two MIDI data bytes (0..127). ``data2`` is
+     *                       ignored for the single-byte messages.
+     *
+     *  Non-channel-voice statuses (program change, system, meta) are ignored:
+     *  the synth core has no concept of them. A NOTE_ON with velocity 0 is the
+     *  conventional running-status NOTE_OFF and is routed as such.
+     */
+    template <class SynthTarget>
+    inline void routeChannelVoiceMessage(SynthTarget& target, unsigned char statusNibble,
+                                         unsigned char channelNibble, unsigned char data1,
+                                         unsigned char data2) {
+      const int channel = static_cast<int>(channelNibble) + 1; // synth channels are 1..16
+      const int note = static_cast<int>(data1);
+
+      switch (statusNibble & 0xF0) {
+      case MSG_NOTE_ON:
+        // Velocity 0 is a note-off by convention.
+        if (data2 == 0) {
+          target.noteOff(channel, note, 0.f);
+        } else {
+          target.noteOn(channel, note, static_cast<float>(data2) / 127.f);
+        }
+        break;
+
+      case MSG_NOTE_OFF:
+        target.noteOff(channel, note, static_cast<float>(data2) / 127.f);
+        break;
+
+      case MSG_CONTROL_CHANGE:
+        // CC 64 / 66 / 67 are intercepted by the synth as the sustain /
+        // sostenuto / soft pedals; every other CC is stored per channel. The
+        // synth does that interception itself, so we forward every CC as-is.
+        target.controller(channel, note, static_cast<float>(data2) / 127.f);
+        break;
+
+      case MSG_PITCH_BEND: {
+        // 14-bit value, LSB then MSB, centre 8192. Normalize to [-1, 1].
+        const int raw = (static_cast<int>(data2) << 7) | static_cast<int>(data1);
+        target.pitchWheel(channel, static_cast<float>(raw - 8192) / 8192.f);
+        break;
+      }
+
+      case MSG_POLY_AFTERTOUCH:
+        // Per-note pressure: data1 = note, data2 = pressure.
+        target.aftertouch(channel, note, static_cast<float>(data2) / 127.f);
+        break;
+
+      case MSG_CHANNEL_AFTERTOUCH:
+        // Channel-wide pressure (data1 = pressure). note == -1 broadcasts to
+        // every voice on the channel.
+        target.aftertouch(channel, -1, static_cast<float>(data1) / 127.f);
+        break;
+
+      default:
+        // Program change (0xC0) and anything else: not part of the synth core.
+        break;
+      }
+    }
+
+  } // namespace MIDI
+} // namespace YSE
+
+#endif // YSE_MIDI_MIDISYNTHROUTING_HPP

--- a/YseEngine/midi/midifile.cpp
+++ b/YseEngine/midi/midifile.cpp
@@ -37,11 +37,11 @@ void YSE::MIDI::file::pause() {
 void YSE::MIDI::file::stop() {
   pimpl->stop();
 }
-/*
-void YSE::MIDI::file::connect(synth * player) {
-  pimpl->connect(player);
+
+void YSE::MIDI::file::connect(YSE::synth& synth) {
+  pimpl->connect(&synth);
 }
 
-void YSE::MIDI::file::disconnect(synth * player) {
-  pimpl->disconnect(player);
-}*/
+void YSE::MIDI::file::disconnect(YSE::synth& synth) {
+  pimpl->disconnect(&synth);
+}

--- a/YseEngine/midi/midifile.hpp
+++ b/YseEngine/midi/midifile.hpp
@@ -12,7 +12,7 @@
 #define MIDIFILE_H_INCLUDED
 
 #include <string>
-// #include "../synth/synth.hpp"
+#include "../synth/synth.hpp" // YSE::synth (for connect/disconnect)
 #include "../headers/defines.hpp"
 
 namespace YSE {
@@ -45,6 +45,19 @@ namespace YSE {
 
       /** @brief Stop playback and rewind to the start. */
       void stop();
+
+      /** @brief Route this file's playback into a synth.
+       *
+       *  While the file plays, every note / controller / pitch-bend event it
+       *  contains is delivered to ``synth`` (block-accurately, on the audio
+       *  thread). May be called for several synths to drive them together.
+       *
+       *  @warning ``synth`` must outlive the connection: ``disconnect`` it (or
+       *           destroy this file) before destroying the synth. */
+      void connect(YSE::synth& synth);
+
+      /** @brief Stop routing this file's playback into ``synth``. */
+      void disconnect(YSE::synth& synth);
 
     private:
       fileImpl* pimpl;

--- a/YseEngine/midi/midifileImplementation.cpp
+++ b/YseEngine/midi/midifileImplementation.cpp
@@ -5,157 +5,382 @@
     Created: 12 Jul 2014 7:09:29pm
     Author:  yvan
 
+    Engine-native Standard MIDI File parser + block-accurate playback into
+    synths (issue #155). Replaces the JUCE MidiFile / MidiMessageSequence
+    implementation removed with the JUCE backend: create() decodes the file
+    into a time-sorted event list off the audio thread, and advance() (driven
+    once per callback by MIDI::managerObject::updatePlayback) pushes the events
+    that fall in each block onto the connected synths' inboxes.
+
   ==============================================================================
 */
 
 #include "midifileImplementation.h"
 
-YSE::MIDI::fileImpl::fileImpl(file* head)
-  : head(head),
-    intent(SS_STOPPED),
-    objectStatus(OBJECT_READY),
-    hasFile(false)
-//, startSample(0)
-{}
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
 
-YSE::MIDI::fileImpl::~fileImpl() {
-  // disconnect all players
-  /*for (auto i = readers.begin(); i != readers.end(); i++) {
-    (*i)->removeMidiFile(this);
-  }*/
+#include "../synth/synthInterface.hpp"
+#include "midiSynthRouting.hpp"
+
+namespace {
+
+  // ─── low-level byte readers (all bounds-checked by the caller) ───────────────
+
+  // Big-endian fixed-width reads. `pos` is advanced past the bytes read.
+  uint16_t readU16(const std::vector<unsigned char>& d, std::size_t& pos) {
+    uint16_t v = static_cast<uint16_t>((d[pos] << 8) | d[pos + 1]);
+    pos += 2;
+    return v;
+  }
+
+  uint32_t readU32(const std::vector<unsigned char>& d, std::size_t& pos) {
+    uint32_t v = (static_cast<uint32_t>(d[pos]) << 24) | (static_cast<uint32_t>(d[pos + 1]) << 16) |
+                 (static_cast<uint32_t>(d[pos + 2]) << 8) | static_cast<uint32_t>(d[pos + 3]);
+    pos += 4;
+    return v;
+  }
+
+  // MIDI variable-length quantity: 7 bits per byte, MSB set = "more bytes".
+  // Returns false on truncation (pos past end before the value terminates).
+  bool readVarLen(const std::vector<unsigned char>& d, std::size_t& pos, uint32_t& out) {
+    uint32_t value = 0;
+    for (int i = 0; i < 4; ++i) {
+      if (pos >= d.size()) return false;
+      const unsigned char byte = d[pos++];
+      value = (value << 7) | static_cast<uint32_t>(byte & 0x7F);
+      if ((byte & 0x80) == 0) {
+        out = value;
+        return true;
+      }
+    }
+    return false; // more than 4 continuation bytes is malformed
+  }
+
+  // Number of data bytes a running-status channel-voice message carries.
+  int channelDataBytes(unsigned char statusNibble) {
+    switch (statusNibble & 0xF0) {
+    case 0xC0: // program change
+    case 0xD0: // channel aftertouch
+      return 1;
+    default: // note on/off, poly aftertouch, CC, pitch bend
+      return 2;
+    }
+  }
+
+  // A tempo change: microseconds per quarter note in effect from `tick`.
+  struct TempoEntry {
+    uint64_t tick;
+    uint32_t usPerQuarter;
+    double cumUs; // accumulated microseconds at `tick`
+  };
+
+  std::vector<unsigned char> readWholeFile(const std::string& path) {
+    std::ifstream in(path, std::ios::binary | std::ios::ate);
+    if (!in.is_open()) return {};
+    const std::streamsize size = in.tellg();
+    if (size <= 0) return {};
+    in.seekg(0, std::ios::beg);
+    std::vector<unsigned char> bytes(static_cast<std::size_t>(size));
+    if (!in.read(reinterpret_cast<char*>(bytes.data()), size)) return {};
+    return bytes;
+  }
+
+} // namespace
+
+YSE::MIDI::fileImpl::fileImpl(file* head)
+  : head(head), intent(SS_STOPPED), objectStatus(OBJECT_READY), hasFile(false) {
+  for (auto& slot : synths)
+    slot.store(nullptr, std::memory_order_relaxed);
 }
 
-bool YSE::MIDI::fileImpl::create(const std::string& /*fileName*/) {
-  assert(!hasFile);
+YSE::MIDI::fileImpl::~fileImpl() {}
 
-  /*if (!IO().getActive()) {
-    File file = File::getCurrentWorkingDirectory().getChildFile(juce::String(fileName));
-    if (!file.existsAsFile()) {
-      INTERNAL::LogImpl().emit(E_FILE_ERROR, "file not found for " +
-  file.getFullPathName().toStdString()); return false;
-    }
-    FileInputStream * midiFileInputStream = file.createInputStream();
-    midiFile.readFrom(*midiFileInputStream);
+bool YSE::MIDI::fileImpl::create(const std::string& fileName) {
+  // Reset so create() can be re-called (main thread, before play()).
+  hasFile = false;
+  midiEvents.clear();
+  playhead = 0;
+  nextEvent = 0;
+
+  std::vector<unsigned char> data = readWholeFile(fileName);
+  if (data.empty()) {
+    INTERNAL::LogImpl().emit(E_FILE_ERROR, "MIDI file not found or empty: " + fileName);
+    return false;
   }
-  else {
-    if (!INTERNAL::CALLBACK::fileExists(fileName.c_str())) {
-      INTERNAL::LogImpl().emit(E_FILE_ERROR, "file not found for " + fileName);
+
+  std::size_t pos = 0;
+
+  // ---- header chunk (MThd) -------------------------------------------------
+  if (data.size() < 14 || data[0] != 'M' || data[1] != 'T' || data[2] != 'h' || data[3] != 'd') {
+    INTERNAL::LogImpl().emit(E_FILE_ERROR, "Not a standard MIDI file: " + fileName);
+    return false;
+  }
+  pos = 4;
+  const uint32_t headerLen = readU32(data, pos);
+  const std::size_t headerEnd = pos + headerLen;
+  if (headerLen < 6 || headerEnd > data.size()) {
+    INTERNAL::LogImpl().emit(E_FILE_ERROR, "Malformed MIDI header: " + fileName);
+    return false;
+  }
+  pos += 2; // format — Type 0/1/2 are all parsed the same way (merge tracks by time)
+  const uint16_t numTracks = readU16(data, pos);
+  const uint16_t division = readU16(data, pos);
+  pos = headerEnd; // skip any extra header bytes
+
+  // Tick -> time conversion. PPQN (tempo-driven) is the common case; SMPTE is
+  // a fixed tick rate independent of tempo.
+  const bool smpte = (division & 0x8000) != 0;
+  double smpteSamplesPerTick = 0.0;
+  uint32_t ppqn = 96;
+  if (smpte) {
+    const int framesPerSecond = -static_cast<int8_t>(division >> 8);
+    const int ticksPerFrame = division & 0xFF;
+    const double ticksPerSecond = static_cast<double>(framesPerSecond) * ticksPerFrame;
+    if (ticksPerSecond > 0.0)
+      smpteSamplesPerTick = static_cast<double>(SAMPLERATE) / ticksPerSecond;
+  } else {
+    ppqn = division & 0x7FFF;
+    if (ppqn == 0) ppqn = 96; // guard against a zero division
+  }
+
+  // ---- decode every track into (tick, event) pairs -------------------------
+  struct RawEvent {
+    uint64_t tick;
+    unsigned char status;
+    unsigned char data1;
+    unsigned char data2;
+  };
+  std::vector<RawEvent> raw;
+  std::vector<TempoEntry> tempo;
+
+  for (uint16_t t = 0; t < numTracks; ++t) {
+    if (pos + 8 > data.size()) break; // no room for another chunk header
+    const bool isTrack =
+        data[pos] == 'M' && data[pos + 1] == 'T' && data[pos + 2] == 'r' && data[pos + 3] == 'k';
+    pos += 4;
+    const uint32_t trackLen = readU32(data, pos);
+    const std::size_t trackEnd = pos + trackLen;
+    if (trackEnd > data.size()) {
+      INTERNAL::LogImpl().emit(E_FILE_ERROR, "Truncated MIDI track: " + fileName);
       return false;
     }
-    INTERNAL::customFileReader * cfr = new INTERNAL::customFileReader;
-    cfr->create(fileName.c_str());
-    midiFile.readFrom(*cfr);
+    if (!isTrack) {
+      pos = trackEnd; // unknown chunk type — skip it whole
+      continue;
+    }
+
+    uint64_t tick = 0;
+    unsigned char runningStatus = 0;
+
+    while (pos < trackEnd) {
+      uint32_t delta = 0;
+      if (!readVarLen(data, pos, delta) || pos >= trackEnd) {
+        INTERNAL::LogImpl().emit(E_FILE_ERROR, "Malformed MIDI delta-time: " + fileName);
+        return false;
+      }
+      tick += delta;
+
+      unsigned char statusByte = data[pos];
+      if (statusByte & 0x80) {
+        ++pos;
+      } else {
+        // Running status: reuse the previous channel-voice status byte.
+        statusByte = runningStatus;
+        if ((statusByte & 0x80) == 0) {
+          INTERNAL::LogImpl().emit(E_FILE_ERROR, "MIDI running status without status: " + fileName);
+          return false;
+        }
+      }
+
+      if (statusByte == 0xFF) {
+        // Meta event: FF type len data...
+        if (pos >= trackEnd) return false;
+        const unsigned char metaType = data[pos++];
+        uint32_t metaLen = 0;
+        if (!readVarLen(data, pos, metaLen) || pos + metaLen > trackEnd) {
+          INTERNAL::LogImpl().emit(E_FILE_ERROR, "Malformed MIDI meta event: " + fileName);
+          return false;
+        }
+        if (metaType == 0x51 && metaLen == 3) { // set tempo (us per quarter)
+          const uint32_t us = (static_cast<uint32_t>(data[pos]) << 16) |
+                              (static_cast<uint32_t>(data[pos + 1]) << 8) |
+                              static_cast<uint32_t>(data[pos + 2]);
+          tempo.push_back({tick, us, 0.0});
+        }
+        pos += metaLen;
+        runningStatus = 0; // meta cancels running status
+      } else if (statusByte == 0xF0 || statusByte == 0xF7) {
+        // SysEx (or escape): F0/F7 len data... — skipped.
+        uint32_t sysexLen = 0;
+        if (!readVarLen(data, pos, sysexLen) || pos + sysexLen > trackEnd) {
+          INTERNAL::LogImpl().emit(E_FILE_ERROR, "Malformed MIDI sysex event: " + fileName);
+          return false;
+        }
+        pos += sysexLen;
+        runningStatus = 0; // sysex cancels running status
+      } else {
+        // Channel-voice message.
+        runningStatus = statusByte;
+        const int nBytes = channelDataBytes(statusByte);
+        if (pos + static_cast<std::size_t>(nBytes) > trackEnd) {
+          INTERNAL::LogImpl().emit(E_FILE_ERROR, "Truncated MIDI channel message: " + fileName);
+          return false;
+        }
+        const unsigned char d1 = data[pos];
+        const unsigned char d2 = nBytes == 2 ? data[pos + 1] : 0;
+        pos += static_cast<std::size_t>(nBytes);
+        raw.push_back({tick, statusByte, d1, d2});
+      }
+    }
+    pos = trackEnd; // resynchronise to the declared chunk boundary
   }
 
-  midiFile.convertTimestampTicksToSeconds();
-  for (int i = 0; i < midiFile.getNumTracks(); i++) {
-    sequence.addSequence(*midiFile.getTrack(i), 0, 0, midiFile.getTrack(i)->getEndTime() + 1);
+  // ---- build the tempo map and convert ticks to samples --------------------
+  std::stable_sort(tempo.begin(), tempo.end(),
+                   [](const TempoEntry& a, const TempoEntry& b) { return a.tick < b.tick; });
+  if (tempo.empty() || tempo.front().tick != 0) {
+    tempo.insert(tempo.begin(), {0, 500000, 0.0}); // default 120 BPM before any change
   }
-  sequence.sort();
-  sequence.updateMatchedPairs();
+  tempo.front().cumUs = 0.0;
+  for (std::size_t i = 1; i < tempo.size(); ++i) {
+    const uint64_t deltaTicks = tempo[i].tick - tempo[i - 1].tick;
+    tempo[i].cumUs =
+        tempo[i - 1].cumUs + static_cast<double>(deltaTicks) * tempo[i - 1].usPerQuarter / ppqn;
+  }
 
-  hasFile = true;*/
+  auto tickToSample = [&](uint64_t targetTick) -> uint64_t {
+    if (smpte)
+      return static_cast<uint64_t>(
+          std::llround(static_cast<double>(targetTick) * smpteSamplesPerTick));
+    // Last tempo entry whose tick <= targetTick.
+    std::size_t idx = 0;
+    for (std::size_t i = 0; i < tempo.size(); ++i) {
+      if (tempo[i].tick <= targetTick)
+        idx = i;
+      else
+        break;
+    }
+    const double us = tempo[idx].cumUs + static_cast<double>(targetTick - tempo[idx].tick) *
+                                             tempo[idx].usPerQuarter / ppqn;
+    return static_cast<uint64_t>(std::llround(us * static_cast<double>(SAMPLERATE) / 1'000'000.0));
+  };
+
+  midiEvents.reserve(raw.size());
+  for (const RawEvent& e : raw)
+    midiEvents.push_back({tickToSample(e.tick), e.status, e.data1, e.data2});
+
+  // Stable sort so simultaneous events keep their in-file (track) order.
+  std::stable_sort(
+      midiEvents.begin(), midiEvents.end(),
+      [](const fileEvent& a, const fileEvent& b) { return a.sampleTime < b.sampleTime; });
+
+  hasFile = true;
   return true;
 }
 
 void YSE::MIDI::fileImpl::play() {
-  assert(hasFile);
-  intent = SS_WANTSTOPLAY;
+  intent.store(SS_WANTSTOPLAY, std::memory_order_release);
 }
 
 void YSE::MIDI::fileImpl::pause() {
-  assert(hasFile);
-  intent = SS_WANTSTOPAUSE;
+  intent.store(SS_WANTSTOPAUSE, std::memory_order_release);
 }
 
 void YSE::MIDI::fileImpl::stop() {
-  assert(hasFile);
-  intent = SS_WANTSTOSTOP;
+  intent.store(SS_WANTSTOSTOP, std::memory_order_release);
 }
 
-/*void YSE::MIDI::fileImpl::connect(synth * player) {
-  for (auto i = readers.begin(); i != readers.end(); i++) {
-    if (*i == player->pimpl) {
-      // this synth is already connected
-      assert(false);
-      return;
-    }
+// ---- synth wiring (main thread) --------------------------------------------
+
+void YSE::MIDI::fileImpl::connect(SYNTH::interfaceObject* target) {
+  if (target == nullptr) return;
+  int freeIdx = -1;
+  for (std::size_t i = 0; i < kMaxSynths; ++i) {
+    SYNTH::interfaceObject* cur = synths[i].load(std::memory_order_acquire);
+    if (cur == target) return; // already connected
+    if (cur == nullptr && freeIdx < 0) freeIdx = static_cast<int>(i);
   }
-  readers.push_front(player->pimpl);
-  player->pimpl->registerMidiFile(this);
-}
-void YSE::MIDI::fileImpl::disconnect(synth * player) {
-  auto previous = readers.before_begin();
-  for (auto i = readers.begin(); i != readers.end(); i++) {
-    if (*i == player->pimpl) {
-      player->pimpl->removeMidiFile(this);
-      readers.erase_after(previous);
-      return;
-    }
-    previous++;
+  if (freeIdx < 0) {
+    INTERNAL::LogImpl().emit(E_WARNING,
+                             "MIDI::file: synth connection table full, ignoring connect");
+    return;
   }
-  // this synth was not found!
-  assert(false);
+  // Release so advance()'s acquire-load sees a fully-published target pointer.
+  synths[static_cast<std::size_t>(freeIdx)].store(target, std::memory_order_release);
 }
 
-void YSE::MIDI::fileImpl::removeDevice(SYNTH::implementationObject * player) {
-  auto previous = readers.before_begin();
-  for (auto i = readers.begin(); i != readers.end(); i++) {
-    if (*i == player) {
-      readers.erase_after(previous);
+void YSE::MIDI::fileImpl::disconnect(SYNTH::interfaceObject* target) {
+  if (target == nullptr) return;
+  for (auto& slot : synths) {
+    if (slot.load(std::memory_order_acquire) == target) {
+      slot.store(nullptr, std::memory_order_release);
       return;
     }
-    previous++;
   }
 }
-*/
 
-/*
-void YSE::MIDI::fileImpl::getMessages(MidiBuffer & incomingMidi) {
-  switch (intent.load()) {
-    case SS_PLAYING: break;
-    case SS_STOPPED: return;
-    case SS_PAUSED: return;
-    case SS_WANTSTOPAUSE: {
-      for (int i = 1; i < 17; i++) {
-        incomingMidi.addEvent(MidiMessage::allNotesOff(i), 0);
-      }
-      intent = SS_PAUSED;
-      return;
+// ---- playback (audio thread) -----------------------------------------------
 
-    }
-    case SS_WANTSTOSTOP: {
-      for (int i = 1; i < 17; i++) {
-        incomingMidi.addEvent(MidiMessage::allNotesOff(i), 0);
-      }
-      intent = SS_STOPPED;
-      startSample = 0;
-      return;
-    }
-    case SS_WANTSTOPLAY: {
-      intent = SS_PLAYING;
-      break;
-    }
+void YSE::MIDI::fileImpl::advance(int numSamples) {
+  switch (intent.load(std::memory_order_acquire)) {
+  case SS_WANTSTOPLAY:
+    intent.store(SS_PLAYING, std::memory_order_release);
+    break; // start emitting this block
+  case SS_PLAYING:
+    break;
+  case SS_WANTSTOPAUSE:
+    allNotesOffToSynths();
+    intent.store(SS_PAUSED, std::memory_order_release);
+    return;
+  case SS_WANTSTOSTOP:
+    allNotesOffToSynths();
+    playhead = 0;
+    nextEvent = 0;
+    intent.store(SS_STOPPED, std::memory_order_release);
+    return;
+  default: // SS_STOPPED / SS_PAUSED — idle
+    return;
   }
 
-  Int currentEvent = sequence.getNextIndexAtTime(startSample / (double)SAMPLERATE);
-  Int currentSample = (Int)(sequence.getEventTime(currentEvent) * SAMPLERATE);
+  if (!hasFile || numSamples <= 0) return;
 
-  while ((currentSample - startSample) < (Int)STANDARD_BUFFERSIZE && currentEvent <
-sequence.getNumEvents()) { incomingMidi.addEvent(sequence.getEventPointer(currentEvent)->message,
-currentSample - startSample); currentEvent++; currentSample =
-(Int)(sequence.getEventTime(currentEvent) * SAMPLERATE);
+  const uint64_t blockEnd = playhead + static_cast<uint64_t>(numSamples);
+  while (nextEvent < midiEvents.size() && midiEvents[nextEvent].sampleTime < blockEnd) {
+    dispatchEvent(midiEvents[nextEvent]);
+    ++nextEvent;
   }
+  playhead = blockEnd;
 
-  if (currentEvent > sequence.getNumEvents()) {
-    intent = SS_STOPPED;
-    startSample = 0;
+  if (nextEvent >= midiEvents.size()) {
+    // One-shot playback: release held notes and rewind to the start.
+    allNotesOffToSynths();
+    playhead = 0;
+    nextEvent = 0;
+    intent.store(SS_STOPPED, std::memory_order_release);
   }
-  else {
-    startSample += STANDARD_BUFFERSIZE;
+}
+
+void YSE::MIDI::fileImpl::dispatchEvent(const fileEvent& event) {
+  const unsigned char statusNibble = event.status & 0xF0;
+  const unsigned char channelNibble = event.status & 0x0F;
+  for (auto& slot : synths) {
+    SYNTH::interfaceObject* s = slot.load(std::memory_order_acquire);
+    if (s != nullptr)
+      routeChannelVoiceMessage(*s, statusNibble, channelNibble, event.data1, event.data2);
   }
-  return;
-}*/
+}
+
+void YSE::MIDI::fileImpl::allNotesOffToSynths() {
+  for (auto& slot : synths) {
+    SYNTH::interfaceObject* s = slot.load(std::memory_order_acquire);
+    if (s != nullptr) s->allNotesOff(0);
+  }
+}
+
+// ---- lifecycle -------------------------------------------------------------
 
 void YSE::MIDI::fileImpl::removeInterface() {
   head.store(nullptr);

--- a/YseEngine/midi/midifileImplementation.h
+++ b/YseEngine/midi/midifileImplementation.h
@@ -11,11 +11,13 @@
 #ifndef MIDIFILEIMPLEMENTATION_H_INCLUDED
 #define MIDIFILEIMPLEMENTATION_H_INCLUDED
 
-#include <string>
+#include <array>
 #include <atomic>
+#include <cstdint>
+#include <string>
+#include <vector>
 #include "../internalHeaders.h"
-// #include "../synth/synthImplementation.h"
-#include <forward_list>
+#include "../synth/synth.hpp" // YSE::synth / SYNTH::interfaceObject forward decls
 
 namespace YSE {
   namespace MIDI {
@@ -25,20 +27,36 @@ namespace YSE {
       fileImpl(file* head);
       ~fileImpl();
 
+      // ---- main thread -----------------------------------------------------
+
+      /** Parse a standard MIDI file into the block-accurate event list. Reads
+          the file off the audio thread (main thread). @return true on success. */
       bool create(const std::string& fileName);
 
       void play();
       void pause();
       void stop();
 
-      // void connect   (synth * player);
-      // void disconnect(synth * player);
+      /** Wire this file's playback to a synth. Every channel-voice event in the
+          file is delivered to ``target``'s inbox as playback advances (§10 of
+          docs/design/synth_core.md lists MIDI-file playback as a synth control
+          producer). The synth must outlive the connection (disconnect, or
+          destroy the file, before destroying the synth). Main-thread only. */
+      void connect(SYNTH::interfaceObject* target);
 
-      // void getMessages(MidiBuffer & incomingMidi);
+      /** Stop delivering this file's events to ``target``. Main-thread only. */
+      void disconnect(SYNTH::interfaceObject* target);
 
-      // this is called only by a synth destructor which still
-      // has pointers to this file acive
-      // void removeDevice(SYNTH::implementationObject * player);
+      // ---- audio thread ----------------------------------------------------
+
+      /** Advance playback by ``numSamples`` and push every event that falls in
+          this block onto the connected synths' inboxes. Called once per audio
+          callback from MIDI::managerObject::updatePlayback(). Allocation-free,
+          lock-free — every event is pre-parsed and every push is a non-blocking
+          try_push (§11). */
+      void advance(int numSamples);
+
+      // ---- lifecycle -------------------------------------------------------
 
       // Called by the main thread from ~file(); publishes head==null so the
       // audio thread observes the orphaned impl on its next update() tick.
@@ -59,13 +77,33 @@ namespace YSE {
         return impl.objectStatus.load() == OBJECT_DELETE;
       }
 
+      // ---- parsed representation (also read by tests) ----------------------
+
+      /** One decoded channel-voice event at an absolute sample position. Meta,
+          tempo and SysEx events are consumed during parsing (tempo feeds the
+          tick->sample conversion) and are not stored here. */
+      struct fileEvent {
+        uint64_t sampleTime; // absolute sample offset from playback start
+        unsigned char status; // full status byte, incl. channel nibble
+        unsigned char data1;
+        unsigned char data2;
+      };
+
+      /** The decoded, time-sorted event list. Built by create() on the main
+          thread; immutable during playback. Exposed for the parser tests. */
+      const std::vector<fileEvent>& events() const {
+        return midiEvents;
+      }
+
     private:
+      // Deliver one decoded event to every connected synth (audio thread).
+      void dispatchEvent(const fileEvent& event);
+      // Release every held note on every connected synth (pause / stop / EOT).
+      void allNotesOffToSynths();
+
       // Interface object. Atomic: the main thread nulls it in removeInterface()
       // while the audio thread reads it in hasInterface() (issue #190).
       std::atomic<file*> head;
-
-      // MidiFile midiFile;
-      // MidiMessageSequence sequence;
 
       std::atomic<SOUND_STATUS> intent;
 
@@ -75,9 +113,22 @@ namespace YSE {
       std::atomic<OBJECT_IMPLEMENTATION_STATE> objectStatus;
 
       bool hasFile;
-      // int startSample;
 
-      // std::forward_list<YSE::SYNTH::implementationObject *> readers;
+      // Decoded events, sorted by sampleTime. Written only by create() (main
+      // thread, before play()); read by advance() (audio thread). The intent
+      // release/acquire on play() publishes it to the audio thread.
+      std::vector<fileEvent> midiEvents;
+
+      // Playback cursor — audio-thread only (seeded by create() before play()).
+      uint64_t playhead = 0; // absolute sample position
+      std::size_t nextEvent = 0; // index of the next event to fire
+
+      // Connected synths (§9 caller-owned lifetime). A fixed-size atomic table
+      // so connect/disconnect (main thread) never lock and advance() (audio
+      // thread) never allocates. 0 = all channels; the file carries channel in
+      // each event's status byte, so no per-connection channel filter is needed.
+      static constexpr std::size_t kMaxSynths = 8;
+      std::array<std::atomic<SYNTH::interfaceObject*>, kMaxSynths> synths;
     };
 
   } // namespace MIDI

--- a/YseEngine/midi/midifileManager.cpp
+++ b/YseEngine/midi/midifileManager.cpp
@@ -89,3 +89,12 @@ void YSE::MIDI::managerObject::update() {
     ++i;
   }
 }
+
+void YSE::MIDI::managerObject::updatePlayback(int numSamples) {
+  // Audio-thread-owned working list — safe to walk here (same thread that
+  // drains it in update()). Each file advances its own clock and pushes any
+  // events for this block onto its connected synths' inboxes.
+  for (fileImpl* impl : inUse) {
+    impl->advance(numSamples);
+  }
+}

--- a/YseEngine/midi/midifileManager.h
+++ b/YseEngine/midi/midifileManager.h
@@ -32,6 +32,13 @@ namespace YSE {
       fileImpl* addImplementation(file* head);
       void update();
 
+      /** Advance every live file's playback by ``numSamples`` and push the
+          events that fall in this block onto their connected synths (issue
+          #155). Called once per audio callback, separately from update()'s
+          lifecycle tick, so playback stays block-accurate (mirrors how
+          PLAYER::Manager().update() is driven every callback). Audio thread. */
+      void updatePlayback(int numSamples);
+
     private:
       // Canonical list of all fileImpls. Touched by the main thread
       // (addImplementation emplace_front) and by the slow-pool deleteJob


### PR DESCRIPTION
## Summary

Routes the two MIDI inputs the engine already supports — hardware **device
input** and standard **MIDI file** playback — into `YSE::synth`, by pushing
`SYNTH::MESSAGE` ops onto the synth's lock-free SPSC inbox. Implements the
`#155` slice of the synth-core contract (`docs/design/synth_core.md`).

Two commented-out call sites the epic (#150) deliberately preserved are
revived here — `MIDI::file::connect(synth&)` / `disconnect` — against the
engine-native synth API rather than the removed JUCE code.

## Linked issue

Closes #155

## Changes

**Shared mapping**
- `midi/midiSynthRouting.hpp` (new): the single, templated, unit-tested place
  raw 7-bit / 14-bit MIDI is normalized onto the synth note API — velocity /
  CC / aftertouch → `[0,1]`, pitch bend → `[-1,1]`, velocity-0 note-on → note-off,
  MIDI channel `0..15` → synth channel `1..16`. Used by both input paths.

**MIDI file → synth**
- `midifileImplementation.*`: a from-scratch Standard MIDI File parser
  (`MThd`/`MTrk`, variable-length quantities, running status, tempo map →
  sample-time conversion incl. PPQN + SMPTE, meta/SysEx skipping). `create()`
  decodes the file into a time-sorted event list off the audio thread; bounds
  checked so a malformed file fails rather than crashes.
- `advance(numSamples)` (audio thread) emits each block's events to connected
  synths and honours play/pause/stop; connections live in a fixed-size atomic
  table (`connect`/`disconnect`, main thread).
- `midifileManager::updatePlayback(numSamples)` walks the audio-thread-owned
  file list; `deviceManager` drives it once per callback next to the player, so
  file events reach the synth **block-accurately**, before the synths render.

**MIDI device → synth** (gated by `YSE_ENABLE_MIDI_DEVICE`)
- `midiIn::connect(synth, channelFilter)` / `disconnect`; `dispatch()` fans
  channel-voice messages out to connected synths on RtMidi's input thread —
  the additive-subscriber hook the port hub was explicitly left open for (#52).

## Design / RT-safety notes

- **No allocation / lock / block on any audio path.** Every push is a
  non-allocating `try_push`; the file→synth and device→synth connection tables
  are fixed-size atomic arrays, so neither the audio thread nor RtMidi's input
  thread ever locks or allocates. Events are pre-parsed off the audio thread.
- The synth is driven through its **public note API** (`noteOn`/`controller`/…),
  exactly as `synth_core.md` §10 describes the MIDI-in producer — so no new
  coupling or friendship is added to the synth.
- Lifetime is caller-owned and documented (disconnect, or destroy the source,
  before destroying the synth), consistent with the engine's other couplings.
- **Android unaffected:** all device/RtMidi additions sit inside the existing
  `YSE_ENABLE_MIDI_DEVICE` guard; the file path is portable (`std::ifstream`).

## Test plan

- [x] `clang-format` 22.1.4 clean on all changed files (matches the CI gate).
- [x] `python yse.py analyze` clean on every changed `.cpp` — no new findings.
      (The one pre-existing `deviceManager.cpp:17` virtual-call-in-dtor finding
      is baseline, untouched by this change.)
- [x] `python yse.py test` — **20/20 ctest suites pass, 0 failed**.
  - `yse_tests_midi` (84 cases): +12 raw-MIDI→synth mapping (recording sink,
    every message type), +4 SMF-parser cases (fixture decode, sort order,
    missing-file + garbage rejection).
  - `yse_tests_midisynth` (3 cases, **new isolated process**): end-to-end
    file-playback → synth and device-input → synth event-log comparison, plus
    device channel-filter gating. Isolated like `synthlifecycle` because it
    drives `System::close()` — contains the pre-existing #298 teardown fragility.
  - `synthlifecycle`, `integration` and all other suites still green.

## Notes / possible follow-ups (out of scope for #155)

- MIDI file loading uses `std::ifstream`, so Android **asset**-backed `.mid`
  loading (the old JUCE IO path) is not wired up. No regression — that path was
  non-functional after the JUCE removal — but a candidate follow-up if wanted.
- A synth should be driven by a single MIDI source at a time (the "one producer
  per impl" SPSC constraint from `synth_core.md` §10); connecting a device *and*
  a file to the same synth is unsupported by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
