### PR TITLE
DSP: Plate reverb module (Dattorro) (#162)

### DIFF
--- a/Bench/CMakeLists.txt
+++ b/Bench/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(yse_benchmarks
   dsp/bench_delay.cpp
   dsp/bench_math.cpp
   dsp/bench_reverb.cpp
+  dsp/bench_plate_reverb.cpp
   internal/bench_mpmcqueue.cpp
   patcher/bench_patcher.cpp
   integration/bench_mixing.cpp

--- a/Bench/dsp/bench_plate_reverb.cpp
+++ b/Bench/dsp/bench_plate_reverb.cpp
@@ -1,0 +1,73 @@
+// Tier 1 microbenchmark for the Dattorro plate reverb module (issue #162).
+//
+// The plate reverb is one of the expensive DSP modules — a four-allpass input
+// diffuser plus a cross-coupled figure-eight tank of eight delay/allpass lines
+// and two damping filters, all running per sample. This benchmark measures the
+// steady-state per-block cost of process() so regressions in the tank inner
+// loop are caught, and gives a direct CPU comparison point against the existing
+// Freeverb-derived INTERNAL::reverbDSP (whose own process() has no public entry
+// point — see bench_reverb.cpp for that config-path benchmark).
+//
+// No engine init is needed: SAMPLERATE has its static-init default (44100) from
+// the portaudioDeviceManager TU, which is all the module's create() reads.
+
+#include "dsp/buffer.hpp"
+#include "dsp/modules/plateReverb.hpp"
+#include "headers/defines.hpp"
+
+#include <benchmark/benchmark.h>
+
+namespace {
+
+  constexpr unsigned int kBlock = 1024;
+
+} // namespace
+
+// ── stereo process (the send-return / insert use case) ──────────────────────
+
+static void BM_PlateReverb_ProcessStereo(benchmark::State& state) {
+  YSE::DSP::MODULES::plateReverb rev;
+  rev.decay(0.8f).damping(6000.0f).preDelay(20.0f).impact(0.5f);
+
+  MULTICHANNELBUFFER buf(2);
+  buf[0].resize(kBlock);
+  buf[1].resize(kBlock);
+  buf[0] = 0.25f;
+  buf[1] = 0.25f;
+
+  // Warm up so create()/sizing and the tank fill happen outside the timed loop.
+  for (int i = 0; i < 8; ++i)
+    rev.process(buf);
+
+  for (auto _ : state) {
+    buf[0] = 0.25f;
+    buf[1] = 0.25f;
+    rev.process(buf);
+    benchmark::DoNotOptimize(buf[0].getPtr());
+    benchmark::DoNotOptimize(buf[1].getPtr());
+  }
+  state.SetItemsProcessed(state.iterations() * kBlock * 2);
+}
+BENCHMARK(BM_PlateReverb_ProcessStereo);
+
+// ── mono process (downmix-to-tank, single-channel distribution) ─────────────
+
+static void BM_PlateReverb_ProcessMono(benchmark::State& state) {
+  YSE::DSP::MODULES::plateReverb rev;
+  rev.decay(0.8f).damping(6000.0f).impact(0.5f);
+
+  MULTICHANNELBUFFER buf(1);
+  buf[0].resize(kBlock);
+  buf[0] = 0.25f;
+
+  for (int i = 0; i < 8; ++i)
+    rev.process(buf);
+
+  for (auto _ : state) {
+    buf[0] = 0.25f;
+    rev.process(buf);
+    benchmark::DoNotOptimize(buf[0].getPtr());
+  }
+  state.SetItemsProcessed(state.iterations() * kBlock);
+}
+BENCHMARK(BM_PlateReverb_ProcessMono);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(YSE_TEST_SOURCES
   dsp/test_module_delays.cpp
   dsp/test_module_feedback_delay.cpp
   dsp/test_module_chorus.cpp
+  dsp/test_module_plate_reverb.cpp
   dsp/test_module_multichannel.cpp
   dsp/test_synth_voice.cpp
   patcher/test_graph.cpp

--- a/Tests/dsp/test_module_plate_reverb.cpp
+++ b/Tests/dsp/test_module_plate_reverb.cpp
@@ -1,0 +1,396 @@
+// Behavioural tests for the Dattorro plate reverb MODULE (issue #162).
+//
+// plateReverb is an insert/return-grade reverb built on the Dattorro plate
+// topology: a four-allpass input diffuser feeding a cross-coupled figure-eight
+// tank (two symmetric halves, each a modulated allpass + delay + damping
+// low-pass + allpass + delay). Mono is downmixed into the tank; a stereo pair
+// is read from seven fixed node taps. The wet/dry balance is the inherited
+// impact(); with impact = 1 the output is the pure wet reverb, so an impulse in
+// produces a decaying, diffuse tail.
+//
+// The acceptance criteria (issue #162) drive the cases below:
+//   - RT60 scales with the decay parameter (measured on a rendered impulse)
+//   - damping affects HF decay; pre-delay offsets the first reflection
+//   - no allocation in process(); output stays bounded
+//
+// No audio device required — SAMPLERATE is initialised by the
+// portaudioDeviceManager translation unit at static-initialisation time (44100
+// by default; CI also forces 48000 via YSE_TEST_FORCED_RATE). Every tone,
+// window, and sample count below is derived from the *actual* SAMPLERATE so the
+// tests hold at any rate.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include "dsp/modules/plateReverb.hpp"
+#include "headers/defines.hpp"
+#include "support/alloc_probe.hpp"
+#include "support/audio_helpers.hpp"
+
+static constexpr float kPi = 3.14159265358979323846f;
+
+namespace {
+
+  // The engine sample rate this run is using (honours the forced-rate env).
+  inline float sr() {
+    return static_cast<float>(YSE::SAMPLERATE);
+  }
+
+  // Milliseconds -> whole audio blocks of the given block size (rounded up), so
+  // observation windows are wall-clock durations independent of the sample rate.
+  inline int blocksForMs(float ms, unsigned blockSize) {
+    float samples = ms * 0.001f * sr();
+    return static_cast<int>(std::ceil(samples / static_cast<float>(blockSize)));
+  }
+
+  inline void zeroFill(YSE::DSP::buffer& buf) {
+    buf = 0.0f;
+  }
+
+  inline void fillSine(YSE::DSP::buffer& buf, float freq) {
+    float* p = buf.getPtr();
+    for (unsigned i = 0; i < buf.getLength(); ++i)
+      p[i] = std::sin(2.0f * kPi * freq * static_cast<float>(i) / sr());
+  }
+
+  inline float maxAbs(YSE::DSP::buffer& buf) {
+    float* p = buf.getPtr();
+    float m = 0.0f;
+    for (unsigned i = 0; i < buf.getLength(); ++i) {
+      float a = std::abs(p[i]);
+      if (a > m) m = a;
+    }
+    return m;
+  }
+
+  // Drive one broadband impulse through the reverb, then run silence and sum the
+  // wet RMS of every block over `windowMs` of wall-clock time. A longer tail
+  // integrates more energy, so this is a monotone proxy for RT60.
+  float tailEnergy(YSE::DSP::MODULES::plateReverb& rev, float windowMs, unsigned blockSize = 128) {
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(blockSize);
+    buf[1].resize(blockSize);
+    zeroFill(buf[0]);
+    zeroFill(buf[1]);
+    buf[0].getPtr()[0] = 1.0f;
+    buf[1].getPtr()[0] = 1.0f;
+    rev.process(buf);
+
+    float energy = 0.0f;
+    int blocks = blocksForMs(windowMs, blockSize);
+    for (int iter = 0; iter < blocks; ++iter) {
+      zeroFill(buf[0]);
+      zeroFill(buf[1]);
+      rev.process(buf);
+      energy += TestHelpers::measureRms(buf[0]) + TestHelpers::measureRms(buf[1]);
+    }
+    return energy;
+  }
+
+} // anonymous namespace
+
+TEST_SUITE("dsp") {
+
+  // ─── parameters ───────────────────────────────────────────────────────────────
+
+  TEST_CASE("plateReverb: sensible defaults") {
+    YSE::DSP::MODULES::plateReverb rev;
+    CHECK(rev.decay() == doctest::Approx(0.5f).epsilon(1e-5f));
+    CHECK(rev.damping() == doctest::Approx(8000.0f).epsilon(1e-5f));
+    CHECK(rev.preDelay() == doctest::Approx(0.0f).epsilon(1e-5f));
+  }
+
+  TEST_CASE("plateReverb: setter/getter round-trips") {
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(0.8f).damping(3000.0f).preDelay(20.0f);
+    CHECK(rev.decay() == doctest::Approx(0.8f).epsilon(1e-5f));
+    CHECK(rev.damping() == doctest::Approx(3000.0f).epsilon(1e-5f));
+    CHECK(rev.preDelay() == doctest::Approx(20.0f).epsilon(1e-5f));
+  }
+
+  TEST_CASE("plateReverb: parameters are clamped to safe ranges") {
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(5.0f); // above the stable maximum
+    CHECK(rev.decay() <= 0.98f);
+    rev.decay(-1.0f);
+    CHECK(rev.decay() == doctest::Approx(0.0f));
+    rev.preDelay(1.0e9f); // absurd — clamp to the line maximum
+    CHECK(rev.preDelay() <= 100.0f);
+    rev.preDelay(-5.0f);
+    CHECK(rev.preDelay() == doctest::Approx(0.0f));
+    rev.damping(1.0e9f); // clamp below Nyquist
+    CHECK(rev.damping() <= 0.5f * sr());
+  }
+
+  // ─── impulse response ─────────────────────────────────────────────────────────
+
+  TEST_CASE("plateReverb: an impulse produces a diffuse wet tail") {
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(0.7f).damping(10000.0f).impact(1.0f);
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    zeroFill(buf[0]);
+    zeroFill(buf[1]);
+    buf[0].getPtr()[0] = 1.0f;
+    buf[1].getPtr()[0] = 1.0f;
+    rev.process(buf);
+
+    // Within ~120 ms of wall clock the tank must fill and surface wet energy on
+    // both output channels (the figure-eight cross-couples into both halves).
+    bool sawLeft = false, sawRight = false;
+    int blocks = blocksForMs(120.0f, 128);
+    for (int iter = 0; iter < blocks; ++iter) {
+      zeroFill(buf[0]);
+      zeroFill(buf[1]);
+      rev.process(buf);
+      if (TestHelpers::measureRms(buf[0]) > 1e-4f) sawLeft = true;
+      if (TestHelpers::measureRms(buf[1]) > 1e-4f) sawRight = true;
+    }
+    CHECK(sawLeft);
+    CHECK(sawRight);
+  }
+
+  // ─── RT60 scales with decay (acceptance) ────────────────────────────────────────
+
+  TEST_CASE("plateReverb: higher decay lengthens the tail (RT60)") {
+    // Same impulse, same damping, only the decay parameter differs. A larger
+    // decay recirculates the tank longer, so its integrated tail energy over a
+    // fixed wall-clock window is strictly greater.
+    auto energyFor = [](float decay) {
+      YSE::DSP::MODULES::plateReverb rev;
+      rev.decay(decay).damping(20000.0f).impact(1.0f);
+      return tailEnergy(rev, 600.0f);
+    };
+    CHECK(energyFor(0.85f) > energyFor(0.4f));
+  }
+
+  // ─── damping affects HF decay (acceptance) ──────────────────────────────────────
+
+  TEST_CASE("plateReverb: damping darkens the tail (HF decay)") {
+    // Excite the tank with a bright tone, then let it ring. The heavily-damped
+    // plate sheds high-frequency energy in the loop faster, so its steady-state
+    // tail RMS is lower than the barely-damped one at the same decay.
+    auto tailAfterBright = [](float dampHz) {
+      YSE::DSP::MODULES::plateReverb rev;
+      rev.decay(0.8f).damping(dampHz).impact(1.0f);
+      MULTICHANNELBUFFER buf(2);
+      buf[0].resize(128);
+      buf[1].resize(128);
+      // A high tone (a quarter of Nyquist) is bright at any sample rate.
+      float bright = 0.25f * sr();
+      for (int iter = 0; iter < 8; ++iter) {
+        fillSine(buf[0], bright);
+        fillSine(buf[1], bright);
+        rev.process(buf);
+      }
+      float energy = 0.0f;
+      int blocks = blocksForMs(300.0f, 128);
+      for (int iter = 0; iter < blocks; ++iter) {
+        zeroFill(buf[0]);
+        zeroFill(buf[1]);
+        rev.process(buf);
+        energy += TestHelpers::measureRms(buf[0]) + TestHelpers::measureRms(buf[1]);
+      }
+      return energy;
+    };
+    CHECK(tailAfterBright(18000.0f) > tailAfterBright(1500.0f));
+  }
+
+  // ─── pre-delay offsets the onset (acceptance) ───────────────────────────────────
+
+  TEST_CASE("plateReverb: pre-delay offsets the reverb onset") {
+    // With a substantial pre-delay the tank is fed pure silence for the
+    // pre-delay duration, so the wet output stays *exactly* zero until the
+    // delayed impulse reaches the tank. Detecting the first non-silent block
+    // (output is bit-zero before arrival) isolates the pre-delay offset cleanly:
+    // the pre-delayed plate's onset must land strictly later.
+    auto onsetBlock = [](float preMs) {
+      YSE::DSP::MODULES::plateReverb rev;
+      rev.decay(0.7f).damping(15000.0f).preDelay(preMs).impact(1.0f);
+      MULTICHANNELBUFFER buf(2);
+      buf[0].resize(64);
+      buf[1].resize(64);
+      zeroFill(buf[0]);
+      zeroFill(buf[1]);
+      buf[0].getPtr()[0] = 1.0f;
+      buf[1].getPtr()[0] = 1.0f;
+      rev.process(buf);
+      int block = 1;
+      int limit = blocksForMs(400.0f, 64);
+      for (; block < limit; ++block) {
+        zeroFill(buf[0]);
+        zeroFill(buf[1]);
+        rev.process(buf);
+        if (TestHelpers::measureRms(buf[0]) > 1e-6f) break;
+      }
+      return block;
+    };
+    // A ~40 ms extra pre-delay is many blocks of silence at 64 samples/block,
+    // comfortably clear of the first-arrival jitter.
+    CHECK(onsetBlock(80.0f) > onsetBlock(0.0f) + 2);
+  }
+
+  // ─── stability ──────────────────────────────────────────────────────────────────
+
+  TEST_CASE("plateReverb: output stays bounded for sustained input") {
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(0.98f).damping(6000.0f).impact(1.0f); // hottest stable setting
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    for (int iter = 0; iter < 400; ++iter) {
+      fillSine(buf[0], 440.0f);
+      fillSine(buf[1], 660.0f);
+      rev.process(buf);
+      CHECK(maxAbs(buf[0]) < 20.0f);
+      CHECK(maxAbs(buf[1]) < 20.0f);
+    }
+  }
+
+  TEST_CASE("plateReverb: tail decays to silence after input stops") {
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(0.7f).damping(8000.0f).impact(1.0f);
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    // Drive a short burst.
+    for (int iter = 0; iter < 8; ++iter) {
+      fillSine(buf[0], 500.0f);
+      fillSine(buf[1], 500.0f);
+      rev.process(buf);
+    }
+    // Then a long silence; the tail must decay toward zero (decay < 1).
+    int blocks = blocksForMs(6000.0f, 128);
+    for (int iter = 0; iter < blocks; ++iter) {
+      zeroFill(buf[0]);
+      zeroFill(buf[1]);
+      rev.process(buf);
+    }
+    CHECK(TestHelpers::measureRms(buf[0]) < 1e-3f);
+    CHECK(TestHelpers::measureRms(buf[1]) < 1e-3f);
+  }
+
+  // ─── wet/dry mix ────────────────────────────────────────────────────────────────
+
+  TEST_CASE("plateReverb: impact(0) is a passthrough") {
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(0.7f).impact(0.0f); // fully dry
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(128);
+    fillSine(buf[0], 300.0f);
+    YSE::DSP::buffer expected(128);
+    expected = buf[0];
+    rev.process(buf);
+    CHECK(TestHelpers::buffersNearlyEqual(buf[0], expected, 1e-5f));
+  }
+
+  // ─── N-channel behaviour (defined here per the issue) ────────────────────────────
+
+  TEST_CASE("plateReverb: mono downmix produces a wet tail") {
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(0.7f).damping(12000.0f).impact(1.0f);
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(128);
+    zeroFill(buf[0]);
+    buf[0].getPtr()[0] = 1.0f;
+    rev.process(buf);
+    bool sawTail = false;
+    int blocks = blocksForMs(200.0f, 128);
+    for (int iter = 0; iter < blocks; ++iter) {
+      zeroFill(buf[0]);
+      rev.process(buf);
+      if (TestHelpers::measureRms(buf[0]) > 1e-4f) {
+        sawTail = true;
+        break;
+      }
+    }
+    CHECK(sawTail);
+  }
+
+  TEST_CASE("plateReverb: even/odd channels carry the stereo tank outputs") {
+    // Four channels: even (0, 2) get the left tank output, odd (1, 3) the right.
+    // The two halves are decorrelated, so channels of the same parity match and
+    // opposite parity differ — and all four carry non-trivial wet energy.
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(0.75f).damping(12000.0f).impact(1.0f);
+    MULTICHANNELBUFFER buf(4);
+    for (int c = 0; c < 4; ++c)
+      buf[c].resize(128);
+    // Impulse on every channel so the mono downmix is well excited.
+    for (int c = 0; c < 4; ++c) {
+      zeroFill(buf[c]);
+      buf[c].getPtr()[0] = 1.0f;
+    }
+    rev.process(buf);
+    bool sawEnergy = false;
+    int blocks = blocksForMs(200.0f, 128);
+    for (int iter = 0; iter < blocks && !sawEnergy; ++iter) {
+      for (int c = 0; c < 4; ++c)
+        zeroFill(buf[c]);
+      rev.process(buf);
+      if (TestHelpers::measureRms(buf[0]) > 1e-3f) {
+        sawEnergy = true;
+        // Same-parity channels are bit-identical; opposite parity decorrelated.
+        CHECK(TestHelpers::buffersNearlyEqual(buf[0], buf[2], 1e-6f));
+        CHECK(TestHelpers::buffersNearlyEqual(buf[1], buf[3], 1e-6f));
+        CHECK_FALSE(TestHelpers::buffersNearlyEqual(buf[0], buf[1], 1e-4f));
+      }
+    }
+    CHECK(sawEnergy);
+  }
+
+  // ─── real-time discipline (acceptance) ───────────────────────────────────────────
+
+  TEST_CASE("plateReverb: steady-state processing is allocation-free") {
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(0.8f).damping(6000.0f).preDelay(20.0f).impact(1.0f);
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+
+    // Warm up: the one-time create()/sizing allocation happens here.
+    for (int b = 0; b < 6; ++b) {
+      fillSine(buf[0], 440.0f);
+      fillSine(buf[1], 660.0f);
+      rev.process(buf);
+    }
+
+    // Steady state: no allocation allowed on the audio path.
+    {
+      TestHelpers::ProbeScope probe;
+      for (int b = 0; b < 8; ++b) {
+        fillSine(buf[0], 440.0f);
+        fillSine(buf[1], 660.0f);
+        rev.process(buf);
+      }
+    }
+    CHECK(TestHelpers::g_alloc_count.load() == 0);
+  }
+
+  // ─── sample-rate robustness ──────────────────────────────────────────────────────
+
+  TEST_CASE("plateReverb: tolerates a change in input buffer length") {
+    YSE::DSP::MODULES::plateReverb rev;
+    rev.decay(0.6f).impact(1.0f);
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(64);
+    buf[1].resize(64);
+    fillSine(buf[0], 500.0f);
+    fillSine(buf[1], 500.0f);
+    rev.process(buf);
+    CHECK(buf[0].getLength() == 64u);
+
+    buf[0].resize(256);
+    buf[1].resize(256);
+    fillSine(buf[0], 500.0f);
+    fillSine(buf[1], 500.0f);
+    rev.process(buf);
+    CHECK(buf[0].getLength() == 256u);
+    // Still bounded after the block-size change.
+    CHECK(maxAbs(buf[0]) < 20.0f);
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -41,6 +41,7 @@ set(YSE_SRCS
   dsp/modules/hilbert.cpp
   dsp/modules/chorus.cpp
   dsp/modules/phaser.cpp
+  dsp/modules/plateReverb.cpp
   dsp/modules/ringModulator.cpp
   dsp/modules/sineWave.cpp
   dsp/oscillators.cpp

--- a/YseEngine/dsp/modules/plateReverb.cpp
+++ b/YseEngine/dsp/modules/plateReverb.cpp
@@ -1,0 +1,379 @@
+/*
+  ==============================================================================
+
+    plateReverb.cpp
+    Dattorro plate reverb module (issue #162).
+
+  ==============================================================================
+*/
+
+#include "plateReverb.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace {
+  // Dattorro publishes his delay/allpass lengths (in samples) at a 29761 Hz
+  // reference rate. Every length below is scaled by SAMPLERATE / REFERENCE_RATE
+  // so the reverb is identical at any engine rate.
+  constexpr Flt REFERENCE_RATE = 29761.0f;
+
+  // Input diffuser lengths (samples @ reference rate).
+  constexpr Flt DIFF1_LEN = 142.0f;
+  constexpr Flt DIFF2_LEN = 107.0f;
+  constexpr Flt DIFF3_LEN = 379.0f;
+  constexpr Flt DIFF4_LEN = 277.0f;
+
+  // Tank lengths (samples @ reference rate).
+  constexpr Flt APL1_LEN = 672.0f; // left modulated allpass
+  constexpr Flt DELL1_LEN = 4453.0f; // left delay 1
+  constexpr Flt APL2_LEN = 1800.0f; // left allpass 2
+  constexpr Flt DELL2_LEN = 3720.0f; // left delay 2
+  constexpr Flt APR1_LEN = 908.0f; // right modulated allpass
+  constexpr Flt DELR1_LEN = 4217.0f; // right delay 1
+  constexpr Flt APR2_LEN = 2656.0f; // right allpass 2
+  constexpr Flt DELR2_LEN = 3163.0f; // right delay 2
+
+  // Diffusion coefficients (dimensionless, rate-independent).
+  constexpr Flt INPUT_DIFF_1 = 0.75f; // first pair of input diffusers
+  constexpr Flt INPUT_DIFF_2 = 0.625f; // second pair of input diffusers
+  constexpr Flt DECAY_DIFF_1 = 0.70f; // tank modulated allpass
+  constexpr Flt DECAY_DIFF_2 = 0.50f; // tank second allpass
+
+  // Modulation of the tank's first allpass: excursion (samples @ ref rate) and
+  // rate (Hz). Small and slow — this is the plate shimmer, not a vibrato.
+  constexpr Flt MOD_EXCURSION = 16.0f;
+  constexpr Flt MOD_RATE_HZ = 0.7f;
+
+  // Pre-delay ceiling; the line is sized to this so process() never reallocates.
+  constexpr Flt MAX_PREDELAY_MS = 100.0f;
+
+  constexpr Flt MAX_DECAY = 0.98f;
+  constexpr Flt MIN_DAMPING_HZ = 20.0f;
+
+  // Output level trim applied to the 7-tap tank sum so a fully-wet plate sits at
+  // a sensible loudness relative to the dry signal.
+  constexpr Flt OUTPUT_GAIN = 0.6f;
+
+  constexpr Flt TWO_PI = 6.283185307179586f;
+
+  // A couple of extra samples past every buffer's addressable length so the
+  // fractional read of the modulated allpass and the node taps never index one
+  // past the end.
+  constexpr std::size_t GUARD = 4;
+
+  // Scale a reference-rate length to the current sample rate, at least 1 sample.
+  inline std::size_t scaledLen(Flt refLen) {
+    Flt s = static_cast<Flt>(YSE::SAMPLERATE) / REFERENCE_RATE;
+    std::size_t n = static_cast<std::size_t>(std::lround(refLen * s));
+    return (n < 1) ? 1 : n;
+  }
+} // namespace
+
+// ─── DelayLine ────────────────────────────────────────────────────────────────
+
+void YSE::DSP::MODULES::plateReverb::DelayLine::init(std::size_t len) {
+  buf.assign(len, 0.0f);
+  pos = 0;
+}
+
+Flt YSE::DSP::MODULES::plateReverb::DelayLine::process(Flt x) {
+  Flt out = buf[pos];
+  buf[pos] = x;
+  if (++pos >= buf.size()) pos = 0;
+  return out;
+}
+
+Flt YSE::DSP::MODULES::plateReverb::DelayLine::tap(std::size_t k) const {
+  // Most recent write lives at pos-1; tap(k) reads k samples before that.
+  std::size_t len = buf.size();
+  if (k >= len) k = len - 1;
+  std::size_t idx = (pos + len - 1 - k) % len;
+  return buf[idx];
+}
+
+// ─── Allpass ──────────────────────────────────────────────────────────────────
+
+void YSE::DSP::MODULES::plateReverb::Allpass::init(std::size_t len) {
+  buf.assign(len, 0.0f);
+  pos = 0;
+}
+
+Flt YSE::DSP::MODULES::plateReverb::Allpass::process(Flt x, Flt g) {
+  // Lattice allpass: H(z) = (z^-m - g) / (1 - g z^-m), |H| = 1.
+  Flt w = buf[pos];
+  Flt out = -g * x + w;
+  buf[pos] = x + g * out;
+  if (++pos >= buf.size()) pos = 0;
+  return out;
+}
+
+Flt YSE::DSP::MODULES::plateReverb::Allpass::tap(std::size_t k) const {
+  std::size_t len = buf.size();
+  if (k >= len) k = len - 1;
+  std::size_t idx = (pos + len - 1 - k) % len;
+  return buf[idx];
+}
+
+// ─── ModAllpass ───────────────────────────────────────────────────────────────
+
+void YSE::DSP::MODULES::plateReverb::ModAllpass::init(std::size_t len, Flt base) {
+  buf.assign(len, 0.0f);
+  pos = 0;
+  baseDelay = base;
+}
+
+Flt YSE::DSP::MODULES::plateReverb::ModAllpass::process(Flt x, Flt g, Flt delaySamps) {
+  // Fractional (linearly interpolated) read of the delay-line content at
+  // delaySamps back from the current write position. The buffer is sized to
+  // baseDelay + excursion + guard, so delaySamps is always in bounds and the
+  // i1 neighbour never indexes past the end.
+  const std::size_t len = buf.size();
+  const Flt lenF = static_cast<Flt>(len);
+  Flt rp = static_cast<Flt>(pos) - delaySamps;
+  while (rp < 0.0f)
+    rp += lenF;
+  while (rp >= lenF)
+    rp -= lenF;
+  std::size_t i0 = static_cast<std::size_t>(rp);
+  if (i0 >= len) i0 = len - 1; // guard the float boundary
+  const Flt frac = rp - static_cast<Flt>(i0);
+  std::size_t i1 = i0 + 1;
+  if (i1 >= len) i1 = 0;
+  const Flt w = buf[i0] * (1.0f - frac) + buf[i1] * frac;
+
+  Flt out = -g * x + w;
+  buf[pos] = x + g * out;
+  if (++pos >= len) pos = 0;
+  return out;
+}
+
+// ─── plateReverb ──────────────────────────────────────────────────────────────
+
+YSE::DSP::MODULES::plateReverb::plateReverb()
+  : parmDecay(0.5f),
+    parmDamping(8000.0f),
+    parmPreDelay(0.0f),
+    dampL(0.0f),
+    dampR(0.0f),
+    fbL(0.0f),
+    fbR(0.0f),
+    lfoPhase(0.0f),
+    modExcursion(0.0f),
+    modInc(0.0f),
+    builtRate(0),
+    blockLength(0) {
+  for (std::size_t i = 0; i < 7; ++i) {
+    tapL[i] = 0;
+    tapR[i] = 0;
+  }
+}
+
+YSE::DSP::MODULES::plateReverb& YSE::DSP::MODULES::plateReverb::decay(Flt value) {
+  parmDecay.store(std::clamp(value, 0.0f, MAX_DECAY));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::plateReverb::decay() {
+  return parmDecay;
+}
+
+YSE::DSP::MODULES::plateReverb& YSE::DSP::MODULES::plateReverb::damping(Flt hz) {
+  Flt nyquist = 0.5f * static_cast<Flt>(SAMPLERATE);
+  parmDamping.store(std::clamp(hz, MIN_DAMPING_HZ, nyquist));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::plateReverb::damping() {
+  return parmDamping;
+}
+
+YSE::DSP::MODULES::plateReverb& YSE::DSP::MODULES::plateReverb::preDelay(Flt ms) {
+  parmPreDelay.store(std::clamp(ms, 0.0f, MAX_PREDELAY_MS));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::plateReverb::preDelay() {
+  return parmPreDelay;
+}
+
+void YSE::DSP::MODULES::plateReverb::build() {
+  // Input diffusers.
+  diff1.init(scaledLen(DIFF1_LEN) + GUARD);
+  diff2.init(scaledLen(DIFF2_LEN) + GUARD);
+  diff3.init(scaledLen(DIFF3_LEN) + GUARD);
+  diff4.init(scaledLen(DIFF4_LEN) + GUARD);
+
+  // Pre-delay line, sized to the maximum pre-delay.
+  std::size_t preLen =
+      static_cast<std::size_t>(MAX_PREDELAY_MS * 0.001f * static_cast<Flt>(SAMPLERATE)) + GUARD + 1;
+  preLine.init(preLen);
+
+  // Tank. The modulated allpasses get room for their excursion.
+  modExcursion = MOD_EXCURSION * static_cast<Flt>(SAMPLERATE) / REFERENCE_RATE;
+  std::size_t excSamps = static_cast<std::size_t>(std::lround(modExcursion));
+
+  apL1.init(scaledLen(APL1_LEN) + excSamps + GUARD, static_cast<Flt>(scaledLen(APL1_LEN)));
+  delL1.init(scaledLen(DELL1_LEN) + GUARD);
+  apL2.init(scaledLen(APL2_LEN) + GUARD);
+  delL2.init(scaledLen(DELL2_LEN) + GUARD);
+
+  apR1.init(scaledLen(APR1_LEN) + excSamps + GUARD, static_cast<Flt>(scaledLen(APR1_LEN)));
+  delR1.init(scaledLen(DELR1_LEN) + GUARD);
+  apR2.init(scaledLen(APR2_LEN) + GUARD);
+  delR2.init(scaledLen(DELR2_LEN) + GUARD);
+
+  dampL = 0.0f;
+  dampR = 0.0f;
+  fbL = 0.0f;
+  fbR = 0.0f;
+  lfoPhase = 0.0f;
+
+  modInc = TWO_PI * MOD_RATE_HZ / static_cast<Flt>(SAMPLERATE);
+
+  // Output taps (reference-rate offsets, scaled to this rate). Each index sits
+  // well inside its source line, so scaling keeps it in bounds; tap() clamps
+  // defensively regardless.
+  tapL[0] = scaledLen(266.0f); // delR1
+  tapL[1] = scaledLen(2974.0f); // delR1
+  tapL[2] = scaledLen(1913.0f); // apR2
+  tapL[3] = scaledLen(1996.0f); // delR2
+  tapL[4] = scaledLen(1990.0f); // delL1
+  tapL[5] = scaledLen(187.0f); // apL2
+  tapL[6] = scaledLen(1066.0f); // delL2
+
+  tapR[0] = scaledLen(353.0f); // delL1
+  tapR[1] = scaledLen(3627.0f); // delL1
+  tapR[2] = scaledLen(1228.0f); // apL2
+  tapR[3] = scaledLen(2673.0f); // delL2
+  tapR[4] = scaledLen(2111.0f); // delR1
+  tapR[5] = scaledLen(335.0f); // apR2
+  tapR[6] = scaledLen(121.0f); // delR2
+
+  builtRate = SAMPLERATE;
+}
+
+void YSE::DSP::MODULES::plateReverb::create() {
+  // Size every buffer from the engine sample rate (off the audio thread).
+  build();
+}
+
+void YSE::DSP::MODULES::plateReverb::process(MULTICHANNELBUFFER& buffer) {
+  createIfNeeded();
+
+  if (buffer.empty()) return;
+
+  // Rebuild only if the sample rate changed since the last sizing (device
+  // restart at a new rate). Steady state never enters here.
+  if (builtRate != SAMPLERATE) build();
+
+  const std::size_t length = buffer[0].getLength();
+  if (length != blockLength) {
+    wetL.resize(length);
+    wetR.resize(length);
+    blockLength = length;
+  }
+
+  const std::size_t n = buffer.size();
+
+  // Damping one-pole coefficient from the cut-off (Hz) and sample rate.
+  // c in [0,1]: 1 = open (no damping), smaller = darker.
+  Flt fc = std::clamp(parmDamping.load(), MIN_DAMPING_HZ, 0.5f * static_cast<Flt>(SAMPLERATE));
+  Flt dampCoef = 1.0f - std::exp(-TWO_PI * fc / static_cast<Flt>(SAMPLERATE));
+
+  const Flt dec = std::clamp(parmDecay.load(), 0.0f, MAX_DECAY);
+
+  // Pre-delay offset in samples (clamped inside the line).
+  std::size_t preSamps =
+      static_cast<std::size_t>(std::clamp(parmPreDelay.load(), 0.0f, MAX_PREDELAY_MS) * 0.001f *
+                               static_cast<Flt>(SAMPLERATE));
+  if (preSamps >= preLine.length()) preSamps = preLine.length() - 1;
+
+  Flt* wl = wetL.getPtr();
+  Flt* wr = wetR.getPtr();
+
+  Flt phase = lfoPhase;
+
+  for (std::size_t i = 0; i < length; ++i) {
+    // Downmix every input channel to the mono tank input.
+    Flt mono = 0.0f;
+    for (std::size_t ch = 0; ch < n; ++ch)
+      mono += buffer[ch].getPtr()[i];
+    mono /= static_cast<Flt>(n);
+
+    // Pre-delay: write the fresh input, then read `preSamps` samples back. With
+    // preSamps == 0 the read lands on the sample just written (a true
+    // passthrough); a larger offset walks back into the line's history.
+    const std::size_t preLen = preLine.buf.size();
+    preLine.buf[preLine.pos] = mono;
+    std::size_t preRead = (preLine.pos + preLen - preSamps) % preLen;
+    Flt pd = preLine.buf[preRead];
+    if (++preLine.pos >= preLen) preLine.pos = 0;
+
+    // Input diffusion (four series allpasses).
+    Flt in = pd;
+    in = diff1.process(in, INPUT_DIFF_1);
+    in = diff2.process(in, INPUT_DIFF_1);
+    in = diff3.process(in, INPUT_DIFF_2);
+    in = diff4.process(in, INPUT_DIFF_2);
+
+    // Tank modulation: the first allpass of each half reads a modulated delay.
+    Flt lfo = std::sin(phase);
+    Flt modL = static_cast<Flt>(apL1.baseDelay) - modExcursion * (0.5f + 0.5f * lfo);
+    Flt modR = static_cast<Flt>(apR1.baseDelay) - modExcursion * (0.5f - 0.5f * lfo);
+    phase += modInc;
+    if (phase >= TWO_PI) phase -= TWO_PI;
+
+    // Cross-coupled figure-eight tank. Each half uses the *other* half's
+    // previous-sample output for the cross term (the long delay lines carry the
+    // real loop memory, so the one-sample cross latency is inaudible and keeps
+    // the update symmetric).
+    Flt leftIn = in + dec * fbR;
+    Flt rightIn = in + dec * fbL;
+
+    // Left half.
+    Flt a = apL1.process(leftIn, DECAY_DIFF_1, modL);
+    Flt d1 = delL1.process(a);
+    dampL += (d1 - dampL) * dampCoef;
+    Flt node = dec * dampL;
+    Flt a2 = apL2.process(node, DECAY_DIFF_2);
+    Flt d2 = delL2.process(a2);
+    Flt leftTankOut = dec * d2;
+
+    // Right half.
+    Flt b = apR1.process(rightIn, DECAY_DIFF_1, modR);
+    Flt e1 = delR1.process(b);
+    dampR += (e1 - dampR) * dampCoef;
+    Flt nodeR = dec * dampR;
+    Flt b2 = apR2.process(nodeR, DECAY_DIFF_2);
+    Flt e2 = delR2.process(b2);
+    Flt rightTankOut = dec * e2;
+
+    fbL = leftTankOut;
+    fbR = rightTankOut;
+
+    // Seven-tap stereo output read from the tank nodes.
+    Flt outL = delR1.tap(tapL[0]) + delR1.tap(tapL[1]) - apR2.tap(tapL[2]) + delR2.tap(tapL[3]) -
+               delL1.tap(tapL[4]) - apL2.tap(tapL[5]) - delL2.tap(tapL[6]);
+    Flt outR = delL1.tap(tapR[0]) + delL1.tap(tapR[1]) - apL2.tap(tapR[2]) + delL2.tap(tapR[3]) -
+               delR1.tap(tapR[4]) - apR2.tap(tapR[5]) - delR2.tap(tapR[6]);
+
+    wl[i] = outL * OUTPUT_GAIN;
+    wr[i] = outR * OUTPUT_GAIN;
+  }
+
+  lfoPhase = phase;
+
+  // Distribute the stereo wet signal across the output channels and apply the
+  // wet/dry balance per channel.
+  if (n == 1) {
+    // Mono: average the two tank outputs.
+    for (std::size_t i = 0; i < length; ++i)
+      wl[i] = 0.5f * (wl[i] + wr[i]);
+    calculateImpact(buffer[0], wetL);
+  } else {
+    for (std::size_t ch = 0; ch < n; ++ch) {
+      DSP::buffer& wet = (ch & 1u) ? wetR : wetL;
+      calculateImpact(buffer[ch], wet);
+    }
+  }
+}

--- a/YseEngine/dsp/modules/plateReverb.hpp
+++ b/YseEngine/dsp/modules/plateReverb.hpp
@@ -1,0 +1,183 @@
+/*
+  ==============================================================================
+
+    plateReverb.hpp
+    Dattorro plate reverb module (issue #162).
+
+  ==============================================================================
+*/
+
+#ifndef PLATEREVERB_HPP_INCLUDED
+#define PLATEREVERB_HPP_INCLUDED
+
+#include "../../headers/defines.hpp"
+#include "../../headers/types.hpp"
+#include "../dspObject.hpp"
+#include "../buffer.hpp"
+#include <cstddef>
+#include <vector>
+
+namespace YSE {
+  namespace DSP {
+    namespace MODULES {
+
+      /**
+       *  @brief Insert/return-grade plate reverb packaged as a chainable ``dspObject``.
+       *
+       *  Implements the classic Dattorro plate topology ("Effect Design, Part 1",
+       *  JAES 1997): a four-allpass input diffuser feeding a cross-coupled
+       *  figure-eight tank of two symmetric halves, each a modulated allpass, a
+       *  long delay, a damping low-pass, a second allpass, and a final delay. The
+       *  stereo output is read from seven fixed taps across the tank nodes, giving
+       *  the smooth, dense, slightly shimmering plate character.
+       *
+       *  This is distinct from the engine's existing global *spatial* reverb
+       *  (``INTERNAL::reverbDSP``, welded to the listener/zone system): the plate
+       *  is a plain effect you drop on a channel insert or a send return.
+       *
+       *  ### N-channel behaviour
+       *
+       *  The plate is a genuinely stereo device — its figure-eight tank
+       *  cross-couples its two halves — so it is *not* a per-channel fan-out.
+       *  Instead the whole multichannel buffer is downmixed to a mono tank input
+       *  (the average of all input channels), the single stereo tank runs, and the
+       *  two wet outputs are distributed back across the channels:
+       *
+       *  - **1 channel (mono):** the two tank outputs are averaged into the one
+       *    channel.
+       *  - **2 channels (stereo):** left tank output to channel 0, right to
+       *    channel 1.
+       *  - **N > 2:** even channels receive the left tank output, odd channels the
+       *    right (a plain, predictable spread).
+       *
+       *  Every input channel contributes to the tank and every output channel
+       *  receives wet signal, and the module tolerates a changing channel count
+       *  between calls (see the N-channel contract on ``dspObject::process``). The
+       *  tank buffers are sized once from the engine sample rate, so a device
+       *  restart at a new channel count allocates nothing.
+       *
+       *  The wet/dry balance is the inherited ``impact()``: ``impact(0.25)`` is a
+       *  natural insert mix, ``impact(1)`` is fully wet (send-return use). All
+       *  buffers are sized on the ``create()`` / sample-rate-change path;
+       *  ``process`` allocates nothing in steady state. Every delay, allpass, and
+       *  output-tap length is derived from ``SAMPLERATE`` (relative to the paper's
+       *  29761 Hz reference), so the reverb sounds the same at any rate.
+       */
+      class API plateReverb : public dspObject {
+      public:
+        plateReverb();
+        virtual ~plateReverb() {};
+
+        /** @brief Set the tank decay in [0, 0.98]. Higher values recirculate the
+         *  tank longer, lengthening the reverb tail (RT60). */
+        plateReverb& decay(Flt value);
+
+        /** @brief Current tank decay. */
+        Flt decay();
+
+        /** @brief Set the damping cut-off in Hz — a low-pass inside each tank
+         *  half. Lower values shed high-frequency energy faster, so the tail
+         *  darkens as it decays. */
+        plateReverb& damping(Flt hz);
+
+        /** @brief Current damping cut-off in Hz. */
+        Flt damping();
+
+        /** @brief Set the pre-delay in milliseconds (clamped to the module's
+         *  maximum). Offsets the onset of the reverb from the dry signal. */
+        plateReverb& preDelay(Flt ms);
+
+        /** @brief Current pre-delay in milliseconds. */
+        Flt preDelay();
+
+        /** @brief dspObject lifecycle hook. */
+        virtual void create();
+
+        /** @brief dspObject audio-thread entry point. */
+        virtual void process(MULTICHANNELBUFFER& buffer);
+
+      private:
+        aFlt parmDecay; // tank decay, [0, 0.98]
+        aFlt parmDamping; // damping low-pass cut-off, Hz
+        aFlt parmPreDelay; // pre-delay, milliseconds
+
+        // ─── Audio-thread-only DSP building blocks (all owned buffers) ───
+
+        /** @brief Fixed-length delay line with node tapping for output reads. */
+        struct DelayLine {
+          std::vector<Flt> buf;
+          std::size_t pos; // next write index
+          void init(std::size_t len);
+          Flt process(Flt x); // push x, return the sample len taps ago
+          Flt tap(std::size_t k) const; // read k samples before the last write
+          std::size_t length() const {
+            return buf.size();
+          }
+        };
+
+        /** @brief Schroeder allpass with node tapping. */
+        struct Allpass {
+          std::vector<Flt> buf;
+          std::size_t pos;
+          void init(std::size_t len);
+          Flt process(Flt x, Flt g);
+          Flt tap(std::size_t k) const;
+          std::size_t length() const {
+            return buf.size();
+          }
+        };
+
+        /** @brief Allpass whose delay is modulated by a fractional excursion —
+         *  the plate's tank chorusing. Read is linearly interpolated. */
+        struct ModAllpass {
+          std::vector<Flt> buf;
+          std::size_t pos;
+          Flt baseDelay; // nominal delay in samples
+          void init(std::size_t len, Flt base);
+          Flt process(Flt x, Flt g, Flt delaySamps); // fractional delay
+        };
+
+        // Input diffusers (four series allpasses).
+        Allpass diff1, diff2, diff3, diff4;
+
+        // Pre-delay line (read at a variable offset).
+        DelayLine preLine;
+
+        // Left tank half.
+        ModAllpass apL1;
+        DelayLine delL1;
+        Allpass apL2;
+        DelayLine delL2;
+        Flt dampL; // damping low-pass state
+
+        // Right tank half.
+        ModAllpass apR1;
+        DelayLine delR1;
+        Allpass apR2;
+        DelayLine delR2;
+        Flt dampR; // damping low-pass state
+
+        // Cross-coupling feedback (previous sample's tank outputs).
+        Flt fbL, fbR;
+
+        Flt lfoPhase; // tank modulation LFO phase (radians)
+        Flt modExcursion; // modulation excursion in samples (from SR)
+        Flt modInc; // per-sample LFO phase increment (from SR)
+
+        // Output tap offsets (samples), pre-scaled from the reference rate.
+        std::size_t tapL[7];
+        std::size_t tapR[7];
+
+        UInt builtRate; // SAMPLERATE the buffers were sized for (0 = unbuilt)
+        std::size_t blockLength; // last seen block length (scratch sizing)
+
+        DSP::buffer wetL, wetR; // per-block wet scratch
+
+        void build(); // size every buffer/tap from the current SAMPLERATE
+      };
+
+    } // namespace MODULES
+  } // namespace DSP
+} // namespace YSE
+
+#endif // PLATEREVERB_HPP_INCLUDED


### PR DESCRIPTION
## Summary

Adds `YSE::DSP::MODULES::plateReverb`, an insert/return-grade plate reverb built on the **Dattorro plate** topology ("Effect Design, Part 1", JAES 1997): a four-allpass input diffuser feeding a cross-coupled figure-eight tank of two symmetric halves (modulated allpass → delay → damping low-pass → allpass → delay), read out through seven fixed node taps. This is distinct from the engine's existing global *spatial* reverb (`INTERNAL::reverbDSP`), which stays welded to the listener/zone system.

## Linked issue

Closes #162 (part of #146; the N-channel contract prerequisite #158 is in via #310).

## Design notes

- **N-channel behaviour** (defined in tests, per the issue): the plate is a genuinely stereo device, so it is *not* a per-channel fan-out. All input channels are downmixed to the mono tank input, the single stereo tank runs, and the two wet outputs are distributed back — mono = average of both halves, stereo = L/R, N>2 = even channels get the left half / odd get the right. Every input channel contributes and every output channel receives wet, and a mid-stream channel-count change reallocates nothing.
- **Rate-agnostic:** every delay/allpass/tap length is derived from `SAMPLERATE` relative to the paper's 29761 Hz reference. Buffers are sized in `create()` / on a sample-rate change; `process()` is allocation-free (asserted via the alloc probe). The modulated-allpass fractional read and all node taps are bounds-guarded (no one-past-end reads).
- **Parameters:** `decay` (RT60), `damping` (HF decay, Hz), `preDelay` (ms); wet/dry via the inherited `impact()`.

## Changes

- `YseEngine/dsp/modules/plateReverb.{hpp,cpp}` — the module (+ CMake registration)
- `Tests/dsp/test_module_plate_reverb.cpp` — behavioural test suite (+ CMake)
- `Bench/dsp/bench_plate_reverb.cpp` — stereo/mono `process()` microbench for CPU comparison vs `reverbDSP` (+ CMake)

## Test plan

- [x] `clang-format` (22.1.4) clean on the new `YseEngine/` and `Tests/` files
- [x] `python yse.py analyze` clean on `plateReverb.cpp` and the test (no new findings in user code)
- [x] Unit tests pass — full `ctest` **100% (23/23)** at the default rate **and** at the CI-forced **48000** (`YSE_TEST_FORCED_RATE=48000`); the 14 plate cases cover the acceptance criteria (RT60 scales with decay, damping darkens the tail, pre-delay offsets the onset), stability, decay-to-silence, the N-channel distribution, allocation-freedom, and a block-size change
- [x] Benchmark suite builds and runs (`BM_PlateReverb_ProcessStereo` ~34 µs / 1024-frame stereo block)

No integration/e2e test: this is a leaf DSP node with no user-visible app flow to drive — its behaviour is fully exercised by the rendered-impulse behavioural tests above, the project norm for DSP modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
