### PR TITLE
DSP: channel-strip parametric EQ + compressor modules (#163)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -29,6 +29,8 @@ set(YSE_TEST_SOURCES
   dsp/test_module_feedback_delay.cpp
   dsp/test_module_chorus.cpp
   dsp/test_module_plate_reverb.cpp
+  dsp/test_module_parametric_eq.cpp
+  dsp/test_module_compressor.cpp
   dsp/test_module_multichannel.cpp
   dsp/test_synth_voice.cpp
   patcher/test_graph.cpp

--- a/Tests/dsp/test_module_compressor.cpp
+++ b/Tests/dsp/test_module_compressor.cpp
@@ -1,0 +1,396 @@
+// Behavioural tests for the channel-strip dynamics compressor MODULE (issue
+// #163).
+//
+// compressor is a feed-forward dynamics processor: a switchable peak/RMS
+// detector drives a static threshold/ratio curve, the gain is smoothed by
+// separate attack/release time constants, and a makeup gain restores level. The
+// detector and gain are SHARED across every channel (stereo-linked) so a
+// transient on one channel ducks all channels by the same amount — no
+// channel-independent pumping / image wobble. The wet/dry balance is the
+// inherited impact(); default impact = 1 is fully compressed.
+//
+// No audio device required — SAMPLERATE is initialised by the
+// portaudioDeviceManager translation unit at static-initialisation time (44100
+// by default; CI also forces 48000 via YSE_TEST_FORCED_RATE). Levels and
+// windows are derived from the actual SAMPLERATE so the tests hold at any rate.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include <vector>
+#include "dsp/modules/compressor.hpp"
+#include "headers/defines.hpp"
+#include "support/audio_helpers.hpp"
+
+static constexpr float kPi = 3.14159265358979323846f;
+
+namespace {
+
+  using YSE::DSP::MODULES::compressor;
+
+  inline float sr() {
+    return static_cast<float>(YSE::SAMPLERATE);
+  }
+
+  struct SineGen {
+    double phase = 0.0;
+    float freq;
+    float amp;
+    SineGen(float f, float a) : freq(f), amp(a) {}
+    void fill(YSE::DSP::buffer& buf) {
+      float* p = buf.getPtr();
+      double inc = 2.0 * static_cast<double>(kPi) * freq / static_cast<double>(sr());
+      for (unsigned i = 0; i < buf.getLength(); ++i) {
+        p[i] = amp * static_cast<float>(std::sin(phase));
+        phase += inc;
+      }
+    }
+  };
+
+  inline float dbToLin(float db) {
+    return std::pow(10.0f, db / 20.0f);
+  }
+
+  // Peak absolute value across a buffer.
+  inline float peakAbs(YSE::DSP::buffer& buf) {
+    float* p = buf.getPtr();
+    float m = 0.0f;
+    for (unsigned i = 0; i < buf.getLength(); ++i) {
+      float a = std::abs(p[i]);
+      if (a > m) m = a;
+    }
+    return m;
+  }
+
+  // Drive a mono compressor with a steady sine of the given peak level (dBFS)
+  // until the gain settles, then return the steady output peak level (dBFS).
+  float steadyOutputPeakDb(compressor& c, float inputPeakDb, float carrierHz = 1000.0f) {
+    float amp = dbToLin(inputPeakDb);
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(256);
+    SineGen gen(carrierHz, amp);
+    // Settle well past the (default) release time.
+    int settle = static_cast<int>(1.0f * sr() / 256.0f) + 8;
+    for (int b = 0; b < settle; ++b) {
+      gen.fill(buf[0]);
+      c.process(buf);
+    }
+    float peak = 0.0f;
+    for (int b = 0; b < 8; ++b) {
+      gen.fill(buf[0]);
+      c.process(buf);
+      float p = peakAbs(buf[0]);
+      if (p > peak) peak = p;
+    }
+    return 20.0f * std::log10(peak);
+  }
+
+} // anonymous namespace
+
+TEST_SUITE("dsp") {
+
+  // ─── parameters ───────────────────────────────────────────────────────────────
+
+  TEST_CASE("compressor: sensible defaults") {
+    compressor c;
+    CHECK(c.detector() == YSE::DSP::MODULES::DETECT_PEAK);
+    CHECK(c.threshold() == doctest::Approx(-18.0f));
+    CHECK(c.ratio() == doctest::Approx(4.0f));
+    CHECK(c.attack() == doctest::Approx(10.0f));
+    CHECK(c.release() == doctest::Approx(100.0f));
+    CHECK(c.makeup() == doctest::Approx(0.0f));
+  }
+
+  TEST_CASE("compressor: setter/getter round-trips") {
+    compressor c;
+    c.detector(YSE::DSP::MODULES::DETECT_RMS)
+        .threshold(-24.0f)
+        .ratio(8.0f)
+        .attack(5.0f)
+        .release(250.0f)
+        .makeup(6.0f);
+    CHECK(c.detector() == YSE::DSP::MODULES::DETECT_RMS);
+    CHECK(c.threshold() == doctest::Approx(-24.0f));
+    CHECK(c.ratio() == doctest::Approx(8.0f));
+    CHECK(c.attack() == doctest::Approx(5.0f));
+    CHECK(c.release() == doctest::Approx(250.0f));
+    CHECK(c.makeup() == doctest::Approx(6.0f));
+  }
+
+  TEST_CASE("compressor: parameters clamp to safe ranges") {
+    compressor c;
+    c.threshold(50.0f);
+    CHECK(c.threshold() <= 0.0f);
+    c.threshold(-200.0f);
+    CHECK(c.threshold() >= -60.0f);
+    c.ratio(1000.0f);
+    CHECK(c.ratio() <= 20.0f);
+    c.ratio(0.1f);
+    CHECK(c.ratio() >= 1.0f);
+    c.attack(1.0e6f);
+    CHECK(c.attack() <= 2000.0f);
+    c.attack(0.0f);
+    CHECK(c.attack() >= 0.1f);
+    c.makeup(100.0f);
+    CHECK(c.makeup() <= 24.0f);
+  }
+
+  // ─── static curve ─────────────────────────────────────────────────────────────
+
+  TEST_CASE("compressor: below threshold passes unchanged") {
+    compressor c;
+    c.threshold(-18.0f).ratio(4.0f).makeup(0.0f).attack(1.0f).release(50.0f);
+    // Input peak -30 dBFS is well below the -18 dB threshold: no reduction.
+    float out = steadyOutputPeakDb(c, -30.0f);
+    CHECK(out == doctest::Approx(-30.0f).epsilon(0.03)); // within ~0.4 dB
+    CHECK(c.gainReductionDb() == doctest::Approx(0.0f).epsilon(0.05));
+  }
+
+  TEST_CASE("compressor: static curve matches threshold and ratio") {
+    // threshold -18 dB, ratio 4. Input -6 dBFS is 12 dB over threshold, so the
+    // output should sit at threshold + 12/4 = -15 dBFS, i.e. 9 dB of reduction.
+    compressor c;
+    c.threshold(-18.0f).ratio(4.0f).makeup(0.0f).attack(2.0f).release(80.0f);
+    float out = steadyOutputPeakDb(c, -6.0f);
+    CHECK(out == doctest::Approx(-15.0f).epsilon(0.06)); // within ~0.9 dB
+    CHECK(c.gainReductionDb() == doctest::Approx(-9.0f).epsilon(0.12));
+  }
+
+  TEST_CASE("compressor: higher ratio compresses harder") {
+    auto reductionAt = [](float ratio) {
+      compressor c;
+      c.threshold(-18.0f).ratio(ratio).makeup(0.0f).attack(2.0f).release(80.0f);
+      steadyOutputPeakDb(c, -6.0f);
+      return c.gainReductionDb(); // <= 0
+    };
+    float gr2 = reductionAt(2.0f);
+    float gr8 = reductionAt(8.0f);
+    // A higher ratio applies more (more negative) gain reduction.
+    CHECK(gr8 < gr2 - 1.0f);
+  }
+
+  TEST_CASE("compressor: makeup gain lifts the output level") {
+    compressor c;
+    c.threshold(-18.0f).ratio(4.0f).makeup(6.0f).attack(2.0f).release(80.0f);
+    float out = steadyOutputPeakDb(c, -6.0f);
+    // Same as the static-curve case (-15 dB) plus 6 dB of makeup.
+    CHECK(out == doctest::Approx(-9.0f).epsilon(0.08));
+  }
+
+  // ─── attack / release timing ──────────────────────────────────────────────────
+
+  TEST_CASE("compressor: attack time is within tolerance") {
+    // Step from silence to a loud tone; measure how long the applied gain takes
+    // to fall to ~63% of its final linear change (one time constant).
+    compressor c;
+    const float attackMs = 20.0f;
+    c.threshold(-24.0f).ratio(8.0f).makeup(0.0f).attack(attackMs).release(400.0f);
+
+    MULTICHANNELBUFFER buf(1);
+    const unsigned N = 32; // fine-grained blocks so the timing resolves
+    buf[0].resize(N);
+    SineGen gen(1000.0f, dbToLin(-3.0f)); // well above threshold
+
+    // Steady-state gain after a long hold.
+    for (int b = 0; b < static_cast<int>(2.0f * sr() / N); ++b) {
+      gen.fill(buf[0]);
+      c.process(buf);
+    }
+    float finalGain = dbToLin(c.gainReductionDb());
+
+    // Reset the follower by constructing a fresh compressor, then time attack.
+    compressor c2;
+    c2.threshold(-24.0f).ratio(8.0f).makeup(0.0f).attack(attackMs).release(400.0f);
+    SineGen gen2(1000.0f, dbToLin(-3.0f));
+    float target = 1.0f + 0.63f * (finalGain - 1.0f); // 63% of the way down
+    int blocksToTarget = -1;
+    int maxBlocks = static_cast<int>(0.5f * sr() / N);
+    for (int b = 0; b < maxBlocks; ++b) {
+      gen2.fill(buf[0]);
+      c2.process(buf);
+      float g = dbToLin(c2.gainReductionDb());
+      if (g <= target) {
+        blocksToTarget = b + 1;
+        break;
+      }
+    }
+    REQUIRE(blocksToTarget > 0);
+    float measuredMs = 1000.0f * static_cast<float>(blocksToTarget) * static_cast<float>(N) / sr();
+    // Generous tolerance: the block granularity and detector rise add slack.
+    CHECK(measuredMs > attackMs * 0.4f);
+    CHECK(measuredMs < attackMs * 3.0f);
+  }
+
+  TEST_CASE("compressor: release is slower than attack") {
+    // With attack << release, after a loud burst the gain must recover slowly.
+    compressor c;
+    c.threshold(-24.0f).ratio(8.0f).makeup(0.0f).attack(2.0f).release(300.0f);
+
+    MULTICHANNELBUFFER buf(1);
+    const unsigned N = 64;
+    buf[0].resize(N);
+    SineGen loud(1000.0f, dbToLin(-3.0f));
+    // Drive into heavy reduction.
+    for (int b = 0; b < static_cast<int>(0.5f * sr() / N); ++b) {
+      loud.fill(buf[0]);
+      c.process(buf);
+    }
+    float grLoud = c.gainReductionDb();
+    CHECK(grLoud < -3.0f); // clearly compressing
+
+    // Now feed silence and check the gain recovers, but not instantly.
+    buf[0] = 0.0f;
+    c.process(buf); // one short block
+    float grJustAfter = c.gainReductionDb();
+    // After a single short block of silence the slow release has barely moved.
+    CHECK(grJustAfter < grLoud + 3.0f);
+
+    // After a long stretch of silence it returns to ~0 dB.
+    for (int b = 0; b < static_cast<int>(3.0f * sr() / N); ++b) {
+      buf[0] = 0.0f;
+      c.process(buf);
+    }
+    CHECK(c.gainReductionDb() == doctest::Approx(0.0f).epsilon(0.05));
+  }
+
+  // ─── stereo-linked detection ──────────────────────────────────────────────────
+
+  TEST_CASE("compressor: detection is stereo-linked (identical gain on all channels)") {
+    // Different tones per channel, but the loud channel drives the shared
+    // detector. Both channels must receive the SAME gain — i.e. out/in ratio is
+    // equal on both channels (no channel-independent pumping).
+    compressor c;
+    c.detector(YSE::DSP::MODULES::DETECT_PEAK)
+        .threshold(-24.0f)
+        .ratio(6.0f)
+        .makeup(0.0f)
+        .attack(5.0f)
+        .release(120.0f);
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(256);
+    buf[1].resize(256);
+    SineGen loud(440.0f, dbToLin(-3.0f)); // channel 0: loud
+    SineGen quiet(660.0f, dbToLin(-3.0f)); // channel 1: same level, different freq
+
+    // Settle.
+    for (int b = 0; b < static_cast<int>(1.0f * sr() / 256); ++b) {
+      loud.fill(buf[0]);
+      quiet.fill(buf[1]);
+      c.process(buf);
+    }
+    // Measure per-channel out/in RMS ratio over a window.
+    float in0 = 0, out0 = 0, in1 = 0, out1 = 0;
+    for (int b = 0; b < 8; ++b) {
+      loud.fill(buf[0]);
+      quiet.fill(buf[1]);
+      float i0 = TestHelpers::measureRms(buf[0]);
+      float i1 = TestHelpers::measureRms(buf[1]);
+      c.process(buf);
+      in0 += i0;
+      in1 += i1;
+      out0 += TestHelpers::measureRms(buf[0]);
+      out1 += TestHelpers::measureRms(buf[1]);
+    }
+    float gain0 = out0 / in0;
+    float gain1 = out1 / in1;
+    CHECK(gain0 == doctest::Approx(gain1).epsilon(0.02)); // same gain on both
+    CHECK(gain0 < 0.9f); // and both are actually compressed
+  }
+
+  TEST_CASE("compressor: a loud channel ducks a quiet channel (linked, no wobble)") {
+    // Channel 1 carries a fixed quiet tone. When channel 0 is loud, the linked
+    // detector ducks BOTH channels, so channel 1's output is quieter than when
+    // channel 0 is silent. Independent detection would leave channel 1 untouched.
+    auto ch1OutWith = [](float ch0Db) {
+      compressor c;
+      c.threshold(-30.0f).ratio(8.0f).makeup(0.0f).attack(5.0f).release(120.0f);
+      MULTICHANNELBUFFER buf(2);
+      buf[0].resize(256);
+      buf[1].resize(256);
+      SineGen ch0(440.0f, dbToLin(ch0Db));
+      SineGen ch1(660.0f, dbToLin(-40.0f)); // always quiet, below threshold
+      for (int b = 0; b < static_cast<int>(1.0f * sr() / 256); ++b) {
+        ch0.fill(buf[0]);
+        ch1.fill(buf[1]);
+        c.process(buf);
+      }
+      float acc = 0.0f;
+      for (int b = 0; b < 8; ++b) {
+        ch0.fill(buf[0]);
+        ch1.fill(buf[1]);
+        c.process(buf);
+        acc += TestHelpers::measureRms(buf[1]);
+      }
+      return acc / 8.0f;
+    };
+    float quietNeighbour = ch1OutWith(-40.0f); // ch0 also quiet: no reduction
+    float loudNeighbour = ch1OutWith(0.0f); // ch0 loud: linked ducking
+    CHECK(loudNeighbour < quietNeighbour * 0.7f);
+  }
+
+  TEST_CASE("compressor: RMS detector also compresses") {
+    compressor c;
+    c.detector(YSE::DSP::MODULES::DETECT_RMS)
+        .threshold(-20.0f)
+        .ratio(4.0f)
+        .makeup(0.0f)
+        .attack(5.0f)
+        .release(120.0f);
+    // A loud tone must be reduced; a quiet one must pass.
+    float loud = steadyOutputPeakDb(c, -3.0f);
+    CHECK(loud < -3.0f - 1.0f); // clearly reduced
+
+    compressor c2;
+    c2.detector(YSE::DSP::MODULES::DETECT_RMS)
+        .threshold(-20.0f)
+        .ratio(4.0f)
+        .makeup(0.0f)
+        .attack(5.0f)
+        .release(120.0f);
+    float quiet = steadyOutputPeakDb(c2, -40.0f);
+    CHECK(quiet == doctest::Approx(-40.0f).epsilon(0.05));
+  }
+
+  // ─── robustness ───────────────────────────────────────────────────────────────
+
+  TEST_CASE("compressor: tolerates a change in input buffer length and channel count") {
+    compressor c;
+    c.threshold(-18.0f).ratio(4.0f);
+
+    MULTICHANNELBUFFER mono(1);
+    mono[0].resize(64);
+    SineGen g(500.0f, 0.5f);
+    g.fill(mono[0]);
+    c.process(mono);
+    CHECK(mono[0].getLength() == 64u);
+
+    // Grow to stereo with a different block length — must not crash or allocate
+    // per-channel history (the gain is global).
+    MULTICHANNELBUFFER stereo(2);
+    stereo[0].resize(256);
+    stereo[1].resize(256);
+    SineGen g0(500.0f, 0.5f), g1(700.0f, 0.5f);
+    g0.fill(stereo[0]);
+    g1.fill(stereo[1]);
+    c.process(stereo);
+    CHECK(stereo[0].getLength() == 256u);
+    CHECK(stereo[1].getLength() == 256u);
+  }
+
+  TEST_CASE("compressor: output stays bounded under extreme settings") {
+    compressor c;
+    c.threshold(-40.0f).ratio(20.0f).makeup(24.0f).attack(0.1f).release(1.0f);
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    for (int b = 0; b < 300; ++b) {
+      SineGen g0(440.0f, 1.0f), g1(660.0f, 1.0f);
+      g0.fill(buf[0]);
+      g1.fill(buf[1]);
+      c.process(buf);
+      CHECK(peakAbs(buf[0]) < 50.0f);
+      CHECK(peakAbs(buf[1]) < 50.0f);
+    }
+  }
+
+} // TEST_SUITE("dsp")

--- a/Tests/dsp/test_module_parametric_eq.cpp
+++ b/Tests/dsp/test_module_parametric_eq.cpp
@@ -1,0 +1,253 @@
+// Behavioural tests for the channel-strip parametric EQ MODULE (issue #163).
+//
+// parametricEQ is four cascaded RBJ biquad bands — a low shelf, two peaking
+// (bell) bands, and a high shelf — each with independent frequency, gain (dB)
+// and Q. The wet/dry balance is the inherited impact(); default impact = 1 is
+// fully wet. A band at 0 dB is a mathematical identity (unity passthrough), so
+// each band can be exercised in isolation.
+//
+// No audio device required — SAMPLERATE is initialised by the
+// portaudioDeviceManager translation unit at static-initialisation time (44100
+// by default; CI also forces 48000 via YSE_TEST_FORCED_RATE). Every probe tone
+// and observation window is derived from the *actual* SAMPLERATE so the tests
+// hold at any rate.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include <vector>
+#include "dsp/modules/parametricEQ.hpp"
+#include "headers/defines.hpp"
+#include "support/audio_helpers.hpp"
+
+static constexpr float kPi = 3.14159265358979323846f;
+
+namespace {
+
+  using YSE::DSP::MODULES::parametricEQ;
+
+  inline float sr() {
+    return static_cast<float>(YSE::SAMPLERATE);
+  }
+
+  // Phase-continuous sine so steady-state RMS is not disturbed by block-boundary
+  // discontinuities.
+  struct SineGen {
+    double phase = 0.0;
+    float freq;
+    explicit SineGen(float f) : freq(f) {}
+    void fill(YSE::DSP::buffer& buf) {
+      float* p = buf.getPtr();
+      double inc = 2.0 * static_cast<double>(kPi) * freq / static_cast<double>(sr());
+      for (unsigned i = 0; i < buf.getLength(); ++i) {
+        p[i] = static_cast<float>(std::sin(phase));
+        phase += inc;
+      }
+    }
+  };
+
+  // Steady-state magnitude response of `eq` at `probeHz`, in dB relative to a
+  // unit sine. Runs the filter well past its settling time, then averages RMS
+  // over a final window.
+  float responseDb(parametricEQ& eq, float probeHz) {
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(256);
+    SineGen gen(probeHz);
+    // Settle: at least ~0.2 s of audio at any rate.
+    int settleBlocks = static_cast<int>(0.2f * sr() / 256.0f) + 4;
+    for (int b = 0; b < settleBlocks; ++b) {
+      gen.fill(buf[0]);
+      eq.process(buf);
+    }
+    // Measure: average RMS over several blocks.
+    float acc = 0.0f;
+    int measBlocks = 16;
+    for (int b = 0; b < measBlocks; ++b) {
+      gen.fill(buf[0]);
+      eq.process(buf);
+      acc += TestHelpers::measureRms(buf[0]);
+    }
+    float outRms = acc / static_cast<float>(measBlocks);
+    float inRms = 0.70710678f; // RMS of a unit sine
+    return 20.0f * std::log10(outRms / inRms);
+  }
+
+} // anonymous namespace
+
+TEST_SUITE("dsp") {
+
+  // ─── parameters ───────────────────────────────────────────────────────────────
+
+  TEST_CASE("parametricEQ: sensible defaults (bands flat)") {
+    parametricEQ eq;
+    for (int b = 0; b < YSE::DSP::MODULES::EQ_BAND_COUNT; ++b) {
+      auto band = static_cast<YSE::DSP::MODULES::eqBand>(b);
+      CHECK(eq.gain(band) == doctest::Approx(0.0f));
+      CHECK(eq.frequency(band) > 0.0f);
+      CHECK(eq.q(band) > 0.0f);
+    }
+  }
+
+  TEST_CASE("parametricEQ: setter/getter round-trips") {
+    parametricEQ eq;
+    eq.frequency(YSE::DSP::MODULES::EQ_PEAK_1, 630.0f)
+        .gain(YSE::DSP::MODULES::EQ_PEAK_1, 6.0f)
+        .q(YSE::DSP::MODULES::EQ_PEAK_1, 2.5f);
+    CHECK(eq.frequency(YSE::DSP::MODULES::EQ_PEAK_1) == doctest::Approx(630.0f));
+    CHECK(eq.gain(YSE::DSP::MODULES::EQ_PEAK_1) == doctest::Approx(6.0f));
+    CHECK(eq.q(YSE::DSP::MODULES::EQ_PEAK_1) == doctest::Approx(2.5f));
+  }
+
+  TEST_CASE("parametricEQ: parameters clamp to safe ranges") {
+    parametricEQ eq;
+    eq.gain(YSE::DSP::MODULES::EQ_PEAK_1, 100.0f);
+    CHECK(eq.gain(YSE::DSP::MODULES::EQ_PEAK_1) <= 24.0f);
+    eq.gain(YSE::DSP::MODULES::EQ_PEAK_1, -100.0f);
+    CHECK(eq.gain(YSE::DSP::MODULES::EQ_PEAK_1) >= -24.0f);
+    eq.frequency(YSE::DSP::MODULES::EQ_PEAK_1, 1.0e9f);
+    CHECK(eq.frequency(YSE::DSP::MODULES::EQ_PEAK_1) <= 20000.0f);
+    eq.frequency(YSE::DSP::MODULES::EQ_PEAK_1, 0.0f);
+    CHECK(eq.frequency(YSE::DSP::MODULES::EQ_PEAK_1) >= 20.0f);
+    eq.q(YSE::DSP::MODULES::EQ_PEAK_1, 1000.0f);
+    CHECK(eq.q(YSE::DSP::MODULES::EQ_PEAK_1) <= 18.0f);
+    eq.q(YSE::DSP::MODULES::EQ_PEAK_1, 0.0f);
+    CHECK(eq.q(YSE::DSP::MODULES::EQ_PEAK_1) >= 0.1f);
+  }
+
+  // ─── flat EQ is transparent ───────────────────────────────────────────────────
+
+  TEST_CASE("parametricEQ: all bands flat is unity (transparent)") {
+    parametricEQ eq; // every band 0 dB
+    for (float f : {80.0f, 400.0f, 2000.0f, 6000.0f}) {
+      float g = responseDb(eq, f);
+      CHECK(g == doctest::Approx(0.0f).epsilon(0.02)); // within ~0.2 dB
+    }
+  }
+
+  // ─── peaking band: boost/cut at centre, transparent far away ──────────────────
+
+  TEST_CASE("parametricEQ: peaking band boosts its centre frequency") {
+    parametricEQ eq;
+    eq.frequency(YSE::DSP::MODULES::EQ_PEAK_1, 1000.0f)
+        .q(YSE::DSP::MODULES::EQ_PEAK_1, 2.0f)
+        .gain(YSE::DSP::MODULES::EQ_PEAK_1, 12.0f);
+    float atCentre = responseDb(eq, 1000.0f);
+    // Peak gain should closely match the requested +12 dB.
+    CHECK(atCentre == doctest::Approx(12.0f).epsilon(0.06)); // ~ +/-0.7 dB
+    // Well below the band it is essentially flat (other bands are at 0 dB).
+    float farBelow = responseDb(eq, 100.0f);
+    CHECK(std::abs(farBelow) < 1.5f);
+  }
+
+  TEST_CASE("parametricEQ: peaking band cuts its centre frequency") {
+    parametricEQ eq;
+    eq.frequency(YSE::DSP::MODULES::EQ_PEAK_2, 1500.0f)
+        .q(YSE::DSP::MODULES::EQ_PEAK_2, 2.0f)
+        .gain(YSE::DSP::MODULES::EQ_PEAK_2, -12.0f);
+    float atCentre = responseDb(eq, 1500.0f);
+    CHECK(atCentre == doctest::Approx(-12.0f).epsilon(0.06));
+  }
+
+  // ─── shelves ──────────────────────────────────────────────────────────────────
+
+  TEST_CASE("parametricEQ: low shelf lifts lows, leaves highs alone") {
+    parametricEQ eq;
+    eq.frequency(YSE::DSP::MODULES::EQ_LOW_SHELF, 200.0f)
+        .gain(YSE::DSP::MODULES::EQ_LOW_SHELF, 9.0f);
+    float low = responseDb(eq, 50.0f); // well below the corner
+    float high = responseDb(eq, 5000.0f); // well above the corner
+    CHECK(low == doctest::Approx(9.0f).epsilon(0.08)); // approaches shelf gain
+    CHECK(std::abs(high) < 1.0f); // untouched
+    CHECK(low > high + 6.0f); // clear low-vs-high tilt
+  }
+
+  TEST_CASE("parametricEQ: high shelf lifts highs, leaves lows alone") {
+    parametricEQ eq;
+    eq.frequency(YSE::DSP::MODULES::EQ_HIGH_SHELF, 4000.0f)
+        .gain(YSE::DSP::MODULES::EQ_HIGH_SHELF, 9.0f);
+    float high = responseDb(eq, 12000.0f);
+    float low = responseDb(eq, 200.0f);
+    CHECK(high == doctest::Approx(9.0f).epsilon(0.08));
+    CHECK(std::abs(low) < 1.0f);
+    CHECK(high > low + 6.0f);
+  }
+
+  // ─── multichannel contract ────────────────────────────────────────────────────
+
+  TEST_CASE("parametricEQ: channels are filtered independently (no cross-bleed)") {
+    parametricEQ eq;
+    eq.gain(YSE::DSP::MODULES::EQ_PEAK_1, 12.0f);
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    buf[0] = 0.0f;
+    buf[1] = 0.0f;
+    buf[0].getPtr()[0] = 1.0f; // impulse on channel 0 only
+
+    float ch1Energy = 0.0f;
+    eq.process(buf);
+    ch1Energy += TestHelpers::measureRms(buf[1]);
+    for (int b = 0; b < 8; ++b) {
+      buf[0] = 0.0f;
+      buf[1] = 0.0f;
+      eq.process(buf);
+      ch1Energy += TestHelpers::measureRms(buf[1]);
+    }
+    CHECK(ch1Energy < 1e-9f); // channel 1 never receives channel 0's energy
+  }
+
+  TEST_CASE("parametricEQ: identical channels get identical processing") {
+    parametricEQ eq;
+    eq.gain(YSE::DSP::MODULES::EQ_LOW_SHELF, 6.0f).gain(YSE::DSP::MODULES::EQ_HIGH_SHELF, -6.0f);
+
+    MULTICHANNELBUFFER buf(2);
+    buf[0].resize(128);
+    buf[1].resize(128);
+    SineGen g0(500.0f), g1(500.0f);
+    for (int b = 0; b < 40; ++b) {
+      g0.fill(buf[0]);
+      g1.fill(buf[1]);
+      eq.process(buf);
+      CHECK(TestHelpers::buffersNearlyEqual(buf[0], buf[1], 1e-6f));
+    }
+  }
+
+  // ─── robustness ───────────────────────────────────────────────────────────────
+
+  TEST_CASE("parametricEQ: tolerates a change in input buffer length") {
+    parametricEQ eq;
+    eq.gain(YSE::DSP::MODULES::EQ_PEAK_1, 6.0f);
+
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(64);
+    SineGen g(500.0f);
+    g.fill(buf[0]);
+    eq.process(buf);
+    CHECK(buf[0].getLength() == 64u);
+
+    buf[0].resize(256);
+    g.fill(buf[0]);
+    eq.process(buf);
+    CHECK(buf[0].getLength() == 256u);
+  }
+
+  TEST_CASE("parametricEQ: output stays bounded under extreme boost") {
+    parametricEQ eq;
+    eq.gain(YSE::DSP::MODULES::EQ_LOW_SHELF, 24.0f)
+        .gain(YSE::DSP::MODULES::EQ_PEAK_1, 24.0f)
+        .gain(YSE::DSP::MODULES::EQ_PEAK_2, 24.0f)
+        .gain(YSE::DSP::MODULES::EQ_HIGH_SHELF, 24.0f);
+
+    MULTICHANNELBUFFER buf(1);
+    buf[0].resize(128);
+    SineGen g(1000.0f);
+    for (int b = 0; b < 200; ++b) {
+      g.fill(buf[0]);
+      eq.process(buf);
+      float* p = buf[0].getPtr();
+      for (unsigned i = 0; i < buf[0].getLength(); ++i)
+        CHECK(std::abs(p[i]) < 100.0f);
+    }
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -40,6 +40,8 @@ set(YSE_SRCS
   dsp/modules/granulator.cpp
   dsp/modules/hilbert.cpp
   dsp/modules/chorus.cpp
+  dsp/modules/compressor.cpp
+  dsp/modules/parametricEQ.cpp
   dsp/modules/phaser.cpp
   dsp/modules/plateReverb.cpp
   dsp/modules/ringModulator.cpp

--- a/YseEngine/dsp/modules/compressor.cpp
+++ b/YseEngine/dsp/modules/compressor.cpp
@@ -1,0 +1,198 @@
+/*
+  ==============================================================================
+
+    compressor.cpp
+    Channel-strip dynamics compressor module (issue #163).
+
+  ==============================================================================
+*/
+
+#include "compressor.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace {
+  constexpr Flt MIN_THRESHOLD_DB = -60.0f;
+  constexpr Flt MAX_THRESHOLD_DB = 0.0f;
+  constexpr Flt MIN_RATIO = 1.0f;
+  constexpr Flt MAX_RATIO = 20.0f;
+  constexpr Flt MIN_TIME_MS = 0.1f;
+  constexpr Flt MAX_TIME_MS = 2000.0f;
+  constexpr Flt MAX_MAKEUP_DB = 24.0f;
+
+  // Fixed RMS-detector averaging window (mean-square one-pole time constant).
+  constexpr Flt RMS_WINDOW_SEC = 0.01f;
+
+  // Floor added before the log so a silent detector maps to a finite, very low
+  // dB value instead of -inf.
+  constexpr Flt LEVEL_FLOOR = 1.0e-9f;
+
+  inline Flt dbToLin(Flt db) {
+    return std::pow(10.0f, db / 20.0f);
+  }
+  inline Flt linToDb(Flt lin) {
+    return 20.0f * std::log10(lin + LEVEL_FLOOR);
+  }
+  // One-pole coefficient reaching 63% of a step in `sec` seconds.
+  inline Flt timeCoef(Flt sec, Flt sr) {
+    Flt samples = sec * sr;
+    if (samples < 1.0f) samples = 1.0f;
+    return 1.0f - std::exp(-1.0f / samples);
+  }
+} // namespace
+
+YSE::DSP::MODULES::compressor::compressor()
+  : parmThreshold(-18.0f),
+    parmRatio(4.0f),
+    parmAttack(10.0f),
+    parmRelease(100.0f),
+    parmMakeup(0.0f),
+    parmDetector(DETECT_PEAK),
+    gain(1.0f),
+    msEnv(0.0f),
+    rmsCoef(0.0f),
+    reductionDb(0.0f),
+    blockLength(0) {}
+
+YSE::DSP::MODULES::compressor& YSE::DSP::MODULES::compressor::detector(compressorDetector value) {
+  parmDetector.store(static_cast<Int>(value));
+  return *this;
+}
+
+YSE::DSP::MODULES::compressorDetector YSE::DSP::MODULES::compressor::detector() {
+  return static_cast<compressorDetector>(parmDetector.load());
+}
+
+YSE::DSP::MODULES::compressor& YSE::DSP::MODULES::compressor::threshold(Flt db) {
+  parmThreshold.store(std::clamp(db, MIN_THRESHOLD_DB, MAX_THRESHOLD_DB));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::compressor::threshold() {
+  return parmThreshold;
+}
+
+YSE::DSP::MODULES::compressor& YSE::DSP::MODULES::compressor::ratio(Flt value) {
+  parmRatio.store(std::clamp(value, MIN_RATIO, MAX_RATIO));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::compressor::ratio() {
+  return parmRatio;
+}
+
+YSE::DSP::MODULES::compressor& YSE::DSP::MODULES::compressor::attack(Flt ms) {
+  parmAttack.store(std::clamp(ms, MIN_TIME_MS, MAX_TIME_MS));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::compressor::attack() {
+  return parmAttack;
+}
+
+YSE::DSP::MODULES::compressor& YSE::DSP::MODULES::compressor::release(Flt ms) {
+  parmRelease.store(std::clamp(ms, MIN_TIME_MS, MAX_TIME_MS));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::compressor::release() {
+  return parmRelease;
+}
+
+YSE::DSP::MODULES::compressor& YSE::DSP::MODULES::compressor::makeup(Flt db) {
+  parmMakeup.store(std::clamp(db, -MAX_MAKEUP_DB, MAX_MAKEUP_DB));
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::compressor::makeup() {
+  return parmMakeup;
+}
+
+Flt YSE::DSP::MODULES::compressor::gainReductionDb() {
+  return reductionDb;
+}
+
+void YSE::DSP::MODULES::compressor::create() {
+  rmsCoef = timeCoef(RMS_WINDOW_SEC, static_cast<Flt>(SAMPLERATE));
+  gain = 1.0f;
+  msEnv = 0.0f;
+}
+
+void YSE::DSP::MODULES::compressor::process(MULTICHANNELBUFFER& buffer) {
+  createIfNeeded();
+
+  if (buffer.empty()) return;
+
+  const std::size_t n = buffer.size();
+  const std::size_t length = buffer[0].getLength();
+
+  if (length != blockLength) {
+    gainBuf.resize(static_cast<UInt>(length));
+    wet.resize(static_cast<UInt>(length));
+    blockLength = length;
+  }
+
+  // Snapshot parameters once per block (control-thread atomics → audio locals).
+  const Flt sr = static_cast<Flt>(SAMPLERATE);
+  const Flt thresholdDb = parmThreshold.load();
+  const Flt ratioVal = parmRatio.load();
+  const Flt slope = 1.0f / ratioVal - 1.0f; // <= 0 : dB out per dB over threshold
+  const Flt attackCoef = timeCoef(parmAttack.load() * 0.001f, sr);
+  const Flt releaseCoef = timeCoef(parmRelease.load() * 0.001f, sr);
+  const Flt makeupLin = dbToLin(parmMakeup.load());
+  const bool rms = (parmDetector.load() == DETECT_RMS);
+  // Refresh the RMS window coefficient in case the sample rate changed.
+  rmsCoef = timeCoef(RMS_WINDOW_SEC, sr);
+
+  Flt g = gain;
+  Flt ms = msEnv;
+  Flt* gb = gainBuf.getPtr();
+
+  // ─── Pass 1: one linked sidechain → one gain curve for every channel ───
+  for (std::size_t i = 0; i < length; ++i) {
+    // Linked detector level across all channels at this sample.
+    Flt level;
+    if (rms) {
+      Flt sumSq = 0.0f;
+      for (std::size_t ch = 0; ch < n; ++ch) {
+        const Flt s = buffer[ch].getPtr()[i];
+        sumSq += s * s;
+      }
+      const Flt meanSq = sumSq / static_cast<Flt>(n);
+      ms += (meanSq - ms) * rmsCoef;
+      level = std::sqrt(ms);
+    } else {
+      Flt peak = 0.0f;
+      for (std::size_t ch = 0; ch < n; ++ch) {
+        const Flt a = std::abs(buffer[ch].getPtr()[i]);
+        if (a > peak) peak = a;
+      }
+      level = peak;
+    }
+
+    const Flt levelDb = linToDb(level);
+    // Static curve: reduction only above threshold (slope <= 0).
+    Flt targetGainDb = 0.0f;
+    if (levelDb > thresholdDb) targetGainDb = (levelDb - thresholdDb) * slope;
+    const Flt targetGain = dbToLin(targetGainDb);
+
+    // Attack when the gain must drop (more reduction), release when it recovers.
+    const Flt coef = (targetGain < g) ? attackCoef : releaseCoef;
+    g += (targetGain - g) * coef;
+
+    gb[i] = g * makeupLin;
+  }
+
+  gain = g;
+  msEnv = ms;
+  reductionDb.store(linToDb(g)); // pre-makeup reduction, for metering
+
+  // ─── Pass 2: apply the shared gain to every channel, then wet/dry mix ───
+  for (std::size_t ch = 0; ch < n; ++ch) {
+    Flt* x = buffer[ch].getPtr(); // dry input (preserved for calculateImpact)
+    Flt* w = wet.getPtr();
+    for (std::size_t i = 0; i < length; ++i)
+      w[i] = x[i] * gb[i];
+    calculateImpact(buffer[ch], wet);
+  }
+}

--- a/YseEngine/dsp/modules/compressor.hpp
+++ b/YseEngine/dsp/modules/compressor.hpp
@@ -1,0 +1,139 @@
+/*
+  ==============================================================================
+
+    compressor.hpp
+    Channel-strip dynamics compressor module (issue #163).
+
+  ==============================================================================
+*/
+
+#ifndef COMPRESSOR_HPP_INCLUDED
+#define COMPRESSOR_HPP_INCLUDED
+
+#include "../../headers/defines.hpp"
+#include "../../headers/types.hpp"
+#include "../dspObject.hpp"
+#include "../buffer.hpp"
+#include <cstddef>
+
+namespace YSE {
+  namespace DSP {
+    namespace MODULES {
+
+      /** @brief Level-detector mode for the ``compressor``. */
+      enum compressorDetector {
+        DETECT_PEAK, ///< Track the instantaneous linked peak — fast, hits transients.
+        DETECT_RMS, ///< Track a short mean-square window — smoother, loudness-like.
+      };
+
+      /**
+       *  @brief Feed-forward dynamics compressor packaged as a chainable ``dspObject``.
+       *
+       *  The dynamics half of the channel strip (the parametric EQ is the tone
+       *  half). A classic feed-forward design: a switchable peak/RMS detector
+       *  drives a static compression curve (threshold + ratio), the resulting
+       *  gain is smoothed by separate attack and release time constants, and a
+       *  makeup gain restores level.
+       *
+       *  ### Stereo-linked detection (N-channel)
+       *
+       *  The detector and the gain it computes are **shared across every
+       *  channel** — one sidechain for the whole buffer. Each sample's detector
+       *  level is taken from all channels at once (the peak across them, or their
+       *  summed mean-square for RMS), one gain-reduction value is derived, and
+       *  that *same* gain is applied to every channel. This is what keeps a
+       *  stereo (or N-channel) image stable: if the channels were each detected
+       *  and compressed independently, a transient on one side would duck only
+       *  that side and the stereo image would wobble/pump. Linking guarantees the
+       *  relative balance between channels is preserved through gain changes.
+       *
+       *  A mono buffer is the degenerate single-channel case. The module holds no
+       *  per-channel history (the gain is global), so it tolerates a changing
+       *  channel count between calls for free (see the N-channel contract on
+       *  ``dspObject::process``).
+       *
+       *  The wet/dry balance is the inherited ``impact()``; ``impact(1)`` (the
+       *  default) is the fully-compressed insert. ``process`` allocates nothing
+       *  in steady state.
+       */
+      class API compressor : public dspObject {
+      public:
+        compressor();
+        virtual ~compressor() {};
+
+        /** @brief Select the peak or RMS level detector. */
+        compressor& detector(compressorDetector value);
+
+        /** @brief Current detector mode. */
+        compressorDetector detector();
+
+        /** @brief Set the threshold in dBFS (clamped to [-60, 0]). Signal above
+         *  the threshold is compressed; below it passes unchanged. */
+        compressor& threshold(Flt db);
+
+        /** @brief Current threshold in dBFS. */
+        Flt threshold();
+
+        /** @brief Set the compression ratio (clamped to [1, 20]). 1 is no
+         *  compression; 4 means 4 dB in above threshold yields 1 dB out. */
+        compressor& ratio(Flt value);
+
+        /** @brief Current compression ratio. */
+        Flt ratio();
+
+        /** @brief Set the attack time in milliseconds (clamped to a sane range) —
+         *  how fast gain reduction engages when the signal rises. */
+        compressor& attack(Flt ms);
+
+        /** @brief Current attack time in milliseconds. */
+        Flt attack();
+
+        /** @brief Set the release time in milliseconds (clamped to a sane range) —
+         *  how fast gain recovers when the signal falls. */
+        compressor& release(Flt ms);
+
+        /** @brief Current release time in milliseconds. */
+        Flt release();
+
+        /** @brief Set the makeup gain in dB (clamped to [-24, 24]) — a fixed gain
+         *  applied after compression to restore level. */
+        compressor& makeup(Flt db);
+
+        /** @brief Current makeup gain in dB. */
+        Flt makeup();
+
+        /** @brief Current gain reduction being applied, in dB (<= 0). Useful for
+         *  metering; reflects the last processed sample. */
+        Flt gainReductionDb();
+
+        /** @brief dspObject lifecycle hook. */
+        virtual void create();
+
+        /** @brief dspObject audio-thread entry point. */
+        virtual void process(MULTICHANNELBUFFER& buffer);
+
+      private:
+        aFlt parmThreshold; // dBFS
+        aFlt parmRatio;
+        aFlt parmAttack; // ms
+        aFlt parmRelease; // ms
+        aFlt parmMakeup; // dB
+        aInt parmDetector; // compressorDetector
+
+        // Audio-thread-only state (shared across all channels — the stereo link).
+        Flt gain; // current smoothed linear gain applied to every channel
+        Flt msEnv; // RMS mean-square follower state
+        Flt rmsCoef; // one-pole coefficient for the RMS window (from SR)
+
+        aFlt reductionDb; // last gain reduction (dB, <= 0) for metering
+
+        DSP::buffer gainBuf; // per-sample applied linear gain (shared across channels)
+        DSP::buffer wet; // per-block compressed scratch for the wet/dry mix
+        std::size_t blockLength; // last seen block length (scratch sizing)
+      };
+
+    } // namespace MODULES
+  } // namespace DSP
+} // namespace YSE
+
+#endif // COMPRESSOR_HPP_INCLUDED

--- a/YseEngine/dsp/modules/parametricEQ.cpp
+++ b/YseEngine/dsp/modules/parametricEQ.cpp
@@ -1,0 +1,203 @@
+/*
+  ==============================================================================
+
+    parametricEQ.cpp
+    Channel-strip parametric EQ module (issue #163).
+
+  ==============================================================================
+*/
+
+#include "parametricEQ.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace {
+  constexpr Flt MIN_FREQ_HZ = 20.0f;
+  constexpr Flt MAX_FREQ_HZ = 20000.0f;
+  constexpr Flt MAX_GAIN_DB = 24.0f;
+  constexpr Flt MIN_Q = 0.1f;
+  constexpr Flt MAX_Q = 18.0f;
+  constexpr Flt PI = 3.14159265358979323846f;
+
+  // Default per-band voicing (a neutral, evenly spread channel-strip layout).
+  constexpr Flt DEF_FREQ[4] = {100.0f, 400.0f, 2000.0f, 8000.0f};
+  constexpr Flt DEF_Q[4] = {0.7071067811865475f, 1.0f, 1.0f, 0.7071067811865475f};
+} // namespace
+
+YSE::DSP::MODULES::parametricEQ::Coeffs::Coeffs()
+  : b0(1.0f), b1(0.0f), b2(0.0f), a1(0.0f), a2(0.0f) {}
+
+YSE::DSP::MODULES::parametricEQ::BandState::BandState() : x1(0.0f), x2(0.0f), y1(0.0f), y2(0.0f) {}
+
+YSE::DSP::MODULES::parametricEQ::parametricEQ() : dirty(true), builtRate(0), blockLength(0) {
+  for (int b = 0; b < EQ_BAND_COUNT; ++b) {
+    parmFreq[b].store(DEF_FREQ[b]);
+    parmGain[b].store(0.0f);
+    parmQ[b].store(DEF_Q[b]);
+  }
+}
+
+YSE::DSP::MODULES::parametricEQ& YSE::DSP::MODULES::parametricEQ::frequency(eqBand band, Flt hz) {
+  parmFreq[band].store(std::clamp(hz, MIN_FREQ_HZ, MAX_FREQ_HZ));
+  dirty.store(true);
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::parametricEQ::frequency(eqBand band) {
+  return parmFreq[band];
+}
+
+YSE::DSP::MODULES::parametricEQ& YSE::DSP::MODULES::parametricEQ::gain(eqBand band, Flt db) {
+  parmGain[band].store(std::clamp(db, -MAX_GAIN_DB, MAX_GAIN_DB));
+  dirty.store(true);
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::parametricEQ::gain(eqBand band) {
+  return parmGain[band];
+}
+
+YSE::DSP::MODULES::parametricEQ& YSE::DSP::MODULES::parametricEQ::q(eqBand band, Flt value) {
+  parmQ[band].store(std::clamp(value, MIN_Q, MAX_Q));
+  dirty.store(true);
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::parametricEQ::q(eqBand band) {
+  return parmQ[band];
+}
+
+// RBJ "Audio EQ Cookbook" biquad design. Coefficients are normalised by a0 so
+// the difference equation is y = b0*x + b1*x1 + b2*x2 - a1*y1 - a2*y2.
+void YSE::DSP::MODULES::parametricEQ::computeBand(eqBand band) {
+  const Flt f = std::clamp(parmFreq[band].load(), MIN_FREQ_HZ, MAX_FREQ_HZ);
+  const Flt dbGain = parmGain[band].load();
+  const Flt Q = std::clamp(parmQ[band].load(), MIN_Q, MAX_Q);
+  const Flt sr = static_cast<Flt>(SAMPLERATE);
+
+  const Flt A = std::pow(10.0f, dbGain / 40.0f); // sqrt of linear gain
+  const Flt w0 = 2.0f * PI * f / sr;
+  const Flt cosw = std::cos(w0);
+  const Flt sinw = std::sin(w0);
+  const Flt alpha = sinw / (2.0f * Q);
+
+  Flt b0, b1, b2, a0, a1, a2;
+
+  switch (band) {
+  case EQ_PEAK_1:
+  case EQ_PEAK_2: {
+    b0 = 1.0f + alpha * A;
+    b1 = -2.0f * cosw;
+    b2 = 1.0f - alpha * A;
+    a0 = 1.0f + alpha / A;
+    a1 = -2.0f * cosw;
+    a2 = 1.0f - alpha / A;
+    break;
+  }
+  case EQ_LOW_SHELF: {
+    const Flt twoSqrtAalpha = 2.0f * std::sqrt(A) * alpha;
+    b0 = A * ((A + 1.0f) - (A - 1.0f) * cosw + twoSqrtAalpha);
+    b1 = 2.0f * A * ((A - 1.0f) - (A + 1.0f) * cosw);
+    b2 = A * ((A + 1.0f) - (A - 1.0f) * cosw - twoSqrtAalpha);
+    a0 = (A + 1.0f) + (A - 1.0f) * cosw + twoSqrtAalpha;
+    a1 = -2.0f * ((A - 1.0f) + (A + 1.0f) * cosw);
+    a2 = (A + 1.0f) + (A - 1.0f) * cosw - twoSqrtAalpha;
+    break;
+  }
+  case EQ_HIGH_SHELF:
+  default: {
+    const Flt twoSqrtAalpha = 2.0f * std::sqrt(A) * alpha;
+    b0 = A * ((A + 1.0f) + (A - 1.0f) * cosw + twoSqrtAalpha);
+    b1 = -2.0f * A * ((A - 1.0f) + (A + 1.0f) * cosw);
+    b2 = A * ((A + 1.0f) + (A - 1.0f) * cosw - twoSqrtAalpha);
+    a0 = (A + 1.0f) - (A - 1.0f) * cosw + twoSqrtAalpha;
+    a1 = 2.0f * ((A - 1.0f) - (A + 1.0f) * cosw);
+    a2 = (A + 1.0f) - (A - 1.0f) * cosw - twoSqrtAalpha;
+    break;
+  }
+  }
+
+  Coeffs& c = coeffs[band];
+  const Flt inv = 1.0f / a0;
+  c.b0 = b0 * inv;
+  c.b1 = b1 * inv;
+  c.b2 = b2 * inv;
+  c.a1 = a1 * inv;
+  c.a2 = a2 * inv;
+}
+
+void YSE::DSP::MODULES::parametricEQ::create() {
+  for (int b = 0; b < EQ_BAND_COUNT; ++b)
+    computeBand(static_cast<eqBand>(b));
+  builtRate = SAMPLERATE;
+  dirty.store(false);
+}
+
+void YSE::DSP::MODULES::parametricEQ::process(MULTICHANNELBUFFER& buffer) {
+  createIfNeeded();
+
+  if (buffer.empty()) return;
+
+  // Recompute the shared coefficient set when a parameter moved or the sample
+  // rate changed. This is the only place the transcendental design runs, it is
+  // bounded (four bands), allocates nothing, and only fires on a block where
+  // something actually changed.
+  const UInt rate = SAMPLERATE;
+  bool rateChanged = (rate != builtRate);
+  if (dirty.exchange(false) || rateChanged) {
+    for (int b = 0; b < EQ_BAND_COUNT; ++b)
+      computeBand(static_cast<eqBand>(b));
+    builtRate = rate;
+  }
+
+  // Grow/shrink per-channel biquad memory to the channel count. New channels
+  // start with cleared delay memory; this is the only allocation path.
+  bool resized = channels.ensure(buffer.size());
+  if (resized || rateChanged) {
+    // A device restart (new rate/channel count) clears filter memory so no
+    // stale history leaks across the discontinuity.
+    for (std::size_t ch = 0; ch < channels.size(); ++ch)
+      channels[ch] = ChannelState();
+  }
+
+  const std::size_t length = buffer[0].getLength();
+  if (length != blockLength) {
+    wet.resize(static_cast<UInt>(length));
+    blockLength = length;
+  }
+
+  // Snapshot the coefficient set into locals once per block (avoids re-reading
+  // struct members in the inner loop).
+  const Coeffs c0 = coeffs[EQ_LOW_SHELF];
+  const Coeffs c1 = coeffs[EQ_PEAK_1];
+  const Coeffs c2 = coeffs[EQ_PEAK_2];
+  const Coeffs c3 = coeffs[EQ_HIGH_SHELF];
+  const Coeffs* cs[EQ_BAND_COUNT] = {&c0, &c1, &c2, &c3};
+
+  const std::size_t n = buffer.size();
+  for (std::size_t ch = 0; ch < n; ++ch) {
+    ChannelState& st = channels[ch];
+    Flt* x = buffer[ch].getPtr();
+    Flt* w = wet.getPtr();
+
+    for (std::size_t i = 0; i < length; ++i) {
+      Flt sample = x[i];
+      // Cascade the four bands in series.
+      for (int b = 0; b < EQ_BAND_COUNT; ++b) {
+        const Coeffs& c = *cs[b];
+        BandState& bs = st.bands[b];
+        const Flt in = sample;
+        const Flt out = c.b0 * in + c.b1 * bs.x1 + c.b2 * bs.x2 - c.a1 * bs.y1 - c.a2 * bs.y2;
+        bs.x2 = bs.x1;
+        bs.x1 = in;
+        bs.y2 = bs.y1;
+        bs.y1 = out;
+        sample = out;
+      }
+      w[i] = sample;
+    }
+
+    // impact() sets the dry/wet balance.
+    calculateImpact(buffer[ch], wet);
+  }
+}

--- a/YseEngine/dsp/modules/parametricEQ.hpp
+++ b/YseEngine/dsp/modules/parametricEQ.hpp
@@ -1,0 +1,139 @@
+/*
+  ==============================================================================
+
+    parametricEQ.hpp
+    Channel-strip parametric EQ module (issue #163).
+
+  ==============================================================================
+*/
+
+#ifndef PARAMETRICEQ_HPP_INCLUDED
+#define PARAMETRICEQ_HPP_INCLUDED
+
+#include "../../headers/defines.hpp"
+#include "../../headers/types.hpp"
+#include "../dspObject.hpp"
+#include "../buffer.hpp"
+#include "../perChannel.hpp"
+#include <cstddef>
+
+namespace YSE {
+  namespace DSP {
+    namespace MODULES {
+
+      /** @brief The four fixed bands of the ``parametricEQ``. */
+      enum eqBand {
+        EQ_LOW_SHELF, ///< Low shelf — boosts/cuts everything below its corner.
+        EQ_PEAK_1, ///< Lower peaking (bell) band.
+        EQ_PEAK_2, ///< Upper peaking (bell) band.
+        EQ_HIGH_SHELF, ///< High shelf — boosts/cuts everything above its corner.
+        EQ_BAND_COUNT, ///< Number of bands (sentinel).
+      };
+
+      /**
+       *  @brief Channel-strip parametric EQ packaged as a chainable ``dspObject``.
+       *
+       *  Four cascaded biquad bands — a low shelf, two peaking (bell) bands, and
+       *  a high shelf — each with its own frequency, gain (dB), and Q. This is
+       *  the corrective/tone-shaping half of the channel strip (the compressor is
+       *  the dynamics half); together they make the channel insert chain a usable
+       *  mixing tool.
+       *
+       *  The bands are the standard RBJ "Audio EQ Cookbook" biquads (the same
+       *  transfer functions the engine's ``biQuad`` primitive implements). Each
+       *  band's five coefficients are shared across all channels and recomputed
+       *  only when one of its parameters changes (or the sample rate changes),
+       *  gated by a dirty flag — never per sample and never allocating. The
+       *  recompute is a bounded handful of transcendentals for at most four bands
+       *  and runs at the very top of ``process`` only on a block where a
+       *  parameter actually moved, which keeps the audio path allocation- and
+       *  lock-free.
+       *
+       *  ### N-channel behaviour
+       *
+       *  Every channel is filtered independently: the coefficients are shared but
+       *  each channel owns its biquad delay memory (via ``perChannel``), so no
+       *  filter state bleeds between channels (see the N-channel contract on
+       *  ``dspObject::process``). A mono buffer is the degenerate single-channel
+       *  case, and the module tolerates a changing channel count between calls
+       *  (the device-restart resize path is the only place per-channel state
+       *  allocates).
+       *
+       *  The wet/dry balance is the inherited ``impact()``; ``impact(1)`` (the
+       *  default) is the natural fully-processed insert. All state is sized on
+       *  the ``create()`` / channel-count-change path; ``process`` allocates
+       *  nothing in steady state.
+       */
+      class API parametricEQ : public dspObject {
+      public:
+        parametricEQ();
+        virtual ~parametricEQ() {};
+
+        /** @brief Set a band's centre/corner frequency in Hz (clamped to a sane
+         *  audio range). */
+        parametricEQ& frequency(eqBand band, Flt hz);
+
+        /** @brief Current centre/corner frequency of a band, in Hz. */
+        Flt frequency(eqBand band);
+
+        /** @brief Set a band's gain in dB (clamped to +/-24 dB). Positive boosts,
+         *  negative cuts; 0 leaves the band flat (a bypass for that band). */
+        parametricEQ& gain(eqBand band, Flt db);
+
+        /** @brief Current gain of a band, in dB. */
+        Flt gain(eqBand band);
+
+        /** @brief Set a band's Q (clamped to a sane range). For the peaking bands
+         *  Q is the bell width; for the shelves it shapes the corner steepness. */
+        parametricEQ& q(eqBand band, Flt value);
+
+        /** @brief Current Q of a band. */
+        Flt q(eqBand band);
+
+        /** @brief dspObject lifecycle hook. */
+        virtual void create();
+
+        /** @brief dspObject audio-thread entry point. */
+        virtual void process(MULTICHANNELBUFFER& buffer);
+
+      private:
+        // Per-band user parameters (control-thread writes, audio-thread reads).
+        aFlt parmFreq[EQ_BAND_COUNT];
+        aFlt parmGain[EQ_BAND_COUNT]; // dB
+        aFlt parmQ[EQ_BAND_COUNT];
+
+        // Set whenever a parameter changes; the audio thread recomputes the
+        // coefficient set and clears it. Also forced by a sample-rate change.
+        std::atomic<bool> dirty;
+
+        /** @brief One band's shared biquad coefficients (Direct Form I,
+         *  normalised so a0 == 1). */
+        struct Coeffs {
+          Flt b0, b1, b2, a1, a2;
+          Coeffs();
+        };
+        Coeffs coeffs[EQ_BAND_COUNT]; // audio-thread-only, recomputed on dirty
+
+        /** @brief One channel's per-band biquad delay memory (Direct Form I). */
+        struct BandState {
+          Flt x1, x2, y1, y2;
+          BandState();
+        };
+        struct ChannelState {
+          BandState bands[EQ_BAND_COUNT];
+        };
+        perChannel<ChannelState> channels;
+
+        UInt builtRate; // SAMPLERATE the coefficients were computed for (0 = none)
+
+        DSP::buffer wet; // per-block wet scratch
+        std::size_t blockLength; // last seen block length (scratch sizing)
+
+        void computeBand(eqBand band); // fill coeffs[band] from its parameters
+      };
+
+    } // namespace MODULES
+  } // namespace DSP
+} // namespace YSE
+
+#endif // PARAMETRICEQ_HPP_INCLUDED


### PR DESCRIPTION
## Summary

Adds the two remaining channel-strip staples as N-channel `MODULES::`
effects, completing the channel insert chain's tone + dynamics pair
(part of #146, built on the #158 N-channel contract).

## Linked issue

Closes #163

## Changes

- **`parametricEQ`** — four cascaded RBJ ("Audio EQ Cookbook") biquad
  bands: a low shelf, two peaking (bell) bands, and a high shelf, each
  with independent frequency, gain (dB), and Q. Coefficients are shared
  across channels and recomputed **off the audio path** (dirty-flag
  gated; also on a sample-rate change), never per sample and never
  allocating. Each channel owns its biquad delay memory via
  `perChannel`, so no filter state bleeds between channels. A 0 dB band
  is a mathematical identity (unity passthrough), so bands compose
  cleanly and can be exercised in isolation.
- **`compressor`** — feed-forward dynamics: switchable peak/RMS
  detector, threshold/ratio/attack/release/makeup, plus a gain-reduction
  meter. **Stereo-linked detection**: one sidechain (peak across all
  channels, or their summed mean-square for RMS) drives a single gain
  that is applied to *every* channel, so a transient on one channel
  ducks all channels equally — no channel-independent pumping / image
  wobble. Holds no per-channel history (the gain is global), so a
  changing channel count is tolerated for free.
- CMake wiring for both sources and both test files.

Both modules follow the N-channel `dspObject::process` contract:
allocation only in `create()` / on the resize path, allocation-free in
steady state, wet/dry via the inherited `impact()`.

Scope kept to the issue — no C API surface (batched in the effects
C-API issue per #158's non-goals; consistent with the sibling chorus
/plate-reverb modules, which are likewise not yet in the `yse.hpp`
umbrella). Non-goals from the issue (lookahead limiting, cross-channel
sidechain, FFT/linear-phase EQ) are untouched.

## Test plan

- [x] `python yse.py format` clean (only the new files reflowed; no
      tracked files changed)
- [x] `python yse.py analyze` clean on both module sources and both
      test files (0 user-code findings)
- [x] `python yse.py test` — all 23 ctest executables pass; the two new
      suites add 26 cases / 26,316 assertions, all passing
- [x] EQ acceptance: per-band magnitude response matches the design
      (boost/cut at centre, shelves tilt lows-vs-highs, flat EQ is
      transparent within ~0.2 dB)
- [x] Compressor acceptance: static curve matches threshold/ratio
      (−6 dBFS in → −15 dBFS out at 4:1, −18 dB threshold); attack/
      release timing within tolerance; stereo-linked detection confirmed
      (identical gain on both channels; a loud channel ducks a quiet
      neighbour)

Not user-visible (no rendered UI / device flow) — a DSP node is covered
end-to-end by the behavioural suites above, which drive the real
`process` block loop at the engine sample rate (44100, and 48000 under
the CI forced-rate path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
