### PR TITLE
ENGINE: fix static-teardown UAF when a sound impl outlives its channel (#298)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,3 +253,16 @@ jobs:
         # and sets ASAN_OPTIONS=detect_leaks=0 on the asan leg (the process-global
         # thread pools / named bus are intentionally never torn down).
         run: ctest --preset tests-${{ matrix.san }} --output-on-failure
+      - name: Run static-teardown UAF gate (lifecycle suite, issue #298)
+        # The lifecycle suite deliberately leaves a SOUND::implementationObject
+        # alive at engine teardown; its destructor used to read a freed parent
+        # channel impl during static destruction (issue #298), a flaky SIGSEGV
+        # that normal builds miss because it is heap-layout dependent. Run the
+        # isolated lifecycle process under AddressSanitizer so that
+        # use-after-free is caught deterministically. Asan leg only.
+        # detect_leaks=0 for the same reason as the patcher gate above (the
+        # process-global pools/bus are never torn down); this gate is about UAF.
+        if: matrix.san == 'asan'
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+        run: ctest --test-dir build-tests-asan -R yse_tests_lifecycle --output-on-failure

--- a/Tests/system/test_lifecycle.cpp
+++ b/Tests/system/test_lifecycle.cpp
@@ -124,4 +124,74 @@ TEST_SUITE("lifecycle") {
     YSE::System().close();
   }
 
+  // Regression test for issue #298: a SOUND::implementationObject that is still
+  // alive at engine teardown (never drained to OBJECT_DELETE before close())
+  // must not use-after-free its parent channel impl.
+  //
+  // The ordering that triggers the bug: a file-backed sound is driven to
+  // OBJECT_READY — at which point doThisWhenReady() has run, so the impl is
+  // linked into its parent channel's `sounds` list and connectedToParent is
+  // set. The sound interface is then destroyed while the engine is still up,
+  // but close() is called BEFORE the manager pumps the impl through
+  // OBJECT_RELEASE→OBJECT_DELETE, so it lingers in SOUND::Manager's
+  // `implementations` list still pointing at its parent channel impl. Pre-fix,
+  // close() freed the channel impls (CHANNEL::Manager().destroy()) while that
+  // sound impl was still referencing one, leaving `parent` dangling — then
+  // dereferenced either at the next init() (the audio thread reprocesses the
+  // lingering impl and calls parent->disconnect on freed storage) or during
+  // static destruction of the manager singletons at process exit. A flaky
+  // SIGSEGV in normal builds (heap-layout dependent), a deterministic
+  // heap-use-after-free under AddressSanitizer. The fix drains the sound
+  // manager in close() (SOUND::Manager().destroy()) BEFORE the channels are
+  // freed, plus gates the impl destructor's parent disconnect on
+  // Global().isActive() as defence in depth.
+  //
+  // This case sets up exactly that lingering-impl-past-close state and then
+  // re-inits and closes again. Post-fix nothing dangles: the drain tears the
+  // impl down while its parent is still alive, so the re-init is clean and
+  // there is nothing left for static teardown to touch. The CHECKs below assert
+  // the cycle completes; the real regression gate is the AddressSanitizer CI
+  // leg, which runs this suite (build.yml: Sanitizers/asan) and would report
+  // the freed-parent read deterministically if the drain regressed.
+  TEST_CASE("lifecycle: a sound impl lingering past close() is torn down cleanly (issue #298)") {
+    YSE::System().close(); // normalize to a closed engine
+
+    if (!YSE::System().initOffline()) return; // no offline device on this host
+
+    {
+      YSE::sound s;
+      s.create(WAV_FIXTURE);
+      if (s.isValid()) { // skip only if the fixture is missing on this host
+        // Drive the sound all the way to OBJECT_READY so doThisWhenReady() has
+        // run: this is what links it into the parent channel and sets
+        // connectedToParent — the precondition for the dangling-parent bug.
+        // Audio is paused, so the test thread pumps the manager itself.
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (std::chrono::steady_clock::now() < deadline) {
+          YSE::INTERNAL::Time().update();
+          YSE::SOUND::Manager().update();
+          if (s.isReady()) break;
+          std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        CHECK(s.isReady());
+      }
+      // ~sound fires here (engine still up), nulling the impl's head. Crucially
+      // we do NOT pump SOUND::Manager().update() afterwards, so the impl never
+      // reaches OBJECT_DELETE and lingers into close() below with its parent
+      // link still live.
+    }
+
+    // close() must drain the still-connected sound impl (SOUND::Manager().
+    // destroy()) before freeing its parent channel — the fix for #298.
+    YSE::System().close();
+
+    // A second lifecycle: with the drain in place nothing from session 1
+    // survives, so re-init/close is clean. Pre-fix the lingering impl's stale
+    // parent pointer was reprocessed here (or blew up at static exit).
+    REQUIRE(YSE::System().initOffline());
+    YSE::System().close();
+
+    CHECK(true); // completing the cycle without a crash is the observable win
+  }
+
 } // TEST_SUITE("lifecycle")

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -82,7 +82,19 @@ YSE::SOUND::implementationObject::~implementationObject() {
   // setup-failure path: impls that died before doThisWhenReady ever ran).
   // In that case `connectedToParent` is false and parent->sounds doesn't
   // contain us — the slow-pool just skips the disconnect entirely.
-  if (parent != nullptr &&
+  //
+  // The isActive() gate handles engine teardown (issue #298): a sound impl
+  // that never drained to OBJECT_DELETE before System::close() lingers in
+  // SOUND::Manager's `implementations` list with connectedToParent still set.
+  // close() sets Global().active=false and then CHANNEL::Manager().destroy()
+  // frees the parent channel impls, so `parent` is already dangling by the
+  // time this runs — whether at close() or, worse, during static destruction
+  // of the Meyers-singleton managers (CHANNEL::Manager may be destroyed before
+  // SOUND::Manager). Touching parent->sounds then is a use-after-free. When the
+  // engine is inactive the whole graph is being torn down, so parent->sounds
+  // membership no longer matters — skip the disconnect. Mirrors the identical
+  // guard in ~CHANNEL::implementationObject.
+  if (INTERNAL::Global().isActive() && parent != nullptr &&
       connectedToParent.load(
           std::memory_order_acquire)) { // NOSONAR S8417: intentional acquire — pairs with release
                                         // in doThisWhenReady() / Manager::update() handshake

--- a/YseEngine/sound/soundManager.cpp
+++ b/YseEngine/sound/soundManager.cpp
@@ -52,6 +52,46 @@ YSE::SOUND::managerObject::~managerObject() noexcept {
   }
 }
 
+void YSE::SOUND::managerObject::destroy() {
+  // Runs from system::close() after both thread pools are joined and the audio
+  // device is closed, with Global().active already false. Drains every
+  // lingering sound impl BEFORE CHANNEL::Manager().destroy() frees the channel
+  // impls, so no sound impl is left holding a dangling `parent` pointer — the
+  // root of the static-teardown / re-init use-after-free (issue #298). An impl
+  // whose interface was destroyed while the engine was up but that never got
+  // pumped to OBJECT_DELETE before close() lingers here otherwise: at the next
+  // init() the audio thread would reprocess it (parent already freed), and at
+  // static exit its destructor would disconnect from freed channel storage.
+  // Mirrors CHANNEL::Manager().destroy() (issue #132) and the "no persistence
+  // across init/close" guarantee (issue #121).
+
+  // No-ops once the pools are down, but mirror the destructor's contract that
+  // no setup/delete/GC job is mid-flight before the lists are torn.
+  mgrSetup.join();
+  mgrDelete.join();
+  mgrFileGC.join();
+
+  // Drain the main->audio inbox; the pointers it holds reference impls owned by
+  // `implementations` and would dangle once that list is cleared below.
+  implementationObject* drained;
+  while (toLoadInbox.try_pop(drained)) {
+    (void)drained;
+  }
+  toLoad.clear();
+  inUse.clear();
+  {
+    // Clear `implementations` before `soundFiles`: each impl destructor calls
+    // file->release(this) on its (shared) soundFile, which must still be alive.
+    std::scoped_lock lk(implementationsMutex);
+    implementations.clear();
+  }
+  {
+    std::scoped_lock lk(soundFilesMutex);
+    soundFiles.clear();
+  }
+  runDelete = false;
+}
+
 YSE::INTERNAL::soundFile* YSE::SOUND::managerObject::addFile(const std::string& fileName) {
   // Serialise with the slow-pool GC job that erases from soundFiles (issue #186).
   std::scoped_lock lk(soundFilesMutex);

--- a/YseEngine/sound/soundManager.h
+++ b/YseEngine/sound/soundManager.h
@@ -74,6 +74,16 @@ namespace YSE {
       // `implementations` list. Call only from the audio callback. (issue #200)
       Bool empty();
 
+      /** Tear down every sound implementation synchronously from
+          system::close(). Called after both thread pools are joined and the
+          device is closed (Global().active already false), and BEFORE
+          CHANNEL::Manager().destroy() frees the channel impls — so no sound
+          impl is left holding a dangling `parent` pointer into freed channel
+          storage. This closes the static-teardown / re-init use-after-free
+          (issue #298) and honours the "no persistence across init/close"
+          guarantee (issue #121). Mirrors CHANNEL::Manager().destroy(). */
+      void destroy();
+
       /** Sets the maximum amount of sounds to be processed. The soundmanager
           will try to find the sounds that are most relevant and virtualize
           the rest.

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -135,6 +135,14 @@ void YSE::system::close() {
     INTERNAL::Global().active = false;
     DEVICE::Manager().close();
     INTERNAL::Global().close();
+    // Drain the sound manager BEFORE the channel manager: a sound impl that
+    // never reached OBJECT_DELETE before close() still holds a `parent` pointer
+    // into a channel impl. Freeing the channels first (CHANNEL::destroy) would
+    // leave that pointer dangling, to be dereferenced either at the next init()
+    // or during static teardown — a use-after-free (issue #298). Clearing the
+    // sound impls here, while the channels they reference are still alive,
+    // removes the lingering references entirely.
+    SOUND::Manager().destroy();
     // Tear down the channel manager last: Global().close() has joined both
     // thread pools and the device is already closed, so the persistent
     // master/named channels can be cleared synchronously. This drops their


### PR DESCRIPTION
## Summary

Fixes a use-after-free at engine teardown: a `SOUND::implementationObject`
still alive when `System::close()` runs (never drained to `OBJECT_DELETE`)
held a `parent` pointer into a `CHANNEL::implementationObject`. `close()`
freed the channel impls (`CHANNEL::Manager().destroy()`) while the sound impl
still referenced one, leaving `parent` dangling — dereferenced either at the
next `init()` (the audio thread reprocesses the lingering impl) or, worse,
during uncoordinated static destruction of the Meyers-singleton managers at
process exit (`CHANNEL::Manager` may be destroyed before `SOUND::Manager`).
A flaky, heap-layout-dependent SIGSEGV, surfaced by the synth subsystem
(#153) perturbing teardown order (~8/20 runs of the combined repro).

## Linked issue

Closes #298

## Changes

- **Root-cause fix** — add `SOUND::managerObject::destroy()` (mirrors the
  existing `CHANNEL::managerObject::destroy()`) and call it in
  `System::close()` **before** `CHANNEL::Manager().destroy()`. Lingering sound
  impls are now cleared while the channels they reference are still alive, so
  nothing dangles and nothing persists across an init/close cycle (honours the
  #121 "no persistence" guarantee).
- **Defence in depth** — gate the `~SOUND::implementationObject` parent
  disconnect on `Global().isActive()`, matching the identical guard already in
  `~CHANNEL::implementationObject`.
- **Test** — new isolated `lifecycle` case that reproduces the
  lingering-impl-past-close state, then re-inits/closes.
- **CI** — the `Sanitizers/asan` leg now also runs the `lifecycle` suite so
  the teardown UAF is gated under AddressSanitizer.

## Real-time discipline

No locks or allocations added to the audio callback path. `destroy()` runs on
the control thread from `close()` after both thread pools are joined and the
device is closed; the destructor guard is a single relaxed-cost atomic read on
the (non-audio) slow-pool/teardown path.

## Test plan

- [x] `clang-format --dry-run --Werror` clean on all changed files
- [x] `python yse.py analyze` on changed files — no new findings (2 pre-existing
      baseline warnings in `soundImplementation.cpp` unrelated to the change)
- [x] Full suite green: 23/23 ctest processes pass (`python yse.py test`)
- [x] `lifecycle` suite **clean under Linux/clang AddressSanitizer** (the gate);
      0/60 native stress runs and 0/30 of the original `re-init* + standalone
      synth` repro (was a flaky SIGSEGV before the fix)
- [x] Pre-fix UAF confirmed via lldb: `parent->disconnect(this)` →
      `IntrusiveForwardList::remove` reading freed channel storage

Note: the UAF fires at static destruction / re-init, which no in-process
`CHECK` can observe (the manager singletons outlive every test). The
deterministic regression gate is therefore the ASan CI leg, per CLAUDE.md's
guidance for static-destruction-order bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)