### PR TITLE
DSP: guard ADSRenvelope against RELEASE/RESUME before ATTACK (#300)

### DIFF
--- a/Tests/dsp/test_envelope.cpp
+++ b/Tests/dsp/test_envelope.cpp
@@ -165,6 +165,53 @@ TEST_SUITE("dsp") {
       CHECK(ptr[i] == doctest::Approx(0.0f).epsilon(1e-5f));
   }
 
+  // Regression tests for #300: a RELEASE (or RESUME) issued before any ATTACK
+  // must not dereference the uninitialised `phase` pointer. This happens for a
+  // voice released before it ever renders a block (NOTE_ON + NOTE_OFF draining
+  // in one audio block, or an all-notes-off before the first render). Without
+  // the guard these crash / trip ASan; with it they settle to silence + isAtEnd.
+
+  TEST_CASE("ADSRenvelope: RELEASE before ATTACK is silent and at-end (no loop)") {
+    YSE::DSP::ADSRenvelope adsr;
+    adsr.addPoint({0.0f, 0.0f, 1.0f});
+    adsr.addPoint({0.1f, 1.0f, 1.0f});
+    adsr.generate();
+    // No ATTACK has primed `phase`.
+    YSE::DSP::buffer& buf = adsr(YSE::DSP::ADSRenvelope::RELEASE);
+    float* ptr = buf.getPtr();
+    for (unsigned i = 0; i < buf.getLength(); ++i)
+      CHECK(ptr[i] == doctest::Approx(0.0f).epsilon(1e-5f));
+    CHECK(adsr.isAtEnd());
+  }
+
+  TEST_CASE("ADSRenvelope: RELEASE before ATTACK is silent and at-end (sustain loop)") {
+    // A sustain loop makes generate() set loopEnd != nullptr, which drives the
+    // RELEASE branch's `while (*phase != *search) search--;` — the exact path
+    // from #300 that dereferences the uninitialised `phase`.
+    YSE::DSP::ADSRenvelope adsr;
+    adsr.addPoint({0.0f, 0.0f, 1.0f});
+    adsr.addPoint({0.05f, 1.0f, 1.0f, /*loopStart*/ true});
+    adsr.addPoint({0.1f, 1.0f, 1.0f, /*loopStart*/ false, /*loopEnd*/ true});
+    adsr.generate();
+    YSE::DSP::buffer& buf = adsr(YSE::DSP::ADSRenvelope::RELEASE);
+    float* ptr = buf.getPtr();
+    for (unsigned i = 0; i < buf.getLength(); ++i)
+      CHECK(ptr[i] == doctest::Approx(0.0f).epsilon(1e-5f));
+    CHECK(adsr.isAtEnd());
+  }
+
+  TEST_CASE("ADSRenvelope: RESUME before ATTACK is silent and at-end") {
+    YSE::DSP::ADSRenvelope adsr;
+    adsr.addPoint({0.0f, 0.0f, 1.0f});
+    adsr.addPoint({0.1f, 1.0f, 1.0f});
+    adsr.generate();
+    YSE::DSP::buffer& buf = adsr(YSE::DSP::ADSRenvelope::RESUME);
+    float* ptr = buf.getPtr();
+    for (unsigned i = 0; i < buf.getLength(); ++i)
+      CHECK(ptr[i] == doctest::Approx(0.0f).epsilon(1e-5f));
+    CHECK(adsr.isAtEnd());
+  }
+
   // ─── envelope (breakpoint extractor) ─────────────────────────────────────────
   //
   // Known implementation issue: envelope::create() computes the window size as

--- a/YseEngine/dsp/ADSRenvelope.cpp
+++ b/YseEngine/dsp/ADSRenvelope.cpp
@@ -62,6 +62,15 @@ YSE::DSP::buffer& YSE::DSP::ADSRenvelope::operator()(STATE state, UInt length) {
     endReached = false;
   }
 
+  // A RELEASE/RESUME that arrives before any ATTACK has primed `phase` — e.g. a
+  // voice released before it ever rendered a block — has nothing to play. Treat
+  // it as already ended instead of dereferencing a null phase.
+  if (phase == nullptr) {
+    endReached = true;
+    result = 0.f;
+    return result;
+  }
+
   // when called after release has reached zero
   if (endReached) {
     result = 0.f;

--- a/YseEngine/dsp/ADSRenvelope.hpp
+++ b/YseEngine/dsp/ADSRenvelope.hpp
@@ -80,12 +80,12 @@ namespace YSE {
     private:
       std::vector<breakPoint> breakPoints;
       buffer envelope, result;
-      Flt* phase;
-      Flt* loopStart;
-      Flt* loopEnd;
-      Flt* envelopeEnd;
-      Bool looping;
-      Bool endReached;
+      Flt* phase = nullptr;
+      Flt* loopStart = nullptr;
+      Flt* loopEnd = nullptr;
+      Flt* envelopeEnd = nullptr;
+      Bool looping = false;
+      Bool endReached = false;
     };
 
   } // namespace DSP


### PR DESCRIPTION
## Summary

`DSP::ADSRenvelope`'s `phase`/`loopStart`/`loopEnd`/`envelopeEnd` raw pointers were left uninitialised and only assigned by `ATTACK` (`phase`) / `generate()`. A `RELEASE` or `RESUME` issued **before any `ATTACK`** dereferenced the uninitialised `phase` — in the RELEASE `while (*phase != *search) search--;` search loop and in the fill loop — a crash / OOB read.

This surfaces whenever a synth voice is released before it ever renders a block: a `NOTE_ON` + `NOTE_OFF` that drain in the same audio block, or an all-notes-off / pedal release that lands before the first render (readily reachable via the #154 keyboard state machine). #154 only fixed the reference `sineVoice`; this hardens the node itself so **every** `dspVoice` author is protected.

## Linked issue

Closes #300

## Changes

- `ADSRenvelope.hpp`: default-initialise `phase`/`loopStart`/`loopEnd`/`envelopeEnd` to `nullptr` and `looping`/`endReached` to `false`.
- `ADSRenvelope.cpp`: in `operator()`, treat a null `phase` on any non-`ATTACK` state as already-ended — emit silence and set `endReached`, before the RELEASE search / fill loops run.
- `Tests/dsp/test_envelope.cpp`: regression tests driving RELEASE-before-ATTACK (plain), RELEASE-before-ATTACK with a sustain loop (the exact search-loop deref path), and RESUME-before-ATTACK.

RT-safety: the fix is pure pointer/branch guards — no locks, no allocations — so the audio-thread path stays real-time safe.

## Test plan

- [x] `python yse.py format` — clean (no diff to committed files)
- [x] `python yse.py analyze` on both changed `.cpp` — no new findings (all suppressed baseline/non-user)
- [x] Unit tests: `python yse.py test` — 23/23 ctest binaries pass; `dsp` suite green
- [x] Regression verified failing on unpatched code: under `-ftrivial-auto-var-init=pattern` the new cases crash with an access violation (`0xC0000005`); with the fix they pass (3 cases / 387 assertions)
- [ ] Integration/e2e: not applicable — this is DSP-node logic with no user-visible flow to drive; fully covered by the unit regression tests above