### PR TITLE
C-API: Synth surface (#157)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(YSE_TEST_SOURCES
   synth/test_synth.cpp
   synth/test_synth_keyboard.cpp
   synth/test_synth_close.cpp
+  synth/test_c_api_synth.cpp
   reverb/test_reverb_dsp.cpp
   reverb/test_reverb_concurrency.cpp
   midi/test_midifile.cpp
@@ -167,11 +168,12 @@ set_target_properties(yse_tests PROPERTIES
 if(NOT ANDROID)
 add_test(
   NAME    yse_unit_tests
-  # `lifecycle`, `synthlifecycle`, `midisynth` and `playersynth` are excluded
-  # alongside `integration`: they drive System::close(), which permanently stops
-  # the global thread pools and would break every later suite sharing this
+  # `lifecycle`, `synthlifecycle`, `synthcapi`, `midisynth` and `playersynth` are
+  # excluded alongside `integration`: they drive System::close(), which permanently
+  # stops the global thread pools and would break every later suite sharing this
   # process. Each runs in its own process via yse_tests_lifecycle /
-  # yse_tests_synthlifecycle / yse_tests_midisynth / yse_tests_playersynth.
+  # yse_tests_synthlifecycle / yse_tests_synthcapi / yse_tests_midisynth /
+  # yse_tests_playersynth.
   #
   # `* concurrency: *` (the cross-subsystem create/destroy + race stress cases:
   # channel/sound/reverb/io/listener/midifile) is excluded here too and runs
@@ -184,7 +186,7 @@ add_test(
   # suite exclusions above and loses no coverage: yse_tests_concurrency plus the
   # per-suite entries still run every case. Tracked in #304; the root fix is
   # #41/#298 engine work.
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,midisynth,playersynth "--test-case-exclude=* concurrency: *" --duration=true
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthcapi,midisynth,playersynth "--test-case-exclude=* concurrency: *" --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -270,6 +272,19 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_synthlifecycle PROPERTIES LABELS "synth;lifecycle")
+
+# C-API synth surface (issue #157). Drives the synth entirely through the flat
+# C ABI under an offline engine (yse_system_init_offline), then yse_system_close().
+# Isolated in its own process for the same reason as yse_tests_synthlifecycle:
+# System::close() tears down process-global state (thread pools) the rest of the
+# suite assumes stays up (#298). initOffline() needs no audio hardware, so it
+# runs in CI.
+add_test(
+  NAME    yse_tests_synthcapi
+  COMMAND yse_tests --test-suite=synthcapi
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_synthcapi PROPERTIES LABELS "synth;c-api;lifecycle")
 
 add_test(
   NAME    yse_tests_midi

--- a/Tests/synth/test_c_api_synth.cpp
+++ b/Tests/synth/test_c_api_synth.cpp
@@ -1,0 +1,268 @@
+// C-API synth surface tests (issue #157) — exercises YseEngine/c_api/yse_synth.*
+// entirely through the flat C ABI (no engine C++ headers), mirroring the C++
+// synth coverage in test_synth.cpp / test_synth_keyboard.cpp at the C surface.
+//
+// The engine is driven offline (yse_system_init_offline + render_offline), so
+// no audio hardware is needed and the suite runs in CI. Because it calls
+// yse_system_close() it lives in its own TEST_SUITE("synthcapi") and its own
+// ctest process (see Tests/CMakeLists.txt) — the same isolation the
+// synthlifecycle / midisynth / playersynth suites use, keeping System::close()'s
+// process-global teardown out of the crowded combined suite (#298/#304).
+
+#include <doctest/doctest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "yse_c/yse_synth.h"
+#include "yse_c/yse_sound.h"
+#include "yse_c/yse_system.h"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+  // Pump the engine offline until the synth has cloned `expected` voices (i.e.
+  // reached OBJECT_READY on the setup pool) or the budget expires. Mirrors the
+  // drain() helper the C++ playersynth/midisynth suites use, but through the C
+  // surface: update() flags the managers, render_offline() runs the audio
+  // callback that promotes setup and renders a block.
+  bool drainUntilVoices(YseSystem* sys, YseSynth* syn, int expected,
+                        std::chrono::milliseconds budget = 2000ms) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 1);
+      if (yse_synth_get_num_voices(syn) >= expected) return true;
+      std::this_thread::sleep_for(2ms);
+    }
+    return yse_synth_get_num_voices(syn) >= expected;
+  }
+
+  // Render `blocks` offline blocks so queued note/control events are drained on
+  // the audio thread and any release tails advance.
+  void render(YseSystem* sys, int blocks) {
+    for (int i = 0; i < blocks; ++i) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 1);
+    }
+  }
+
+  // Pump the engine for `budget` so the manager delete jobs run on the setup
+  // pool and released sound/synth impls are fully freed BEFORE yse_system_close()
+  // tears down the thread pools. Skipping this races teardown against the
+  // pending deletes (the #298/#304 lineage) and can segfault at close. Mirrors
+  // the drain() the C++ playersynth/midisynth suites run before System::close().
+  void drainFor(YseSystem* sys, std::chrono::milliseconds budget) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 1);
+      std::this_thread::sleep_for(2ms);
+    }
+  }
+
+  // ---- note-callback probe (issue #157 §7 hook) ------------------------------
+  // Captureless C function pointer, per the onNoteEvent contract. Counts the
+  // events it sees and transposes every note up an octave in place — the
+  // transpose proves the hook can rewrite the note before allocation, and doing
+  // it on note-off as well as note-on keeps a released note matching its
+  // note-on's rewritten identity (docs/design/synth_core.md §7).
+  std::atomic<int> g_noteOnCalls{0};
+  std::atomic<int> g_noteOffCalls{0};
+
+  void YSE_C_CALLBACK testNoteCb(int note_on, float* note_number, float* velocity) {
+    (void)velocity;
+    if (note_number) *note_number += 12.0f;
+    if (note_on) {
+      g_noteOnCalls.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      g_noteOffCalls.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("synthcapi") {
+
+  // ─── null-handle safety (no engine required) ──────────────────────────────
+
+  TEST_CASE("c-api synth: NULL handles are null-safe") {
+    CHECK(yse_synth_is_valid(nullptr) == 0);
+    CHECK(yse_synth_get_num_voices(nullptr) == 0);
+    CHECK(yse_synth_add_voices_sine(nullptr, 4, 0, 0, 127, 0.01f, 0.1f, 0.8f, 0.2f) ==
+          YSE_ERR_INVALID_HANDLE);
+    CHECK(yse_synth_attach_to_sound(nullptr, nullptr, nullptr, 1.0f) == YSE_ERR_INVALID_HANDLE);
+
+    // Void entry points must no-op, not crash, on a NULL handle.
+    yse_synth_note_on(nullptr, 1, 60, 1.0f);
+    yse_synth_note_off(nullptr, 1, 60, 0.0f);
+    yse_synth_all_notes_off(nullptr, 0);
+    yse_synth_pitch_wheel(nullptr, 1, 0.5f);
+    yse_synth_controller(nullptr, 1, 74, 0.5f);
+    yse_synth_aftertouch(nullptr, 1, 60, 0.5f);
+    yse_synth_sustain(nullptr, 1, 1);
+    yse_synth_sostenuto(nullptr, 1, 1);
+    yse_synth_soft_pedal(nullptr, 1, 1);
+    yse_synth_set_note_callback(nullptr, &testNoteCb);
+    yse_synth_destroy(nullptr);
+  }
+
+  // ─── build, attach, and drive a polyphonic note sequence ──────────────────
+
+  TEST_CASE("c-api synth: build, attach, and drive a polyphonic sequence") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return; // unavailable → skip
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    CHECK(yse_synth_is_valid(syn) == 1);
+
+    // Invalid voice count is rejected before any group is recorded.
+    CHECK(yse_synth_add_voices_sine(syn, 0, 0, 0, 127, 0.01f, 0.1f, 0.8f, 0.2f) ==
+          YSE_ERR_INVALID_ARGUMENT);
+
+    // 8-voice omni pool, snappy envelope so releases finish quickly.
+    REQUIRE(yse_synth_add_voices_sine(syn, 8, 0, 0, 127, 0.001f, 0.001f, 1.0f, 0.05f) == YSE_OK);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    CHECK(yse_sound_is_valid(snd) == 1);
+    yse_sound_play(snd);
+
+    // Setup pool clones the voices; wait until the pool is playable.
+    REQUIRE(drainUntilVoices(sys, syn, 8));
+    CHECK(yse_synth_get_num_voices(syn) == 8);
+
+    // Sound a C-major triad, then exercise the full control surface.
+    yse_synth_note_on(syn, 1, 60, 1.0f);
+    yse_synth_note_on(syn, 1, 64, 0.8f);
+    yse_synth_note_on(syn, 1, 67, 0.6f);
+    render(sys, 4);
+
+    yse_synth_pitch_wheel(syn, 1, 0.25f);
+    yse_synth_controller(syn, 1, 74, 0.5f); // non-pedal CC → stored
+    yse_synth_aftertouch(syn, 1, 60, 0.7f); // per-note pressure
+    yse_synth_aftertouch(syn, 1, -1, 0.4f); // channel-wide pressure
+    render(sys, 2);
+
+    // Sustain pedal: note-offs defer until the pedal lifts.
+    yse_synth_sustain(syn, 1, 1);
+    yse_synth_note_off(syn, 1, 60, 0.0f);
+    yse_synth_note_off(syn, 1, 64, 0.0f);
+    render(sys, 2);
+    yse_synth_sustain(syn, 1, 0); // release the sustained notes now
+    render(sys, 2);
+
+    // Sostenuto + soft pedal smoke, then a hard bulk release.
+    yse_synth_sostenuto(syn, 1, 1);
+    yse_synth_soft_pedal(syn, 1, 1);
+    yse_synth_note_on(syn, 1, 72, 0.9f);
+    render(sys, 2);
+    yse_synth_soft_pedal(syn, 1, 0);
+    yse_synth_sostenuto(syn, 1, 0);
+    yse_synth_all_notes_off(syn, 0);
+    render(sys, 8);
+
+    // The synth and its voice pool survive the whole sequence intact.
+    CHECK(yse_synth_is_valid(syn) == 1);
+    CHECK(yse_synth_get_num_voices(syn) == 8);
+
+    yse_sound_destroy(snd); // sound must go before the synth it renders
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms); // let the delete jobs free the impls before close
+    yse_system_close(sys);
+  }
+
+  // ─── onNoteEvent hook installs, fires on the audio thread, and clears ─────
+
+  TEST_CASE("c-api synth: note callback fires and clears") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return;
+
+    g_noteOnCalls.store(0, std::memory_order_relaxed);
+    g_noteOffCalls.store(0, std::memory_order_relaxed);
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    REQUIRE(yse_synth_add_voices_sine(syn, 4, 0, 0, 127, 0.001f, 0.001f, 1.0f, 0.02f) == YSE_OK);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 1.0f) == YSE_OK);
+    yse_sound_play(snd);
+    REQUIRE(drainUntilVoices(sys, syn, 4));
+
+    // Install the hook, then drive note-ons/offs; the hook fires inside the
+    // offline render (audio thread), before allocation.
+    yse_synth_set_note_callback(syn, &testNoteCb);
+    yse_synth_note_on(syn, 1, 60, 1.0f);
+    yse_synth_note_on(syn, 1, 62, 1.0f);
+    render(sys, 3);
+    yse_synth_note_off(syn, 1, 60, 0.0f);
+    yse_synth_note_off(syn, 1, 62, 0.0f);
+    render(sys, 3);
+
+    CHECK(g_noteOnCalls.load(std::memory_order_relaxed) == 2);
+    CHECK(g_noteOffCalls.load(std::memory_order_relaxed) == 2);
+
+    // Clear the hook: subsequent events must not reach it.
+    yse_synth_set_note_callback(syn, nullptr);
+    const int onsBefore = g_noteOnCalls.load(std::memory_order_relaxed);
+    yse_synth_note_on(syn, 1, 64, 1.0f);
+    render(sys, 3);
+    CHECK(g_noteOnCalls.load(std::memory_order_relaxed) == onsBefore);
+
+    yse_synth_all_notes_off(syn, 0);
+    render(sys, 4);
+
+    yse_sound_destroy(snd);
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms); // let the delete jobs free the impls before close
+    yse_system_close(sys);
+  }
+
+  // ─── split keyboard: several groups sum into one voice count ──────────────
+
+  TEST_CASE("c-api synth: split keyboard builds multiple groups") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return;
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    // Bass below C3, lead C3 and up — both on channel 1.
+    REQUIRE(yse_synth_add_voices_sine(syn, 4, 1, 0, 47, 0.005f, 0.05f, 0.8f, 0.1f) == YSE_OK);
+    REQUIRE(yse_synth_add_voices_sine(syn, 6, 1, 48, 127, 0.005f, 0.05f, 0.8f, 0.1f) == YSE_OK);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.7f) == YSE_OK);
+    yse_sound_play(snd);
+
+    REQUIRE(drainUntilVoices(sys, syn, 10));
+    CHECK(yse_synth_get_num_voices(syn) == 10);
+
+    // A low note lands in the bass group, a high note in the lead group.
+    yse_synth_note_on(syn, 1, 36, 1.0f);
+    yse_synth_note_on(syn, 1, 72, 1.0f);
+    render(sys, 4);
+    yse_synth_all_notes_off(syn, 1);
+    render(sys, 6);
+
+    CHECK(yse_synth_get_num_voices(syn) == 10);
+
+    yse_sound_destroy(snd);
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms); // let the delete jobs free the impls before close
+    yse_system_close(sys);
+  }
+
+} // TEST_SUITE("synthcapi")

--- a/YseEngine/c_api/CMakeLists.txt
+++ b/YseEngine/c_api/CMakeLists.txt
@@ -26,6 +26,7 @@ set(YSE_C_API_SRCS
   yse_patcher.cpp
   yse_midi.cpp
   yse_music.cpp
+  yse_synth.cpp
   yse_log.cpp
   yse_buffer_io.cpp
   yse_python.cpp

--- a/YseEngine/c_api/include/yse_c/yse_all.h
+++ b/YseEngine/c_api/include/yse_c/yse_all.h
@@ -19,6 +19,7 @@
 #include "yse_patcher.h"
 #include "yse_midi.h"
 #include "yse_music.h"
+#include "yse_synth.h"
 #include "yse_log.h"
 #include "yse_buffer_io.h"
 #include "yse_python.h"

--- a/YseEngine/c_api/include/yse_c/yse_synth.h
+++ b/YseEngine/c_api/include/yse_c/yse_synth.h
@@ -1,0 +1,143 @@
+/*
+  yse_synth.h — polyphonic synthesiser voice pool rendered behind one sound.
+  C ABI mirror of YseEngine/synth/synthInterface.hpp (YSE::synth) and
+  §12 ("Public API surface") of docs/design/synth_core.md.
+
+  A synth owns polyphony, voice allocation, stealing and keyboard/pedal
+  state; you drive it with note, controller and pedal events. Build the
+  voice pool from a built-in voice type with yse_synth_add_voices_*, attach
+  it behind a positioned sound with yse_synth_attach_to_sound(), then play
+  notes. Cloning happens off the audio thread on the engine's setup pool, so
+  a synth becomes playable a short moment after add-voices returns (poll
+  yse_synth_get_num_voices() for the cloned count) — exactly like a
+  file-backed sound is not playable until its buffer finishes loading.
+
+  Scope: only the BUILT-IN reference voice (sine + ADSR, issue #152) is
+  exposed, via yse_synth_add_voices_sine. Defining a custom dspVoice
+  subclass from C is deliberately DEFERRED — it needs the same audio-thread
+  dspSourceObject callback plumbing that keeps dspSourceObject unwrapped
+  (see yse_dsp.h and docs/design/synth_core.md §1 non-goals). Instrument
+  voices (#148) will add more yse_synth_add_voices_* variants later.
+
+  Convention: every void-returning function in this header is a null-safe
+  no-op when called with a NULL handle. Status queries return 0 / false on
+  NULL. Operations that can fail (add-voices, attach) return YseStatus and
+  populate yse_last_error() on failure. Channels follow the engine's synth
+  API: 0 = omni / all channels, 1..16 = a specific MIDI channel. Velocity,
+  controller and aftertouch values are normalised to [0, 1]; the pitch wheel
+  to [-1, 1].
+*/
+
+#ifndef YSE_C_SYNTH_H_INCLUDED
+#define YSE_C_SYNTH_H_INCLUDED
+
+#include "yse_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Owned — release with yse_synth_destroy. The handle also owns the built-in
+   voice prototypes created by yse_synth_add_voices_*, freeing them on
+   destroy; keep the synth alive until after any sound rendering it is
+   destroyed (see yse_synth_attach_to_sound). */
+typedef struct YseSynth YseSynth;
+
+/* Forward declarations — see yse_sound.h / yse_channel.h for ownership. */
+typedef struct YseSound YseSound;
+typedef struct YseChannel YseChannel;
+
+/* Audio-thread note-rewrite hook, mirroring YSE::synth::onNoteEvent
+   (docs/design/synth_core.md §7). Invoked by the engine on the AUDIO THREAD
+   for every note-on / note-off, before keyboard bookkeeping and voice
+   allocation. It may rewrite *note_number and *velocity in place — the
+   classic use is transposition, retuning, velocity curves or note filtering.
+
+   note_on is 1 for a note-on, 0 for a note-off. Same real-time rules as a
+   voice's render: no allocation, no locks, no blocking I/O. There is no
+   user_data slot — the engine hook is a bare captureless function pointer,
+   so state must be reached through globals (matches the C++ API, which
+   accepts only a free function / captureless lambda). */
+typedef void(YSE_C_CALLBACK* YseSynthNoteCallback)(int note_on, float* note_number,
+                                                   float* velocity);
+
+/* ─── lifecycle ───────────────────────────────────────────────────────── */
+
+/* Create and register a synth. Ready to receive add-voices and note events
+   immediately (runs the C++ constructor and YSE::synth::create()). Returns
+   NULL on allocation failure with yse_last_error() set. */
+YSE_C_API YseSynth* yse_synth_create(void);
+YSE_C_API void yse_synth_destroy(YseSynth* h);
+
+/* Whether the synth has a live implementation (registered with the engine). */
+YSE_C_API int yse_synth_is_valid(YseSynth* h);
+
+/* ─── voice groups (built-in voices only) ─────────────────────────────── */
+
+/* Add a group of `num_voices` built-in sine voices (sine oscillator shaped
+   by an ADSR envelope) responding to note numbers in
+   [lowest_note, highest_note] on `channel` (0 = omni). May be called several
+   times to build layered or split keyboards. attack / decay / release are in
+   seconds; sustain is a level in [0, 1]. Must be called before the synth is
+   played; adding voices after the pool is built is rejected (a non-goal, see
+   docs/design/synth_core.md §1). Returns YseStatus; on failure yse_last_error()
+   is set and no group is added. */
+YSE_C_API YseStatus yse_synth_add_voices_sine(YseSynth* h, int num_voices, int channel,
+                                              int lowest_note, int highest_note, float attack,
+                                              float decay, float sustain, float release);
+
+/* Total number of allocated (cloned) voices across every group. Zero until
+   the setup pool finishes cloning; poll it to know the synth is playable. */
+YSE_C_API int yse_synth_get_num_voices(YseSynth* h);
+
+/* ─── notes and control ───────────────────────────────────────────────── */
+
+/* Start / release a note. velocity is normalised to [0, 1]. */
+YSE_C_API void yse_synth_note_on(YseSynth* h, int channel, int note_number, float velocity);
+YSE_C_API void yse_synth_note_off(YseSynth* h, int channel, int note_number, float velocity);
+
+/* Release every held note on `channel` (0 = all channels). A bulk note-off:
+   voices enter their normal release, they are not cut. */
+YSE_C_API void yse_synth_all_notes_off(YseSynth* h, int channel);
+
+/* Bend every voice on `channel`. value is normalised to [-1, 1] (0 = centre). */
+YSE_C_API void yse_synth_pitch_wheel(YseSynth* h, int channel, float value);
+
+/* Send a control-change. value is normalised to [0, 1]. CC 64 / 66 / 67 act
+   as the sustain / sostenuto / soft pedals; other CC numbers are stored as
+   the channel's last controller value. */
+YSE_C_API void yse_synth_controller(YseSynth* h, int channel, int number, float value);
+
+/* Apply aftertouch pressure, normalised to [0, 1]. note_number == -1 is
+   channel-wide; otherwise only the voice(s) sounding that note receive it. */
+YSE_C_API void yse_synth_aftertouch(YseSynth* h, int channel, int note_number, float value);
+
+/* Pedals (down is a boolean: non-zero = down). */
+YSE_C_API void yse_synth_sustain(YseSynth* h, int channel, int down);
+YSE_C_API void yse_synth_sostenuto(YseSynth* h, int channel, int down);
+YSE_C_API void yse_synth_soft_pedal(YseSynth* h, int channel, int down);
+
+/* Install (or clear, with NULL) the audio-thread note-rewrite hook. The
+   engine stores the pointer atomically; passing NULL disables the hook.
+   See the YseSynthNoteCallback contract above. */
+YSE_C_API void yse_synth_set_note_callback(YseSynth* h, YseSynthNoteCallback cb);
+
+/* ─── attachment ──────────────────────────────────────────────────────── */
+
+/* Render this synth behind `sound`, which supplies the single 3D position,
+   channel routing and master play/stop intent (mirrors the C++
+   YSE::sound::create(synth&, channel*, volume)). Build the synth's voices
+   with yse_synth_add_voices_* before calling this. `channel` may be NULL for
+   the master channel. volume is a linear gain.
+
+   Lifetime: the synth must outlive the sound — destroy the sound before the
+   synth. Returns YseStatus; on failure (e.g. the sound could not be created)
+   yse_last_error() is set. */
+YSE_C_API YseStatus yse_synth_attach_to_sound(YseSynth* h, YseSound* sound, YseChannel* channel,
+                                              float volume);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/YseEngine/c_api/yse_synth.cpp
+++ b/YseEngine/c_api/yse_synth.cpp
@@ -1,0 +1,171 @@
+#include "yse_c/yse_synth.h"
+#include "yse_c_internal.hpp"
+
+#include "../synth/synthInterface.hpp"
+#include "../synth/sineVoice.hpp"
+#include "../synth/dspVoice.hpp"
+#include "../sound/soundInterface.hpp"
+#include "../channel/channelInterface.hpp"
+
+#include <exception>
+#include <memory>
+#include <vector>
+
+namespace {
+
+  // A synth handle owns its YSE::synth plus the built-in voice prototypes
+  // handed to addVoices(). The engine records a raw prototype pointer at
+  // add-voices time and clones from it LATER, on the setup pool
+  // (docs/design/synth_core.md §3/§8) — it never copies or owns the
+  // prototype. So the C API must keep each prototype alive past setup; the
+  // simplest correct owner is the handle itself, freeing them on destroy.
+  // All allocation here happens on the control thread (never the audio
+  // thread), matching the C++ contract.
+  struct YseSynthImpl {
+    YSE::synth synth;
+    std::vector<std::unique_ptr<YSE::SYNTH::dspVoice>> prototypes;
+  };
+
+  inline YseSynthImpl* to_impl(YseSynth* h) {
+    return reinterpret_cast<YseSynthImpl*>(h);
+  }
+  inline YSE::sound* to_cpp(YseSound* s) {
+    return reinterpret_cast<YSE::sound*>(s);
+  }
+  inline YSE::channel* to_cpp(YseChannel* ch) {
+    return reinterpret_cast<YSE::channel*>(ch);
+  }
+
+} // namespace
+
+extern "C" {
+
+// ─── lifecycle ─────────────────────────────────────────────────────────
+
+YSE_C_API YseSynth* yse_synth_create(void) {
+  try {
+    auto* impl = new YseSynthImpl();
+    impl->synth.create(); // register with the engine so the handle is live
+    return reinterpret_cast<YseSynth*>(impl);
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("yse_synth_create: unknown C++ exception");
+    return nullptr;
+  }
+}
+
+YSE_C_API void yse_synth_destroy(YseSynth* h) {
+  if (h) delete to_impl(h);
+}
+
+YSE_C_API int yse_synth_is_valid(YseSynth* h) {
+  return h && to_impl(h)->synth.isValid() ? 1 : 0;
+}
+
+// ─── voice groups (built-in voices only) ───────────────────────────────
+
+YSE_C_API YseStatus yse_synth_add_voices_sine(YseSynth* h, int num_voices, int channel,
+                                              int lowest_note, int highest_note, float attack,
+                                              float decay, float sustain, float release) {
+  if (!h) return YSE_ERR_INVALID_HANDLE;
+  if (num_voices <= 0) return YSE_ERR_INVALID_ARGUMENT;
+  try {
+    auto* impl = to_impl(h);
+    // Build and configure the prototype, then hand ownership to the handle
+    // BEFORE addVoices records its pointer — the pointed-to voice never moves
+    // (only the unique_ptr does), so the pointer stays valid across the setup
+    // pool's clone().
+    auto proto = std::make_unique<YSE::SYNTH::sineVoice>();
+    proto->attack(attack).decay(decay).sustain(sustain).release(release);
+    YSE::SYNTH::dspVoice* raw = proto.get();
+    impl->prototypes.push_back(std::move(proto));
+    impl->synth.addVoices(*raw, num_voices, channel, lowest_note, highest_note);
+    return YSE_OK;
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return YSE_ERR_EXCEPTION;
+  } catch (...) {
+    yse_c::set_last_error("yse_synth_add_voices_sine: unknown C++ exception");
+    return YSE_ERR_EXCEPTION;
+  }
+}
+
+YSE_C_API int yse_synth_get_num_voices(YseSynth* h) {
+  return h ? to_impl(h)->synth.getNumVoices() : 0;
+}
+
+// ─── notes and control ─────────────────────────────────────────────────
+
+YSE_C_API void yse_synth_note_on(YseSynth* h, int channel, int note_number, float velocity) {
+  if (h) to_impl(h)->synth.noteOn(channel, note_number, velocity);
+}
+YSE_C_API void yse_synth_note_off(YseSynth* h, int channel, int note_number, float velocity) {
+  if (h) to_impl(h)->synth.noteOff(channel, note_number, velocity);
+}
+YSE_C_API void yse_synth_all_notes_off(YseSynth* h, int channel) {
+  if (h) to_impl(h)->synth.allNotesOff(channel);
+}
+YSE_C_API void yse_synth_pitch_wheel(YseSynth* h, int channel, float value) {
+  if (h) to_impl(h)->synth.pitchWheel(channel, value);
+}
+YSE_C_API void yse_synth_controller(YseSynth* h, int channel, int number, float value) {
+  if (h) to_impl(h)->synth.controller(channel, number, value);
+}
+YSE_C_API void yse_synth_aftertouch(YseSynth* h, int channel, int note_number, float value) {
+  if (h) to_impl(h)->synth.aftertouch(channel, note_number, value);
+}
+YSE_C_API void yse_synth_sustain(YseSynth* h, int channel, int down) {
+  if (h) to_impl(h)->synth.sustain(channel, down != 0);
+}
+YSE_C_API void yse_synth_sostenuto(YseSynth* h, int channel, int down) {
+  if (h) to_impl(h)->synth.sostenuto(channel, down != 0);
+}
+YSE_C_API void yse_synth_soft_pedal(YseSynth* h, int channel, int down) {
+  if (h) to_impl(h)->synth.softPedal(channel, down != 0);
+}
+
+YSE_C_API void yse_synth_set_note_callback(YseSynth* h, YseSynthNoteCallback cb) {
+  if (!h) return;
+  // The engine's onNoteEvent hook is a bare captureless function pointer with
+  // no user_data slot, so a stateful atomic-swap bridge is impossible (a
+  // stateless bridge could not recover which synth called it). Pass the
+  // pointer straight through; YSE::synth stores it atomically (release-store,
+  // audio-thread acquire-load — see synthImplementation::setNoteCallback), so
+  // the atomic-swap discipline lives on the engine side and the C layer adds
+  // no lock and no allocation. NULL clears the hook.
+  //
+  // The C typedef takes `int note_on` per the C-API bool-as-int convention;
+  // the engine invokes with a C++ `bool` (always 0/1). The signatures are
+  // otherwise identical, so reinterpret_cast the pointer (same precedent as
+  // yse_midi.cpp's parsed-callback bridge).
+  using EngineCb = void (*)(bool, float*, float*);
+  to_impl(h)->synth.onNoteEvent(reinterpret_cast<EngineCb>(cb));
+}
+
+// ─── attachment ────────────────────────────────────────────────────────
+
+YSE_C_API YseStatus yse_synth_attach_to_sound(YseSynth* h, YseSound* sound, YseChannel* channel,
+                                              float volume) {
+  if (!h) return YSE_ERR_INVALID_HANDLE;
+  if (!sound) return YSE_ERR_INVALID_ARGUMENT;
+  try {
+    to_cpp(sound)->create(to_impl(h)->synth, to_cpp(channel), volume);
+    // create() leaves the sound invalid if it could not attach the synth's
+    // aggregate source; surface that as an error for C consumers.
+    if (!to_cpp(sound)->isValid()) {
+      yse_c::set_last_error("sound not created from synth (attach failed)");
+      return YSE_ERR_GENERIC;
+    }
+    return YSE_OK;
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return YSE_ERR_EXCEPTION;
+  } catch (...) {
+    yse_c::set_last_error("yse_synth_attach_to_sound: unknown C++ exception");
+    return YSE_ERR_EXCEPTION;
+  }
+}
+
+} // extern "C"


### PR DESCRIPTION
## Summary

Exposes the engine-native `YSE::synth` subsystem (#152–#156) through the flat C ABI in `YseEngine/c_api/`, so FFI consumers (dart-yse, Python ctypes) can build a synth, add built-in voices, attach it behind a sound, and drive notes / controllers / pedals — mirroring §12 ("Public API surface") of `docs/design/synth_core.md`.

Follows the established `c-api-extend` conventions: opaque handle, null-safe void no-ops, `YseStatus` + `set_last_error()` for fallible operations, `YSE_C_CALLBACK` on the callback typedef, and no engine C++ type across the ABI. No engine code was modified — this is a pure wrapping pass. No new enums, so no `yse_enums.h` / drift-guard changes were needed.

## Linked issue

Closes #157

## Changes

New `YseEngine/c_api/yse_synth.{h,cpp}`:
- `yse_synth_create` / `yse_synth_destroy` / `yse_synth_is_valid`
- `yse_synth_add_voices_sine` — the built-in reference voice (sine + ADSR, #152). **Custom `dspVoice` subclassing from C stays deferred** (documented in the header): it needs the same audio-thread `dspSourceObject` callback plumbing that keeps `dspSourceObject` unwrapped. Instrument voices (#148) will add more `yse_synth_add_voices_*` variants.
- `yse_synth_note_on` / `note_off` / `all_notes_off`
- `yse_synth_pitch_wheel` / `controller` / `aftertouch`
- `yse_synth_sustain` / `sostenuto` / `soft_pedal`
- `yse_synth_set_note_callback` — the `onNoteEvent` audio-thread hook
- `yse_synth_get_num_voices`, `yse_synth_attach_to_sound`

Wiring: `yse_synth.h` added to `yse_all.h`; `yse_synth.cpp` added to `c_api/CMakeLists.txt`.

### RT-safety / ownership notes
- **Callback bridge:** the engine's `onNoteEvent` is a bare captureless function pointer with no `user_data`, so a stateful atomic-swap bridge is impossible (a stateless one couldn't recover which synth called it). The C entry point is a thin pass-through; the atomic-swap discipline lives on the engine side (`setNoteCallback` release-store / audio-thread acquire-load). The C layer adds **no mutex and no allocation** on any path. `grep std::mutex|std::lock_guard YseEngine/c_api/` is clean.
- **Prototype ownership:** `addVoices` records a raw prototype pointer and clones from it *later* on the setup pool, so the prototype must outlive setup. The `YseSynth` handle owns the built-in prototypes it creates and frees them on `destroy` — all allocation happens on the control thread, never the audio thread.

## Test plan

New `Tests/synth/test_c_api_synth.cpp` — a **C-only** suite (`TEST_SUITE("synthcapi")`, no engine headers) that drives everything through the C surface under an **offline** engine (`yse_system_init_offline` / `render_offline`), so it runs in CI with no audio hardware:
- null-handle safety across the whole surface,
- build → attach → play → **polyphonic note sequence** with the full pedal / controller / aftertouch / pitch-wheel surface,
- the `onNoteEvent` hook fires on the audio thread, rewrites the note, and clears,
- a split keyboard (two voice groups summing to the expected voice count),
- invalid-argument / invalid-handle status codes.

Because it drives `System::close()`, it is isolated in its own ctest process (`yse_tests_synthcapi`) and **excluded from the monolithic `yse_unit_tests`** — matching the `synthlifecycle` / `midisynth` / `playersynth` suites and keeping the #298/#304 teardown lineage out of the crowded process. It drains the manager delete jobs before each `close()` so teardown is deterministic (verified: 23 consecutive clean isolated runs after that fix).

- [x] `python yse.py format` clean (no diff on the changed files)
- [x] `python yse.py analyze YseEngine/c_api/yse_synth.cpp` and `Tests/synth/test_c_api_synth.cpp` — no new findings (all warnings in engine/vendored headers, the tracked baseline)
- [x] `python yse.py build` succeeds, no new warnings
- [x] `python yse.py test` — **22/22 ctest entries pass**, including `yse_tests_synthcapi` (4 cases, 34 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
