### PR TITLE
MUSIC/c-api: give yse_player_create a working create() path (#268)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -77,6 +77,7 @@ set(YSE_TEST_SOURCES
   music/test_motif.cpp
   music/test_player_alloc.cpp
   music/test_player_synth.cpp
+  music/test_c_api_player.cpp
   listener/test_listener.cpp
   listener/test_listener_concurrency.cpp
   io/test_bufferIO.cpp
@@ -168,12 +169,12 @@ set_target_properties(yse_tests PROPERTIES
 if(NOT ANDROID)
 add_test(
   NAME    yse_unit_tests
-  # `lifecycle`, `synthlifecycle`, `synthcapi`, `midisynth` and `playersynth` are
-  # excluded alongside `integration`: they drive System::close(), which permanently
-  # stops the global thread pools and would break every later suite sharing this
-  # process. Each runs in its own process via yse_tests_lifecycle /
-  # yse_tests_synthlifecycle / yse_tests_synthcapi / yse_tests_midisynth /
-  # yse_tests_playersynth.
+  # `lifecycle`, `synthlifecycle`, `synthcapi`, `midisynth`, `playersynth` and
+  # `playercapi` are excluded alongside `integration`: they drive System::close(),
+  # which permanently stops the global thread pools and would break every later
+  # suite sharing this process. Each runs in its own process via yse_tests_lifecycle
+  # / yse_tests_synthlifecycle / yse_tests_synthcapi / yse_tests_midisynth /
+  # yse_tests_playersynth / yse_tests_playercapi.
   #
   # `* concurrency: *` (the cross-subsystem create/destroy + race stress cases:
   # channel/sound/reverb/io/listener/midifile) is excluded here too and runs
@@ -186,7 +187,7 @@ add_test(
   # suite exclusions above and loses no coverage: yse_tests_concurrency plus the
   # per-suite entries still run every case. Tracked in #304; the root fix is
   # #41/#298 engine work.
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthcapi,midisynth,playersynth "--test-case-exclude=* concurrency: *" --duration=true
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthcapi,midisynth,playersynth,playercapi "--test-case-exclude=* concurrency: *" --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -321,6 +322,19 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_playersynth PROPERTIES LABELS "music;synth;lifecycle")
+
+# C-API generative-player surface (issue #268). Drives the player create -> play
+# path entirely through the flat C ABI under an offline engine, then
+# yse_system_close(). Isolated in its own process for the same reason as
+# yse_tests_synthcapi / yse_tests_playersynth: System::close() tears down
+# process-global state (thread pools) the rest of the suite assumes stays up
+# (#298). initOffline() needs no audio hardware, so it runs in CI.
+add_test(
+  NAME    yse_tests_playercapi
+  COMMAND yse_tests --test-suite=playercapi
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_playercapi PROPERTIES LABELS "music;synth;c-api;lifecycle")
 
 add_test(
   NAME    yse_tests_listener

--- a/Tests/music/test_c_api_player.cpp
+++ b/Tests/music/test_c_api_player.cpp
@@ -1,0 +1,198 @@
+// C-API generative-player surface tests (issue #268) — exercises the player
+// create -> play path in YseEngine/c_api/yse_music.* entirely through the flat
+// C ABI (no engine C++ headers).
+//
+// Before #268 the C API had no working create path: yse_player_create() took
+// no synth, so the YSE::player it returned was never bound to an implementation
+// (pimpl stayed null). Driving it did nothing useful, and the original crash
+// (yse_player_play() dereferencing the null pimpl) was the reachable symptom.
+// #268 gives yse_player_create() a synth handle and calls player::create()
+// under the hood, so the returned player is live: play() actually generates
+// notes into the synth.
+//
+// Coverage here:
+//   * NULL-handle safety (no engine): yse_player_create(NULL) fails cleanly and
+//     every void entry point no-ops on a NULL handle.
+//   * End-to-end: build a synth behind a sound, create a player BOUND TO THAT
+//     synth through the C ABI, play it, and assert the synth actually receives
+//     note-ons (proving the create path connected the player) — this is the
+//     regression: an unbound player generates zero notes. stop() then halts
+//     generation.
+//
+// ISOLATION: like the synthcapi / playersynth suites, these cases call
+// yse_system_close() (process-global thread-pool teardown), so they run as a
+// dedicated ctest process in TEST_SUITE("playercapi"), excluded from the
+// combined run (#298/#304). initOffline() needs no audio hardware, so the
+// end-to-end case runs in CI; if it is unavailable the case bails out and
+// doctest counts it as a pass.
+
+#include <doctest/doctest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "yse_c/yse_music.h"
+#include "yse_c/yse_synth.h"
+#include "yse_c/yse_sound.h"
+#include "yse_c/yse_system.h"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+  // Captureless note-event probe (onNoteEvent contract). Counts the note-ons the
+  // synth receives from the player. The offline render is single-threaded (the
+  // test thread also drives the render), so a relaxed atomic is ample.
+  std::atomic<int> g_playerNoteOns{0};
+
+  void YSE_C_CALLBACK countNoteOn(int note_on, float* /*note_number*/, float* /*velocity*/) {
+    if (note_on) g_playerNoteOns.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  bool drainUntilVoices(YseSystem* sys, YseSynth* syn, int expected,
+                        std::chrono::milliseconds budget = 2000ms) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 1);
+      if (yse_synth_get_num_voices(syn) >= expected) return true;
+      std::this_thread::sleep_for(2ms);
+    }
+    return yse_synth_get_num_voices(syn) >= expected;
+  }
+
+  // Advance the engine `blocks` blocks. update() ticks the gated managers
+  // (scale drain, player generation, synth lifecycle) alongside the audio
+  // render that drains the player's note messages into the synth.
+  void render(YseSystem* sys, int blocks) {
+    for (int i = 0; i < blocks; ++i) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 1);
+    }
+  }
+
+  // Pump the engine so the manager delete jobs free released impls BEFORE
+  // yse_system_close() tears down the pools (the #298/#304 lineage).
+  void drainFor(YseSystem* sys, std::chrono::milliseconds budget) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 1);
+      std::this_thread::sleep_for(2ms);
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("playercapi") {
+
+  // ─── NULL-handle safety (no engine required) ──────────────────────────────
+
+  TEST_CASE("c-api player: NULL handles are null-safe") {
+    // create() with a NULL synth must fail cleanly, not crash or hand back an
+    // unbound player.
+    CHECK(yse_player_create(nullptr) == nullptr);
+
+    // Every void entry point no-ops on a NULL handle; queries return 0.
+    yse_player_play(nullptr);
+    yse_player_stop(nullptr);
+    CHECK(yse_player_is_playing(nullptr) == 0);
+    yse_player_set_minimum_pitch(nullptr, 48.f, 0.f);
+    yse_player_set_maximum_pitch(nullptr, 72.f, 0.f);
+    yse_player_set_minimum_velocity(nullptr, 0.3f, 0.f);
+    yse_player_set_maximum_velocity(nullptr, 0.8f, 0.f);
+    yse_player_set_minimum_gap(nullptr, 0.f, 0.f);
+    yse_player_set_maximum_gap(nullptr, 0.f, 0.f);
+    yse_player_set_minimum_length(nullptr, 0.1f, 0.f);
+    yse_player_set_maximum_length(nullptr, 0.3f, 0.f);
+    yse_player_set_voices(nullptr, 4, 0.f);
+    yse_player_set_scale(nullptr, nullptr, 0.f);
+    yse_player_play_motifs(nullptr, 0.5f, 0.f);
+    yse_player_play_partial_motifs(nullptr, 0.5f, 0.f);
+    yse_player_fit_motifs_to_scale(nullptr, 1.f, 0.f);
+    yse_player_destroy(nullptr);
+    CHECK(true); // reached here without dereferencing a NULL handle
+  }
+
+  // ─── create -> play actually drives notes into the synth ──────────────────
+
+  TEST_CASE("c-api player: create(synth) binds the player and play() drives notes") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return; // unavailable → skip
+
+    g_playerNoteOns.store(0, std::memory_order_relaxed);
+
+    // Synth behind a sound, with a note probe installed so we can see exactly
+    // what the player sends it.
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    REQUIRE(yse_synth_add_voices_sine(syn, 8, 0, 0, 127, 0.001f, 0.001f, 1.0f, 0.05f) == YSE_OK);
+    yse_synth_set_note_callback(syn, &countNoteOn);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    yse_sound_play(snd);
+    REQUIRE(drainUntilVoices(sys, syn, 8));
+
+    // Create the player BOUND to the synth — the #268 create path. A pre-#268
+    // unbound player would generate nothing below.
+    YsePlayer* pl = yse_player_create(syn);
+    REQUIRE(pl != nullptr);
+    CHECK(yse_player_is_playing(pl) == 0);
+
+    // Constrain to a C-major scale and set tight, gapless timing so notes fire
+    // quickly.
+    YseScale* sc = yse_scale_create();
+    REQUIRE(sc != nullptr);
+    yse_scale_add(sc, 60.f, 12.f);
+    yse_scale_add(sc, 62.f, 12.f);
+    yse_scale_add(sc, 64.f, 12.f);
+    yse_scale_add(sc, 65.f, 12.f);
+    yse_scale_add(sc, 67.f, 12.f);
+    yse_scale_add(sc, 69.f, 12.f);
+    yse_scale_add(sc, 71.f, 12.f);
+
+    yse_player_set_scale(pl, sc, 0.f);
+    yse_player_set_minimum_pitch(pl, 48.f, 0.f);
+    yse_player_set_maximum_pitch(pl, 84.f, 0.f);
+    yse_player_set_minimum_velocity(pl, 0.4f, 0.f);
+    yse_player_set_maximum_velocity(pl, 0.9f, 0.f);
+    yse_player_set_minimum_gap(pl, 0.f, 0.f);
+    yse_player_set_maximum_gap(pl, 0.f, 0.f);
+    yse_player_set_minimum_length(pl, 0.02f, 0.f);
+    yse_player_set_maximum_length(pl, 0.06f, 0.f);
+    yse_player_set_voices(pl, 4, 0.f);
+
+    // Drain the scale + config messages into the impl before generating.
+    render(sys, 20);
+    yse_player_play(pl);
+    CHECK(yse_player_is_playing(pl) == 1);
+
+    render(sys, 3000);
+
+    // The create path connected the player: play() actually produced notes on
+    // the synth. (Zero here would mean the player was never bound — the #268
+    // regression.)
+    CHECK(g_playerNoteOns.load(std::memory_order_relaxed) > 0);
+
+    // stop() halts generation: no NEW note-ons after it settles.
+    yse_player_stop(pl);
+    CHECK(yse_player_is_playing(pl) == 0);
+    render(sys, 300); // let outstanding notes finish
+    const int mark = g_playerNoteOns.load(std::memory_order_relaxed);
+    render(sys, 600);
+    CHECK(g_playerNoteOns.load(std::memory_order_relaxed) == mark);
+
+    yse_player_destroy(pl);
+    yse_scale_destroy(sc);
+    yse_sound_destroy(snd); // sound before the synth it renders
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms); // let the delete jobs free the impls before close
+    yse_system_close(sys);
+  }
+
+} // TEST_SUITE("playercapi")

--- a/YseEngine/c_api/include/yse_c/yse_music.h
+++ b/YseEngine/c_api/include/yse_c/yse_music.h
@@ -33,6 +33,11 @@ typedef struct YseMotif YseMotif;
 /* Owned — release with yse_player_destroy. */
 typedef struct YsePlayer YsePlayer;
 
+/* Forward declaration — the synth a player drives. Owned by the caller and
+   created via yse_synth_create (see yse_synth.h); it must outlive the player.
+   The player feeds every note it generates into this synth's lock-free inbox. */
+typedef struct YseSynth YseSynth;
+
 /* ─── note ────────────────────────────────────────────────────────── */
 
 YSE_C_API YseNote* yse_note_create(float pitch, float volume, float length, int channel);
@@ -90,7 +95,14 @@ YSE_C_API unsigned int yse_motif_size(YseMotif* m);
 
 /* ─── player — generative sequencer ───────────────────────────────── */
 
-YSE_C_API YsePlayer* yse_player_create(void);
+/* Create a generative player bound to `synth` and register it with the engine.
+   `synth` must be a live handle from yse_synth_create and must outlive the
+   player — every note the player generates is delivered to it. Returns NULL
+   (with yse_last_error() set) when `synth` is NULL or on allocation failure.
+   This is the only create path: a player has no useful state until it is bound
+   to a synth, so unlike most create functions it takes its target up front
+   (issue #268). */
+YSE_C_API YsePlayer* yse_player_create(YseSynth* synth);
 YSE_C_API void yse_player_destroy(YsePlayer* p);
 YSE_C_API void yse_player_play(YsePlayer* p);
 YSE_C_API void yse_player_stop(YsePlayer* p);

--- a/YseEngine/c_api/yse_c_internal.hpp
+++ b/YseEngine/c_api/yse_c_internal.hpp
@@ -73,11 +73,28 @@
 
 #include <string>
 
+// Forward declarations for the cross-TU synth-handle accessor below. Kept
+// minimal so this header stays free of engine includes; the definitions live
+// in yse_synth.cpp (YseSynthImpl) and the engine synth headers.
+struct YseSynth;
+namespace YSE {
+  namespace SYNTH {
+    class interfaceObject;
+  }
+  typedef SYNTH::interfaceObject synth;
+} // namespace YSE
+
 namespace yse_c {
 
   // Stash a human-readable error in the thread-local last_error slot.
   // Retrieved by the C client via yse_last_error().
   void set_last_error(const char* msg);
   void set_last_error(const std::string& msg);
+
+  // Return the engine synth backing a YseSynth handle, or nullptr for a NULL
+  // handle. Defined in yse_synth.cpp — lets yse_music.cpp's player create()
+  // reach the synth a player must drive without exposing YseSynthImpl's private
+  // layout across translation units (issue #268).
+  YSE::synth* synth_from_handle(YseSynth* h);
 
 } // namespace yse_c

--- a/YseEngine/c_api/yse_music.cpp
+++ b/YseEngine/c_api/yse_music.cpp
@@ -1,4 +1,5 @@
 #include "yse_c/yse_music.h"
+#include "yse_c/yse_synth.h" // YseSynth handle — the synth a player is bound to (#268)
 #include "yse_c_internal.hpp"
 
 #include "../music/note.hpp"
@@ -198,9 +199,19 @@ YSE_C_API unsigned int yse_motif_size(YseMotif* m) {
 
 // ─── player ────────────────────────────────────────────────────────
 
-YSE_C_API YsePlayer* yse_player_create(void) {
+YSE_C_API YsePlayer* yse_player_create(YseSynth* synth) {
+  YSE::synth* instrument = yse_c::synth_from_handle(synth);
+  if (instrument == nullptr) {
+    yse_c::set_last_error("player_create: synth handle is NULL");
+    return nullptr;
+  }
   try {
-    return reinterpret_cast<YsePlayer*>(new YSE::player());
+    // Bind the player to its synth up front (player::create) — without this the
+    // pimpl is never assigned and every subsequent call is an inert no-op
+    // (issue #268). create() registers the player with PLAYER::Manager().
+    auto* p = new YSE::player();
+    p->create(*instrument);
+    return reinterpret_cast<YsePlayer*>(p);
   } catch (const std::exception& e) {
     yse_c::set_last_error(e.what());
     return nullptr;

--- a/YseEngine/c_api/yse_synth.cpp
+++ b/YseEngine/c_api/yse_synth.cpp
@@ -29,6 +29,8 @@ namespace {
   inline YseSynthImpl* to_impl(YseSynth* h) {
     return reinterpret_cast<YseSynthImpl*>(h);
   }
+  // (definition of yse_c::synth_from_handle appears after this namespace, once
+  // to_impl / YseSynthImpl are in scope)
   inline YSE::sound* to_cpp(YseSound* s) {
     return reinterpret_cast<YSE::sound*>(s);
   }
@@ -37,6 +39,15 @@ namespace {
   }
 
 } // namespace
+
+// Cross-TU accessor declared in yse_c_internal.hpp: hand the engine synth out
+// to yse_music.cpp so a player can be created bound to it (issue #268). Kept
+// here, in the only TU that knows YseSynthImpl's layout.
+namespace yse_c {
+  YSE::synth* synth_from_handle(YseSynth* h) {
+    return h ? &to_impl(h)->synth : nullptr;
+  }
+} // namespace yse_c
 
 extern "C" {
 


### PR DESCRIPTION
## Summary

The C API had no usable player create path: `yse_player_create()` took no synth, so the `YSE::player` it returned was never bound to an implementation (its `pimpl` stayed null). The player was permanently inert, and the original crash (`yse_player_play()` dereferencing the null pimpl) was the reachable symptom that issue #268 tracked.

The engine-side pieces #268 also mentions — the active `create(synth&)`, the `checkCreated()` null-safety guard, and the `managerObject::update()` iterator/lifecycle rework (no more `erase_after` + `++i` UB, `removeImplementation` gone) — all landed with #156. This PR closes the remaining **C-API half**: wiring `yse_player_create` to actually bind a synth, now that #157 has exposed the synth surface.

## Linked issue

Closes #268

## Changes

- `yse_player_create(void)` -> `yse_player_create(YseSynth* synth)`: constructs the player, then calls `YSE::player::create(synth&)` so it is registered with `PLAYER::Manager()` and bound to the synth it drives. A NULL synth fails cleanly (returns NULL, `yse_last_error()` set).
- Added `yse_c::synth_from_handle` (declared in `yse_c_internal.hpp`, defined in `yse_synth.cpp`) so `yse_music.cpp` can reach the engine synth behind a `YseSynth` handle without exposing `YseSynthImpl`'s private layout across translation units.
- New test `Tests/music/test_c_api_player.cpp` in its own isolated suite/process `playercapi` (same `System::close()` isolation as `synthcapi`/`playersynth`, per #298/#304).

## Test plan

- [x] `python yse.py format` clean (touched only this branch's files)
- [x] `python yse.py analyze` clean on `yse_music.cpp`, `yse_synth.cpp`, `test_c_api_player.cpp` — no new user-code findings
- [x] Full suite green: `100% tests passed, 0 failed out of 23` (`ctest` on tests-debug), including the new `yse_tests_playercapi`
- [x] Regression verified: the end-to-end case fails (0 note-ons, `is_playing == 0`) when `create()` is stubbed out (unbound player), and passes once the player is bound — confirming it catches the #268 defect

🤖 Generated with [Claude Code](https://claude.com/claude-code)