### PR TITLE
ENGINE: Channel insert DSP chain (#159)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(YSE_TEST_SOURCES
   channel/test_channel_metering.cpp
   channel/test_channel_bus.cpp
   channel/test_channel_layout.cpp
+  channel/test_channel_dsp.cpp
   sound/test_sound_state.cpp
   sound/test_sound_streaming.cpp
   sound/test_sound_bufferrace.cpp

--- a/Tests/channel/test_channel_dsp.cpp
+++ b/Tests/channel/test_channel_dsp.cpp
@@ -1,0 +1,262 @@
+// Tests for the channel insert DSP chain (issue #159, part of epic #146).
+//
+// Covers:
+//   - CHANNEL::ATTACH_DSP message id is distinct from the other channel IDs.
+//   - The pre-fader insert chain audibly processes the summed channel signal
+//     (a gain-inverting / gain-scaling test module applied to `out`).
+//   - Chained modules (dspObject::link) both run, in order.
+//   - A bypassed module passes the signal through unchanged.
+//   - Attach/replace/detach follow the sound-path `calledfrom` swap discipline
+//     (#298): replacing clears the old plugin's back-reference, detaching with
+//     nullptr severs it, and a plugin destroyed before the channel nulls the
+//     impl's insert_dsp instead of leaving it dangling.
+//   - Interface-level setDSP()/getDSP() round-trip on a live channel.
+//
+// The behavioural cases drive CHANNEL::implementationObject directly (the same
+// pattern the motif/player tests use): setup() sizes `out`, we write a known
+// signal into GetBuffers(), attach a module via parseMessage(ATTACH_DSP), then
+// call processInsertDSP() — exactly what dsp() invokes pre-fader — and assert
+// on the resulting buffers. Engine-dependent cases guard on engineInit().
+
+#include <doctest/doctest.h>
+#include <chrono>
+#include <thread>
+#include <vector>
+#include "channel/channelInterface.hpp"
+#include "channel/channelImplementation.h"
+#include "channel/channelManager.h"
+#include "channel/channelMessage.h"
+#include "dsp/dspObject.hpp"
+#include "sound/soundManager.h"
+#include "internal/time.h"
+#include "support/null_device.hpp"
+
+namespace {
+  // A minimal N-channel-aware insert module: multiplies every sample of every
+  // channel by `gain`. Honours the dspObject N-channel contract (processes all
+  // of buffer[0..size-1], no per-channel history so nothing to fan out).
+  struct GainDsp : YSE::DSP::dspObject {
+    explicit GainDsp(float g) : gain(g) {}
+    void create() override {}
+    void process(std::vector<YSE::DSP::buffer>& buffer) override {
+      for (auto& ch : buffer) {
+        float* p = ch.getPtr();
+        const UInt n = ch.getLength();
+        for (UInt i = 0; i < n; ++i)
+          p[i] *= gain;
+      }
+    }
+    float gain;
+  };
+
+  // Build a channel impl whose `out` is sized to the device layout. Requires a
+  // live engine (setup() reads CHANNEL::Manager().getNumberOfOutputs()).
+  void primeImpl(YSE::CHANNEL::implementationObject& impl) {
+    impl.setStatus(YSE::OBJECT_CREATED);
+    impl.setup();
+  }
+
+  // Fill every channel of `out` with a constant value.
+  void fill(std::vector<YSE::DSP::buffer>& bufs, float value) {
+    for (auto& b : bufs) {
+      float* p = b.getPtr();
+      const UInt n = b.getLength();
+      for (UInt i = 0; i < n; ++i)
+        p[i] = value;
+    }
+  }
+
+  // True if every sample of every channel equals `value`.
+  bool allEqual(std::vector<YSE::DSP::buffer>& bufs, float value) {
+    for (auto& b : bufs) {
+      float* p = b.getPtr();
+      const UInt n = b.getLength();
+      for (UInt i = 0; i < n; ++i)
+        if (p[i] != doctest::Approx(value)) return false;
+    }
+    return true;
+  }
+
+  void attach(YSE::CHANNEL::implementationObject& impl, YSE::DSP::dspObject* dsp) {
+    YSE::CHANNEL::messageObject m;
+    m.ID = YSE::CHANNEL::ATTACH_DSP;
+    m.ptrValue = dsp;
+    impl.parseMessage(m);
+  }
+
+  void drainChannels(int iterations = 8) {
+    for (int i = 0; i < iterations; ++i) {
+      YSE::INTERNAL::Time().update();
+      YSE::SOUND::Manager().update();
+      YSE::CHANNEL::Manager().update();
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+  }
+} // namespace
+
+TEST_SUITE("channel") {
+
+  // ─── Message id ───────────────────────────────────────────────────────────
+
+  TEST_CASE("channel dsp: ATTACH_DSP id is distinct from the other channel IDs") {
+    YSE::CHANNEL::messageObject m;
+    m.ID = YSE::CHANNEL::ATTACH_DSP;
+    CHECK(m.ID == YSE::CHANNEL::ATTACH_DSP);
+    CHECK(m.ID != YSE::CHANNEL::VOLUME);
+    CHECK(m.ID != YSE::CHANNEL::MOVE);
+    CHECK(m.ID != YSE::CHANNEL::VIRTUAL);
+    CHECK(m.ID != YSE::CHANNEL::ATTACH_REVERB);
+  }
+
+  // ─── Pre-fader processing behaviour ────────────────────────────────────────
+
+  TEST_CASE("channel dsp: insert module scales the summed channel signal") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::CHANNEL::implementationObject impl(nullptr);
+    primeImpl(impl);
+    auto& bufs = impl.GetBuffers();
+    REQUIRE(bufs.size() > 0);
+
+    fill(bufs, 0.5f);
+    GainDsp doubler(2.0f);
+    attach(impl, &doubler);
+    impl.processInsertDSP();
+    CHECK(allEqual(bufs, 1.0f));
+  }
+
+  TEST_CASE("channel dsp: gain-inverting insert flips the summed signal (acceptance)") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::CHANNEL::implementationObject impl(nullptr);
+    primeImpl(impl);
+    auto& bufs = impl.GetBuffers();
+    REQUIRE(bufs.size() > 0);
+
+    fill(bufs, 0.25f);
+    GainDsp inverter(-1.0f);
+    attach(impl, &inverter);
+    impl.processInsertDSP();
+    CHECK(allEqual(bufs, -0.25f));
+  }
+
+  TEST_CASE("channel dsp: no attached chain leaves the signal untouched") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::CHANNEL::implementationObject impl(nullptr);
+    primeImpl(impl);
+    auto& bufs = impl.GetBuffers();
+    REQUIRE(bufs.size() > 0);
+
+    fill(bufs, 0.3f);
+    impl.processInsertDSP(); // insert_dsp == nullptr -> no-op
+    CHECK(allEqual(bufs, 0.3f));
+  }
+
+  TEST_CASE("channel dsp: linked modules both process, in order") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::CHANNEL::implementationObject impl(nullptr);
+    primeImpl(impl);
+    auto& bufs = impl.GetBuffers();
+    REQUIRE(bufs.size() > 0);
+
+    fill(bufs, 0.1f);
+    GainDsp a(2.0f);
+    GainDsp b(3.0f);
+    a.link(b); // chain: a -> b
+    attach(impl, &a);
+    impl.processInsertDSP();
+    CHECK(allEqual(bufs, 0.6f)); // 0.1 * 2 * 3
+  }
+
+  TEST_CASE("channel dsp: bypassed module passes the signal through unchanged") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::CHANNEL::implementationObject impl(nullptr);
+    primeImpl(impl);
+    auto& bufs = impl.GetBuffers();
+    REQUIRE(bufs.size() > 0);
+
+    fill(bufs, 0.4f);
+    GainDsp doubler(2.0f);
+    doubler.bypass(true);
+    attach(impl, &doubler);
+    impl.processInsertDSP();
+    CHECK(allEqual(bufs, 0.4f));
+  }
+
+  // ─── Attach / replace / detach discipline (calledfrom) ─────────────────────
+
+  TEST_CASE("channel dsp: replacing a plugin clears the old plugin's calledfrom") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::CHANNEL::implementationObject impl(nullptr);
+    primeImpl(impl);
+
+    GainDsp first(2.0f);
+    GainDsp second(3.0f);
+    attach(impl, &first);
+    CHECK(first.calledfrom != nullptr);
+
+    attach(impl, &second);
+    CHECK(first.calledfrom == nullptr); // old back-reference severed
+    CHECK(second.calledfrom != nullptr); // new one points into the impl
+
+    // Only the second module is now in the chain.
+    auto& bufs = impl.GetBuffers();
+    fill(bufs, 0.5f);
+    impl.processInsertDSP();
+    CHECK(allEqual(bufs, 1.5f)); // 0.5 * 3, not * 2 or * 6
+  }
+
+  TEST_CASE("channel dsp: detaching with nullptr severs the chain") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::CHANNEL::implementationObject impl(nullptr);
+    primeImpl(impl);
+
+    GainDsp doubler(2.0f);
+    attach(impl, &doubler);
+    CHECK(doubler.calledfrom != nullptr);
+
+    attach(impl, nullptr); // detach
+    CHECK(doubler.calledfrom == nullptr);
+
+    auto& bufs = impl.GetBuffers();
+    fill(bufs, 0.5f);
+    impl.processInsertDSP(); // chain empty -> no-op
+    CHECK(allEqual(bufs, 0.5f));
+  }
+
+  TEST_CASE("channel dsp: plugin destroyed before the channel nulls insert_dsp (no UAF)") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::CHANNEL::implementationObject impl(nullptr);
+    primeImpl(impl);
+    auto& bufs = impl.GetBuffers();
+
+    {
+      GainDsp scoped(2.0f);
+      attach(impl, &scoped);
+      CHECK(scoped.calledfrom != nullptr);
+    } // ~GainDsp writes *calledfrom = nullptr -> impl.insert_dsp becomes nullptr
+
+    // The now-empty chain must be a safe no-op, not a use-after-free.
+    fill(bufs, 0.5f);
+    impl.processInsertDSP();
+    CHECK(allEqual(bufs, 0.5f));
+  }
+
+  // ─── Interface-level API round-trip ────────────────────────────────────────
+
+  TEST_CASE("channel dsp: setDSP / getDSP round-trip on a live channel") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::channel c;
+    c.create("dsp_iface_channel", YSE::ChannelMaster());
+    drainChannels();
+    CHECK(c.getDSP() == nullptr);
+
+    GainDsp gain(2.0f);
+    c.setDSP(&gain);
+    CHECK(c.getDSP() == &gain);
+    drainChannels();
+
+    c.setDSP(nullptr); // detach so the stack module doesn't outlive the impl
+    CHECK(c.getDSP() == nullptr);
+    drainChannels();
+  }
+
+} // TEST_SUITE("channel")

--- a/YseEngine/channel/channel.hpp
+++ b/YseEngine/channel/channel.hpp
@@ -27,6 +27,7 @@ namespace YSE {
       MOVE,
       VIRTUAL,
       ATTACH_REVERB,
+      ATTACH_DSP,
     };
   } // namespace CHANNEL
 } // namespace YSE

--- a/YseEngine/channel/channelImplementation.cpp
+++ b/YseEngine/channel/channelImplementation.cpp
@@ -11,7 +11,12 @@
 #include "../internalHeaders.h"
 
 YSE::CHANNEL::implementationObject::implementationObject(channel* head)
-  : head(head), newVolume(1.f), lastVolume(1.f), parent(nullptr), allowVirtual(true) {}
+  : head(head),
+    newVolume(1.f),
+    lastVolume(1.f),
+    parent(nullptr),
+    insert_dsp(nullptr),
+    allowVirtual(true) {}
 
 YSE::CHANNEL::implementationObject::~implementationObject() noexcept {
   try {
@@ -32,6 +37,14 @@ YSE::CHANNEL::implementationObject::~implementationObject() noexcept {
         parent->disconnect(this);
         childrenToParent();
       }
+    }
+
+    // Sever the insert plugin's back-reference before we die, so a plugin that
+    // outlives this channel (e.g. a process-lifetime static destroyed at exit)
+    // can't write through calledfrom into our freed insert_dsp field. Mirrors
+    // the sound-path guard in ~SOUND::implementationObject (#298).
+    if (insert_dsp != nullptr && insert_dsp->calledfrom != nullptr) {
+      insert_dsp->calledfrom = nullptr;
     }
 
     if (head.load() != nullptr) {
@@ -109,6 +122,12 @@ void YSE::CHANNEL::implementationObject::dsp() {
     }
   }
 
+  // Pre-fader insert chain: process the summed channel signal in place, before
+  // reverb and before the channel volume is applied (buffersToParent). The
+  // `out` vector is MULTICHANNELBUFFER-shaped, so it type-matches
+  // dspObject::process (N-channel contract, #158).
+  if (insert_dsp != nullptr) processInsertDSP();
+
   REVERB::Manager().process(this);
 
   if (INTERNAL::UnderWaterEffect().channel() == this) {
@@ -161,6 +180,32 @@ void YSE::CHANNEL::implementationObject::buffersToParent() {
 
 void YSE::CHANNEL::implementationObject::attachUnderWaterFX() {
   INTERNAL::UnderWaterEffect().channel(this);
+}
+
+void YSE::CHANNEL::implementationObject::addDSP(DSP::dspObject* ptr) {
+  // Detach any previously-attached plugin first and clear its back-reference
+  // (calledfrom) — otherwise, when that old plugin is destructed later, its
+  // destructor's `*calledfrom = nullptr` would write to this impl's insert_dsp
+  // field, which may already have been freed. Same discipline as
+  // SOUND::implementationObject::addDSP (the sound-path UAF, #298). Pointer
+  // swap only: safe on the audio thread, no allocation or locking. A null
+  // `ptr` simply detaches the chain.
+  if (insert_dsp != nullptr) {
+    insert_dsp->calledfrom = nullptr;
+  }
+
+  insert_dsp = ptr;
+  if (insert_dsp != nullptr) {
+    insert_dsp->calledfrom = &insert_dsp;
+  }
+}
+
+void YSE::CHANNEL::implementationObject::processInsertDSP() {
+  DSP::dspObject* ptr = insert_dsp;
+  while (ptr != nullptr) {
+    if (!ptr->bypass()) ptr->process(out);
+    ptr = ptr->link();
+  }
 }
 
 void YSE::CHANNEL::implementationObject::setup() {
@@ -274,6 +319,9 @@ void YSE::CHANNEL::implementationObject::parseMessage(const messageObject& messa
   switch (message.ID) {
   case ATTACH_REVERB:
     REVERB::Manager().attachToChannel(this);
+    break;
+  case ATTACH_DSP:
+    addDSP((DSP::dspObject*)message.ptrValue);
     break;
   case MOVE: {
     channel* ptr = (channel*)message.ptrValue;

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -199,6 +199,24 @@ namespace YSE {
         return out;
       }
 
+      /**
+        Attach (or replace/detach) the pre-fader insert DSP chain for this
+        channel. Mirrors SOUND::implementationObject::addDSP: the previously
+        attached head's back-reference (calledfrom) is cleared before the swap
+        so a later destruction of the old plugin can't write through a stale
+        pointer into this impl's insert_dsp field (the sound-path UAF fixed in
+        #298). Passing nullptr detaches the chain. Runs on the audio thread via
+        parseMessage(ATTACH_DSP) — pointer-swap only, no allocation or locking.
+      */
+      void addDSP(DSP::dspObject* ptr);
+
+      /**
+        Run the attached insert chain over `out` in place. Called from dsp()
+        pre-fader (before reverb); public so the pre-fader insert behaviour can
+        be driven directly in tests after populating `out`.
+      */
+      void processInsertDSP();
+
       /////////////////////////////////////////////////////
       // Output peak metering (control-thread readers)
       /////////////////////////////////////////////////////
@@ -284,6 +302,13 @@ namespace YSE {
 
       std::vector<output> outConf;
       std::vector<DSP::buffer> out;
+
+      // Head of the pre-fader insert DSP chain, or nullptr when none is
+      // attached. Owned by the caller (the interface's dspObject), not by this
+      // impl. Swapped only on the audio thread in addDSP(); the plugin's
+      // `calledfrom` back-reference points here so a plugin destroyed before
+      // detach nulls this field instead of leaving it dangling.
+      DSP::dspObject* insert_dsp;
 
       // Per-output peak (absolute sample value), refreshed once per DSP block.
       // Sized to out.size() and resized on the same path as out (audio thread

--- a/YseEngine/channel/channelInterface.cpp
+++ b/YseEngine/channel/channelInterface.cpp
@@ -170,6 +170,21 @@ YSE::channel& YSE::channel::attachReverb() {
   return (*this);
 }
 
+YSE::channel& YSE::channel::setDSP(YSE::DSP::dspObject* value) {
+  if (_dsp != value) {
+    _dsp = value;
+    CHANNEL::messageObject m;
+    m.ID = CHANNEL::ATTACH_DSP;
+    m.ptrValue = value;
+    pimpl->sendMessage(m);
+  }
+  return (*this);
+}
+
+YSE::DSP::dspObject* YSE::channel::getDSP() {
+  return _dsp;
+}
+
 int YSE::channel::getNumOutputs() {
   if (pimpl == nullptr) return 0;
   return pimpl->getNumOutputs();

--- a/YseEngine/channel/channelInterface.hpp
+++ b/YseEngine/channel/channelInterface.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <string>
+#include "../classes.hpp"
 #include "../headers/defines.hpp"
 #include "../headers/types.hpp"
 #include "channel.hpp"
@@ -107,6 +108,29 @@ namespace YSE {
     channel& attachReverb();
 
     /**
+     *  @brief Attach a pre-fader insert DSP effect to this channel.
+     *
+     *  Mirrors ``YSE::sound::setDSP`` but at the channel level: the effect
+     *  processes this channel's *summed* output (all its sounds and
+     *  subchannels mixed together) in place, **pre-fader** — before reverb and
+     *  before the channel volume is applied. This is the DAW "insert" slot;
+     *  put a delay on ``ChannelMusic()`` or a compressor on ``ChannelVoice()``.
+     *
+     *  The effect must honour the N-channel ``dspObject::process`` contract
+     *  (process every channel of the buffer). Chain several effects with
+     *  ``dspObject::link``. Pass ``nullptr`` to detach. The engine takes no
+     *  ownership — the ``dspObject`` must outlive the channel or be detached
+     *  first.
+     *
+     *  @param value The effect chain head, or ``nullptr`` to detach.
+     *  @return ``*this`` for fluent chaining.
+     */
+    channel& setDSP(DSP::dspObject* value);
+
+    /** @brief The currently attached insert effect, or ``nullptr`` if none. */
+    DSP::dspObject* getDSP();
+
+    /**
      *  @brief Allow or disallow sounds on this channel to be virtualised.
      *
      *  Virtualised sounds keep their playback state but stop consuming DSP
@@ -180,6 +204,11 @@ namespace YSE {
     Bool allowVirtual;
     std::string logName; // label passed to create(); used for log output
     CHANNEL::implementationObject* pimpl;
+
+    // Cached head of the attached insert chain (interface-side mirror of the
+    // impl's insert_dsp). Used by getDSP() and to skip redundant messages when
+    // setDSP() is called with an unchanged pointer. Not owned.
+    DSP::dspObject* _dsp{nullptr};
 
     // Bus addressing state. Empty busName = anonymous = not on the bus.
     // busOwner is true only when this channel won the name and holds a live


### PR DESCRIPTION
## Summary

DAW-style insert effects on mixer channels. Adds `channel::setDSP(DSP::dspObject*)` / `getDSP()` and a new `CHANNEL::ATTACH_DSP` message, mirroring the `attachReverb` handshake. The attached chain processes the channel's **summed** signal **pre-fader** — in `dsp()`, right before `REVERB::Manager().process(this)` — over the `MULTICHANNELBUFFER`-shaped `out` vector, so it type-matches `dspObject::process` (the N-channel contract from #158/#310).

## Linked issue

Closes #159

## Changes

- `channel/channel.hpp` — new `ATTACH_DSP` message id.
- `channel/channelInterface.{hpp,cpp}` — `setDSP()` / `getDSP()` on the public interface; interface-side `_dsp` cache (skips redundant messages, backs `getDSP()`).
- `channel/channelImplementation.{h,cpp}` — `insert_dsp` chain head, `addDSP()` (RT-safe pointer swap), `processInsertDSP()` (walks the chain over `out`, honouring `bypass()`), the `dsp()` pre-fader call site, the `ATTACH_DSP` parse case, and destructor teardown.
- `Tests/channel/test_channel_dsp.cpp` + CMake registration.

## Real-time / audio-thread discipline

Chain swap copies the `calledfrom` back-reference discipline from `SOUND::implementationObject::addDSP` (the sound-path UAF, #298): the old plugin's back-reference is cleared before the swap so a plugin destroyed after detach can't write through a stale pointer into the impl's freed `insert_dsp`. Attach/detach is a pointer swap only — no allocation, lock, or blocking on the audio thread. `nullptr` detaches; the destructor severs any still-attached plugin's back-reference.

Scope kept tight per the issue non-goals: no post-fader inserts, no C API (batched later).

## Test plan

- [x] `yse.py format` clean (ran, no diff on the changed files)
- [x] `yse.py analyze` clean on changed files (no new user-code findings; only pre-existing baseline `enum`/override warnings in headers)
- [x] Unit + behavioural tests pass — `yse.py test`: **23/23 test executables passed, 0 failed** (incl. the monolithic `yse_unit_tests` and `yse_tests_channel`).
- [x] New `channel dsp` suite: **10 cases / 27 assertions, all passed, none skipped** (engineInit succeeded, so the behavioural asserts genuinely ran). Covers: pre-fader gain-scaling + gain-inverting acceptance over `out`, linked-module ordering, bypass passthrough, attach/replace/detach `calledfrom` discipline, plugin-destroyed-before-channel UAF guard, and the `setDSP`/`getDSP` round-trip.

The behavioural cases drive `CHANNEL::implementationObject` directly (same pattern as the motif/player tests): `setup()` sizes `out`, a known signal is written into `GetBuffers()`, a module is attached via `parseMessage(ATTACH_DSP)`, then `processInsertDSP()` — the exact method `dsp()` calls pre-fader — runs and the buffers are asserted. A full end-to-end audio run isn't feasible in the unit harness (audio is paused by `engineInit()` and there's no default device on CI); the direct-impl driver exercises the real production code path instead.