### PR TITLE
DSP: chorus/flanger module (#161)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(YSE_TEST_SOURCES
   dsp/test_module_filters.cpp
   dsp/test_module_delays.cpp
   dsp/test_module_feedback_delay.cpp
+  dsp/test_module_chorus.cpp
   dsp/test_module_multichannel.cpp
   dsp/test_synth_voice.cpp
   patcher/test_graph.cpp

--- a/Tests/dsp/test_module_chorus.cpp
+++ b/Tests/dsp/test_module_chorus.cpp
@@ -12,8 +12,11 @@
 // click-free by construction. The wet/dry balance is the inherited impact();
 // default impact = 1 is fully wet.
 //
-// No audio device required — SAMPLERATE is initialised to 44100 by the
-// portaudioDeviceManager translation unit at static-initialisation time.
+// No audio device required — SAMPLERATE is initialised by the
+// portaudioDeviceManager translation unit at static-initialisation time (44100
+// by default; CI also forces 48000 via YSE_TEST_FORCED_RATE). Every tone and
+// observation window below is derived from the *actual* SAMPLERATE so the tests
+// hold at any rate.
 
 #include <doctest/doctest.h>
 #include <cmath>
@@ -23,20 +26,25 @@
 #include "support/audio_helpers.hpp"
 
 static constexpr float kPi = 3.14159265358979323846f;
-static constexpr float kSr = 44100.0f;
 
 namespace {
 
+  // The engine sample rate this test run is using (honours the forced-rate env).
+  inline float sr() {
+    return static_cast<float>(YSE::SAMPLERATE);
+  }
+
   // Phase-continuous sine generator: the *input* stream has no block-boundary
   // discontinuity of its own, so any jump in the output comes purely from the
-  // effect — exactly what the click-free test needs to isolate.
+  // effect — exactly what the click-free test needs to isolate. The tone is
+  // generated at the actual engine rate, so `freq` is correct in the stream.
   struct SineGen {
     double phase = 0.0;
     float freq;
     explicit SineGen(float f) : freq(f) {}
     void fill(YSE::DSP::buffer& buf) {
       float* p = buf.getPtr();
-      double inc = 2.0 * static_cast<double>(kPi) * freq / kSr;
+      double inc = 2.0 * static_cast<double>(kPi) * freq / static_cast<double>(sr());
       for (unsigned i = 0; i < buf.getLength(); ++i) {
         p[i] = static_cast<float>(std::sin(phase));
         phase += inc;
@@ -51,7 +59,7 @@ namespace {
   inline void fillSine(YSE::DSP::buffer& buf, float freq) {
     float* p = buf.getPtr();
     for (unsigned i = 0; i < buf.getLength(); ++i)
-      p[i] = std::sin(2.0f * kPi * freq * static_cast<float>(i) / kSr);
+      p[i] = std::sin(2.0f * kPi * freq * static_cast<float>(i) / sr());
   }
 
   inline float maxAbs(YSE::DSP::buffer& buf) {
@@ -84,18 +92,25 @@ namespace {
   }
 
   // Peak-to-peak spread of the interval (in samples) between successive upward
-  // zero crossings — a proxy for the pitch modulation depth of a sine.
+  // zero crossings — a proxy for the pitch-modulation depth of a sine. The
+  // crossing position is interpolated to sub-sample precision, so the metric is
+  // continuous (not quantised to the sample grid) and a pure, unmodulated tone
+  // reads a spread of ~0 regardless of the sample rate.
   float zeroCrossPeriodSpread(const std::vector<float>& sig, std::size_t skip) {
     float minP = 1e30f, maxP = -1e30f;
-    long lastCross = -1;
+    double lastCross = -1.0;
     for (std::size_t i = skip + 1; i < sig.size(); ++i) {
       if (sig[i - 1] <= 0.0f && sig[i] > 0.0f) { // rising zero crossing
-        if (lastCross >= 0) {
-          float period = static_cast<float>(static_cast<long>(i) - lastCross);
+        // Linear-interpolated sub-sample position where the signal hits zero.
+        double denom = static_cast<double>(sig[i]) - static_cast<double>(sig[i - 1]);
+        double cross = static_cast<double>(i - 1);
+        if (denom != 0.0) cross += -static_cast<double>(sig[i - 1]) / denom;
+        if (lastCross >= 0.0) {
+          float period = static_cast<float>(cross - lastCross);
           if (period < minP) minP = period;
           if (period > maxP) maxP = period;
         }
-        lastCross = static_cast<long>(i);
+        lastCross = cross;
       }
     }
     if (maxP < 0.0f) return 0.0f;
@@ -161,8 +176,11 @@ TEST_SUITE("dsp") {
     // First block: read position is ~15 ms back = silence (line just primed).
     CHECK(TestHelpers::measureRms(buf[0]) < 1e-4f);
 
+    // The ~15 ms base delay is a rate-dependent number of blocks; cover it with
+    // margin so the delayed impulse is guaranteed to surface at any sample rate.
+    const int blocks = static_cast<int>(std::ceil(0.015f * sr() / 128.0f)) + 6;
     bool sawWet = false;
-    for (int iter = 0; iter < 12; ++iter) { // ~15 ms ≈ 5 blocks; look a bit further
+    for (int iter = 0; iter < blocks; ++iter) {
       zeroFill(buf[0]);
       c.process(buf);
       if (TestHelpers::measureRms(buf[0]) > 1e-3f) {
@@ -179,22 +197,26 @@ TEST_SUITE("dsp") {
     // A moving delay pitch-modulates the wet copy. With a larger depth the
     // delay sweeps further per LFO cycle, so the instantaneous pitch deviates
     // more — measured here as a wider spread of zero-crossing periods.
-    auto spreadFor = [](float depth) {
+    // Skip past the delay-line fill + smoother settle (well beyond the ~15 ms
+    // base delay) before measuring, at whatever the sample rate is.
+    const std::size_t skip = static_cast<std::size_t>(0.05f * sr());
+    auto spreadFor = [skip](float depth) {
       YSE::DSP::MODULES::chorus c;
       c.mode(YSE::DSP::MODULES::MODE_CHORUS).rate(2.0f).depth(depth).impact(1.0f);
-      // ~1.5 LFO cycles at 2 Hz; skip the first block while the line fills.
+      // ~1.5 LFO cycles at 2 Hz.
       std::vector<float> out = runContinuous(c, 1000.0f, 260);
-      return zeroCrossPeriodSpread(out, 512);
+      return zeroCrossPeriodSpread(out, skip);
     };
     float shallow = spreadFor(0.1f);
     float deep = spreadFor(0.9f);
     // Deeper modulation must widen the pitch swing appreciably.
     CHECK(deep > shallow * 1.5f);
-    // A zero-depth chorus is a fixed delay — no pitch modulation at all.
+    // A zero-depth chorus is a fixed delay — no pitch modulation at all, so its
+    // (sub-sample-interpolated) period spread is essentially zero.
     YSE::DSP::MODULES::chorus flat;
     flat.mode(YSE::DSP::MODULES::MODE_CHORUS).rate(2.0f).depth(0.0f).impact(1.0f);
     std::vector<float> flatOut = runContinuous(flat, 1000.0f, 260);
-    CHECK(zeroCrossPeriodSpread(flatOut, 512) < shallow);
+    CHECK(zeroCrossPeriodSpread(flatOut, skip) < shallow);
   }
 
   // ─── flanger: comb notches, and they move ─────────────────────────────────────
@@ -242,7 +264,8 @@ TEST_SUITE("dsp") {
         c.process(buf);
       }
       float minR = 1e30f, maxR = -1e30f;
-      int blocksPerSecond = static_cast<int>(kSr / 128.0f) + 1;
+      // Observe a full LFO period (1 s at rate 1 Hz), plus a block of slack.
+      int blocksPerSecond = static_cast<int>(sr() / 128.0f) + 2;
       for (int b = 0; b < blocksPerSecond; ++b) {
         gen.fill(buf[0]);
         c.process(buf);

--- a/Tests/dsp/test_module_chorus.cpp
+++ b/Tests/dsp/test_module_chorus.cpp
@@ -1,0 +1,395 @@
+// Behavioural tests for the multichannel chorus/flanger MODULE (issue #161).
+//
+// chorus is a modulated fractional-delay effect with a mode switch:
+//   - MODE_CHORUS  : longer base delay, wide gentle sweep, no feedback by
+//                    default — a moving delay pitch-modulates the wet copy
+//                    (detune/vibrato), the classic thickening effect.
+//   - MODE_FLANGER : short base delay + feedback — mixing the swept delayed
+//                    copy with the dry signal makes a comb filter whose notches
+//                    sweep as the delay moves (the "jet" sound).
+//
+// The delay read is fractional (linearly interpolated) so the sweep is
+// click-free by construction. The wet/dry balance is the inherited impact();
+// default impact = 1 is fully wet.
+//
+// No audio device required — SAMPLERATE is initialised to 44100 by the
+// portaudioDeviceManager translation unit at static-initialisation time.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include <vector>
+#include "dsp/modules/chorus.hpp"
+#include "headers/defines.hpp"
+#include "support/audio_helpers.hpp"
+
+static constexpr float kPi = 3.14159265358979323846f;
+static constexpr float kSr = 44100.0f;
+
+namespace {
+
+  // Phase-continuous sine generator: the *input* stream has no block-boundary
+  // discontinuity of its own, so any jump in the output comes purely from the
+  // effect — exactly what the click-free test needs to isolate.
+  struct SineGen {
+    double phase = 0.0;
+    float freq;
+    explicit SineGen(float f) : freq(f) {}
+    void fill(YSE::DSP::buffer& buf) {
+      float* p = buf.getPtr();
+      double inc = 2.0 * static_cast<double>(kPi) * freq / kSr;
+      for (unsigned i = 0; i < buf.getLength(); ++i) {
+        p[i] = static_cast<float>(std::sin(phase));
+        phase += inc;
+      }
+    }
+  };
+
+  inline void zeroFill(YSE::DSP::buffer& buf) {
+    buf = 0.0f;
+  }
+
+  inline void fillSine(YSE::DSP::buffer& buf, float freq) {
+    float* p = buf.getPtr();
+    for (unsigned i = 0; i < buf.getLength(); ++i)
+      p[i] = std::sin(2.0f * kPi * freq * static_cast<float>(i) / kSr);
+  }
+
+  inline float maxAbs(YSE::DSP::buffer& buf) {
+    float* p = buf.getPtr();
+    float m = 0.0f;
+    for (unsigned i = 0; i < buf.getLength(); ++i) {
+      float a = std::abs(p[i]);
+      if (a > m) m = a;
+    }
+    return m;
+  }
+
+  // Run a mono chorus over `blocks` blocks of a continuous sine and return the
+  // concatenated output samples.
+  std::vector<float> runContinuous(YSE::DSP::MODULES::chorus& c, float carrierHz, int blocks,
+                                   unsigned len = 128) {
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(len);
+    SineGen gen(carrierHz);
+    std::vector<float> out;
+    out.reserve(static_cast<std::size_t>(blocks) * len);
+    for (int b = 0; b < blocks; ++b) {
+      gen.fill(buf[0]);
+      c.process(buf);
+      float* p = buf[0].getPtr();
+      for (unsigned i = 0; i < len; ++i)
+        out.push_back(p[i]);
+    }
+    return out;
+  }
+
+  // Peak-to-peak spread of the interval (in samples) between successive upward
+  // zero crossings — a proxy for the pitch modulation depth of a sine.
+  float zeroCrossPeriodSpread(const std::vector<float>& sig, std::size_t skip) {
+    float minP = 1e30f, maxP = -1e30f;
+    long lastCross = -1;
+    for (std::size_t i = skip + 1; i < sig.size(); ++i) {
+      if (sig[i - 1] <= 0.0f && sig[i] > 0.0f) { // rising zero crossing
+        if (lastCross >= 0) {
+          float period = static_cast<float>(static_cast<long>(i) - lastCross);
+          if (period < minP) minP = period;
+          if (period > maxP) maxP = period;
+        }
+        lastCross = static_cast<long>(i);
+      }
+    }
+    if (maxP < 0.0f) return 0.0f;
+    return maxP - minP;
+  }
+
+} // anonymous namespace
+
+TEST_SUITE("dsp") {
+
+  // ─── parameters ───────────────────────────────────────────────────────────────
+
+  TEST_CASE("chorus: sensible defaults") {
+    YSE::DSP::MODULES::chorus c;
+    CHECK(c.mode() == YSE::DSP::MODULES::MODE_CHORUS);
+    CHECK(c.rate() == doctest::Approx(0.8f).epsilon(1e-5f));
+    CHECK(c.depth() == doctest::Approx(0.5f).epsilon(1e-5f));
+    CHECK(c.feedback() == doctest::Approx(0.0f).epsilon(1e-5f));
+    CHECK(c.spread() == doctest::Approx(0.0f).epsilon(1e-5f));
+  }
+
+  TEST_CASE("chorus: setter/getter round-trips") {
+    YSE::DSP::MODULES::chorus c;
+    c.mode(YSE::DSP::MODULES::MODE_FLANGER).rate(3.0f).depth(0.7f).feedback(0.4f).spread(0.5f);
+    CHECK(c.mode() == YSE::DSP::MODULES::MODE_FLANGER);
+    CHECK(c.rate() == doctest::Approx(3.0f).epsilon(1e-5f));
+    CHECK(c.depth() == doctest::Approx(0.7f).epsilon(1e-5f));
+    CHECK(c.feedback() == doctest::Approx(0.4f).epsilon(1e-5f));
+    CHECK(c.spread() == doctest::Approx(0.5f).epsilon(1e-5f));
+  }
+
+  TEST_CASE("chorus: parameters are clamped to safe ranges") {
+    YSE::DSP::MODULES::chorus c;
+    c.depth(5.0f);
+    CHECK(c.depth() == doctest::Approx(1.0f));
+    c.depth(-1.0f);
+    CHECK(c.depth() == doctest::Approx(0.0f));
+    c.feedback(5.0f);
+    CHECK(c.feedback() <= 0.95f);
+    c.feedback(-5.0f);
+    CHECK(c.feedback() >= -0.95f);
+    c.spread(3.0f);
+    CHECK(c.spread() == doctest::Approx(1.0f));
+    c.rate(1.0e6f);
+    CHECK(c.rate() <= 20.0f);
+    c.rate(0.0f);
+    CHECK(c.rate() >= 0.01f);
+  }
+
+  // ─── wet signal is a delayed copy ─────────────────────────────────────────────
+
+  TEST_CASE("chorus: fully-wet output is a delayed (non-trivial) copy of the input") {
+    // impact defaults to 1 (fully wet). Feed one impulse block then silence;
+    // within the base-delay window the delayed impulse must surface.
+    YSE::DSP::MODULES::chorus c;
+    c.mode(YSE::DSP::MODULES::MODE_CHORUS).depth(0.0f); // static ~15 ms delay
+
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(128);
+    zeroFill(buf[0]);
+    buf[0].getPtr()[0] = 1.0f;
+    c.process(buf);
+    // First block: read position is ~15 ms back = silence (line just primed).
+    CHECK(TestHelpers::measureRms(buf[0]) < 1e-4f);
+
+    bool sawWet = false;
+    for (int iter = 0; iter < 12; ++iter) { // ~15 ms ≈ 5 blocks; look a bit further
+      zeroFill(buf[0]);
+      c.process(buf);
+      if (TestHelpers::measureRms(buf[0]) > 1e-3f) {
+        sawWet = true;
+        break;
+      }
+    }
+    CHECK(sawWet);
+  }
+
+  // ─── chorus detune: pitch deviation scales with depth ─────────────────────────
+
+  TEST_CASE("chorus: detune depth scales with the depth parameter") {
+    // A moving delay pitch-modulates the wet copy. With a larger depth the
+    // delay sweeps further per LFO cycle, so the instantaneous pitch deviates
+    // more — measured here as a wider spread of zero-crossing periods.
+    auto spreadFor = [](float depth) {
+      YSE::DSP::MODULES::chorus c;
+      c.mode(YSE::DSP::MODULES::MODE_CHORUS).rate(2.0f).depth(depth).impact(1.0f);
+      // ~1.5 LFO cycles at 2 Hz; skip the first block while the line fills.
+      std::vector<float> out = runContinuous(c, 1000.0f, 260);
+      return zeroCrossPeriodSpread(out, 512);
+    };
+    float shallow = spreadFor(0.1f);
+    float deep = spreadFor(0.9f);
+    // Deeper modulation must widen the pitch swing appreciably.
+    CHECK(deep > shallow * 1.5f);
+    // A zero-depth chorus is a fixed delay — no pitch modulation at all.
+    YSE::DSP::MODULES::chorus flat;
+    flat.mode(YSE::DSP::MODULES::MODE_CHORUS).rate(2.0f).depth(0.0f).impact(1.0f);
+    std::vector<float> flatOut = runContinuous(flat, 1000.0f, 260);
+    CHECK(zeroCrossPeriodSpread(flatOut, 512) < shallow);
+  }
+
+  // ─── flanger: comb notches, and they move ─────────────────────────────────────
+
+  TEST_CASE("chorus: flanger comb attenuates a tuned notch frequency") {
+    // Static flanger (depth 0) at the 1 ms base delay. Dry+wet at impact 0.5 is
+    // a comb: with a 1 ms delay the first notch sits at 500 Hz and the first
+    // peak at 1000 Hz. The notch tone must come out quieter than the peak tone.
+    auto steadyRms = [](float probeHz) {
+      YSE::DSP::MODULES::chorus c;
+      c.mode(YSE::DSP::MODULES::MODE_FLANGER).depth(0.0f).feedback(0.0f).impact(0.5f);
+      float energy = 0.0f;
+      int counted = 0;
+      MULTICHANNELBUFFER buf(1);
+      buf[0].resize(128);
+      SineGen gen(probeHz);
+      for (int b = 0; b < 60; ++b) {
+        gen.fill(buf[0]);
+        c.process(buf);
+        if (b >= 20) { // let the delay line and smoother settle
+          energy += TestHelpers::measureRms(buf[0]);
+          ++counted;
+        }
+      }
+      return energy / static_cast<float>(counted);
+    };
+    float notch = steadyRms(500.0f);
+    float peak = steadyRms(1000.0f);
+    CHECK(notch < peak * 0.8f);
+  }
+
+  TEST_CASE("chorus: flanger sweep makes the comb notches move") {
+    // A swept flanger's comb filter walks across the spectrum, so a fixed probe
+    // tone is alternately notched and reinforced — its per-block RMS varies over
+    // the LFO cycle. A depth-0 flanger has a static comb, so its RMS is flat.
+    auto rmsRange = [](float depth) {
+      YSE::DSP::MODULES::chorus c;
+      c.mode(YSE::DSP::MODULES::MODE_FLANGER).rate(1.0f).depth(depth).feedback(0.5f).impact(0.5f);
+      MULTICHANNELBUFFER buf(1);
+      buf[0].resize(128);
+      SineGen gen(1500.0f);
+      // Warm up past the smoother, then observe one full LFO period (1 s).
+      for (int b = 0; b < 40; ++b) {
+        gen.fill(buf[0]);
+        c.process(buf);
+      }
+      float minR = 1e30f, maxR = -1e30f;
+      int blocksPerSecond = static_cast<int>(kSr / 128.0f) + 1;
+      for (int b = 0; b < blocksPerSecond; ++b) {
+        gen.fill(buf[0]);
+        c.process(buf);
+        float r = TestHelpers::measureRms(buf[0]);
+        if (r < minR) minR = r;
+        if (r > maxR) maxR = r;
+      }
+      return maxR - minR;
+    };
+    float moving = rmsRange(1.0f);
+    float still = rmsRange(0.0f);
+    // The moving comb modulates the probe amplitude far more than the static one.
+    CHECK(moving > still * 3.0f);
+    CHECK(moving > 0.01f);
+  }
+
+  // ─── fractional interpolation is click-free under a fast LFO ───────────────────
+
+  TEST_CASE("chorus: fast LFO sweep stays click-free (fractional interpolation)") {
+    // Fully-wet, fast, deep sweep. The fractional read keeps the output
+    // continuous — an integer-quantised read would step the pointer and click.
+    YSE::DSP::MODULES::chorus c;
+    c.mode(YSE::DSP::MODULES::MODE_CHORUS).rate(8.0f).depth(1.0f).feedback(0.0f).impact(1.0f);
+
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(128);
+    SineGen gen(300.0f);
+
+    // Warm up so the line holds continuous content.
+    for (int b = 0; b < 40; ++b) {
+      gen.fill(buf[0]);
+      c.process(buf);
+    }
+
+    float prev = buf[0].getPtr()[buf[0].getLength() - 1];
+    float worstStep = 0.0f;
+    for (int b = 0; b < 200; ++b) {
+      gen.fill(buf[0]);
+      c.process(buf);
+      float* p = buf[0].getPtr();
+      float boundary = std::abs(p[0] - prev); // across the block boundary
+      if (boundary > worstStep) worstStep = boundary;
+      for (unsigned i = 1; i < buf[0].getLength(); ++i) {
+        float step = std::abs(p[i] - p[i - 1]);
+        if (step > worstStep) worstStep = step;
+      }
+      prev = p[buf[0].getLength() - 1];
+    }
+    // A 300 Hz sine steps at most ~0.05/sample; Doppler from the sweep widens
+    // that a little. A hard delay jump would spike toward ~2.0.
+    CHECK(worstStep < 0.5f);
+  }
+
+  // ─── multichannel contract ────────────────────────────────────────────────────
+
+  TEST_CASE("chorus: channels are processed independently (no cross-bleed)") {
+    // Impulse on channel 0 only; channel 1 must stay silent (each channel owns
+    // its delay line). feedback off, spread 0.
+    YSE::DSP::MODULES::chorus c;
+    c.mode(YSE::DSP::MODULES::MODE_CHORUS).depth(0.3f).feedback(0.0f).spread(0.0f);
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    zeroFill(buf[0]);
+    zeroFill(buf[1]);
+    buf[0].getPtr()[0] = 1.0f; // impulse on channel 0 only
+
+    float ch1Energy = 0.0f;
+    c.process(buf);
+    ch1Energy += TestHelpers::measureRms(buf[1]);
+    for (int b = 0; b < 12; ++b) {
+      zeroFill(buf[0]);
+      zeroFill(buf[1]);
+      c.process(buf);
+      ch1Energy += TestHelpers::measureRms(buf[1]);
+    }
+    CHECK(ch1Energy < 1e-6f);
+  }
+
+  TEST_CASE("chorus: at spread 0 every channel gets identical processing") {
+    YSE::DSP::MODULES::chorus c;
+    c.mode(YSE::DSP::MODULES::MODE_CHORUS).rate(3.0f).depth(0.6f).spread(0.0f).impact(1.0f);
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    for (int b = 0; b < 30; ++b) {
+      fillSine(buf[0], 440.0f);
+      fillSine(buf[1], 440.0f); // same signal on both channels
+      c.process(buf);
+      CHECK(TestHelpers::buffersNearlyEqual(buf[0], buf[1], 1e-6f));
+    }
+  }
+
+  TEST_CASE("chorus: spread makes the channels differ") {
+    YSE::DSP::MODULES::chorus c;
+    c.mode(YSE::DSP::MODULES::MODE_CHORUS).rate(3.0f).depth(0.8f).spread(1.0f).impact(1.0f);
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    bool differed = false;
+    for (int b = 0; b < 60; ++b) {
+      fillSine(buf[0], 440.0f);
+      fillSine(buf[1], 440.0f);
+      c.process(buf);
+      if (!TestHelpers::buffersNearlyEqual(buf[0], buf[1], 1e-3f)) {
+        differed = true;
+        break;
+      }
+    }
+    CHECK(differed);
+  }
+
+  // ─── robustness ───────────────────────────────────────────────────────────────
+
+  TEST_CASE("chorus: output stays bounded under sustained input and feedback") {
+    YSE::DSP::MODULES::chorus c;
+    c.mode(YSE::DSP::MODULES::MODE_FLANGER).rate(2.0f).depth(1.0f).feedback(0.9f).impact(0.7f);
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    for (int b = 0; b < 300; ++b) {
+      fillSine(buf[0], 440.0f);
+      fillSine(buf[1], 660.0f);
+      c.process(buf);
+      CHECK(maxAbs(buf[0]) < 20.0f);
+      CHECK(maxAbs(buf[1]) < 20.0f);
+    }
+  }
+
+  TEST_CASE("chorus: tolerates a change in input buffer length") {
+    YSE::DSP::MODULES::chorus c;
+    c.mode(YSE::DSP::MODULES::MODE_CHORUS).depth(0.5f);
+
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(64);
+    fillSine(buf[0], 500.0f);
+    c.process(buf);
+    CHECK(buf[0].getLength() == 64u);
+
+    buf[0].resize(256);
+    fillSine(buf[0], 500.0f);
+    c.process(buf);
+    CHECK(buf[0].getLength() == 256u);
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -39,6 +39,7 @@ set(YSE_SRCS
   dsp/modules/fm/difference.cpp
   dsp/modules/granulator.cpp
   dsp/modules/hilbert.cpp
+  dsp/modules/chorus.cpp
   dsp/modules/phaser.cpp
   dsp/modules/ringModulator.cpp
   dsp/modules/sineWave.cpp

--- a/YseEngine/dsp/modules/chorus.cpp
+++ b/YseEngine/dsp/modules/chorus.cpp
@@ -1,0 +1,233 @@
+/*
+  ==============================================================================
+
+    chorus.cpp
+    Multichannel chorus/flanger module (issue #161).
+
+  ==============================================================================
+*/
+
+#include "chorus.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace {
+  // Longest delay the line can address, in milliseconds. Lines are sized to
+  // this so the sweep never needs to reallocate.
+  constexpr Flt MAX_DELAY_MS = 50.0f;
+  // A few extra samples past the max delay so the interpolation neighbour and
+  // wrap arithmetic always stay in bounds.
+  constexpr std::size_t LINE_GUARD = 4;
+
+  // Mode presets (Dattorro / Juno-style ranges): chorus is a longer, gentle
+  // sweep; flanger is a short delay that sweeps toward the very short end where
+  // the comb notches are audible.
+  constexpr Flt CHORUS_BASE_MS = 15.0f;
+  constexpr Flt CHORUS_SWEEP_MS = 12.0f;
+  constexpr Flt FLANGER_BASE_MS = 1.0f;
+  constexpr Flt FLANGER_SWEEP_MS = 7.0f;
+
+  constexpr Flt MAX_FEEDBACK = 0.95f;
+  constexpr Flt MIN_RATE_HZ = 0.01f;
+  constexpr Flt MAX_RATE_HZ = 20.0f;
+
+  // Time constant (seconds) for the per-sample delay-time smoother — absorbs
+  // abrupt depth/mode/spread parameter steps so they do not click.
+  constexpr Flt DELAY_SMOOTH_TAU = 0.005f;
+
+  constexpr Flt TWO_PI = 6.283185307179586f;
+} // namespace
+
+YSE::DSP::MODULES::chorus::voice::voice() : writePos(0), smoothedDelay(0.0f), primed(false) {}
+
+YSE::DSP::MODULES::chorus::chorus()
+  : parmRate(0.8f),
+    parmDepth(0.5f),
+    parmFeedback(0.0f),
+    parmSpread(0.0f),
+    parmMode(MODE_CHORUS),
+    lfoCursor(0.0f),
+    delaySmoothCoef(0.0f),
+    lineSize(0),
+    blockLength(0) {}
+
+YSE::DSP::MODULES::chorus& YSE::DSP::MODULES::chorus::mode(chorusMode value) {
+  parmMode.store(static_cast<Int>(value));
+  return *this;
+}
+
+YSE::DSP::MODULES::chorusMode YSE::DSP::MODULES::chorus::mode() {
+  return static_cast<chorusMode>(parmMode.load());
+}
+
+YSE::DSP::MODULES::chorus& YSE::DSP::MODULES::chorus::rate(Flt hz) {
+  parmRate.store(std::clamp(hz, MIN_RATE_HZ, MAX_RATE_HZ));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::chorus::rate() {
+  return parmRate;
+}
+
+YSE::DSP::MODULES::chorus& YSE::DSP::MODULES::chorus::depth(Flt value) {
+  parmDepth.store(std::clamp(value, 0.0f, 1.0f));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::chorus::depth() {
+  return parmDepth;
+}
+
+YSE::DSP::MODULES::chorus& YSE::DSP::MODULES::chorus::feedback(Flt value) {
+  parmFeedback.store(std::clamp(value, -MAX_FEEDBACK, MAX_FEEDBACK));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::chorus::feedback() {
+  return parmFeedback;
+}
+
+YSE::DSP::MODULES::chorus& YSE::DSP::MODULES::chorus::spread(Flt value) {
+  parmSpread.store(std::clamp(value, 0.0f, 1.0f));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::chorus::spread() {
+  return parmSpread;
+}
+
+Flt YSE::DSP::MODULES::chorus::baseDelayMs() const {
+  return (parmMode.load() == MODE_FLANGER) ? FLANGER_BASE_MS : CHORUS_BASE_MS;
+}
+
+Flt YSE::DSP::MODULES::chorus::sweepDelayMs() const {
+  return (parmMode.load() == MODE_FLANGER) ? FLANGER_SWEEP_MS : CHORUS_SWEEP_MS;
+}
+
+void YSE::DSP::MODULES::chorus::create() {
+  // One-pole coefficient for the per-sample delay smoother, from the engine
+  // sample rate (computed off the audio thread).
+  Flt tauSamples = DELAY_SMOOTH_TAU * static_cast<Flt>(SAMPLERATE);
+  if (tauSamples < 1.0f) tauSamples = 1.0f;
+  delaySmoothCoef = 1.0f - std::exp(-1.0f / tauSamples);
+
+  // Line length that covers the longest addressable delay at the current rate.
+  lineSize =
+      static_cast<std::size_t>(MAX_DELAY_MS * 0.001f * static_cast<Flt>(SAMPLERATE)) + LINE_GUARD;
+}
+
+void YSE::DSP::MODULES::chorus::process(MULTICHANNELBUFFER& buffer) {
+  createIfNeeded();
+
+  if (buffer.empty()) return;
+
+  // (Re)derive the line length from the current sample rate. It only changes on
+  // create() or a device restart at a new rate, never in steady state.
+  std::size_t wantLine =
+      static_cast<std::size_t>(MAX_DELAY_MS * 0.001f * static_cast<Flt>(SAMPLERATE)) + LINE_GUARD;
+  bool lineChanged = (wantLine != lineSize);
+  lineSize = wantLine;
+
+  // Grow/shrink per-channel voices to the channel count. New voices get a
+  // zeroed line of the current length; this is the only allocation path.
+  const std::size_t needLine = lineSize;
+  voices.ensure(buffer.size(), [needLine](voice& v) {
+    v.line.assign(needLine, 0.0f);
+    v.writePos = 0;
+    v.primed = false;
+  });
+
+  // Sample-rate change: re-size every existing line (device-restart resize
+  // path, where allocation is permitted). Steady state never enters here.
+  if (lineChanged) {
+    for (std::size_t ch = 0; ch < voices.size(); ++ch) {
+      voices[ch].line.assign(lineSize, 0.0f);
+      voices[ch].writePos = 0;
+      voices[ch].primed = false;
+    }
+  }
+
+  const std::size_t length = buffer[0].getLength();
+
+  // (Re)size shared scratch when the block length changes.
+  if (length != blockLength) {
+    phaseBuf.resize(length);
+    wet.resize(length);
+    blockLength = length;
+  }
+
+  // Build the shared LFO phase for this block (radians). One sweep drives the
+  // whole buffer; per-channel spread is applied as a phase offset below.
+  const Flt phaseInc = TWO_PI * static_cast<Flt>(parmRate) / static_cast<Flt>(SAMPLERATE);
+  {
+    Flt cur = lfoCursor;
+    Flt* ph = phaseBuf.getPtr();
+    for (std::size_t i = 0; i < length; ++i) {
+      ph[i] = cur;
+      cur += phaseInc;
+    }
+    cur = std::fmod(cur, TWO_PI);
+    if (cur < 0.0f) cur += TWO_PI;
+    lfoCursor = cur;
+  }
+
+  const Flt base = baseDelayMs();
+  const Flt sweep = sweepDelayMs() * static_cast<Flt>(parmDepth);
+  const Flt fb = parmFeedback;
+  const Flt spreadAmount = parmSpread;
+  const Flt srMs = 0.001f * static_cast<Flt>(SAMPLERATE);
+  const Flt maxDelaySamps = static_cast<Flt>(lineSize) - 2.0f;
+  const std::size_t n = buffer.size();
+
+  const Flt* ph = phaseBuf.getPtr();
+
+  for (std::size_t ch = 0; ch < n; ++ch) {
+    voice& v = voices[ch];
+    // Even phase spread across the channels for stereo width.
+    const Flt offset = spreadAmount * TWO_PI * static_cast<Flt>(ch) / static_cast<Flt>(n);
+
+    Flt* x = buffer[ch].getPtr();
+    Flt* w = wet.getPtr();
+
+    // Seed the smoother on first use so the sweep starts from its true value
+    // rather than ramping up from zero (which would read a fixed short delay).
+    if (!v.primed) {
+      v.smoothedDelay = base + sweep * 0.5f * (1.0f + std::sin(ph[0] + offset));
+      v.primed = true;
+    }
+    Flt sd = v.smoothedDelay;
+    std::size_t wp = v.writePos;
+
+    for (std::size_t i = 0; i < length; ++i) {
+      const Flt lfo = 0.5f * (1.0f + std::sin(ph[i] + offset)); // [0, 1]
+      const Flt target = base + sweep * lfo;
+      sd += (target - sd) * delaySmoothCoef;
+
+      Flt delaySamps = sd * srMs;
+      if (delaySamps < 1.0f) delaySamps = 1.0f;
+      if (delaySamps > maxDelaySamps) delaySamps = maxDelaySamps;
+
+      // Fractional (linearly interpolated) read from the circular line.
+      Flt rp = static_cast<Flt>(wp) - delaySamps;
+      while (rp < 0.0f)
+        rp += static_cast<Flt>(lineSize);
+      std::size_t i0 = static_cast<std::size_t>(rp);
+      const Flt frac = rp - static_cast<Flt>(i0);
+      std::size_t i1 = i0 + 1;
+      if (i1 >= lineSize) i1 = 0;
+      const Flt delayed = v.line[i0] * (1.0f - frac) + v.line[i1] * frac;
+
+      // Write dry input plus the recirculated (feedback) tap, then advance.
+      v.line[wp] = x[i] + fb * delayed;
+      if (++wp >= lineSize) wp = 0;
+
+      w[i] = delayed; // wet tap
+    }
+
+    v.smoothedDelay = sd;
+    v.writePos = wp;
+
+    // impact() sets the dry/wet balance.
+    calculateImpact(buffer[ch], wet);
+  }
+}

--- a/YseEngine/dsp/modules/chorus.cpp
+++ b/YseEngine/dsp/modules/chorus.cpp
@@ -207,11 +207,20 @@ void YSE::DSP::MODULES::chorus::process(MULTICHANNELBUFFER& buffer) {
       if (delaySamps < 1.0f) delaySamps = 1.0f;
       if (delaySamps > maxDelaySamps) delaySamps = maxDelaySamps;
 
-      // Fractional (linearly interpolated) read from the circular line.
+      // Fractional (linearly interpolated) read from the circular line. Wrap
+      // the read position into [0, lineSize) on both sides: when delaySamps is
+      // fractionally larger than wp, rp goes slightly negative and the
+      // += lineSize can round up to exactly lineSize in float, which would index
+      // one past the end. The upper wrap and the i0 clamp keep the read in
+      // bounds and click-free.
+      const Flt lineSizeF = static_cast<Flt>(lineSize);
       Flt rp = static_cast<Flt>(wp) - delaySamps;
       while (rp < 0.0f)
-        rp += static_cast<Flt>(lineSize);
+        rp += lineSizeF;
+      while (rp >= lineSizeF)
+        rp -= lineSizeF;
       std::size_t i0 = static_cast<std::size_t>(rp);
+      if (i0 >= lineSize) i0 = lineSize - 1; // guard the float boundary
       const Flt frac = rp - static_cast<Flt>(i0);
       std::size_t i1 = i0 + 1;
       if (i1 >= lineSize) i1 = 0;

--- a/YseEngine/dsp/modules/chorus.hpp
+++ b/YseEngine/dsp/modules/chorus.hpp
@@ -1,0 +1,136 @@
+/*
+  ==============================================================================
+
+    chorus.hpp
+    Multichannel chorus/flanger module (issue #161).
+
+  ==============================================================================
+*/
+
+#ifndef CHORUS_HPP_INCLUDED
+#define CHORUS_HPP_INCLUDED
+
+#include "../../headers/defines.hpp"
+#include "../../headers/types.hpp"
+#include "../dspObject.hpp"
+#include "../buffer.hpp"
+#include "../perChannel.hpp"
+#include <cstddef>
+#include <vector>
+
+namespace YSE {
+  namespace DSP {
+    namespace MODULES {
+
+      /** @brief Operating mode for the ``chorus`` module. */
+      enum chorusMode {
+        MODE_CHORUS, ///< Longer base delay, wide slow sweep — thickening/detune.
+        MODE_FLANGER, ///< Short base delay, feedback — sweeping comb notches.
+      };
+
+      /**
+       *  @brief Chorus / flanger effect packaged as a chainable ``dspObject``.
+       *
+       *  Chorus and flanger are the same modulated-delay topology with different
+       *  ranges and feedback, so this is one module with a ``mode()`` switch. An
+       *  internal LFO sweeps a per-channel fractional (linearly interpolated)
+       *  delay line; the sweep is click-free by construction — the delay time is
+       *  a continuous signal and the read is fractional, so no read-pointer step
+       *  is ever taken. ``MODE_CHORUS`` uses a longer base delay and no feedback
+       *  by default (thickening / detune); ``MODE_FLANGER`` uses a short base
+       *  delay and a feedback path (the classic resonant jet-sweep comb).
+       *
+       *  Processes every channel of the multichannel buffer independently, each
+       *  with its own delay line and LFO phase (see the N-channel contract on
+       *  ``dspObject::process``). The LFO is shared — one sweep for the whole
+       *  buffer — but ``spread()`` fans a per-channel phase offset across the
+       *  channels for stereo width; at ``spread(0)`` every channel is in phase
+       *  (and a mono buffer is the degenerate single-channel case).
+       *
+       *  The wet/dry balance is the inherited ``impact()``: ``impact(0.5)`` is a
+       *  natural insert mix, ``impact(1)`` is fully wet. All buffers are sized on
+       *  the ``create()`` / channel-count-change path; ``process`` allocates
+       *  nothing in steady state.
+       */
+      class API chorus : public dspObject {
+      public:
+        chorus();
+        virtual ~chorus() {};
+
+        /** @brief Select chorus or flanger topology. */
+        chorus& mode(chorusMode value);
+
+        /** @brief Current mode. */
+        chorusMode mode();
+
+        /** @brief Set the LFO sweep rate in Hz (clamped to a sane range). */
+        chorus& rate(Flt hz);
+
+        /** @brief Current LFO rate in Hz. */
+        Flt rate();
+
+        /** @brief Set the modulation depth in [0, 1] — scales the sweep width. */
+        chorus& depth(Flt value);
+
+        /** @brief Current modulation depth. */
+        Flt depth();
+
+        /** @brief Set the feedback amount in [-0.95, 0.95]. Drives the resonant
+         *  flanger comb; negative values invert the fed-back signal (the hollow
+         *  "through-zero"-style comb). Typically 0 for chorus. */
+        chorus& feedback(Flt value);
+
+        /** @brief Current feedback amount. */
+        Flt feedback();
+
+        /** @brief Set the stereo spread in [0, 1] — the per-channel LFO phase
+         *  offset. 0 keeps every channel in phase; 1 spreads the channels evenly
+         *  around a full LFO cycle for maximum width. */
+        chorus& spread(Flt value);
+
+        /** @brief Current stereo spread. */
+        Flt spread();
+
+        /** @brief dspObject lifecycle hook. */
+        virtual void create();
+
+        /** @brief dspObject audio-thread entry point. */
+        virtual void process(MULTICHANNELBUFFER& buffer);
+
+      private:
+        aFlt parmRate; // LFO rate, Hz
+        aFlt parmDepth; // modulation depth, [0, 1]
+        aFlt parmFeedback; // feedback amount, [-0.95, 0.95]
+        aFlt parmSpread; // stereo spread, [0, 1]
+        aInt parmMode; // chorusMode
+
+        // Audio-thread-only state.
+        Flt lfoCursor; // shared LFO phase carried across blocks (radians)
+        Flt delaySmoothCoef; // one-pole coef for per-sample delay smoothing
+        std::size_t lineSize; // per-channel delay-line length (samples)
+        std::size_t blockLength; // last seen block length (scratch sizing)
+
+        /** @brief One channel's modulated-delay state. */
+        struct voice {
+          std::vector<Flt> line; // circular fractional delay line (owned)
+          std::size_t writePos; // next write index into line
+          Flt smoothedDelay; // last smoothed delay time (ms)
+          Bool primed; // whether smoothedDelay has been seeded yet
+          voice();
+        };
+
+        perChannel<voice> voices;
+
+        // Per-block scratch, shared across channels (sized on length change).
+        DSP::buffer phaseBuf; // shared LFO phase, one value per sample (radians)
+        DSP::buffer wet; // this block's wet (delayed) signal
+
+        Flt baseDelayMs() const; // mode-dependent base delay
+        Flt sweepDelayMs() const; // mode-dependent sweep width (pre-depth)
+      };
+
+    } // namespace MODULES
+  } // namespace DSP
+} // namespace YSE
+
+#endif // CHORUS_HPP_INCLUDED


### PR DESCRIPTION
## Summary

Adds `MODULES::chorus`, a multichannel chorus/flanger DSP effect built on the N-channel `dspObject::process` contract (PR #310) and matching the conventions of the existing modulation/delay modules (phaser, feedbackDelay).

Chorus and flanger are the same modulated-delay topology with different ranges/feedback, so this is one module with a `mode()` switch:

- **`MODE_CHORUS`** — longer base delay (~15 ms), gentle wide sweep, no feedback by default: a moving delay pitch-modulates the wet copy (detune/thickening).
- **`MODE_FLANGER`** — short base delay (~1 ms) plus a feedback path: mixing the swept delayed copy with the dry signal makes a comb filter whose notches sweep (the "jet" sound).

### Design / RT-safety
- An internal **shared LFO** sweeps a **per-channel fractional (linearly interpolated) circular delay line**. The fractional read makes the sweep click-free by construction (no read-pointer step).
- `spread()` fans a **per-channel LFO phase offset** across channels for stereo width; at `spread(0)` all channels are in phase (a mono buffer is the degenerate single-channel case).
- Abrupt `depth`/`mode`/`spread` parameter steps are absorbed by a per-sample one-pole delay smoother.
- All buffers are sized in `create()` / on the channel-count (and sample-rate) change path; `process()` allocates, locks, and blocks nothing in steady state.
- Wet/dry balance is the inherited `impact()`.

## Linked issue
Closes #161

## Changes
- `YseEngine/dsp/modules/chorus.{hpp,cpp}` — new module.
- `YseEngine/CMakeLists.txt`, `Tests/CMakeLists.txt` — register the new sources.
- `Tests/dsp/test_module_chorus.cpp` — behavioural test suite (13 cases).

## Test plan
- [x] `clang-format` 22.1.4 clean on the changed files (CI format gate)
- [x] `python yse.py analyze` clean on `chorus.cpp` and the test (no new user-code findings; suppressed warnings are all in vendored/system headers)
- [x] Unit/behavioural tests pass — `python yse.py test`: all 23 ctest executables pass; the new chorus suite is 13 cases / 659 assertions, all green
- [x] Acceptance criteria covered by tests: flanger comb notch present + moving under the sweep; chorus detune depth scales with the `depth` parameter; fractional interpolation click-free under a fast LFO; plus multichannel-independence contract, feedback stability, and buffer-length-change tolerance

No integration/end-to-end app run: this is an engine-internal DSP node with no user-visible app surface to drive; behaviour is exercised directly through the node's `process()` in the test suite (the norm for DSP nodes here).