### PR TITLE
PATCHER: patcher-as-insert via ~adc audio input (#167)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(YSE_TEST_SOURCES
   patcher/test_patcher_concurrency.cpp
   patcher/test_patcher_object_races.cpp
   patcher/test_patcher_feedback_loop.cpp
+  patcher/test_patcher_adc.cpp
   patcher/test_timerthread.cpp
   channel/test_channel.cpp
   channel/test_channel_concurrency.cpp
@@ -436,6 +437,7 @@ set_source_files_properties(
   patcher/test_patcher_concurrency.cpp
   patcher/test_patcher_object_races.cpp
   patcher/test_patcher_feedback_loop.cpp
+  patcher/test_patcher_adc.cpp
   patcher/test_timerthread.cpp
   PROPERTIES COMPILE_FLAGS "${_patcher_test_suppress}"
 )

--- a/Tests/patcher/test_patcher_adc.cpp
+++ b/Tests/patcher/test_patcher_adc.cpp
@@ -1,0 +1,305 @@
+// Tests for the ~adc patcher object and the patcher-as-insert host adapter
+// (DSP::patcherInsert) — issue #167.
+//
+// Covers: the ~adc node in isolation (start point, buffer outlets, buffer
+// injection), and the full insert flow — a passthrough graph is bit-transparent,
+// a filter graph measurably processes, JSON round-trips a graph containing
+// ~adc, and host/graph channel-count mismatches follow the documented contract.
+// No audio device required.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include <string>
+#include <vector>
+#include "patcher/patcher.hpp"
+#include "patcher/pHandle.hpp"
+#include "patcher/pObjectList.hpp"
+#include "patcher/genericObjects/pAdc.h"
+#include "dsp/patcherInsert.hpp"
+#include "dsp/buffer.hpp"
+#include "headers/defines.hpp"
+#include "support/audio_helpers.hpp"
+#include "patcher/sinks.hpp"
+
+using TestHelpers::BufferSink;
+using TestHelpers::measureRms;
+
+static constexpr float kPi = 3.14159265358979323846f;
+
+namespace {
+
+  inline void fillSine(YSE::DSP::buffer& buf, float freq, float sr = 44100.0f) {
+    float* p = buf.getPtr();
+    for (unsigned i = 0; i < buf.getLength(); ++i)
+      p[i] = std::sin(2.0f * kPi * freq * static_cast<float>(i) / sr);
+  }
+
+  // A distinctive, non-trivial signal so a bit-transparency check is meaningful.
+  inline void fillPattern(YSE::DSP::buffer& buf, float phase = 0.f) {
+    float* p = buf.getPtr();
+    const unsigned n = buf.getLength();
+    for (unsigned i = 0; i < n; ++i) {
+      p[i] = 0.5f * std::sin(phase + 0.13f * static_cast<float>(i)) +
+             (static_cast<float>(i) / static_cast<float>(n)) - 0.5f;
+    }
+  }
+
+  inline bool exactlyEqual(YSE::DSP::buffer& a, YSE::DSP::buffer& b) {
+    if (a.getLength() != b.getLength()) return false;
+    float* pa = a.getPtr();
+    float* pb = b.getPtr();
+    for (unsigned i = 0; i < a.getLength(); ++i)
+      if (pa[i] != pb[i]) return false;
+    return true;
+  }
+
+} // anonymous namespace
+
+TEST_SUITE("patcher") {
+
+  // ─── pAdc node ──────────────────────────────────────────────────────────────
+
+  TEST_CASE("pAdc: type name, no inlets, N buffer outlets") {
+    YSE::patcher p;
+    p.create(2);
+    YSE::pHandle* h = p.CreateObject(YSE::OBJ::D_ADC);
+    REQUIRE(h != nullptr);
+    CHECK(std::string(h->Type()) == "~adc");
+    CHECK(h->GetInputs() == 0);
+    CHECK(h->GetOutputs() == 2);
+    CHECK(h->OutputDataType(0) == YSE::OUT_TYPE::BUFFER);
+    CHECK(h->OutputDataType(1) == YSE::OUT_TYPE::BUFFER);
+  }
+
+  TEST_CASE("pAdc: is a DSP start point (no active DSP input)") {
+    YSE::PATCHER::pAdc adc(2);
+    CHECK(adc.NumChannels() == 2);
+    CHECK(adc.NumInputs() == 0);
+    CHECK(adc.IsDSPStartPoint());
+  }
+
+  TEST_CASE("pAdc: injected channel buffer is sent through the matching outlet") {
+    YSE::PATCHER::pAdc adc(2);
+    BufferSink sink0, sink1;
+    adc.ConnectOutlet(sink0.GetInlet(0), 0);
+    sink0.ConnectInlet(adc.GetOutlet(0), 0);
+    adc.ConnectOutlet(sink1.GetInlet(0), 1);
+    sink1.ConnectInlet(adc.GetOutlet(1), 0);
+
+    YSE::DSP::buffer ch0(128), ch1(128);
+    ch0 = 1.0f;
+    ch1 = 2.0f;
+    adc.SetChannelBuffer(0, &ch0);
+    adc.SetChannelBuffer(1, &ch1);
+
+    adc.Calculate(YSE::T_DSP);
+
+    CHECK(sink0.received == &ch0);
+    CHECK(sink1.received == &ch1);
+  }
+
+  TEST_CASE("pAdc: a null channel sends nothing on that outlet") {
+    YSE::PATCHER::pAdc adc(2);
+    BufferSink sink0, sink1;
+    adc.ConnectOutlet(sink0.GetInlet(0), 0);
+    sink0.ConnectInlet(adc.GetOutlet(0), 0);
+    adc.ConnectOutlet(sink1.GetInlet(0), 1);
+    sink1.ConnectInlet(adc.GetOutlet(1), 0);
+
+    YSE::DSP::buffer ch0(128);
+    ch0 = 1.0f;
+    adc.SetChannelBuffer(0, &ch0);
+    // channel 1 deliberately left null
+
+    adc.Calculate(YSE::T_DSP);
+
+    CHECK(sink0.received == &ch0);
+    CHECK(sink1.received == nullptr);
+  }
+
+  TEST_CASE("pAdc: SetChannelBuffer ignores out-of-range channels") {
+    YSE::PATCHER::pAdc adc(2);
+    YSE::DSP::buffer buf(128);
+    // Must not crash / write out of bounds.
+    adc.SetChannelBuffer(5, &buf);
+    CHECK(adc.NumChannels() == 2);
+  }
+
+  // ─── patcherInsert: passthrough is bit-transparent ────────────────────────────
+
+  TEST_CASE("patcherInsert: ~adc -> ~dac passthrough is bit-transparent") {
+    YSE::patcher p;
+    p.create(2);
+    YSE::pHandle* adc = p.CreateObject(YSE::OBJ::D_ADC);
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC);
+    REQUIRE(adc != nullptr);
+    REQUIRE(dac != nullptr);
+    p.Connect(adc, 0, dac, 0);
+    p.Connect(adc, 1, dac, 1);
+
+    YSE::DSP::patcherInsert insert(p);
+
+    MULTICHANNELBUFFER io;
+    io.resize(2);
+    io[0].resize(128);
+    io[1].resize(128);
+    fillPattern(io[0], 0.0f);
+    fillPattern(io[1], 1.7f);
+
+    YSE::DSP::buffer dry0(io[0]);
+    YSE::DSP::buffer dry1(io[1]);
+
+    insert.process(io);
+
+    CHECK(exactlyEqual(io[0], dry0));
+    CHECK(exactlyEqual(io[1], dry1));
+  }
+
+  // ─── patcherInsert: a filter graph measurably processes ───────────────────────
+
+  TEST_CASE("patcherInsert: ~adc -> ~lp -> ~dac attenuates a high tone") {
+    YSE::patcher p;
+    p.create(1);
+    YSE::pHandle* adc = p.CreateObject(YSE::OBJ::D_ADC);
+    YSE::pHandle* lp = p.CreateObject(YSE::OBJ::D_LOWPASS, "200"); // 200 Hz cutoff
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC);
+    REQUIRE(adc != nullptr);
+    REQUIRE(lp != nullptr);
+    REQUIRE(dac != nullptr);
+    p.Connect(adc, 0, lp, 0); // adc audio -> lowpass audio in
+    p.Connect(lp, 0, dac, 0); // lowpass out -> dac
+
+    YSE::DSP::patcherInsert insert(p);
+
+    MULTICHANNELBUFFER io;
+    io.resize(1);
+    io[0].resize(128);
+
+    YSE::DSP::buffer dry(128);
+    fillSine(dry, 8000.0f);
+    const float dryRms = measureRms(dry);
+    REQUIRE(dryRms > 0.0f);
+
+    // Feed the tone block after block so the filter settles, measuring the last
+    // processed block.
+    for (int iter = 0; iter < 40; ++iter) {
+      fillSine(io[0], 8000.0f);
+      insert.process(io);
+    }
+
+    const float wetRms = measureRms(io[0]);
+    CHECK(wetRms < dryRms * 0.5f); // clearly attenuated
+    CHECK_FALSE(exactlyEqual(io[0], dry)); // signal was modified
+  }
+
+  // ─── patcherInsert: JSON round-trip of a graph containing ~adc ─────────────────
+
+  TEST_CASE("patcherInsert: JSON round-trip preserves an ~adc passthrough graph") {
+    YSE::patcher src;
+    src.create(2);
+    YSE::pHandle* adc = src.CreateObject(YSE::OBJ::D_ADC);
+    YSE::pHandle* dac = src.CreateObject(YSE::OBJ::D_DAC);
+    src.Connect(adc, 0, dac, 0);
+    src.Connect(adc, 1, dac, 1);
+    std::string json = src.DumpJSON();
+    CHECK(json.find("~adc") != std::string::npos);
+
+    // Rebuild from JSON into a fresh patcher.
+    YSE::patcher loaded;
+    loaded.create(2);
+    loaded.ParseJSON(json);
+    CHECK(loaded.Objects() == 2);
+
+    bool hasAdc = false;
+    for (unsigned i = 0; i < loaded.Objects(); ++i) {
+      YSE::pHandle* h = loaded.GetHandleFromList(i);
+      if (h != nullptr && std::string(h->Type()) == "~adc") hasAdc = true;
+    }
+    CHECK(hasAdc);
+
+    // The restored graph must still work as a bit-transparent insert, which
+    // proves the ~adc -> ~dac connections survived the round-trip.
+    YSE::DSP::patcherInsert insert(loaded);
+    MULTICHANNELBUFFER io;
+    io.resize(2);
+    io[0].resize(128);
+    io[1].resize(128);
+    fillPattern(io[0], 0.3f);
+    fillPattern(io[1], 2.1f);
+    YSE::DSP::buffer dry0(io[0]);
+    YSE::DSP::buffer dry1(io[1]);
+
+    insert.process(io);
+
+    CHECK(exactlyEqual(io[0], dry0));
+    CHECK(exactlyEqual(io[1], dry1));
+  }
+
+  // ─── patcherInsert: channel-count mismatch contract ───────────────────────────
+
+  TEST_CASE("patcherInsert: host has fewer channels than the graph") {
+    // 2-channel graph, 1-channel host buffer. Channel 0 is processed; the graph
+    // never touches a channel the host does not provide.
+    YSE::patcher p;
+    p.create(2);
+    YSE::pHandle* adc = p.CreateObject(YSE::OBJ::D_ADC);
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC);
+    p.Connect(adc, 0, dac, 0);
+    p.Connect(adc, 1, dac, 1);
+
+    YSE::DSP::patcherInsert insert(p);
+
+    MULTICHANNELBUFFER io;
+    io.resize(1);
+    io[0].resize(128);
+    fillPattern(io[0], 0.5f);
+    YSE::DSP::buffer dry0(io[0]);
+
+    insert.process(io); // must not read io[1]
+
+    REQUIRE(io.size() == 1);
+    CHECK(exactlyEqual(io[0], dry0)); // channel 0 passed through
+  }
+
+  TEST_CASE("patcherInsert: host has more channels than the graph produces") {
+    // 1-channel graph, 2-channel host buffer. Channel 0 is replaced by the
+    // graph; channel 1 (beyond the graph's output count) passes through dry.
+    YSE::patcher p;
+    p.create(1);
+    YSE::pHandle* adc = p.CreateObject(YSE::OBJ::D_ADC);
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC);
+    p.Connect(adc, 0, dac, 0);
+
+    YSE::DSP::patcherInsert insert(p);
+
+    MULTICHANNELBUFFER io;
+    io.resize(2);
+    io[0].resize(128);
+    io[1].resize(128);
+    fillPattern(io[0], 0.2f);
+    fillPattern(io[1], 1.1f);
+    YSE::DSP::buffer dry0(io[0]);
+    YSE::DSP::buffer dry1(io[1]);
+
+    insert.process(io);
+
+    CHECK(exactlyEqual(io[0], dry0)); // passthrough graph replaced ch0 with itself
+    CHECK(exactlyEqual(io[1], dry1)); // ch1 left unchanged (dry)
+  }
+
+  TEST_CASE("patcherInsert: null / uncreated patcher process is a safe no-op") {
+    YSE::patcher p; // create() never called -> pimpl is null
+    YSE::DSP::patcherInsert insert(p);
+
+    MULTICHANNELBUFFER io;
+    io.resize(1);
+    io[0].resize(128);
+    fillPattern(io[0], 0.0f);
+    YSE::DSP::buffer dry(io[0]);
+
+    insert.process(io); // must not crash
+
+    CHECK(exactlyEqual(io[0], dry));
+  }
+
+} // TEST_SUITE("patcher")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -28,6 +28,7 @@ set(YSE_SRCS
   dsp/lfo.cpp
   dsp/math.cpp
   dsp/math_functions.cpp
+  dsp/patcherInsert.cpp
   dsp/modules/delay/basicDelay.cpp
   dsp/modules/delay/feedbackDelay.cpp
   dsp/modules/delay/highpassDelay.cpp
@@ -90,6 +91,7 @@ set(YSE_SRCS
   patcher/genericObjects/gRoute.cpp
   patcher/genericObjects/gSend.cpp
   patcher/genericObjects/gSwitch.cpp
+  patcher/genericObjects/pAdc.cpp
   patcher/genericObjects/pDac.cpp
   patcher/genericObjects/pLine.cpp
   patcher/guiObjects/gButton.cpp
@@ -212,6 +214,7 @@ set_source_files_properties(
   patcher/genericObjects/gRoute.cpp
   patcher/genericObjects/gSend.cpp
   patcher/genericObjects/gSwitch.cpp
+  patcher/genericObjects/pAdc.cpp
   patcher/genericObjects/pDac.cpp
   patcher/genericObjects/pLine.cpp
   patcher/guiObjects/gButton.cpp
@@ -246,11 +249,13 @@ set_source_files_properties(
   PROPERTIES COMPILE_FLAGS "${PATCHER_SUPPRESS}"
 )
 
-# soundImplementation.cpp and soundInterface.cpp pull in json.hpp through patcher headers.
+# soundImplementation.cpp, soundInterface.cpp and dsp/patcherInsert.cpp pull in
+# json.hpp through patcher headers.
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set_source_files_properties(
     sound/soundImplementation.cpp
     sound/soundInterface.cpp
+    dsp/patcherInsert.cpp
     PROPERTIES COMPILE_FLAGS "-Wno-deprecated-literal-operator -Wno-tautological-overlap-compare"
   )
 endif()

--- a/YseEngine/dsp/patcherInsert.cpp
+++ b/YseEngine/dsp/patcherInsert.cpp
@@ -1,0 +1,22 @@
+#include "patcherInsert.hpp"
+#include "../patcher/patcher.hpp"
+#include "../patcher/patcherImplementation.h"
+
+using namespace YSE::DSP;
+
+patcherInsert::patcherInsert(YSE::patcher& p) : patch(&p) {}
+
+void patcherInsert::create() {
+  // Nothing to allocate here: the wrapped patcher already owns its graph and
+  // output buffers, built by the caller before this insert was attached.
+}
+
+void patcherInsert::process(MULTICHANNELBUFFER& buffer) {
+  createIfNeeded();
+  if (patch == nullptr) return;
+  // Reach through to the implementation to render the graph in place. patcher's
+  // pimpl is private; patcherInsert is a friend (patcher.hpp).
+  PATCHER::patcherImplementation* impl = patch->pimpl;
+  if (impl == nullptr) return; // patcher::create() was never called
+  impl->ProcessAsInsert(buffer);
+}

--- a/YseEngine/dsp/patcherInsert.hpp
+++ b/YseEngine/dsp/patcherInsert.hpp
@@ -1,0 +1,56 @@
+#ifndef PATCHERINSERT_H_INCLUDED
+#define PATCHERINSERT_H_INCLUDED
+
+#include "dspObject.hpp"
+#include "../headers/defines.hpp"
+
+namespace YSE {
+  class patcher;
+
+  namespace DSP {
+
+    /**
+     *  @brief Runs a ``YSE::patcher`` graph as an insert effect.
+     *
+     *  A ``patcherInsert`` wraps a patcher so it can be attached anywhere a
+     *  ``DSP::dspObject`` chain goes — ``YSE::sound::setDSP`` or
+     *  ``YSE::channel::setDSP`` (issue #167). Each ``process`` call feeds the
+     *  host's incoming audio to the graph's ``~adc`` objects, renders the
+     *  graph, and copies the summed ``~dac`` output back over the host buffer
+     *  in place. This turns a hand-patched network (a filter-delay, a custom
+     *  EQ, ...) into a channel or per-sound insert.
+     *
+     *  Build the patcher (with at least one ``~adc`` and one ``~dac``) before
+     *  attaching the insert, and keep it alive for as long as the insert is
+     *  attached — the insert borrows the patcher, it does not own it.
+     *
+     *  ### Channel-count behaviour
+     *
+     *  The graph is created with a fixed channel count (``patcher::create``).
+     *  When the host buffer has a different channel count than the graph:
+     *  - fewer host channels than graph inputs: the extra ``~adc`` channels get
+     *    no input (silent);
+     *  - fewer graph outputs than host channels: the extra host channels pass
+     *    through unchanged (dry) — only the channels the graph produces are
+     *    replaced.
+     */
+    class API patcherInsert : public dspObject {
+    public:
+      /** @brief Wrap ``patch`` as an insert. ``patch`` must outlive this object. */
+      explicit patcherInsert(YSE::patcher& patch);
+
+      /** @brief No-op: the wrapped patcher owns its own graph and buffers. */
+      void create() override;
+
+      /** @brief Render the patcher over ``buffer`` in place. Audio thread. */
+      void process(MULTICHANNELBUFFER& buffer) override;
+
+    private:
+      // Borrowed, not owned. Null is tolerated (process is a no-op).
+      YSE::patcher* patch;
+    };
+
+  } // namespace DSP
+} // namespace YSE
+
+#endif // PATCHERINSERT_H_INCLUDED

--- a/YseEngine/patcher/genericObjects/pAdc.cpp
+++ b/YseEngine/patcher/genericObjects/pAdc.cpp
@@ -1,0 +1,54 @@
+#include "pAdc.h"
+#include <string>
+
+using namespace YSE::PATCHER;
+
+#define className pAdc
+
+namespace {
+  // Channel count used by the registry / metadata construction path
+  // (pAdc::Create()). The live graph always builds the ADC with the patcher's
+  // real output channel count through the pAdc(int) constructor
+  // (patcherImplementation::CreateObjectUnlocked), so this default only shapes
+  // the documentation snapshot, never a rendered graph.
+  constexpr int kDefaultAdcChannels = 2;
+} // namespace
+
+CONSTRUCT_DSP() {
+  build(kDefaultAdcChannels);
+}
+
+pAdc::pAdc(int channels) : pObject(true) {
+  build(channels);
+}
+
+CALC() {
+  for (unsigned int i = 0; i < channels.size(); i++) {
+    if (channels[i] != nullptr) {
+      outputs[i].SendBuffer(channels[i], thread);
+    }
+  }
+}
+
+void pAdc::SetChannelBuffer(unsigned int channel, YSE::DSP::buffer* buffer) {
+  if (channel < channels.size()) {
+    channels[channel] = buffer;
+  }
+}
+
+unsigned int pAdc::NumChannels() const {
+  return static_cast<unsigned int>(channels.size());
+}
+
+void pAdc::build(int chans) {
+  channels.assign(static_cast<size_t>(chans < 0 ? 0 : chans), nullptr);
+  for (int i = 0; i < chans; i++) {
+    ADD_OUT_BUFFER;
+    OUTLET_DOC(i, "out", "One channel of the host's incoming audio, injected into the graph.",
+               "-1.0 to 1.0");
+  }
+  ADD_DESCRIPTION("Audio input into a patcher graph. When the patcher runs as a channel or sound "
+                  "insert, each outlet carries one channel of the host's incoming audio, so the "
+                  "graph can process external audio rather than only generating it.");
+  ADD_CATEGORY(pCategory::GENERIC);
+}

--- a/YseEngine/patcher/genericObjects/pAdc.h
+++ b/YseEngine/patcher/genericObjects/pAdc.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "../pObject.h"
+
+namespace YSE {
+  namespace PATCHER {
+
+    // Audio input into a patcher graph: the mirror of pDac. Where pDac is a
+    // DSP sink that collects the graph's per-channel output, pAdc is a DSP
+    // start point that injects an externally-supplied, per-channel buffer into
+    // the graph. It is the entry point that lets a patcher run as a channel /
+    // sound insert (issue #167): the host adapter (DSP::patcherInsert) points
+    // each channel at the host's incoming audio just before the graph renders.
+    PATCHER_CLASS(pAdc, YSE::OBJ::D_ADC)
+    pAdc(int channels);
+    _NO_MESSAGES
+    _DO_CALCULATE
+
+    // Point one output channel at an externally-owned buffer, borrowed for the
+    // duration of the next Calculate(). A null pointer means "no input for this
+    // channel this block" (the outlet stays silent). Out-of-range channels are
+    // ignored. Called by the host adapter on the audio thread; a plain pointer
+    // store, so RT-safe.
+    void SetChannelBuffer(unsigned int channel, YSE::DSP::buffer* buffer);
+
+    // Number of audio channels (== number of buffer outlets).
+    unsigned int NumChannels() const;
+
+  private:
+    // Shared construction body for the default (registry / metadata) and the
+    // channel-count constructors.
+    void build(int channels);
+
+    // Borrowed, externally-owned input buffers, one per outlet. Deliberately
+    // not cleared by ResetDSP: the host adapter sets these immediately before
+    // Calculate(), and Calculate() runs ResetDSP() on every object first, so
+    // clearing here would wipe the freshly injected input before it is read.
+    std::vector<DSP::buffer*> channels;
+  };
+
+} // namespace PATCHER
+} // namespace YSE

--- a/YseEngine/patcher/graphState.h
+++ b/YseEngine/patcher/graphState.h
@@ -35,6 +35,11 @@ namespace YSE {
       // DAC sinks whose channel buffers are summed into the patcher output.
       std::vector<pObject*> dacs;
 
+      // ADC sources fed by an external host buffer when the patcher runs as an
+      // insert (issue #167). The host adapter points each ADC's channels at the
+      // incoming audio before the block renders.
+      std::vector<pObject*> adcs;
+
       // outletTargets[outlet.graphId] = the inlets that outlet feeds. Empty for
       // ids that belong to deleted objects or outlets with no connections.
       std::vector<std::vector<inlet*>> outletTargets;

--- a/YseEngine/patcher/pRegistry.cpp
+++ b/YseEngine/patcher/pRegistry.cpp
@@ -3,6 +3,7 @@
 #include "pObjectList.hpp"
 
 #include "genericObjects/pDac.h"
+#include "genericObjects/pAdc.h"
 #include "genericObjects/pLine.h"
 #include "genericObjects/gSwitch.h"
 #include "genericObjects/gGate.h"
@@ -70,6 +71,12 @@ pRegistry::pRegistry() {
 
   // Generic DSP
   Add(OBJ::D_LINE, pLine::Create);
+
+  // Audio input into the graph (patcher-as-insert, issue #167). Registered so
+  // ~adc is a valid, documented type and appears in the metadata snapshot; the
+  // rendered graph builds a channel-matched instance in
+  // patcherImplementation::CreateObjectUnlocked rather than via this Create().
+  Add(OBJ::D_ADC, pAdc::Create);
 
   Add(OBJ::D_SINE, pSine::Create);
   Add(OBJ::D_SAW, dSaw::Create);

--- a/YseEngine/patcher/patcher.hpp
+++ b/YseEngine/patcher/patcher.hpp
@@ -8,6 +8,9 @@ namespace YSE {
   namespace PATCHER {
     class patcherImplementation;
   }
+  namespace DSP {
+    class patcherInsert;
+  }
   /// @endcond
 
   /**
@@ -138,6 +141,9 @@ namespace YSE {
     // has run.
     std::string pendingName;
     friend class YSE::sound;
+    // The insert adapter reaches through to pimpl to render the graph in place
+    // (issue #167).
+    friend class YSE::DSP::patcherInsert;
   };
 
 } // namespace YSE

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -4,6 +4,7 @@
 #include "pObjectList.hpp"
 #include "../headers/enums.hpp"
 #include "genericObjects/pDac.h"
+#include "genericObjects/pAdc.h"
 #include "genericObjects/gReceive.h"
 #include "genericObjects/gSend.h"
 #include "pHandle.hpp"
@@ -158,6 +159,44 @@ void patcherImplementation::ResetDSP() {
   }
 }
 
+void patcherImplementation::ProcessAsInsert(MULTICHANNELBUFFER& io) {
+  // Audio thread. Run the patcher as an in-place insert effect over `io`
+  // (issue #167): feed the host's incoming audio to the graph's ~adc objects,
+  // render, then copy the summed ~dac output back over `io`.
+  //
+  // Channel-count contract between the host buffer and the graph I/O:
+  //   - Input:  ADC channel `ch` is fed io[ch] when ch < io.size(), else it is
+  //             left silent (null) — the graph simply gets no input on that
+  //             channel.
+  //   - Output: only the channels the graph produces are written back
+  //             (min(io.size(), output.size())). Host channels beyond the
+  //             graph's output count pass through unchanged (dry).
+  const GraphState* g = active_.load(std::memory_order_acquire);
+  if (g != nullptr) {
+    const unsigned int hostChannels = static_cast<unsigned int>(io.size());
+    for (pObject* obj : g->adcs) {
+      pAdc* adc = static_cast<pAdc*>(obj);
+      const unsigned int n = adc->NumChannels();
+      for (unsigned int ch = 0; ch < n; ch++) {
+        // The ADC pointers survive Calculate()'s ResetDSP pass (the ADC has no
+        // inlets to clear), so setting them here — just before the render — is
+        // exactly the ordering the graph traversal expects.
+        adc->SetChannelBuffer(ch, ch < hostChannels ? &io[ch] : nullptr);
+      }
+    }
+  }
+
+  // Existing render path: invalidates DSP state, fans out from the start points
+  // (the ~adc objects among them), and sums the ~dac buffers into `output`.
+  Calculate(YSE::T_DSP);
+
+  const unsigned int n =
+      std::min(static_cast<unsigned int>(io.size()), static_cast<unsigned int>(output.size()));
+  for (unsigned int ch = 0; ch < n; ch++) {
+    io[ch] = output[ch];
+  }
+}
+
 void patcherImplementation::ConnectUnlocked(YSE::pHandle* from, int outlet, YSE::pHandle* to,
                                             int inlet) {
   PATCHER::outlet* out = from->object->GetOutlet(outlet);
@@ -215,6 +254,13 @@ YSE::pHandle* patcherImplementation::CreateObjectUnlocked(const std::string& typ
     // Give the DAC its patcher parent too, so its inlets resolve DSP-readiness
     // from the pinned snapshot on the audio thread rather than the live wiring
     // (issue #226).
+    object->SetParent(this);
+  } else if (type == OBJ::D_ADC) {
+    // Like the DAC, the ADC is built with the patcher's real channel count
+    // rather than the registry's default-channel Create() (issue #167). The
+    // registry entry exists only so ~adc is a valid, documented type; the
+    // rendered graph always uses this channel-matched instance.
+    object = new pAdc((int)output.size());
     object->SetParent(this);
   } else {
     object = Register().Get(type);
@@ -765,6 +811,7 @@ YSE::PATCHER::GraphState* patcherImplementation::BuildGraph() {
     g->objects.push_back(object);
     if (object->IsDSPStartPoint()) g->startPoints.push_back(object);
     if (strcmp(object->Type(), YSE::OBJ::D_DAC) == 0) g->dacs.push_back(object);
+    if (strcmp(object->Type(), YSE::OBJ::D_ADC) == 0) g->adcs.push_back(object);
 
     for (int i = 0; i < object->NumOutputs(); i++) {
       PATCHER::outlet* out = object->GetOutlet(i);

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -36,6 +36,12 @@ namespace YSE {
       virtual void ResetDSP();
       virtual void Calculate(THREAD thread);
 
+      // Run the patcher as an in-place insert effect over a host buffer
+      // (issue #167): feed the incoming audio to the graph's ~adc objects,
+      // render, and copy the summed ~dac output back. Audio thread only.
+      // See the definition for the host/graph channel-count contract.
+      void ProcessAsInsert(MULTICHANNELBUFFER& io);
+
       // The GraphState pinned for the block currently being rendered, or null
       // between blocks. Read by inlets/outlets to resolve topology without a
       // lock (issue #226).

--- a/YseEngine/yse.hpp
+++ b/YseEngine/yse.hpp
@@ -95,6 +95,9 @@
 #include "patcher/patcher.hpp"
 #include "patcher/pHandle.hpp"
 
+// patcher-as-insert adapter (issue #167)
+#include "dsp/patcherInsert.hpp"
+
 // utilities
 #include "utils/misc.hpp"
 #include "utils/vector.hpp"

--- a/documentation/source/_data/patcher_objects.json
+++ b/documentation/source/_data/patcher_objects.json
@@ -1295,6 +1295,30 @@
       }
     ]
   },
+  "~adc": {
+    "category": "GENERIC",
+    "description": "Audio input into a patcher graph. When the patcher runs as a channel or sound insert, each outlet carries one channel of the host's incoming audio, so the graph can process external audio rather than only generating it.",
+    "inlets": [],
+    "is_dsp": true,
+    "name": "~adc",
+    "outlets": [
+      {
+        "doc": "One channel of the host's incoming audio, injected into the graph.",
+        "index": 0,
+        "label": "out",
+        "range": "-1.0 to 1.0",
+        "type": "BUFFER"
+      },
+      {
+        "doc": "One channel of the host's incoming audio, injected into the graph.",
+        "index": 1,
+        "label": "out",
+        "range": "-1.0 to 1.0",
+        "type": "BUFFER"
+      }
+    ],
+    "params": []
+  },
   "~bp": {
     "category": "FILTER",
     "description": "Bandpass filter. Passes a frequency band centered on 'frequency' with bandwidth shaped by 'Q' (resonance).",


### PR DESCRIPTION
## Summary

Adds the `~adc` patcher object and a host adapter so a hand-patched graph can run as a DSP **insert** on a channel or sound — not just as a generator. Builds on the channel-insert semantics from #159.

## Linked issue

Closes #167

## Changes

- **`pAdc` (`~adc`)** — a DSP start point (mirror of `pDac`) with N buffer outlets and no inlets. On `Calculate` it fans each externally-supplied channel buffer out to the graph. `ResetDSP` deliberately does *not* clear those pointers: the host adapter sets them immediately before the render, and `Calculate` runs `ResetDSP` on every object first. Registered in `pRegistry` with full doc metadata; built with the patcher's real channel count in `CreateObjectUnlocked` (like `pDac`).
- **`DSP::patcherInsert`** — a `dspObject` subclass wrapping a `patcher`. `process()` points the graph's `~adc` objects at the incoming `MULTICHANNELBUFFER`, runs `Calculate(T_DSP)`, and copies the summed `~dac` output back in place. Attachable anywhere a `dspObject` chain goes (`sound::setDSP` / `channel::setDSP`).
- **`GraphState::adcs`** — mirror of `dacs`, so the insert path resolves the ADC objects off the pinned, lock-free snapshot on the audio thread.
- **Channel-count mismatch contract** (documented on the adapter): extra graph inputs get no host audio (silent); host channels beyond the graph's output count pass through unchanged (dry); only channels the graph produces are replaced.
- Regenerated `documentation/source/_data/patcher_objects.json` to include `~adc` (metadata-parity and doc-coverage tests are build-enforced).

Non-goals respected: no patcher polyphony, no sample-rate / block-size conversion inside the graph, no C API surface.

## Test plan

- [x] `clang-format --dry-run --Werror` clean on all changed files (22.1.4)
- [x] `python yse.py analyze <file>` clean on each changed `.cpp` — no new findings (all suppressed as non-user / baseline)
- [x] `python yse.py test` — 23/23 ctest suites pass; patcher suite 230 cases / 4453 assertions, 0 failed
- [x] New `Tests/patcher/test_patcher_adc.cpp` (12 cases): ADC node (start point, buffer injection, null/out-of-range channels), passthrough **bit-transparency**, lowpass graph **measurably attenuates** an 8 kHz tone, **JSON round-trip** of an `~adc` graph, both channel-count-mismatch directions, and null-patcher no-op safety
- [x] Doc-coverage + C API metadata parity tests pass with the new registered `~adc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
