### PR TITLE
DSP: N-channel processing contract for dspObject (upgrade mono modules) (#158)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(YSE_TEST_SOURCES
   dsp/test_modules.cpp
   dsp/test_module_filters.cpp
   dsp/test_module_delays.cpp
+  dsp/test_module_multichannel.cpp
   dsp/test_synth_voice.cpp
   patcher/test_graph.cpp
   patcher/test_nodes.cpp

--- a/Tests/dsp/test_module_multichannel.cpp
+++ b/Tests/dsp/test_module_multichannel.cpp
@@ -1,0 +1,285 @@
+// N-channel processing contract tests for the dspObject filter/delay/effect
+// MODULES upgraded under issue #158.
+//
+// Before #158 these modules processed only buffer[0] (the first channel). They
+// now process every channel of the MULTICHANNELBUFFER independently, each with
+// its own per-channel filter/delay/cascade state (see the contract on
+// DSP::dspObject::process and the DSP::perChannel<> helper).
+//
+// The three things the contract promises, and how they are checked here:
+//
+//   1. Every channel is processed independently. A module fed an N-channel
+//      buffer with a distinct signal per channel produces, on channel k, the
+//      *exact* same output a fresh mono instance produces when fed that same
+//      signal alone. This simultaneously proves (a) channels do not bleed into
+//      each other and (b) the mono path (channel 0 in isolation) is unchanged —
+//      the "bit-identical on mono input" regression requirement.
+//
+//   2. A mid-stream channel-count change (device restart: 6 -> 2 -> 6) neither
+//      crashes nor produces garbage.
+//
+//   3. Steady-state processing at a fixed channel count is allocation-free on
+//      the audio path (the only allocation allowed is the create()/resize
+//      path, exercised outside the probe here).
+//
+// No audio device required — SAMPLERATE is initialised to 44100 by the
+// portaudioDeviceManager translation unit at static-initialisation time.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "dsp/dspObject.hpp"
+#include "dsp/modules/filters/lowpass.hpp"
+#include "dsp/modules/filters/highpass.hpp"
+#include "dsp/modules/filters/bandpass.hpp"
+#include "dsp/modules/filters/sweep.hpp"
+#include "dsp/modules/phaser.hpp"
+#include "dsp/modules/ringModulator.hpp"
+#include "dsp/modules/delay/basicDelay.hpp"
+#include "dsp/modules/delay/lowpassDelay.hpp"
+#include "dsp/modules/delay/highpassDelay.hpp"
+#include "headers/defines.hpp"
+#include "support/audio_helpers.hpp"
+#include "support/alloc_probe.hpp"
+
+namespace {
+
+  constexpr float kPi = 3.14159265358979323846f;
+  constexpr unsigned kLen = 128;
+  constexpr int kBlocks = 40; // enough for filter/delay state to settle
+
+  using ModuleFactory = std::function<std::unique_ptr<YSE::DSP::dspObject>()>;
+
+  // Distinct, well-separated per-channel test frequency so each channel carries
+  // a different signal.
+  inline float channelFreq(std::size_t ch) {
+    return 250.0f + static_cast<float>(ch) * 311.0f;
+  }
+
+  inline void fillSine(YSE::DSP::buffer& buf, float freq, float sr = 44100.0f) {
+    float* p = buf.getPtr();
+    for (unsigned i = 0; i < buf.getLength(); ++i)
+      p[i] = std::sin(2.0f * kPi * freq * static_cast<float>(i) / sr);
+  }
+
+  inline float maxAbs(YSE::DSP::buffer& buf) {
+    float* p = buf.getPtr();
+    float m = 0.0f;
+    for (unsigned i = 0; i < buf.getLength(); ++i) {
+      float a = std::abs(p[i]);
+      if (a > m) m = a;
+    }
+    return m;
+  }
+
+  // Core check: channel k of an N-channel run must equal a mono run fed the
+  // same per-channel signal, for every channel. Also verifies neighbouring
+  // channels differ (they carry different frequencies), so a module that
+  // collapsed all channels onto one would fail.
+  void checkChannelIndependence(const ModuleFactory& make, unsigned channels) {
+    // --- N-channel run ---
+    auto multi = make();
+    MULTICHANNELBUFFER mbuf(channels);
+    for (unsigned ch = 0; ch < channels; ++ch)
+      mbuf[ch].resize(kLen);
+    for (int b = 0; b < kBlocks; ++b) {
+      for (unsigned ch = 0; ch < channels; ++ch)
+        fillSine(mbuf[ch], channelFreq(ch));
+      multi->process(mbuf);
+    }
+    // Capture the final-block output of every channel.
+    std::vector<YSE::DSP::buffer> captured;
+    captured.reserve(channels);
+    for (unsigned ch = 0; ch < channels; ++ch)
+      captured.push_back(mbuf[ch]);
+
+    // --- Per-channel mono reference runs ---
+    for (unsigned ch = 0; ch < channels; ++ch) {
+      auto mono = make();
+      MULTICHANNELBUFFER sbuf(1);
+      sbuf[0].resize(kLen);
+      for (int b = 0; b < kBlocks; ++b) {
+        fillSine(sbuf[0], channelFreq(ch));
+        mono->process(sbuf);
+      }
+      CHECK(TestHelpers::buffersNearlyEqual(captured[ch], sbuf[0], 1e-5f));
+    }
+
+    // Independence sanity: distinct inputs give distinct outputs.
+    if (channels >= 2)
+      CHECK_FALSE(TestHelpers::buffersNearlyEqual(captured[0], captured[1], 1e-4f));
+  }
+
+  // Device-restart survival: 6 -> 2 -> 6 channels mid-stream, no crash, output
+  // stays bounded throughout.
+  void checkChannelCountChange(const ModuleFactory& make) {
+    auto mod = make();
+    for (unsigned channels : {6u, 2u, 6u, 1u, 4u}) {
+      MULTICHANNELBUFFER buf(channels);
+      for (unsigned ch = 0; ch < channels; ++ch)
+        buf[ch].resize(kLen);
+      for (int b = 0; b < 8; ++b) {
+        for (unsigned ch = 0; ch < channels; ++ch)
+          fillSine(buf[ch], channelFreq(ch));
+        mod->process(buf);
+        for (unsigned ch = 0; ch < channels; ++ch)
+          CHECK(maxAbs(buf[ch]) < 50.0f);
+      }
+    }
+  }
+
+  // RT audit: after warming up at a fixed channel count / block length, the
+  // audio-path process() calls must not allocate.
+  void checkNoSteadyStateAllocation(const ModuleFactory& make) {
+    auto mod = make();
+    const unsigned channels = 4;
+    MULTICHANNELBUFFER buf(channels);
+    for (unsigned ch = 0; ch < channels; ++ch)
+      buf[ch].resize(kLen);
+
+    // Warm up: this includes the one-time create()/resize allocation.
+    for (int b = 0; b < 6; ++b) {
+      for (unsigned ch = 0; ch < channels; ++ch)
+        fillSine(buf[ch], channelFreq(ch));
+      mod->process(buf);
+    }
+
+    // Steady state: no allocation allowed.
+    {
+      TestHelpers::ProbeScope probe;
+      for (int b = 0; b < 8; ++b) {
+        for (unsigned ch = 0; ch < channels; ++ch)
+          fillSine(buf[ch], channelFreq(ch));
+        mod->process(buf);
+      }
+    }
+    CHECK(TestHelpers::g_alloc_count.load() == 0);
+  }
+
+  // --- Module factories (fresh, identically configured instance each call) ---
+
+  ModuleFactory lowPassFactory() {
+    return [] {
+      auto m = std::make_unique<YSE::DSP::MODULES::lowPassFilter>();
+      m->frequency(800.0f);
+      return m;
+    };
+  }
+  ModuleFactory highPassFactory() {
+    return [] {
+      auto m = std::make_unique<YSE::DSP::MODULES::highPassFilter>();
+      m->frequency(800.0f);
+      return m;
+    };
+  }
+  ModuleFactory bandPassFactory() {
+    return [] {
+      auto m = std::make_unique<YSE::DSP::MODULES::bandPassFilter>();
+      m->frequency(1200.0f).setQ(2.0f);
+      return m;
+    };
+  }
+  ModuleFactory sweepFactory() {
+    return [] {
+      auto m = std::make_unique<YSE::DSP::MODULES::sweepFilter>();
+      m->speed(1.0f).depth(50).frequency(50);
+      return m;
+    };
+  }
+  ModuleFactory phaserFactory() {
+    return [] {
+      auto m = std::make_unique<YSE::DSP::MODULES::phaser>();
+      m->frequency(0.3f).range(0.1f);
+      return m;
+    };
+  }
+  ModuleFactory ringModFactory() {
+    return [] {
+      auto m = std::make_unique<YSE::DSP::ringModulator>();
+      m->frequency(300.0f);
+      return m;
+    };
+  }
+  ModuleFactory basicDelayFactory() {
+    return [] {
+      auto m = std::make_unique<YSE::DSP::MODULES::basicDelay>();
+      using D = YSE::DSP::MODULES::basicDelay;
+      m->set(D::FIRST, 5.0f, 0.6f);
+      m->set(D::SECOND, 9.0f, 0.4f);
+      return m;
+    };
+  }
+  ModuleFactory lowPassDelayFactory() {
+    return [] {
+      auto m = std::make_unique<YSE::DSP::MODULES::lowPassDelay>();
+      m->frequency(1500.0f);
+      m->set(YSE::DSP::MODULES::basicDelay::FIRST, 5.0f, 0.8f);
+      return m;
+    };
+  }
+  ModuleFactory highPassDelayFactory() {
+    return [] {
+      auto m = std::make_unique<YSE::DSP::MODULES::highPassDelay>();
+      m->frequency(1500.0f);
+      m->set(YSE::DSP::MODULES::basicDelay::FIRST, 5.0f, 0.8f);
+      return m;
+    };
+  }
+
+  struct NamedFactory {
+    const char* name;
+    ModuleFactory make;
+  };
+
+  std::vector<NamedFactory> allModules() {
+    return {
+        {"lowPassFilter", lowPassFactory()},
+        {"highPassFilter", highPassFactory()},
+        {"bandPassFilter", bandPassFactory()},
+        {"sweepFilter", sweepFactory()},
+        {"phaser", phaserFactory()},
+        {"ringModulator", ringModFactory()},
+        {"basicDelay", basicDelayFactory()},
+        {"lowPassDelay", lowPassDelayFactory()},
+        {"highPassDelay", highPassDelayFactory()},
+    };
+  }
+
+} // anonymous namespace
+
+TEST_SUITE("dsp") {
+
+  TEST_CASE("multichannel modules: each channel is processed independently (6 channels)") {
+    for (auto& nf : allModules()) {
+      CAPTURE(nf.name);
+      checkChannelIndependence(nf.make, 6);
+    }
+  }
+
+  TEST_CASE("multichannel modules: single-channel output matches the mono reference") {
+    // A 1-channel buffer is the degenerate case of the contract; this is the
+    // explicit bit-identical mono regression guard.
+    for (auto& nf : allModules()) {
+      CAPTURE(nf.name);
+      checkChannelIndependence(nf.make, 1);
+    }
+  }
+
+  TEST_CASE("multichannel modules: mid-stream channel-count change does not crash") {
+    for (auto& nf : allModules()) {
+      CAPTURE(nf.name);
+      checkChannelCountChange(nf.make);
+    }
+  }
+
+  TEST_CASE("multichannel modules: steady-state processing is allocation-free") {
+    for (auto& nf : allModules()) {
+      CAPTURE(nf.name);
+      checkNoSteadyStateAllocation(nf.make);
+    }
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/dsp/dspObject.hpp
+++ b/YseEngine/dsp/dspObject.hpp
@@ -57,6 +57,35 @@ namespace YSE {
        *  bounded in time. Subclasses typically call ``createIfNeeded()`` at
        *  the start, do their work, then call ``calculateImpact()`` at the end
        *  to apply the wet/dry mix.
+       *
+       *  ### N-channel processing contract
+       *
+       *  ``buffer`` is a ``MULTICHANNELBUFFER`` (a ``std::vector`` of
+       *  ``DSP::buffer``, one per audio channel). Implementations MUST:
+       *
+       *  - **Process every channel** ``buffer[0] .. buffer[buffer.size()-1]``,
+       *    not just ``buffer[0]``. Each channel is an independent signal; state
+       *    that remembers per-sample history (filter memory, delay lines,
+       *    oscillator phase driven by the audio) must be kept *per channel* so
+       *    it does not bleed between them. The ``DSP::perChannel<State>`` helper
+       *    exists for this fan-out; ``reverbDSP`` (per-channel ``reverbChannel``
+       *    structs) is the reference example.
+       *  - **Tolerate a changing channel count between calls.** The device can
+       *    restart with a different output-channel count, so ``buffer.size()``
+       *    may differ from the previous call. Re-sizing per-channel state to
+       *    match is allowed to allocate — that is the device-restart path, not
+       *    the steady state — but this is the *only* place allocation is
+       *    permitted. Do it via ``perChannel::ensure(buffer.size())`` (or an
+       *    equivalent size check) so a steady-state call with an unchanged
+       *    count allocates nothing.
+       *  - **Allocate only in** ``create()`` **or on that resize path.** The
+       *    common per-block scratch (block-length ``result`` buffers, etc.) is
+       *    (re)sized only when the block length changes, exactly as the input
+       *    channels are.
+       *
+       *  A single-channel buffer is the degenerate case: modules upgraded to
+       *  this contract are bit-identical to their former mono-only behaviour
+       *  when ``buffer.size() == 1``.
        */
       virtual void process(MULTICHANNELBUFFER& buffer) = 0;
 

--- a/YseEngine/dsp/modules/delay/basicDelay.cpp
+++ b/YseEngine/dsp/modules/delay/basicDelay.cpp
@@ -57,53 +57,62 @@ Flt YSE::DSP::MODULES::basicDelay::gain(basicDelay::DELAY_NR nr) {
   return gain0; // stop complaining about control paths
 }
 
+YSE::DSP::MODULES::basicDelay::delayChannel::delayChannel() : line(static_cast<Int>(SAMPLERATE)) {}
+
 void YSE::DSP::MODULES::basicDelay::create() {
-  result.reset(new buffer);
-  delayBuffer.reset(new delay(SAMPLERATE));
-  reader.reset(new buffer);
-  createPreFilter();
+  // Per-channel delay lines are sized lazily in process() once the channel
+  // count is known; nothing to allocate up front.
 }
 
-void YSE::DSP::MODULES::basicDelay::createPreFilter() {}
-void YSE::DSP::MODULES::basicDelay::applyPreFilter(DSP::buffer& /*buffer*/) {}
+void YSE::DSP::MODULES::basicDelay::ensurePreFilter(std::size_t /*count*/) {}
+void YSE::DSP::MODULES::basicDelay::applyPreFilter(DSP::buffer& /*buffer*/, std::size_t /*ch*/) {}
 
 void YSE::DSP::MODULES::basicDelay::process(MULTICHANNELBUFFER& buffer) {
   createIfNeeded();
 
-  if (buffer[0].getLength() != result->getLength()) {
-    result->resize(buffer[0].getLength());
-    reader->resize(buffer[0].getLength());
+  if (buffer.empty()) return;
+
+  // Grow/shrink per-channel delay lines (and any subclass pre-filter) to match
+  // the channel count. Allocation-free once the count is stable.
+  channels.ensure(buffer.size());
+  ensurePreFilter(buffer.size());
+
+  for (std::size_t ch = 0; ch < buffer.size(); ++ch) {
+    if (buffer[ch].getLength() != result.getLength()) {
+      result.resize(buffer[ch].getLength());
+      reader.resize(buffer[ch].getLength());
+    }
+
+    result = buffer[ch];
+    applyPreFilter(buffer[ch], ch);
+
+    channels[ch].line.process(buffer[ch]);
+    Int delayCount = 1; // the original signal
+
+    // add delays to signal
+    if (gain0 > 0) {
+      channels[ch].line.read(reader, (UInt)time0);
+      reader *= gain0;
+      result += reader;
+      delayCount++;
+    }
+
+    if (gain1 > 0) {
+      channels[ch].line.read(reader, (UInt)time1);
+      reader *= gain1;
+      result += reader;
+      delayCount++;
+    }
+
+    if (gain2 > 0) {
+      channels[ch].line.read(reader, (UInt)time2);
+      reader *= gain2;
+      result += reader;
+      delayCount++;
+    }
+
+    // adjust total gain
+    result *= (1.f / delayCount);
+    calculateImpact(buffer[ch], result);
   }
-
-  (*result) = buffer[0];
-  applyPreFilter(buffer[0]);
-
-  delayBuffer->process(buffer[0]);
-  Int delayCount = 1; // the original signal
-
-  // add delays to signal
-  if (gain0 > 0) {
-    delayBuffer->read(*reader, (UInt)time0);
-    (*reader) *= gain0;
-    (*result) += (*reader);
-    delayCount++;
-  }
-
-  if (gain1 > 0) {
-    delayBuffer->read(*reader, (UInt)time1);
-    (*reader) *= gain1;
-    (*result) += (*reader);
-    delayCount++;
-  }
-
-  if (gain2 > 0) {
-    delayBuffer->read(*reader, (UInt)time2);
-    (*reader) *= gain2;
-    (*result) += (*reader);
-    delayCount++;
-  }
-
-  // adjust total gain
-  (*result) *= (1.f / delayCount);
-  calculateImpact(buffer[0], (*result));
 }

--- a/YseEngine/dsp/modules/delay/basicDelay.hpp
+++ b/YseEngine/dsp/modules/delay/basicDelay.hpp
@@ -14,7 +14,8 @@
 #include "../../../headers/defines.hpp"
 #include "../../dspObject.hpp"
 #include "../../delay.hpp"
-#include <memory>
+#include "../../perChannel.hpp"
+#include <cstddef>
 
 namespace YSE {
   namespace DSP {
@@ -27,7 +28,9 @@ namespace YSE {
        *  time and gain. Use ``highPassDelay`` / ``lowPassDelay`` for the same
        *  effect with a filter in the feedback path.
        *
-       *  @note Mono only — feeds the first channel of the multichannel buffer.
+       *  Processes every channel of the multichannel buffer independently, each
+       *  with its own delay line (see the N-channel contract on
+       *  ``dspObject::process``).
        */
       class API basicDelay : public dspObject {
       public:
@@ -61,20 +64,28 @@ namespace YSE {
         virtual void process(MULTICHANNELBUFFER& buffer);
 
       protected:
-        /** @brief Hook for subclasses to construct a pre-filter (used by ``lowPassDelay`` /
-         * ``highPassDelay``). */
-        virtual void createPreFilter();
+        /** @brief Hook for subclasses to size their per-channel pre-filter state
+         *  to ``count`` channels. Called from ``process`` on the (rare)
+         *  channel-count-change path. Base implementation does nothing. */
+        virtual void ensurePreFilter(std::size_t count);
 
-        /** @brief Hook for subclasses to apply their pre-filter to ``buffer`` before reading from
-         * the delay line. */
-        virtual void applyPreFilter(DSP::buffer& buffer);
+        /** @brief Hook for subclasses to apply their pre-filter for channel
+         *  ``ch`` to ``buffer`` before it enters the delay line. Base
+         *  implementation does nothing. */
+        virtual void applyPreFilter(DSP::buffer& buffer, std::size_t ch);
 
         aFlt time0, time1, time2;
         aFlt gain0, gain1, gain2;
 
-        std::shared_ptr<DSP::buffer> result;
-        std::shared_ptr<DSP::delay> delayBuffer;
-        std::shared_ptr<DSP::buffer> reader;
+        /** @brief One channel's delay line. */
+        struct delayChannel {
+          DSP::delay line;
+          delayChannel();
+        };
+
+        DSP::buffer result; // per-block scratch, shared across channels
+        DSP::buffer reader; // per-block scratch, shared across channels
+        perChannel<delayChannel> channels;
       };
 
     } // namespace MODULES

--- a/YseEngine/dsp/modules/delay/highpassDelay.cpp
+++ b/YseEngine/dsp/modules/delay/highpassDelay.cpp
@@ -12,13 +12,13 @@
 
 YSE::DSP::MODULES::highPassDelay::highPassDelay() : parmFrequency(1000.f) {}
 
-void YSE::DSP::MODULES::highPassDelay::createPreFilter() {
-  hp.reset(new DSP::highPass);
+void YSE::DSP::MODULES::highPassDelay::ensurePreFilter(std::size_t count) {
+  hp.ensure(count);
 }
 
-void YSE::DSP::MODULES::highPassDelay::applyPreFilter(DSP::buffer& buffer) {
-  (*hp).setFrequency(parmFrequency);
-  buffer = (*hp)(buffer);
+void YSE::DSP::MODULES::highPassDelay::applyPreFilter(DSP::buffer& buffer, std::size_t ch) {
+  hp[ch].setFrequency(parmFrequency);
+  buffer = hp[ch](buffer);
 }
 
 YSE::DSP::MODULES::highPassDelay& YSE::DSP::MODULES::highPassDelay::frequency(Flt value) {

--- a/YseEngine/dsp/modules/delay/highpassDelay.hpp
+++ b/YseEngine/dsp/modules/delay/highpassDelay.hpp
@@ -35,11 +35,11 @@ namespace YSE {
         Flt frequency();
 
       private:
-        virtual void createPreFilter();
-        virtual void applyPreFilter(DSP::buffer& buffer);
+        virtual void ensurePreFilter(std::size_t count);
+        virtual void applyPreFilter(DSP::buffer& buffer, std::size_t ch);
 
         aFlt parmFrequency;
-        std::shared_ptr<DSP::highPass> hp;
+        perChannel<DSP::highPass> hp; // one pre-filter per channel
       };
 
     } // namespace MODULES

--- a/YseEngine/dsp/modules/delay/lowpassDelay.cpp
+++ b/YseEngine/dsp/modules/delay/lowpassDelay.cpp
@@ -12,13 +12,13 @@
 
 YSE::DSP::MODULES::lowPassDelay::lowPassDelay() : parmFrequency(1000.f) {}
 
-void YSE::DSP::MODULES::lowPassDelay::createPreFilter() {
-  lp.reset(new DSP::lowPass);
+void YSE::DSP::MODULES::lowPassDelay::ensurePreFilter(std::size_t count) {
+  lp.ensure(count);
 }
 
-void YSE::DSP::MODULES::lowPassDelay::applyPreFilter(DSP::buffer& buffer) {
-  (*lp).setFrequency(parmFrequency);
-  buffer = (*lp)(buffer);
+void YSE::DSP::MODULES::lowPassDelay::applyPreFilter(DSP::buffer& buffer, std::size_t ch) {
+  lp[ch].setFrequency(parmFrequency);
+  buffer = lp[ch](buffer);
 }
 
 YSE::DSP::MODULES::lowPassDelay& YSE::DSP::MODULES::lowPassDelay::frequency(Flt value) {

--- a/YseEngine/dsp/modules/delay/lowpassDelay.hpp
+++ b/YseEngine/dsp/modules/delay/lowpassDelay.hpp
@@ -35,11 +35,11 @@ namespace YSE {
         Flt frequency();
 
       private:
-        virtual void createPreFilter();
-        virtual void applyPreFilter(DSP::buffer& buffer);
+        virtual void ensurePreFilter(std::size_t count);
+        virtual void applyPreFilter(DSP::buffer& buffer, std::size_t ch);
 
         aFlt parmFrequency;
-        std::shared_ptr<DSP::lowPass> lp;
+        perChannel<DSP::lowPass> lp; // one pre-filter per channel
       };
 
     } // namespace MODULES

--- a/YseEngine/dsp/modules/filters/bandpass.cpp
+++ b/YseEngine/dsp/modules/filters/bandpass.cpp
@@ -31,19 +31,25 @@ Flt YSE::DSP::MODULES::bandPassFilter::getQ() {
 }
 
 void YSE::DSP::MODULES::bandPassFilter::create() {
-  bp.reset(new bandPass);
-  result.reset(new buffer);
+  // Per-channel filters are sized lazily in process() once the channel count
+  // is known; nothing to allocate up front.
 }
 
 void YSE::DSP::MODULES::bandPassFilter::process(MULTICHANNELBUFFER& buffer) {
   createIfNeeded();
 
-  if (buffer[0].getLength() != result->getLength()) {
-    result->resize(buffer[0].getLength());
+  // Grow/shrink per-channel filter state to match the (possibly changed)
+  // channel count. Allocation-free once the count is stable.
+  bp.ensure(buffer.size());
+
+  for (std::size_t ch = 0; ch < buffer.size(); ++ch) {
+    if (buffer[ch].getLength() != result.getLength()) {
+      result.resize(buffer[ch].getLength());
+    }
+
+    bp[ch].set(parmFrequency, parmQ);
+    result = bp[ch](buffer[ch]);
+
+    calculateImpact(buffer[ch], result);
   }
-
-  (*bp).set(parmFrequency, parmQ);
-  (*result) = (*bp)(buffer[0]);
-
-  calculateImpact(buffer[0], (*result));
 }

--- a/YseEngine/dsp/modules/filters/bandpass.hpp
+++ b/YseEngine/dsp/modules/filters/bandpass.hpp
@@ -14,7 +14,7 @@
 #include "../../../headers/defines.hpp"
 #include "../../dspObject.hpp"
 #include "../../filters.hpp"
-#include <memory>
+#include "../../perChannel.hpp"
 
 namespace YSE {
   namespace DSP {
@@ -24,9 +24,9 @@ namespace YSE {
        *  @brief Resonant band-pass filter packaged as a chainable ``dspObject``.
        *
        *  Wraps ``DSP::bandPass`` for use in a sound's DSP chain via
-       *  ``YSE::sound::setDSP``.
-       *
-       *  @note Mono only — feeds the first channel of the multichannel buffer.
+       *  ``YSE::sound::setDSP``. Processes every channel of the multichannel
+       *  buffer independently, each with its own filter state (see the
+       *  N-channel contract on ``dspObject::process``).
        */
       class API bandPassFilter : public dspObject {
       public:
@@ -54,8 +54,8 @@ namespace YSE {
       private:
         aFlt parmFrequency;
         aFlt parmQ;
-        std::shared_ptr<DSP::buffer> result;
-        std::shared_ptr<bandPass> bp;
+        DSP::buffer result; // per-block scratch, shared across channels
+        perChannel<bandPass> bp; // one filter per channel
       };
 
     } // namespace MODULES

--- a/YseEngine/dsp/modules/filters/highpass.cpp
+++ b/YseEngine/dsp/modules/filters/highpass.cpp
@@ -22,19 +22,25 @@ Flt YSE::DSP::MODULES::highPassFilter::frequency() {
 }
 
 void YSE::DSP::MODULES::highPassFilter::create() {
-  hp.reset(new highPass);
-  result.reset(new buffer);
+  // Per-channel filters are sized lazily in process() once the channel count
+  // is known; nothing to allocate up front.
 }
 
 void YSE::DSP::MODULES::highPassFilter::process(MULTICHANNELBUFFER& buffer) {
   createIfNeeded();
 
-  if (buffer[0].getLength() != result->getLength()) {
-    result->resize(buffer[0].getLength());
+  // Grow/shrink per-channel filter state to match the (possibly changed)
+  // channel count. Allocation-free once the count is stable.
+  hp.ensure(buffer.size());
+
+  for (std::size_t ch = 0; ch < buffer.size(); ++ch) {
+    if (buffer[ch].getLength() != result.getLength()) {
+      result.resize(buffer[ch].getLength());
+    }
+
+    hp[ch].setFrequency(parmFrequency);
+    result = hp[ch](buffer[ch]);
+
+    calculateImpact(buffer[ch], result);
   }
-
-  (*hp).setFrequency(parmFrequency);
-  (*result) = (*hp)(buffer[0]);
-
-  calculateImpact(buffer[0], (*result));
 }

--- a/YseEngine/dsp/modules/filters/highpass.hpp
+++ b/YseEngine/dsp/modules/filters/highpass.hpp
@@ -14,7 +14,7 @@
 #include "../../../headers/defines.hpp"
 #include "../../dspObject.hpp"
 #include "../../filters.hpp"
-#include <memory>
+#include "../../perChannel.hpp"
 
 namespace YSE {
   namespace DSP {
@@ -24,9 +24,9 @@ namespace YSE {
        *  @brief High-pass filter packaged as a chainable ``dspObject``.
        *
        *  Wraps ``DSP::highPass`` for use in a sound's DSP chain via
-       *  ``YSE::sound::setDSP``.
-       *
-       *  @note Mono only — feeds the first channel of the multichannel buffer.
+       *  ``YSE::sound::setDSP``. Processes every channel of the multichannel
+       *  buffer independently, each with its own filter state (see the
+       *  N-channel contract on ``dspObject::process``).
        */
       class API highPassFilter : public dspObject {
       public:
@@ -47,8 +47,8 @@ namespace YSE {
 
       private:
         aFlt parmFrequency;
-        std::shared_ptr<DSP::buffer> result;
-        std::shared_ptr<highPass> hp;
+        DSP::buffer result; // per-block scratch, shared across channels
+        perChannel<highPass> hp; // one filter per channel
       };
 
     } // namespace MODULES

--- a/YseEngine/dsp/modules/filters/lowpass.cpp
+++ b/YseEngine/dsp/modules/filters/lowpass.cpp
@@ -22,19 +22,25 @@ Flt YSE::DSP::MODULES::lowPassFilter::frequency() {
 }
 
 void YSE::DSP::MODULES::lowPassFilter::create() {
-  lp.reset(new lowPass);
-  result.reset(new buffer);
+  // Per-channel filters are sized lazily in process() once the channel count
+  // is known; nothing to allocate up front.
 }
 
 void YSE::DSP::MODULES::lowPassFilter::process(MULTICHANNELBUFFER& buffer) {
   createIfNeeded();
 
-  if (buffer[0].getLength() != result->getLength()) {
-    result->resize(buffer[0].getLength());
+  // Grow/shrink per-channel filter state to match the (possibly changed)
+  // channel count. Allocation-free once the count is stable.
+  lp.ensure(buffer.size());
+
+  for (std::size_t ch = 0; ch < buffer.size(); ++ch) {
+    if (buffer[ch].getLength() != result.getLength()) {
+      result.resize(buffer[ch].getLength());
+    }
+
+    lp[ch].setFrequency(parmFrequency);
+    result = lp[ch](buffer[ch]);
+
+    calculateImpact(buffer[ch], result);
   }
-
-  (*lp).setFrequency(parmFrequency);
-  (*result) = (*lp)(buffer[0]);
-
-  calculateImpact(buffer[0], (*result));
 }

--- a/YseEngine/dsp/modules/filters/lowpass.hpp
+++ b/YseEngine/dsp/modules/filters/lowpass.hpp
@@ -14,7 +14,7 @@
 #include "../../../headers/defines.hpp"
 #include "../../dspObject.hpp"
 #include "../../filters.hpp"
-#include <memory>
+#include "../../perChannel.hpp"
 
 namespace YSE {
   namespace DSP {
@@ -24,9 +24,9 @@ namespace YSE {
        *  @brief Low-pass filter packaged as a chainable ``dspObject``.
        *
        *  Wraps ``DSP::lowPass`` for use in a sound's DSP chain via
-       *  ``YSE::sound::setDSP``.
-       *
-       *  @note Mono only — feeds the first channel of the multichannel buffer.
+       *  ``YSE::sound::setDSP``. Processes every channel of the multichannel
+       *  buffer independently, each with its own filter state (see the
+       *  N-channel contract on ``dspObject::process``).
        */
       class API lowPassFilter : public dspObject {
       public:
@@ -47,8 +47,8 @@ namespace YSE {
 
       private:
         aFlt parmFrequency;
-        std::shared_ptr<DSP::buffer> result;
-        std::shared_ptr<lowPass> lp;
+        DSP::buffer result; // per-block scratch, shared across channels
+        perChannel<lowPass> lp; // one filter per channel
       };
 
     } // namespace MODULES

--- a/YseEngine/dsp/modules/filters/sweep.cpp
+++ b/YseEngine/dsp/modules/filters/sweep.cpp
@@ -69,10 +69,9 @@ void YSE::DSP::MODULES::sweepFilter::create() {
 
   osc.reset(new oscillator);
   osc->initialize(*table);
-  filter.reset(new vcf);
-  filter->sharpness(2);
-  result.reset(new DSP::buffer);
   interpolator.reset(new DSP::interpolate4);
+  // Per-channel vcf filters are sized lazily in process(); each is given the
+  // same resonance the mono filter used.
 
   if (!mtofTable.getLength()) {
     mtofTable.resize(130);
@@ -88,15 +87,27 @@ void YSE::DSP::MODULES::sweepFilter::create() {
 void YSE::DSP::MODULES::sweepFilter::process(MULTICHANNELBUFFER& buffer) {
   createIfNeeded();
 
-  if (buffer[0].getLength() != result->getLength()) {
-    result->resize(buffer[0].getLength());
+  if (buffer.empty()) return;
+
+  // Grow/shrink per-channel filters to the channel count. New filters get the
+  // same resonance the mono path used. Allocation-free once the count is stable.
+  filter.ensure(buffer.size(), [](vcf& f) { f.sharpness(2); });
+
+  // The sweep LFO and its frequency mapping are identical across channels, so
+  // compute the cutoff control signal once per block.
+  if (buffer[0].getLength() != control.getLength()) {
+    control.resize(buffer[0].getLength());
   }
+  control = (*osc)(parmSpeed, buffer[0].getLength());
+  control *= (float)parmDepth;
+  control += (float)parmFrequency;
+  DSP::buffer& interpolated = (*interpolator)(control);
 
-  (*result) = (*osc)(parmSpeed, buffer[0].getLength());
-  (*result) *= (float)parmDepth;
-  (*result) += (float)parmFrequency;
-  DSP::buffer& interpolated = (*interpolator)(*result);
-  (*result) = (*filter)(buffer[0], interpolated).real();
-
-  calculateImpact(buffer[0], (*result));
+  for (std::size_t ch = 0; ch < buffer.size(); ++ch) {
+    if (buffer[ch].getLength() != result.getLength()) {
+      result.resize(buffer[ch].getLength());
+    }
+    result = filter[ch](buffer[ch], interpolated).real();
+    calculateImpact(buffer[ch], result);
+  }
 }

--- a/YseEngine/dsp/modules/filters/sweep.hpp
+++ b/YseEngine/dsp/modules/filters/sweep.hpp
@@ -16,6 +16,7 @@
 #include "../../filters.hpp"
 #include "../../oscillators.hpp"
 #include "../../interpolate4.hpp"
+#include "../../perChannel.hpp"
 #include <memory>
 
 namespace YSE {
@@ -74,11 +75,15 @@ namespace YSE {
         aInt parmFrequency;
 
         SHAPE shape;
+        // Shared modulation path: the sweep LFO and its frequency mapping are
+        // identical for every channel, so they run once per block.
         std::shared_ptr<wavetable> table;
         std::shared_ptr<oscillator> osc;
-        std::shared_ptr<vcf> filter;
-        std::shared_ptr<DSP::buffer> result;
         std::shared_ptr<interpolate4> interpolator;
+        DSP::buffer control; // per-block scratch: the cutoff control signal
+        DSP::buffer result; // per-block scratch: one channel's filtered output
+        // Per-channel filter state — each channel keeps its own vcf memory.
+        perChannel<vcf> filter;
       };
 
     } // namespace MODULES

--- a/YseEngine/dsp/modules/phaser.cpp
+++ b/YseEngine/dsp/modules/phaser.cpp
@@ -16,15 +16,8 @@ YSE::DSP::MODULES::phaser::phaser() : parmFrequency(0.3), parmRange(0.1) {}
 
 void YSE::DSP::MODULES::phaser::create() {
   triangle.reset(new lfo);
-  rzero1.reset(new realOneZeroReversed);
-  rzero2.reset(new realOneZeroReversed);
-  rzero3.reset(new realOneZeroReversed);
-  rzero4.reset(new realOneZeroReversed);
-  rpole1.reset(new realOnePole);
-  rpole2.reset(new realOnePole);
-  rpole3.reset(new realOnePole);
-  rpole4.reset(new realOnePole);
-  result.reset(new buffer);
+  // Per-channel all-pass cascades are sized lazily in process() once the
+  // channel count is known; nothing to allocate up front.
 }
 
 YSE::DSP::MODULES::phaser& YSE::DSP::MODULES::phaser::frequency(Flt value) {
@@ -50,27 +43,36 @@ Flt YSE::DSP::MODULES::phaser::range() {
 void YSE::DSP::MODULES::phaser::process(MULTICHANNELBUFFER& buffer) {
   createIfNeeded();
 
-  if (buffer[0].getLength() != result->getLength()) {
-    result->resize(buffer[0].getLength());
-  }
+  if (buffer.empty()) return;
 
-  (*result) = buffer[0];
+  // Grow/shrink per-channel cascades to the channel count. Allocation-free
+  // once the count is stable.
+  chain.ensure(buffer.size());
 
+  // The triangle LFO drives the whole buffer with a single sweep, so compute
+  // its coefficient signal once per block (advancing the LFO once, exactly as
+  // in the mono case).
   DSP::buffer& s = (*triangle)(YSE::DSP::LFO_TRIANGLE, parmFrequency);
-
   s *= parmRange;
   s += 0.98f - parmRange;
 
-  // buffer[0] *= 0.2;
-  // return;
-  DSP::buffer& result1 = (*rzero1)((*result), s);
-  DSP::buffer& result2 = (*rpole1)(result1, s);
-  DSP::buffer& result3 = (*rzero2)(result2, s);
-  DSP::buffer& result4 = (*rpole2)(result3, s);
-  DSP::buffer& result5 = (*rzero3)(result4, s);
-  DSP::buffer& result6 = (*rpole3)(result5, s);
-  DSP::buffer& result7 = (*rzero4)(result6, s);
-  (*result) += (*rpole4)(result7, s);
+  for (std::size_t ch = 0; ch < buffer.size(); ++ch) {
+    if (buffer[ch].getLength() != result.getLength()) {
+      result.resize(buffer[ch].getLength());
+    }
 
-  calculateImpact(buffer[0], (*result));
+    result = buffer[ch];
+
+    allpassChain& c = chain[ch];
+    DSP::buffer& result1 = c.rzero1(result, s);
+    DSP::buffer& result2 = c.rpole1(result1, s);
+    DSP::buffer& result3 = c.rzero2(result2, s);
+    DSP::buffer& result4 = c.rpole2(result3, s);
+    DSP::buffer& result5 = c.rzero3(result4, s);
+    DSP::buffer& result6 = c.rpole3(result5, s);
+    DSP::buffer& result7 = c.rzero4(result6, s);
+    result += c.rpole4(result7, s);
+
+    calculateImpact(buffer[ch], result);
+  }
 }

--- a/YseEngine/dsp/modules/phaser.hpp
+++ b/YseEngine/dsp/modules/phaser.hpp
@@ -14,6 +14,7 @@
 #include "../dspObject.hpp"
 #include "../lfo.hpp"
 #include "../rawFilters.hpp"
+#include "../perChannel.hpp"
 #include <memory>
 
 #include "../math.hpp"
@@ -27,7 +28,10 @@ namespace YSE {
        *  @brief Phaser effect as a chainable ``dspObject``.
        *
        *  Four-stage all-pass cascade modulated by a triangle LFO. Produces
-       *  the familiar sweeping "jet plane" sound.
+       *  the familiar sweeping "jet plane" sound. Processes every channel of
+       *  the multichannel buffer independently — the LFO is shared (one sweep
+       *  for the whole buffer) but each channel keeps its own all-pass cascade
+       *  state (see the N-channel contract on ``dspObject::process``).
        */
       class API phaser : public dspObject {
       public:
@@ -52,21 +56,19 @@ namespace YSE {
         /** @brief dspObject audio-thread entry point. */
         virtual void process(MULTICHANNELBUFFER& buffer);
 
+        /** @brief One channel's four-stage all-pass cascade state. */
+        struct allpassChain {
+          realOneZeroReversed rzero1, rzero2, rzero3, rzero4;
+          realOnePole rpole1, rpole2, rpole3, rpole4;
+        };
+
       private:
         aFlt parmFrequency;
         aFlt parmRange;
 
-        std::shared_ptr<lfo> triangle;
-        std::shared_ptr<realOneZeroReversed> rzero1;
-        std::shared_ptr<realOnePole> rpole1;
-        std::shared_ptr<realOneZeroReversed> rzero2;
-        std::shared_ptr<realOnePole> rpole2;
-        std::shared_ptr<realOneZeroReversed> rzero3;
-        std::shared_ptr<realOnePole> rpole3;
-        std::shared_ptr<realOneZeroReversed> rzero4;
-        std::shared_ptr<realOnePole> rpole4;
-
-        std::shared_ptr<buffer> result;
+        std::shared_ptr<lfo> triangle; // shared LFO — one sweep for the buffer
+        DSP::buffer result; // per-block scratch, shared across channels
+        perChannel<allpassChain> chain; // one cascade per channel
       };
 
     } // namespace MODULES

--- a/YseEngine/dsp/modules/ringModulator.cpp
+++ b/YseEngine/dsp/modules/ringModulator.cpp
@@ -29,15 +29,21 @@ void YSE::DSP::ringModulator::create() {
 void YSE::DSP::ringModulator::process(MULTICHANNELBUFFER& buffer) {
   createIfNeeded();
 
-  if (buffer[0].getLength() != result->getLength()) {
-    result->resize(buffer[0].getLength());
-  }
+  if (buffer.empty()) return;
 
-  // generate sine wave at wanted frequency
+  // A single carrier modulates every channel, so generate the sine once per
+  // block (advancing its phase once, exactly as in the mono case) and apply it
+  // to each channel in turn.
   YSE::DSP::buffer& sin = (*sineGen)(parmFrequency, buffer[0].getLength());
 
-  (*result) = buffer[0];
-  (*result) *= sin;
+  for (std::size_t ch = 0; ch < buffer.size(); ++ch) {
+    if (buffer[ch].getLength() != result->getLength()) {
+      result->resize(buffer[ch].getLength());
+    }
 
-  calculateImpact(buffer[0], (*result));
+    (*result) = buffer[ch];
+    (*result) *= sin;
+
+    calculateImpact(buffer[ch], (*result));
+  }
 }

--- a/YseEngine/dsp/perChannel.hpp
+++ b/YseEngine/dsp/perChannel.hpp
@@ -1,0 +1,114 @@
+/*
+  ==============================================================================
+
+    perChannel.hpp
+    Per-channel state fan-out helper for multichannel dspObject modules.
+
+  ==============================================================================
+*/
+
+#ifndef PERCHANNEL_HPP_INCLUDED
+#define PERCHANNEL_HPP_INCLUDED
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace YSE {
+  namespace DSP {
+
+    /**
+     *  @brief Per-channel state fan-out for multichannel ``dspObject`` modules.
+     *
+     *  A ``dspObject::process(MULTICHANNELBUFFER&)`` must process every channel
+     *  independently (see the contract on ``dspObject::process``). Any state
+     *  that remembers per-sample history — filter memory, delay lines,
+     *  oscillator phase — must exist *once per channel*, otherwise state bleeds
+     *  from one channel into the next and the channels are no longer
+     *  independent.
+     *
+     *  This utility lets a module be written as "one channel's worth of state"
+     *  (a small ``State`` struct) and then be fanned out to N channels without
+     *  hand-rolling a ``std::vector`` and its resize bookkeeping in every
+     *  module. It mirrors the pattern ``reverbDSP`` uses with its
+     *  ``std::vector<reverbChannel>``.
+     *
+     *  @tparam State  A per-channel state bundle. Must be default-constructible
+     *                 (``ensure`` grows the vector by default-constructing new
+     *                 states) and copyable/movable (``std::vector`` may relocate
+     *                 existing states when it grows — copying preserves their
+     *                 history).
+     *
+     *  ### Real-time discipline
+     *
+     *  ``ensure`` is the *only* member that can allocate, and it only does so
+     *  when the requested channel count differs from the current one — i.e. on
+     *  ``create()`` and on the device-restart resize path, never in steady
+     *  state. Call ``ensure(buffer.size())`` at the top of ``process`` and it
+     *  is a no-op (returns ``false``, no allocation) on every steady-state
+     *  callback. All other members are allocation-free.
+     */
+    template <typename State> class perChannel {
+    public:
+      /** @brief Number of channel states currently held. */
+      std::size_t size() const {
+        return states.size();
+      }
+
+      /** @brief Whether no channel states are held yet. */
+      bool empty() const {
+        return states.empty();
+      }
+
+      /** @brief Access the state for channel ``i`` (no bounds check). */
+      State& operator[](std::size_t i) {
+        return states[i];
+      }
+
+      /** @brief Const access to the state for channel ``i`` (no bounds check). */
+      const State& operator[](std::size_t i) const {
+        return states[i];
+      }
+
+      /** @brief Grow or shrink to ``count`` channel states.
+       *
+       *  Returns ``true`` if the channel count changed — in which case an
+       *  allocation may have occurred, so this must only be reached off the
+       *  steady-state audio path (from ``create()`` or the device-restart
+       *  resize path). New states are default-constructed; existing states keep
+       *  their history (a shrink drops the tail, a subsequent grow appends
+       *  fresh states after the retained prefix). Returns ``false`` and does
+       *  nothing when ``count`` already matches ``size()``.
+       */
+      bool ensure(std::size_t count) {
+        if (states.size() == count) return false;
+        states.resize(count);
+        return true;
+      }
+
+      /** @brief Grow or shrink to ``count`` channel states, initialising new ones.
+       *
+       *  Like ``ensure(count)``, but every newly appended state is handed to
+       *  ``initEach(State&)`` after construction. Use it to wire up state a
+       *  default constructor cannot reach — a shared wavetable pointer, a
+       *  filter's resonance, etc. ``initEach`` runs only on the states that
+       *  were just added, never on retained ones. Same allocation contract as
+       *  ``ensure(count)``.
+       */
+      template <typename InitFn> bool ensure(std::size_t count, InitFn&& initEach) {
+        if (states.size() == count) return false;
+        std::size_t previous = states.size();
+        states.resize(count);
+        for (std::size_t i = previous; i < states.size(); ++i)
+          initEach(states[i]);
+        return true;
+      }
+
+    private:
+      std::vector<State> states;
+    };
+
+  } // namespace DSP
+} // namespace YSE
+
+#endif // PERCHANNEL_HPP_INCLUDED


### PR DESCRIPTION
## Summary

Defines and documents the **N-channel processing contract** for
`DSP::dspObject::process(MULTICHANNELBUFFER&)` and upgrades the modules
that were previously mono-only (processed `buffer[0]` alone) so they
process every channel of the multichannel buffer independently. This is
the prerequisite groundwork (part of #146) for channel insert effects,
which must process a channel's full N-device-channel `out` vector.

## Linked issue

Closes #158

## Changes

- **Contract** — documented on `dspObject::process`: process every
  channel, keep per-sample history (filter/delay/oscillator state) *per
  channel*, tolerate a changing `buffer.size()` between calls (device
  restart), and allocate only in `create()` / on the resize path.
- **Helper** — new header-only `DSP::perChannel<State>`
  (`dsp/perChannel.hpp`): fan-out of a "one channel's worth of state"
  struct to N channels, with an `ensure(count)` that only allocates when
  the count changes (mirrors the `reverbDSP` / `reverbChannel` pattern).
- **Modules upgraded in place**:
  - filters: `lowPassFilter`, `highPassFilter`, `bandPassFilter`
    (per-channel filter state); `sweepFilter` (shared sweep LFO +
    interpolator computed once per block, per-channel `vcf`)
  - `phaser` (shared triangle LFO, per-channel all-pass cascade)
  - `ringModulator` (single shared carrier applied to every channel)
  - `basicDelay` + `lowPassDelay` / `highPassDelay` (per-channel delay
    line and per-channel pre-filter; the pre-filter hooks became
    `ensurePreFilter(count)` / `applyPreFilter(buffer, ch)`)

Shared LFOs/carriers still advance once per block and each channel's
state path is unchanged, so **mono (single-channel) output is
bit-identical** to before.

Out of scope (per the issue non-goals): new effect modules, the
`sound::setDSP` attach path, and C API changes. `difference` (FM) and
`granulator` were not on the issue's list and are left untouched.

## Test plan

New suite `Tests/dsp/test_module_multichannel.cpp`, run across all nine
upgraded modules:

- [x] **Per-channel independence** (6 channels): channel *k* of an
      N-channel run equals a fresh mono run fed the same signal
      (bit-identical within 1e-5) — proves channels don't bleed *and* the
      mono path is unchanged, in one check; neighbouring channels with
      different inputs produce different outputs.
- [x] **Single-channel mono equivalence** — explicit degenerate-case guard.
- [x] **Mid-stream channel-count change** (6→2→6→1→4): no crash, bounded output.
- [x] **Steady-state RT-allocation audit**: after warm-up, `process()`
      allocates nothing (heap probe).
- [x] `clang-format --check` clean (`python yse.py format`)
- [x] `clang-tidy` clean on modified code (`python yse.py analyze` — no
      new findings; header `virtual`/`override` hints are the pre-existing
      baseline pattern shared by every module header, non-gating)
- [x] Full suite green: `python yse.py test` — 23/23 CTest targets pass;
      the new suite adds 4 cases / 1449 assertions, all passing.
