### PR TITLE
DSP: initialise reverb size and rolloff in constructor (#263)

### DIFF
--- a/Tests/reverb/test_reverb_dsp.cpp
+++ b/Tests/reverb/test_reverb_dsp.cpp
@@ -15,6 +15,8 @@
 // sequentially so there is no data-race concern.
 
 #include <doctest/doctest.h>
+#include <cstring> // std::memset — dirties storage for the issue #263 regression test
+#include <new> // placement new — construct reverb over pre-dirtied memory
 #include <type_traits>
 // Channel headers must precede reverbManager.h because the manager references
 // CHANNEL::implementationObject without a forward declaration.
@@ -176,6 +178,27 @@ TEST_SUITE("reverb") {
   TEST_CASE("reverb: default dry is 0.5") {
     YSE::reverb r;
     CHECK(r.getDry() == doctest::Approx(0.5f));
+  }
+
+  TEST_CASE("reverb: constructor initialises size and rolloff to zero (issue #263)") {
+    // The constructor must initialise `size` and `rolloff`; before the fix
+    // they were left out of the initialiser list, so getSize()/getRollOff()
+    // (and the setSize()/setRollOff() `if (size != value)` guards) read
+    // indeterminate memory.
+    //
+    // A plain stack-local reverb is an unreliable regression test: the stack
+    // slot is often already zero, so the uninitialised read masquerades as a
+    // pass. Instead we placement-new the object over a buffer pre-filled with
+    // non-zero bytes (0xFF, which reads back as a NaN when interpreted as a
+    // float). If the constructor leaves size/rolloff untouched, the getters
+    // return that NaN and the checks fail; the fix zero-initialises both.
+    alignas(YSE::reverb) unsigned char storage[sizeof(YSE::reverb)];
+    std::memset(storage, 0xFF, sizeof(storage));
+    YSE::reverb* r = new (storage) YSE::reverb();
+    CHECK(r->getSize() == doctest::Approx(0.0f));
+    CHECK(r->getRollOff() == doctest::Approx(0.0f));
+    // No create() was called, so pimpl is null and ~reverb() is trivial-safe.
+    r->~reverb();
   }
 
   TEST_CASE("reverb: default modulation frequency and width are zero") {

--- a/YseEngine/reverb/reverbInterface.cpp
+++ b/YseEngine/reverb/reverbInterface.cpp
@@ -20,6 +20,8 @@ YSE::reverb::reverb(bool global)
     dry(0.5f),
     modFrequency(0),
     modWidth(0),
+    size(0),
+    rolloff(0),
     global(global) {}
 
 YSE::reverb::~reverb() {


### PR DESCRIPTION
## Summary
`YSE::reverb::reverb(bool)` left `size` and `rolloff` out of its constructor initialiser list. `getSize()`/`getRollOff()` and the `setSize()`/`setRollOff()` `if (member != value)` guards therefore read indeterminate memory (UB) on a freshly constructed `reverb`, until the first set call overwrote them. Reported in passing during the #192 lock-free audit.

## Linked issue
Closes #263

## Changes
- `YseEngine/reverb/reverbInterface.cpp`: add `size(0)` and `rolloff(0)` to the constructor initialiser list (in declaration order), matching the zero-initialised impl side.
- `Tests/reverb/test_reverb_dsp.cpp`: add a deterministic regression test. It placement-news a `reverb` over 0xFF-dirtied storage so an uninitialised member surfaces as a NaN — a plain stack-local `reverb` would unreliably read an already-zeroed slot and mask the bug.

Scope kept tight per the issue: only `size`/`rolloff` and the test.

## Test plan
- [x] `clang-format` clean (`python yse.py format` — no changes to the two files)
- [x] `clang-tidy` clean on both changed files (`python yse.py analyze <file>` — no user-code findings)
- [x] Regression test fails on unpatched code (`getSize()`/`getRollOff()` read `nan`) and passes with the fix — verified by reverting/restoring the initialiser
- [x] Full reverb suite passes with the fix: 47 cases / 475 assertions, 0 failed
- [ ] Integration/e2e: not warranted — the bug is a constructor initialisation defect with no distinct user-visible flow beyond the getters; fully covered by the unit regression test above.