### PR TITLE
DSP: Virtual-analog + wavetable voice (#175)

### DIFF
--- a/Bench/CMakeLists.txt
+++ b/Bench/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(yse_benchmarks
   dsp/bench_math.cpp
   dsp/bench_reverb.cpp
   dsp/bench_plate_reverb.cpp
+  dsp/bench_va_voice.cpp
   internal/bench_mpmcqueue.cpp
   patcher/bench_patcher.cpp
   integration/bench_mixing.cpp

--- a/Bench/dsp/bench_va_voice.cpp
+++ b/Bench/dsp/bench_va_voice.cpp
@@ -1,0 +1,84 @@
+// Microbenchmarks for the virtual-analog voice path (issue #175):
+//   - the standalone Moog-style ladder filter (per-block in-place), and
+//   - a full vaVoice render block for the common oscillator/filter modes.
+//
+// These track the per-voice real-time budget documented in
+// docs/design/synth_core.md §11 so a regression in the ladder or the voice's
+// per-sample inner loop is visible.
+
+#include "dsp/ladderFilter.hpp"
+#include "dsp/buffer.hpp"
+#include "synth/vaVoice.hpp"
+#include "headers/constants.hpp"
+#include "headers/enums.hpp"
+
+#include <benchmark/benchmark.h>
+
+namespace {
+
+  constexpr unsigned int kBlock = 1024;
+  constexpr float kSignal = 0.3f;
+
+  // ── ladder filter ───────────────────────────────────────────────────────────
+
+  void BM_LadderFilter(benchmark::State& state) {
+    YSE::DSP::buffer buf(kBlock);
+    YSE::DSP::ladderFilter f;
+    f.setCutoff(1200.0f);
+    f.setResonance(0.7f);
+    f.reset();
+    f.setResonance(0.7f);
+
+    for (auto _ : state) {
+      buf = kSignal;
+      f(buf);
+      benchmark::DoNotOptimize(buf.getPtr());
+    }
+    state.SetItemsProcessed(state.iterations() * kBlock);
+  }
+  BENCHMARK(BM_LadderFilter);
+
+  // ── full vaVoice render ─────────────────────────────────────────────────────
+
+  void runVoice(benchmark::State& state, YSE::SYNTH::VA_WAVEFORM wave, bool dualOsc) {
+    YSE::SYNTH::vaVoice v;
+    YSE::SYNTH::vaParams& p = v.parameters();
+    p.oscWave[0].store(wave);
+    p.oscLevel[0].store(0.7f);
+    if (dualOsc) {
+      p.oscWave[1].store(wave);
+      p.oscLevel[1].store(0.7f);
+      p.oscDetune[1].store(0.1f);
+    }
+    p.filterEnvAmount.store(2.0f);
+    v.frequency(60.0f);
+    v.velocity(0.9f);
+
+    YSE::SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 8; ++i)
+      v.process(intent); // reach sustain
+
+    for (auto _ : state) {
+      v.process(intent); // one STANDARD_BUFFERSIZE block, PLAYING
+      benchmark::DoNotOptimize(v.samples[0].getPtr());
+    }
+    state.SetItemsProcessed(state.iterations() * YSE::STANDARD_BUFFERSIZE);
+  }
+
+  void BM_VaVoice_SingleSaw(benchmark::State& s) {
+    runVoice(s, YSE::SYNTH::VA_SAW, false);
+  }
+  BENCHMARK(BM_VaVoice_SingleSaw);
+
+  void BM_VaVoice_DualSaw(benchmark::State& s) {
+    runVoice(s, YSE::SYNTH::VA_SAW, true);
+  }
+  BENCHMARK(BM_VaVoice_DualSaw);
+
+  void BM_VaVoice_Wavetable(benchmark::State& s) {
+    runVoice(s, YSE::SYNTH::VA_WAVETABLE, false);
+  }
+  BENCHMARK(BM_VaVoice_Wavetable);
+
+} // namespace

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -291,7 +291,7 @@ class dspSourceObject {    // audio generator (replaces file)
 | Category | Modules |
 |----------|---------|
 | Oscillators | sine, cosine, saw, noise, VCF, wavetable |
-| Filters | lowPass, highPass, bandPass, biQuad, sampleHold, sweep, phaser, raw filters |
+| Filters | lowPass, highPass, bandPass, biQuad, sampleHold, sweep, phaser, ladderFilter (Moog-style ZDF ladder), raw filters |
 | Envelopes | envelope, ADSRenvelope, ramp |
 | Modulators | LFO, delay, basicDelay, highpassDelay, lowpassDelay |
 | Math | clip, sqrt, rSqrt, wrap, midiToFreq, freqToMidi, dbToRms, rmsToDb |
@@ -405,7 +405,7 @@ Polyphonic note player with scale constraints, motif sequencing, and randomised 
 
 ### 13. Synth (Implemented but unexposed)
 
-**Files:** `synth/` — `synthInterface.hpp/.cpp`, `synthManager.h/.cpp`, `synthImplementation.h/.cpp`, `samplerSound.cpp`, `dspSound.cpp`, `dspVoice.hpp/.cpp`, `dspVoiceInternal.cpp`
+**Files:** `synth/` — `synthInterface.hpp/.cpp`, `synthManager.h/.cpp`, `synthImplementation.h/.cpp`, `dspVoice.hpp` (voice base), and built-in voices `sineVoice.hpp/.cpp` (reference sine + ADSR) and `vaVoice.hpp/.cpp` (virtual-analog + wavetable: multi-oscillator → `DSP::ladderFilter` → amp/filter ADSR + LFO, with a live-settable shared `vaParams` patch)
 
 Polyphonic sampler/DSP synth. The source files compile into the library; the public interface (`synth.hpp`, `synthInterface.hpp`, `dspVoice.hpp`) is commented out in [yse.hpp](YseEngine/yse.hpp) and not yet part of the public API.
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -33,6 +33,8 @@ set(YSE_TEST_SOURCES
   dsp/test_module_compressor.cpp
   dsp/test_module_multichannel.cpp
   dsp/test_synth_voice.cpp
+  dsp/test_ladder_filter.cpp
+  dsp/test_va_voice.cpp
   patcher/test_graph.cpp
   patcher/test_nodes.cpp
   patcher/test_patcher_math.cpp

--- a/Tests/dsp/test_ladder_filter.cpp
+++ b/Tests/dsp/test_ladder_filter.cpp
@@ -1,0 +1,140 @@
+// Tests for YSE::DSP::ladderFilter (issue #175) — the reusable Moog-style
+// 4-pole resonant low-pass ladder.
+//
+// Coverage:
+//   - low-pass frequency response (a tone above cutoff is attenuated more than
+//     one below it),
+//   - cutoff moves the corner (raising cutoff passes more of a fixed tone),
+//   - resonance emphasises energy at the cutoff,
+//   - self-oscillation at maximum resonance sits at the cutoff frequency
+//     (FFT peak-bin check) and stays bounded (no NaN/blow-up),
+//   - no heap allocation in process() after warm-up.
+//
+// No audio device required; SAMPLERATE is initialised to 44100 by the
+// portaudioDeviceManager translation unit at static-initialisation time.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include "dsp/ladderFilter.hpp"
+#include "dsp/oscillators.hpp"
+#include "dsp/buffer.hpp"
+#include "dsp/fourier/fft.hpp"
+#include "support/audio_helpers.hpp"
+#include "support/alloc_probe.hpp"
+
+TEST_SUITE("dsp") {
+
+  using YSE::DSP::ladderFilter;
+
+  // RMS of a steady sine of `freq` Hz after passing through a fresh ladder set
+  // to `cutoff` Hz / `res` resonance. Warm-up blocks let the coefficient glide
+  // and filter state settle before measuring.
+  static float filteredRms(float cutoff, float res, float freq) {
+    ladderFilter f;
+    f.setCutoff(cutoff);
+    f.setResonance(res);
+    f.reset(); // snap the glide to the target cutoff
+    f.setResonance(res);
+    YSE::DSP::sine osc;
+    const int warmBlocks = 40;
+    const int measureBlocks = 40;
+    double sumsq = 0.0;
+    unsigned count = 0;
+    for (int b = 0; b < warmBlocks + measureBlocks; ++b) {
+      YSE::DSP::buffer blk = osc(freq); // copy of the oscillator block
+      f(blk);
+      if (b >= warmBlocks) {
+        float* p = blk.getPtr();
+        for (unsigned i = 0; i < blk.getLength(); ++i) {
+          sumsq += static_cast<double>(p[i]) * p[i];
+          ++count;
+        }
+      }
+    }
+    return count ? static_cast<float>(std::sqrt(sumsq / count)) : 0.f;
+  }
+
+  // ─── frequency response ─────────────────────────────────────────────────────
+
+  TEST_CASE("ladderFilter: attenuates a tone above the cutoff") {
+    const float cutoff = 500.f;
+    float belowRms = filteredRms(cutoff, 0.f, 100.f); // well below cutoff
+    float aboveRms = filteredRms(cutoff, 0.f, 5000.f); // decade above cutoff
+
+    CHECK(belowRms > 0.2f); // pass-band tone survives
+    CHECK(aboveRms < belowRms * 0.2f); // stop-band tone heavily attenuated
+  }
+
+  TEST_CASE("ladderFilter: raising the cutoff passes more of a fixed tone") {
+    const float tone = 2000.f;
+    float lowCutoff = filteredRms(500.f, 0.f, tone);
+    float highCutoff = filteredRms(8000.f, 0.f, tone);
+    CHECK(highCutoff > lowCutoff);
+    CHECK(highCutoff > lowCutoff * 1.5f); // clearly more energy passes
+  }
+
+  TEST_CASE("ladderFilter: resonance emphasises energy at the cutoff") {
+    const float cutoff = 1500.f;
+    float lowRes = filteredRms(cutoff, 0.1f, cutoff);
+    float highRes = filteredRms(cutoff, 0.85f, cutoff);
+    CHECK(highRes > lowRes); // resonant peak boosts the tone at the corner
+  }
+
+  // ─── self-oscillation ───────────────────────────────────────────────────────
+
+  TEST_CASE("ladderFilter: self-oscillates at the cutoff frequency") {
+    const float cutoff = 1000.f;
+    ladderFilter f;
+    f.setCutoff(cutoff);
+    f.reset();
+    f.setResonance(1.f); // past the self-oscillation threshold
+
+    // Kick the filter so the limit cycle can grow, then let it settle.
+    f.process(1e-3f);
+    for (int i = 0; i < 20000; ++i)
+      f.process(0.f);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    re = 0.f;
+    im = 0.f;
+    float* rp = re.getPtr();
+    for (unsigned i = 0; i < N; ++i)
+      rp[i] = f.process(0.f);
+
+    // Bounded — the loop nonlinearity must keep the oscillation finite.
+    CHECK(std::isfinite(TestHelpers::measureRms(re)));
+    CHECK(TestHelpers::measureRms(re) > 1e-3f); // actually oscillating
+
+    YSE::DSP::fft ft;
+    ft(re, im);
+    unsigned peak = TestHelpers::peakBinIndex(ft.getReal().getPtr(), ft.getImaginary().getPtr(), N);
+    const float binHz = static_cast<float>(YSE::SAMPLERATE) / static_cast<float>(N);
+    const float peakHz = static_cast<float>(peak) * binHz;
+    // Within ~10% of the cutoff — the ladder rings at its corner frequency.
+    CHECK(std::abs(peakHz - cutoff) < cutoff * 0.1f);
+  }
+
+  // ─── real-time discipline ───────────────────────────────────────────────────
+
+  TEST_CASE("ladderFilter: process() does not allocate after warm-up") {
+    ladderFilter f;
+    f.setCutoff(1200.f);
+    f.setResonance(0.6f);
+    f.reset();
+    f.setResonance(0.6f);
+    YSE::DSP::buffer blk(YSE::STANDARD_BUFFERSIZE);
+    blk = 0.3f;
+    f(blk); // warm-up
+
+    {
+      TestHelpers::ProbeScope probe;
+      for (int b = 0; b < 40; ++b) {
+        blk = 0.3f;
+        f(blk);
+      }
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+  }
+
+} // TEST_SUITE("dsp")

--- a/Tests/dsp/test_va_voice.cpp
+++ b/Tests/dsp/test_va_voice.cpp
@@ -1,0 +1,399 @@
+// Tests for YSE::SYNTH::vaVoice (issue #175) — the virtual-analog + wavetable
+// synth voice, and its shared vaParams patch.
+//
+// Coverage:
+//   - intent-driven lifecycle (WANTSTOPLAY -> PLAYING -> release -> STOPPED),
+//   - rendered pitch matches the requested note (sine osc, FFT peak-bin),
+//   - a detuned dual-saw "Minimoog-ish" patch renders with harmonics,
+//   - wavetable morph is click-free (bounded first-difference across a sweep),
+//   - an AKWF-length (600-sample) single-cycle table loads and plays,
+//   - velocity routes to amplitude,
+//   - clone() shares the patch but keeps independent per-voice state,
+//   - no heap allocation in process() after warm-up.
+//
+// No audio device required; SAMPLERATE is initialised to 44100 by the
+// portaudioDeviceManager translation unit at static-initialisation time.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include <memory>
+#include <vector>
+#include "synth/vaVoice.hpp"
+#include "dsp/fourier/fft.hpp"
+#include "dsp/math.hpp"
+#include "support/audio_helpers.hpp"
+#include "support/alloc_probe.hpp"
+
+TEST_SUITE("dsp") {
+
+  using YSE::SOUND_STATUS;
+  using YSE::SYNTH::dspVoice;
+  using YSE::SYNTH::vaParams;
+  using YSE::SYNTH::vaVoice;
+
+  // Render `blocks` blocks of a sustaining voice into a freshly captured
+  // N-sample buffer, starting after `warm` settle blocks. Returns the number
+  // of samples captured.
+  static unsigned captureSustain(vaVoice & v, YSE::DSP::buffer & out, unsigned N, int warm = 8) {
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < warm; ++i)
+      v.process(intent);
+    const unsigned block = YSE::STANDARD_BUFFERSIZE;
+    unsigned filled = 0;
+    while (filled + block <= N) {
+      v.process(intent); // stays PLAYING
+      out.copyFrom(v.samples[0], 0, filled, block);
+      filled += block;
+    }
+    return filled;
+  }
+
+  // ─── lifecycle ──────────────────────────────────────────────────────────────
+
+  TEST_CASE("vaVoice: WANTSTOPLAY settles the intent to PLAYING and sounds") {
+    vaVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    CHECK(intent == YSE::SS_PLAYING);
+    for (int i = 0; i < 20; ++i)
+      v.process(intent);
+    CHECK(TestHelpers::measureRms(v.samples[0]) > 0.02f);
+  }
+
+  TEST_CASE("vaVoice: WANTSTOSTOP releases and settles to STOPPED") {
+    vaVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    v.parameters().ampAttack.store(0.005f);
+    v.parameters().ampRelease.store(0.03f);
+
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 20; ++i)
+      v.process(intent);
+
+    intent = YSE::SS_WANTSTOSTOP;
+    int blocks = 0;
+    const int kMax = 1000;
+    while (intent != YSE::SS_STOPPED && blocks < kMax) {
+      v.process(intent);
+      ++blocks;
+    }
+    CHECK(intent == YSE::SS_STOPPED);
+    CHECK(blocks < kMax);
+    v.process(intent);
+    CHECK(TestHelpers::decaysToSilence(v.samples[0], 1e-4f));
+  }
+
+  TEST_CASE("vaVoice: note-off before attack settles immediately") {
+    vaVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOSTOP; // released before any play
+    v.process(intent);
+    CHECK(intent == YSE::SS_STOPPED);
+    CHECK(v.samples[0].isSilent());
+  }
+
+  // ─── rendered pitch ─────────────────────────────────────────────────────────
+
+  TEST_CASE("vaVoice: rendered pitch matches the requested note (sine osc)") {
+    vaVoice v;
+    vaParams& p = v.parameters();
+    p.oscWave[0].store(YSE::SYNTH::VA_SINE);
+    p.oscLevel[0].store(1.f);
+    p.cutoff.store(16000.f); // filter wide open
+    p.resonance.store(0.f);
+    p.filterEnvAmount.store(0.f);
+    p.keyTracking.store(0.f);
+    p.ampAttack.store(0.001f);
+    p.ampDecay.store(0.001f);
+    p.ampSustain.store(1.f);
+
+    const float note = 69.f; // A4
+    v.frequency(note);
+    v.velocity(1.f);
+    const float noteHz = YSE::DSP::MidiToFreq(note);
+
+    const unsigned N = 2048;
+    YSE::DSP::buffer re(N), im(N);
+    re = 0.f;
+    im = 0.f;
+    unsigned filled = captureSustain(v, re, N);
+    REQUIRE(filled == N);
+
+    YSE::DSP::fft f;
+    f(re, im);
+    unsigned peak = TestHelpers::peakBinIndex(f.getReal().getPtr(), f.getImaginary().getPtr(), N);
+    const float binHz = static_cast<float>(YSE::SAMPLERATE) / static_cast<float>(N);
+    const float peakHz = static_cast<float>(peak) * binHz;
+    CHECK(std::abs(peakHz - noteHz) < 2.f * binHz);
+  }
+
+  // ─── Minimoog-ish dual-saw patch ────────────────────────────────────────────
+
+  TEST_CASE("vaVoice: detuned dual-saw patch renders with harmonics") {
+    vaVoice v;
+    vaParams& p = v.parameters();
+    p.oscWave[0].store(YSE::SYNTH::VA_SAW);
+    p.oscWave[1].store(YSE::SYNTH::VA_SAW);
+    p.oscLevel[0].store(0.6f);
+    p.oscLevel[1].store(0.6f);
+    p.oscDetune[1].store(0.12f); // slight detune → fat unison
+    p.cutoff.store(8000.f);
+    p.resonance.store(0.2f);
+    p.filterEnvAmount.store(0.f);
+    p.keyTracking.store(0.f);
+    p.ampAttack.store(0.001f);
+    p.ampDecay.store(0.001f);
+    p.ampSustain.store(1.f);
+
+    const float note = 45.f; // A2, ~110 Hz — fundamental + harmonics resolvable
+    v.frequency(note);
+    v.velocity(1.f);
+    const float noteHz = YSE::DSP::MidiToFreq(note);
+
+    const unsigned N = 4096;
+    YSE::DSP::buffer re(N), im(N);
+    re = 0.f;
+    im = 0.f;
+    unsigned filled = captureSustain(v, re, N);
+    REQUIRE(filled == N);
+    CHECK(TestHelpers::measureRms(re) > 0.02f);
+
+    YSE::DSP::fft f;
+    f(re, im);
+    float* fr = f.getReal().getPtr();
+    float* fi = f.getImaginary().getPtr();
+    const float binHz = static_cast<float>(YSE::SAMPLERATE) / static_cast<float>(N);
+
+    auto binEnergy = [&](float hz) {
+      int bin = static_cast<int>(hz / binHz + 0.5f);
+      float e = 0.f;
+      for (int k = bin - 1; k <= bin + 1; ++k) { // small window: leakage + detune
+        if (k < 1 || k > static_cast<int>(N / 2)) continue;
+        e += fr[k] * fr[k] + fi[k] * fi[k];
+      }
+      return e;
+    };
+
+    float fund = binEnergy(noteHz);
+    float h2 = binEnergy(noteHz * 2.f);
+    float h3 = binEnergy(noteHz * 3.f);
+    CHECK(fund > 0.f);
+    // A saw is harmonically rich — clear energy above the fundamental.
+    CHECK(h2 > fund * 0.02f);
+    CHECK(h3 > 0.f);
+  }
+
+  // ─── wavetable morph ────────────────────────────────────────────────────────
+
+  TEST_CASE("vaVoice: wavetable morph is click-free across a sweep") {
+    vaVoice v;
+    vaParams& p = v.parameters();
+    p.oscWave[0].store(YSE::SYNTH::VA_WAVETABLE);
+    p.oscLevel[0].store(1.f);
+    p.cutoff.store(16000.f);
+    p.resonance.store(0.f);
+    p.filterEnvAmount.store(0.f);
+    p.keyTracking.store(0.f);
+    p.ampAttack.store(0.002f);
+    p.ampSustain.store(1.f);
+    p.wavetablePosition.store(0.f); // start at bank[0] (sine)
+
+    v.frequency(45.f); // low note → small per-sample steps
+    v.velocity(1.f);
+
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 8; ++i)
+      v.process(intent); // settle amp env
+
+    // Sweep the morph position over the smooth sine→triangle region while
+    // rendering, and track the largest sample-to-sample jump (including across
+    // block boundaries). A morph click would show up as a large discontinuity.
+    const int blocks = 120;
+    float prev = 0.f;
+    bool havePrev = false;
+    float maxStep = 0.f;
+    for (int b = 0; b < blocks; ++b) {
+      float pos = 0.5f * (static_cast<float>(b) / static_cast<float>(blocks - 1));
+      p.wavetablePosition.store(pos); // sine (0) → triangle (~0.5)
+      v.process(intent);
+      float* out = v.samples[0].getPtr();
+      for (unsigned i = 0; i < v.samples[0].getLength(); ++i) {
+        if (havePrev) {
+          float step = std::abs(out[i] - prev);
+          if (step > maxStep) maxStep = step;
+        }
+        prev = out[i];
+        havePrev = true;
+      }
+    }
+    // Sine and triangle are continuous; a crossfade between them at a low note
+    // keeps successive samples close. A click would be near full-scale.
+    CHECK(maxStep < 0.2f);
+  }
+
+  TEST_CASE("vaVoice: morph position changes the timbre") {
+    auto rmsAt = [](float pos) {
+      vaVoice v;
+      vaParams& p = v.parameters();
+      p.oscWave[0].store(YSE::SYNTH::VA_WAVETABLE);
+      p.oscLevel[0].store(1.f);
+      p.cutoff.store(16000.f);
+      p.resonance.store(0.f);
+      p.filterEnvAmount.store(0.f);
+      p.keyTracking.store(0.f);
+      p.ampSustain.store(1.f);
+      p.wavetablePosition.store(pos);
+      v.frequency(57.f);
+      v.velocity(1.f);
+      YSE::DSP::buffer buf(2048);
+      buf = 0.f;
+      captureSustain(v, buf, 2048);
+      return TestHelpers::measureRms(buf);
+    };
+    // bank[0] = sine, bank[3] = square — very different RMS/harmonic content.
+    float sineRms = rmsAt(0.f);
+    float squareRms = rmsAt(1.f);
+    CHECK(sineRms > 0.f);
+    CHECK(squareRms > 0.f);
+    CHECK(std::abs(squareRms - sineRms) > 0.02f);
+  }
+
+  // ─── AKWF-style single-cycle load ───────────────────────────────────────────
+
+  TEST_CASE("vaVoice: a 600-sample AKWF-length table loads and plays") {
+    vaVoice v;
+    vaParams& p = v.parameters();
+
+    // One period of a sine at AKWF's 600-sample resolution.
+    std::vector<float> cycle(600);
+    for (int i = 0; i < 600; ++i)
+      cycle[i] = std::sin(2.f * 3.14159265f * static_cast<float>(i) / 600.f);
+    int slot = p.wavetableCount();
+    p.loadWavetable(slot, cycle);
+    CHECK(p.wavetableCount() == slot + 1);
+
+    p.oscWave[0].store(YSE::SYNTH::VA_WAVETABLE);
+    p.oscLevel[0].store(1.f);
+    p.cutoff.store(16000.f);
+    p.resonance.store(0.f);
+    p.filterEnvAmount.store(0.f);
+    p.keyTracking.store(0.f);
+    p.ampSustain.store(1.f);
+    p.wavetablePosition.store(1.f); // fully onto the newly loaded last slot
+
+    v.frequency(69.f);
+    v.velocity(1.f);
+    YSE::DSP::buffer buf(2048);
+    buf = 0.f;
+    captureSustain(v, buf, 2048);
+    CHECK(TestHelpers::measureRms(buf) > 0.02f);
+  }
+
+  // ─── velocity routing ───────────────────────────────────────────────────────
+
+  TEST_CASE("vaVoice: velocity scales amplitude") {
+    auto rmsForVel = [](float vel) {
+      vaVoice v;
+      vaParams& p = v.parameters();
+      p.ampVelAmount.store(1.f);
+      p.ampSustain.store(1.f);
+      p.cutoff.store(16000.f);
+      p.filterEnvAmount.store(0.f);
+      v.frequency(60.f);
+      v.velocity(vel);
+      YSE::DSP::buffer buf(2048);
+      buf = 0.f;
+      captureSustain(v, buf, 2048);
+      return TestHelpers::measureRms(buf);
+    };
+    float loud = rmsForVel(1.f);
+    float soft = rmsForVel(0.3f);
+    CHECK(loud > soft);
+    CHECK(soft > 0.f);
+  }
+
+  // ─── clone() and shared patch ───────────────────────────────────────────────
+
+  TEST_CASE("vaVoice: clone shares the patch but keeps independent state") {
+    vaVoice proto;
+    proto.parameters().cutoff.store(1234.f);
+
+    std::unique_ptr<dspVoice> a(proto.clone());
+    std::unique_ptr<dspVoice> b(proto.clone());
+    auto* av = dynamic_cast<vaVoice*>(a.get());
+    auto* bv = dynamic_cast<vaVoice*>(b.get());
+    REQUIRE(av != nullptr);
+    REQUIRE(bv != nullptr);
+
+    // Same shared patch across the prototype and all clones.
+    CHECK(av->patch().get() == proto.patch().get());
+    CHECK(bv->patch().get() == proto.patch().get());
+    CHECK(av->patch()->cutoff.load() == doctest::Approx(1234.f));
+
+    // Independent note/render state: driving one leaves the other silent.
+    av->frequency(60.f);
+    av->velocity(1.f);
+    SOUND_STATUS ia = YSE::SS_WANTSTOPLAY;
+    for (int i = 0; i < 5; ++i)
+      av->process(ia);
+    CHECK(bv->samples[0].isSilent());
+  }
+
+  TEST_CASE("vaVoice: editing the shared patch reaches every clone") {
+    vaVoice proto;
+    std::unique_ptr<dspVoice> a(proto.clone());
+    auto* av = dynamic_cast<vaVoice*>(a.get());
+    REQUIRE(av != nullptr);
+    // A control-thread edit via the retained patch pointer is visible to the clone.
+    proto.patch()->resonance.store(0.42f);
+    CHECK(av->patch()->resonance.load() == doctest::Approx(0.42f));
+  }
+
+  // ─── real-time discipline ───────────────────────────────────────────────────
+
+  TEST_CASE("vaVoice: process() does not allocate after warm-up") {
+    vaVoice v;
+    vaParams& p = v.parameters();
+    p.oscLevel[1].store(0.5f);
+    p.oscWave[1].store(YSE::SYNTH::VA_PULSE);
+    p.lfoToCutoff.store(1.f);
+    p.lfoToPitch.store(0.5f);
+    p.filterEnvAmount.store(2.f);
+    v.frequency(64.f);
+    v.velocity(0.8f);
+
+    // Warm up every path: attack, sustain, release, retrigger.
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 30; ++i)
+      v.process(intent);
+    intent = YSE::SS_WANTSTOSTOP;
+    for (int i = 0; i < 1000 && intent != YSE::SS_STOPPED; ++i)
+      v.process(intent);
+    intent = YSE::SS_WANTSTOPLAY;
+    for (int i = 0; i < 5; ++i)
+      v.process(intent);
+
+    {
+      TestHelpers::ProbeScope probe;
+      for (int i = 0; i < 40; ++i)
+        v.process(intent);
+      intent = YSE::SS_WANTSTOSTOP;
+      for (int i = 0; i < 1000 && intent != YSE::SS_STOPPED; ++i)
+        v.process(intent);
+      v.process(intent);
+      intent = YSE::SS_WANTSTOPLAY;
+      for (int i = 0; i < 10; ++i)
+        v.process(intent);
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -25,6 +25,7 @@ set(YSE_SRCS
   dsp/fourier/fft.cpp
   dsp/fourier/mayer.cpp
   dsp/interpolate4.cpp
+  dsp/ladderFilter.cpp
   dsp/lfo.cpp
   dsp/math.cpp
   dsp/math_functions.cpp
@@ -135,6 +136,7 @@ set(YSE_SRCS
   sound/soundInterface.cpp
   sound/soundManager.cpp
   synth/sineVoice.cpp
+  synth/vaVoice.cpp
   synth/synthImplementation.cpp
   synth/synthInterface.cpp
   synth/synthManager.cpp

--- a/YseEngine/dsp/ladderFilter.cpp
+++ b/YseEngine/dsp/ladderFilter.cpp
@@ -1,0 +1,125 @@
+/*
+  ==============================================================================
+
+    ladderFilter.cpp
+    Implementation of the ZDF Moog-style ladder low-pass — see ladderFilter.hpp
+    and issue #175.
+
+  ==============================================================================
+*/
+
+#include "ladderFilter.hpp"
+#include "../headers/constants.hpp"
+
+#include <cmath>
+
+namespace YSE {
+  namespace DSP {
+
+    // Feedback gain at maximum resonance. The normalised trapezoidal ladder
+    // reaches its self-oscillation threshold at a loop feedback of 4; a small
+    // margin above guarantees the filter actually sings at resonance == 1.
+    static const Flt kMaxFeedback = 4.2f;
+
+    // Cutoff bounds. The lower bound keeps the prewarp well away from DC; the
+    // upper bound is a safe fraction of Nyquist so tan() never explodes.
+    static const Flt kMinCutoff = 20.f;
+
+    ladderFilter::ladderFilter()
+      : cutoffHz(1000.f),
+        resonance(0.f),
+        gTarget(0.f),
+        gCur(0.f),
+        smoothCoef(0.f),
+        s1(0.f),
+        s2(0.f),
+        s3(0.f),
+        s4(0.f) {
+      computeTargetG();
+      gCur = gTarget;
+      // ~1 ms coefficient glide at the engine sample rate — fast enough to
+      // track played sweeps, slow enough to suppress zipper noise.
+      smoothCoef = 1.f - std::exp(-1.f / (0.001f * static_cast<Flt>(SAMPLERATE)));
+    }
+
+    void ladderFilter::computeTargetG() {
+      const Flt sr = static_cast<Flt>(SAMPLERATE);
+      Flt fc = cutoffHz;
+      const Flt maxCutoff = 0.45f * sr;
+      if (fc < kMinCutoff) fc = kMinCutoff;
+      if (fc > maxCutoff) fc = maxCutoff;
+      // Prewarped one-pole coefficient g = tan(pi * fc / fs).
+      gTarget = std::tan(3.14159265358979323846f * fc / sr);
+    }
+
+    void ladderFilter::setCutoff(Flt hz) {
+      cutoffHz = hz;
+      computeTargetG();
+    }
+
+    void ladderFilter::setResonance(Flt r) {
+      if (r < 0.f) r = 0.f;
+      if (r > 1.f) r = 1.f;
+      resonance = r;
+    }
+
+    void ladderFilter::reset() {
+      s1 = s2 = s3 = s4 = 0.f;
+      computeTargetG();
+      gCur = gTarget;
+    }
+
+    Flt ladderFilter::process(Flt x) {
+      // Glide the coefficient toward its target for click-free cutoff sweeps.
+      gCur += (gTarget - gCur) * smoothCoef;
+
+      const Flt G = gCur / (1.f + gCur);
+      const Flt k = resonance * kMaxFeedback;
+
+      // Zero-delay feedback resolution. Each TPT one-pole stage outputs
+      //   y_i = G * (in_i - s_i) + s_i = G * in_i + (1 - G) * s_i
+      // so the 4th stage output as a function of the (unknown) ladder input u
+      // is  y4 = G^4 * u + Y4state,  and with feedback u = x - k * y4 we get
+      //   u = (x - k * Y4state) / (1 + k * G^4).
+      const Flt b1 = (1.f - G) * s1;
+      const Flt b2 = (1.f - G) * s2;
+      const Flt b3 = (1.f - G) * s3;
+      const Flt b4 = (1.f - G) * s4;
+      const Flt G2 = G * G;
+      const Flt G3 = G2 * G;
+      const Flt G4 = G3 * G;
+      const Flt Y4state = G3 * b1 + G2 * b2 + G * b3 + b4;
+
+      Flt u = (x - k * Y4state) / (1.f + k * G4);
+      // Saturating nonlinearity in the loop bounds the self-oscillation
+      // amplitude and keeps the filter stable at extreme resonance.
+      u = std::tanh(u);
+
+      // Forward evaluation of the four stages, updating the integrator states.
+      const Flt v1 = G * (u - s1);
+      const Flt y1 = v1 + s1;
+      s1 = y1 + v1;
+      const Flt v2 = G * (y1 - s2);
+      const Flt y2 = v2 + s2;
+      s2 = y2 + v2;
+      const Flt v3 = G * (y2 - s3);
+      const Flt y3 = v3 + s3;
+      s3 = y3 + v3;
+      const Flt v4 = G * (y3 - s4);
+      const Flt y4 = v4 + s4;
+      s4 = y4 + v4;
+
+      return y4;
+    }
+
+    buffer& ladderFilter::operator()(buffer& in) {
+      Flt* ptr = in.getPtr();
+      const UInt n = in.getLength();
+      for (UInt i = 0; i < n; i++) {
+        ptr[i] = process(ptr[i]);
+      }
+      return in;
+    }
+
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/ladderFilter.hpp
+++ b/YseEngine/dsp/ladderFilter.hpp
@@ -1,0 +1,105 @@
+/*
+  ==============================================================================
+
+    ladderFilter.hpp
+    Moog-style 4-pole resonant low-pass ladder filter (issue #175).
+
+    Reusable standalone DSP primitive: a virtual-analog transistor-ladder
+    low-pass with cutoff, resonance and self-oscillation. Used by
+    SYNTH::vaVoice, but has no synth dependency and can be dropped into any
+    DSP path on its own.
+
+    ---------------------------------------------------------------------------
+    Attribution
+
+    This is a clean-room implementation of the zero-delay-feedback (ZDF /
+    "topology-preserving transform", TPT) trapezoidal ladder described in
+    Vadim Zavalishin, "The Art of VA Filter Design" (freely available, rev.
+    2.1.2, chapter 5 — the transistor ladder filter). No third-party source
+    code was copied; the algorithm is derived from the freely published
+    equations. The original Moog transistor-ladder topology (US patent
+    3,475,623) expired in 1986 and is unencumbered. The engine deliberately
+    avoids the LGPL Huovilainen model referenced in the MoogLadders project.
+    ---------------------------------------------------------------------------
+
+  ==============================================================================
+*/
+
+#ifndef YSE_DSP_LADDERFILTER_HPP
+#define YSE_DSP_LADDERFILTER_HPP
+
+#include "../headers/defines.hpp"
+#include "../headers/types.hpp"
+#include "buffer.hpp"
+
+namespace YSE {
+  namespace DSP {
+
+    /**
+     *  @brief Moog-style 4-pole (24 dB/oct) resonant low-pass ladder filter.
+     *
+     *  A zero-delay-feedback trapezoidal ladder: four cascaded one-pole
+     *  low-pass stages wrapped in a resonant feedback loop, with a saturating
+     *  nonlinearity in the loop for stability. At maximum resonance the loop
+     *  self-oscillates at the cutoff frequency, giving the classic sine-like
+     *  tone used for lead and bass patches.
+     *
+     *  Cutoff changes are glided internally (a short one-pole smoother on the
+     *  filter coefficient) so fast sweeps stay click-free — set a new cutoff
+     *  every block without zipper noise.
+     *
+     *  Real-time safe: allocates nothing, locks nothing. Construct off the
+     *  audio thread; ``process`` / ``operator()`` run on the audio thread.
+     *  Not thread-safe for concurrent use of a single instance.
+     */
+    class API ladderFilter {
+    public:
+      /** @brief Construct with a default cutoff (well below Nyquist) and zero resonance. */
+      ladderFilter();
+
+      /** @brief Set the target cutoff frequency in Hz (glided internally). */
+      void setCutoff(Flt hz);
+
+      /** @brief Current (target) cutoff frequency in Hz. */
+      Flt getCutoff() const {
+        return cutoffHz;
+      }
+
+      /**
+       *  @brief Set the resonance in [0, 1].
+       *
+       *  0 is no resonance; 1 pushes the feedback past the self-oscillation
+       *  threshold so the filter sings at the cutoff frequency. Values are
+       *  clamped to [0, 1].
+       */
+      void setResonance(Flt r);
+
+      /** @brief Current resonance in [0, 1]. */
+      Flt getResonance() const {
+        return resonance;
+      }
+
+      /** @brief Clear the filter state and snap the coefficient glide to the target. */
+      void reset();
+
+      /** @brief Process one sample. Audio-thread only. */
+      Flt process(Flt x);
+
+      /** @brief Process a whole block in place. Audio-thread only. */
+      buffer& operator()(buffer& in);
+
+    private:
+      void computeTargetG();
+
+      Flt cutoffHz; // target cutoff (Hz)
+      Flt resonance; // [0,1]
+      Flt gTarget; // prewarped coefficient for cutoffHz
+      Flt gCur; // smoothed coefficient actually used
+      Flt smoothCoef; // per-sample glide coefficient for gCur
+      Flt s1, s2, s3, s4; // one-pole integrator states
+    };
+
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_LADDERFILTER_HPP

--- a/YseEngine/synth/vaVoice.cpp
+++ b/YseEngine/synth/vaVoice.cpp
@@ -1,0 +1,365 @@
+/*
+  ==============================================================================
+
+    vaVoice.cpp
+    Virtual-analog + wavetable voice — see vaVoice.hpp and issue #175.
+
+  ==============================================================================
+*/
+
+#include "vaVoice.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "../dsp/math.hpp"
+#include "../headers/constants.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    // Table resolution for the built-in band-limited shapes and the default
+    // morph bank. A power of two keeps the phase→index math friendly.
+    static const int kTableLen = 2048;
+    // Number of summed partials in the band-limited shapes — bright enough for
+    // a classic saw/square without obvious aliasing at musical pitches.
+    static const int kHarmonics = 64;
+
+    static inline Flt clampf(Flt v, Flt lo, Flt hi) {
+      return v < lo ? lo : (v > hi ? hi : v);
+    }
+
+    // ─── vaADSR ────────────────────────────────────────────────────────────────
+
+    void vaADSR::configure(Flt attack, Flt decay, Flt sustain, Flt release, Flt sampleRate) {
+      sr = sampleRate > 1.f ? sampleRate : 44100.f;
+      sus = clampf(sustain, 0.f, 1.f);
+      const Flt eps = 1e-4f;
+      const Flt a = attack > eps ? attack : eps;
+      const Flt d = decay > eps ? decay : eps;
+      aInc = 1.f / (a * sr);
+      dInc = (1.f - sus) / (d * sr);
+      rSec = release > eps ? release : eps;
+    }
+
+    void vaADSR::gateOn() {
+      stage = ATTACK;
+    }
+
+    void vaADSR::gateOff() {
+      rInc = lvl / (rSec * sr);
+      if (rInc < 1e-9f) rInc = 1e-9f;
+      stage = RELEASE;
+    }
+
+    Flt vaADSR::tick() {
+      switch (stage) {
+      case ATTACK:
+        lvl += aInc;
+        if (lvl >= 1.f) {
+          lvl = 1.f;
+          stage = DECAY;
+        }
+        break;
+      case DECAY:
+        lvl -= dInc;
+        if (lvl <= sus) {
+          lvl = sus;
+          stage = SUSTAIN;
+        }
+        break;
+      case SUSTAIN:
+        lvl = sus;
+        break;
+      case RELEASE:
+        lvl -= rInc;
+        if (lvl <= 0.f) {
+          lvl = 0.f;
+          stage = IDLE;
+        }
+        break;
+      case IDLE:
+      default:
+        lvl = 0.f;
+        break;
+      }
+      return lvl;
+    }
+
+    void vaADSR::advance(int n) {
+      for (int i = 0; i < n; i++)
+        tick();
+    }
+
+    // ─── vaParams ───────────────────────────────────────────────────────────────
+
+    vaParams::vaParams()
+      : wavetablePosition(0.f),
+        cutoff(2000.f),
+        resonance(0.1f),
+        keyTracking(0.5f),
+        filterEnvAmount(2.f),
+        filterVelAmount(0.f),
+        ampAttack(0.005f),
+        ampDecay(0.1f),
+        ampSustain(0.8f),
+        ampRelease(0.2f),
+        ampVelAmount(1.f),
+        filterAttack(0.005f),
+        filterDecay(0.2f),
+        filterSustain(0.3f),
+        filterRelease(0.2f),
+        lfoType(DSP::LFO_SINE),
+        lfoRate(5.f),
+        lfoToPitch(0.f),
+        lfoToCutoff(0.f),
+        lfoToWavetable(0.f),
+        gain(0.8f),
+        sawTable(kTableLen),
+        triTable(kTableLen),
+        sineTable(kTableLen) {
+      // Per-oscillator defaults: a single saw voice out of the box.
+      for (int i = 0; i < kNumOsc; i++) {
+        oscWave[i].store(VA_SAW, std::memory_order_relaxed);
+        oscDetune[i].store(0.f, std::memory_order_relaxed);
+        oscLevel[i].store(i == 0 ? 0.8f : 0.f, std::memory_order_relaxed);
+        oscPulseWidth[i].store(0.5f, std::memory_order_relaxed);
+      }
+
+      // Built-in band-limited shape tables.
+      sawTable.createSaw(kHarmonics, kTableLen);
+      triTable.createTriangle(kHarmonics, kTableLen);
+      sineTable.createFourierTable(std::vector<Flt>{1.f}, kTableLen, 0.f);
+
+      // Default morph bank: sine → triangle → saw → square. Continuous in the
+      // morph position, so a wavetable sweep is click-free by construction.
+      wtBank.reserve(4);
+      wtBank.emplace_back(kTableLen);
+      wtBank.back().createFourierTable(std::vector<Flt>{1.f}, kTableLen, 0.f);
+      wtBank.emplace_back(kTableLen);
+      wtBank.back().createTriangle(kHarmonics, kTableLen);
+      wtBank.emplace_back(kTableLen);
+      wtBank.back().createSaw(kHarmonics, kTableLen);
+      wtBank.emplace_back(kTableLen);
+      wtBank.back().createSquare(kHarmonics, kTableLen);
+    }
+
+    void vaParams::loadWavetable(int slot, const std::vector<Flt>& cycle) {
+      if (slot < 0 || cycle.empty()) return;
+      while (static_cast<int>(wtBank.size()) <= slot) {
+        wtBank.emplace_back(static_cast<UInt>(cycle.size()));
+      }
+      // Build a fresh single-cycle table (with the wrap-around overflow tail)
+      // and copy-assign it into the slot. Setup-thread only.
+      DSP::wavetable fresh(static_cast<UInt>(cycle.size()));
+      Flt* p = fresh.getPtr();
+      for (UInt i = 0; i < cycle.size(); i++)
+        p[i] = cycle[i];
+      fresh.copyOverflow();
+      wtBank[slot] = fresh;
+    }
+
+    // ─── vaVoice ────────────────────────────────────────────────────────────────
+
+    vaVoice::vaVoice(int outputChannels)
+      : dspVoice(outputChannels),
+        params(std::make_shared<vaParams>()),
+        noiseState(0x1234567u),
+        phase(IDLE) {
+      for (int i = 0; i < vaParams::kNumOsc; i++)
+        oscPhase[i] = 0.0;
+    }
+
+    vaVoice::vaVoice(const vaVoice& other)
+      : dspVoice(other),
+        params(other.params), // share the patch — all voices track one sound
+        noiseState(0x1234567u),
+        phase(IDLE) {
+      // Fresh, independent DSP state (phases, filter, envelopes) — a clone
+      // shares only the patch, never the running state.
+      for (int i = 0; i < vaParams::kNumOsc; i++)
+        oscPhase[i] = 0.0;
+      filter.reset();
+      ampEnv.reset();
+      filEnv.reset();
+    }
+
+    dspVoice* vaVoice::clone() {
+      return new vaVoice(*this);
+    }
+
+    Flt vaVoice::readTable(DSP::wavetable& t, Dbl phase) {
+      const UInt len = t.getLength();
+      if (len == 0) return 0.f;
+      Dbl fp = phase - std::floor(phase); // wrap to [0,1)
+      Dbl fidx = fp * len;
+      UInt i0 = static_cast<UInt>(fidx);
+      if (i0 >= len) i0 = len - 1; // guard rounding at the top edge
+      Flt frac = static_cast<Flt>(fidx - i0);
+      Flt* p = t.getPtr(); // storage has a 1-sample overflow tail: p[len] == p[0]
+      return p[i0] + frac * (p[i0 + 1] - p[i0]);
+    }
+
+    Flt vaVoice::renderOsc(int index, Dbl phase, Flt pulseWidth, Flt wtPos) {
+      vaParams& p = *params;
+      switch (static_cast<VA_WAVEFORM>(p.oscWave[index].load(std::memory_order_relaxed))) {
+      case VA_SINE:
+        return readTable(p.sineTable, phase);
+      case VA_TRIANGLE:
+        return readTable(p.triTable, phase);
+      case VA_SAW:
+        return readTable(p.sawTable, phase);
+      case VA_PULSE: {
+        // Band-limited variable-width pulse = saw(φ) − saw(φ + width), both
+        // read from the band-limited saw table. Mean-free for any width.
+        Dbl p2 = phase + pulseWidth;
+        return 0.5f * (readTable(p.sawTable, phase) - readTable(p.sawTable, p2));
+      }
+      case VA_NOISE: {
+        noiseState = noiseState * 1664525u + 1013904223u;
+        return (static_cast<Flt>(noiseState >> 8) / 8388608.f) - 1.f;
+      }
+      case VA_WAVETABLE: {
+        const int cnt = static_cast<int>(p.wtBank.size());
+        if (cnt == 0) return 0.f;
+        if (cnt == 1) return readTable(p.wtBank[0], phase);
+        Flt fpos = clampf(wtPos, 0.f, 1.f) * static_cast<Flt>(cnt - 1);
+        int i0 = static_cast<int>(fpos);
+        if (i0 > cnt - 2) i0 = cnt - 2;
+        if (i0 < 0) i0 = 0;
+        Flt fr = fpos - static_cast<Flt>(i0);
+        return readTable(p.wtBank[i0], phase) * (1.f - fr) +
+               readTable(p.wtBank[i0 + 1], phase) * fr;
+      }
+      default:
+        return 0.f;
+      }
+    }
+
+    void vaVoice::process(SOUND_STATUS& intent) {
+      if (samples.empty()) return; // degenerate 0-channel voice — nothing to render
+      const UInt n = samples[0].getLength();
+
+      // ---- lifecycle / gates -------------------------------------------------
+      if (intent == SS_WANTSTOPLAY || intent == SS_WANTSTORESTART) {
+        // Restart oscillator phase and re-gate the envelopes. The ladder state
+        // is deliberately not cleared: on a fresh voice it is already zero
+        // (constructor / clone reset it), and on a retrigger keeping it avoids
+        // a filter click — the amplitude envelope is at zero at this instant
+        // anyway, so any residual is inaudible.
+        for (int o = 0; o < vaParams::kNumOsc; o++)
+          oscPhase[o] = 0.0;
+        ampEnv.gateOn();
+        filEnv.gateOn();
+        phase = PLAYING;
+        intent = SS_PLAYING;
+      } else if (intent == SS_WANTSTOSTOP || intent == SS_WANTSTOPAUSE) {
+        if (phase == IDLE) {
+          // Released before it ever attacked — settle immediately (mirrors
+          // sineVoice): nothing is sounding.
+          intent = (intent == SS_WANTSTOPAUSE) ? SS_PAUSED : SS_STOPPED;
+          for (UInt ch = 0; ch < samples.size(); ch++)
+            samples[ch] = 0.f;
+          return;
+        }
+        if (phase != RELEASING) {
+          ampEnv.gateOff();
+          filEnv.gateOff();
+          phase = RELEASING;
+        }
+      } else if (intent == SS_PLAYING || intent == SS_PLAYING_FULL_VOLUME) {
+        // keep rendering
+      } else {
+        // SS_STOPPED / SS_PAUSED: emit silence.
+        for (UInt ch = 0; ch < samples.size(); ch++)
+          samples[ch] = 0.f;
+        return;
+      }
+
+      const Flt sr = static_cast<Flt>(SAMPLERATE);
+      vaParams& p = *params;
+
+      // Envelope slopes — recomputed each block so patch times are live-settable.
+      ampEnv.configure(p.ampAttack.load(std::memory_order_relaxed),
+                       p.ampDecay.load(std::memory_order_relaxed),
+                       p.ampSustain.load(std::memory_order_relaxed),
+                       p.ampRelease.load(std::memory_order_relaxed), sr);
+      filEnv.configure(p.filterAttack.load(std::memory_order_relaxed),
+                       p.filterDecay.load(std::memory_order_relaxed),
+                       p.filterSustain.load(std::memory_order_relaxed),
+                       p.filterRelease.load(std::memory_order_relaxed), sr);
+
+      const Flt vel = getVelocity();
+      const Flt wheelSemi = getPitchWheel() * 2.f; // ±2 semitones bend range
+      const Flt baseHz = getFrequency();
+
+      // LFO — one bipolar value per block (control-rate is plenty for an LFO).
+      const DSP::LFO_TYPE lt =
+          static_cast<DSP::LFO_TYPE>(p.lfoType.load(std::memory_order_relaxed));
+      const Flt lfoRate = p.lfoRate.load(std::memory_order_relaxed);
+      Flt lfoS = 0.f;
+      {
+        DSP::buffer& lb = lfoOsc(lt, lfoRate, n > 0 ? n : STANDARD_BUFFERSIZE);
+        if (n > 0) lfoS = lb.getPtr()[n - 1] * 2.f - 1.f;
+      }
+
+      // Per-oscillator phase increments and mix levels (block-rate).
+      const Flt lfoPitchSemi = lfoS * p.lfoToPitch.load(std::memory_order_relaxed);
+      Dbl inc[vaParams::kNumOsc];
+      Flt lvlOsc[vaParams::kNumOsc];
+      Flt pw[vaParams::kNumOsc];
+      for (int o = 0; o < vaParams::kNumOsc; o++) {
+        lvlOsc[o] = p.oscLevel[o].load(std::memory_order_relaxed);
+        pw[o] = clampf(p.oscPulseWidth[o].load(std::memory_order_relaxed), 0.01f, 0.99f);
+        const Flt semi = p.oscDetune[o].load(std::memory_order_relaxed) + lfoPitchSemi + wheelSemi;
+        const Flt hz = baseHz * std::exp2(semi / 12.f);
+        inc[o] = static_cast<Dbl>(hz) / static_cast<Dbl>(sr);
+      }
+      const Flt wtPos = clampf(p.wavetablePosition.load(std::memory_order_relaxed) +
+                                   lfoS * p.lfoToWavetable.load(std::memory_order_relaxed),
+                               0.f, 1.f);
+
+      // Filter cutoff (block-rate, glided inside the ladder for click-free sweeps).
+      const Flt noteMidi = DSP::FreqToMidi(baseHz);
+      const Flt keyOct = p.keyTracking.load(std::memory_order_relaxed) * (noteMidi - 60.f) / 12.f;
+      const Flt envOct = p.filterEnvAmount.load(std::memory_order_relaxed) * filEnv.level();
+      const Flt lfoOct = lfoS * p.lfoToCutoff.load(std::memory_order_relaxed);
+      const Flt velOct = vel * p.filterVelAmount.load(std::memory_order_relaxed);
+      const Flt cutoffHz =
+          p.cutoff.load(std::memory_order_relaxed) * std::exp2(keyOct + envOct + lfoOct + velOct);
+      filter.setResonance(p.resonance.load(std::memory_order_relaxed));
+      filter.setCutoff(cutoffHz);
+      filEnv.advance(static_cast<int>(n)); // move the filter env on for next block
+
+      // Amplitude: velocity blend then master gain.
+      const Flt ampVelAmt = p.ampVelAmount.load(std::memory_order_relaxed);
+      const Flt g = p.gain.load(std::memory_order_relaxed) * ((1.f - ampVelAmt) + ampVelAmt * vel);
+
+      // ---- per-sample render -------------------------------------------------
+      Flt* out = samples[0].getPtr();
+      for (UInt i = 0; i < n; i++) {
+        Flt oscSum = 0.f;
+        for (int o = 0; o < vaParams::kNumOsc; o++) {
+          oscPhase[o] += inc[o];
+          if (oscPhase[o] >= 1.0) oscPhase[o] -= std::floor(oscPhase[o]);
+          if (lvlOsc[o] <= 0.f) continue; // muted osc: keep phase, skip render
+          oscSum += renderOsc(o, oscPhase[o], pw[o], wtPos) * lvlOsc[o];
+        }
+        const Flt filt = filter.process(oscSum);
+        const Flt a = ampEnv.tick();
+        out[i] = filt * a * g;
+      }
+
+      // Mirror the mono voice signal to any extra output channels.
+      for (UInt ch = 1; ch < samples.size(); ch++)
+        samples[ch] = samples[0];
+
+      // Release tail finished — hand the slot back to the engine.
+      if (phase == RELEASING && ampEnv.idle()) {
+        intent = SS_STOPPED;
+        phase = IDLE;
+      }
+    }
+
+  } // namespace SYNTH
+} // namespace YSE

--- a/YseEngine/synth/vaVoice.hpp
+++ b/YseEngine/synth/vaVoice.hpp
@@ -1,0 +1,258 @@
+/*
+  ==============================================================================
+
+    vaVoice.hpp
+    Virtual-analog + wavetable synthesiser voice for YSE::synth (issue #175).
+
+    A SYNTH::dspVoice subclass covering the classic subtractive-synth space:
+    two-to-three oscillators (saw / pulse-with-width / triangle / sine / noise
+    / wavetable-morph) through a Moog-style resonant ladder low-pass, shaped by
+    an amplitude ADSR and an independent filter ADSR, with one LFO routable to
+    pitch, cutoff and wavetable position, plus velocity routing to amplitude
+    and cutoff.
+
+    See docs/design/synth_core.md §3 for the voice contract and issue #175 for
+    the feature scope.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_VAVOICE_HPP
+#define YSE_SYNTH_VAVOICE_HPP
+
+#include <memory>
+#include <vector>
+
+#include "dspVoice.hpp"
+#include "../dsp/ladderFilter.hpp"
+#include "../dsp/lfo.hpp"
+#include "../dsp/wavetable.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /** @brief Oscillator waveform modes for ``vaVoice``. */
+    enum VA_WAVEFORM {
+      VA_SAW, ///< Band-limited sawtooth.
+      VA_PULSE, ///< Band-limited pulse with variable width (PWM).
+      VA_TRIANGLE, ///< Band-limited triangle.
+      VA_SINE, ///< Sine.
+      VA_NOISE, ///< White noise.
+      VA_WAVETABLE, ///< Morph across the wavetable bank (see ``vaParams``).
+    };
+
+    /**
+     *  @brief Live-settable patch shared by every voice of one synth.
+     *
+     *  A ``vaParams`` is the "sound" — all continuous parameters are atomics
+     *  read on the audio thread, so they can be tweaked from a control thread
+     *  while voices play, glitch-free (no allocation, no locks). All voices of
+     *  a synth share **one** ``vaParams`` (the prototype's, carried across
+     *  ``clone()`` by shared pointer), while each voice keeps its own
+     *  independent oscillator phase, filter state and envelope state.
+     *
+     *  Retain the shared pointer (``vaVoice::patch()``) if you want to keep
+     *  editing the patch after the prototype has been handed to
+     *  ``synth::addVoices`` and destroyed.
+     *
+     *  The wavetable bank (used by ``VA_WAVETABLE`` mode) is built once and is
+     *  intended to be populated **before** playback via ``loadWavetable`` —
+     *  like voice allocation, table (re)building is a setup-thread operation,
+     *  not an audio-thread one. The morph *position* is the live control.
+     */
+    class API vaParams {
+    public:
+      /** @brief Number of oscillators per voice. */
+      static const int kNumOsc = 3;
+
+      /** @brief Construct a sensible default patch (osc 1 saw, gentle filter). */
+      vaParams();
+
+      vaParams(const vaParams&) = delete;
+      vaParams& operator=(const vaParams&) = delete;
+
+      // ---- oscillator section (per oscillator) -------------------------------
+      aInt oscWave[kNumOsc]; ///< VA_WAVEFORM per oscillator.
+      aFlt oscDetune[kNumOsc]; ///< Detune in semitones.
+      aFlt oscLevel[kNumOsc]; ///< Mix level in [0, 1].
+      aFlt oscPulseWidth[kNumOsc]; ///< Pulse width in (0, 1) for VA_PULSE.
+      aFlt wavetablePosition; ///< Morph position in [0, 1] for VA_WAVETABLE.
+
+      // ---- ladder filter -----------------------------------------------------
+      aFlt cutoff; ///< Base cutoff in Hz.
+      aFlt resonance; ///< Resonance in [0, 1].
+      aFlt keyTracking; ///< Key-follow in [0, 1] (0 = fixed, 1 = full tracking).
+      aFlt filterEnvAmount; ///< Filter-envelope depth in octaves (may be negative).
+      aFlt filterVelAmount; ///< Velocity → cutoff depth in octaves at full velocity.
+
+      // ---- amplitude envelope (seconds; sustain in [0, 1]) -------------------
+      aFlt ampAttack, ampDecay, ampSustain, ampRelease;
+      aFlt ampVelAmount; ///< Velocity → amplitude amount in [0, 1].
+
+      // ---- filter envelope (seconds; sustain in [0, 1]) ----------------------
+      aFlt filterAttack, filterDecay, filterSustain, filterRelease;
+
+      // ---- LFO ---------------------------------------------------------------
+      aInt lfoType; ///< DSP::LFO_TYPE shape.
+      aFlt lfoRate; ///< LFO rate in Hz.
+      aFlt lfoToPitch; ///< LFO → pitch depth in semitones.
+      aFlt lfoToCutoff; ///< LFO → cutoff depth in octaves.
+      aFlt lfoToWavetable; ///< LFO → wavetable-position depth in [0, 1].
+
+      // ---- output ------------------------------------------------------------
+      aFlt gain; ///< Master voice gain in [0, 1].
+
+      // ---- shared oscillator source tables -----------------------------------
+      // Band-limited single-cycle tables shared (read-only on the audio thread)
+      // by every voice. Built once in the constructor.
+      DSP::wavetable sawTable;
+      DSP::wavetable triTable;
+      DSP::wavetable sineTable;
+
+      /**
+       *  @brief Wavetable bank morphed across by VA_WAVETABLE mode.
+       *
+       *  Defaults to a small set of single-cycle shapes so morph works out of
+       *  the box. Populate with AKWF-style single-cycle tables via
+       *  ``loadWavetable`` before playback.
+       */
+      std::vector<DSP::wavetable> wtBank;
+
+      /**
+       *  @brief Install a single-cycle waveform into bank slot ``slot``.
+       *
+       *  ``cycle`` is one period of a normalised waveform (any length — AKWF
+       *  tables are 600 samples). Slots beyond the current bank size are
+       *  appended. **Setup-thread only** — this allocates/reshapes table
+       *  storage and must not be called while the voice is rendering.
+       */
+      void loadWavetable(int slot, const std::vector<Flt>& cycle);
+
+      /** @brief Number of tables currently in the morph bank. */
+      int wavetableCount() const {
+        return static_cast<int>(wtBank.size());
+      }
+    };
+
+    /**
+     *  @brief Lightweight real-time linear ADSR.
+     *
+     *  A minimal segment-based envelope used for both the amplitude and filter
+     *  contours. Unlike ``DSP::ADSRenvelope`` (breakpoint list + an allocating
+     *  ``generate()``), this recomputes its per-sample slopes from the current
+     *  patch times every block, so envelope times are live-settable with no
+     *  allocation — exactly what the shared ``vaParams`` requires. Internal to
+     *  ``vaVoice``.
+     */
+    class vaADSR {
+    public:
+      /** @brief (Re)compute per-sample slopes from times (seconds) + sustain. */
+      void configure(Flt attack, Flt decay, Flt sustain, Flt release, Flt sampleRate);
+
+      /** @brief Begin the attack segment (from the current level — no click). */
+      void gateOn();
+
+      /** @brief Begin the release segment from the current level. */
+      void gateOff();
+
+      /** @brief Advance one sample and return the new level. */
+      Flt tick();
+
+      /** @brief Advance ``n`` samples (block-rate use). */
+      void advance(int n);
+
+      /** @brief Current level in [0, 1]. */
+      Flt level() const {
+        return lvl;
+      }
+
+      /** @brief Whether the envelope has returned to rest after a release. */
+      bool idle() const {
+        return stage == IDLE;
+      }
+
+      /** @brief Reset to rest (level 0). */
+      void reset() {
+        stage = IDLE;
+        lvl = 0.f;
+      }
+
+    private:
+      enum Stage { IDLE, ATTACK, DECAY, SUSTAIN, RELEASE };
+      Stage stage = IDLE;
+      Flt lvl = 0.f;
+      Flt sus = 0.7f;
+      Flt aInc = 1.f; // per-sample attack slope (toward 1)
+      Flt dInc = 1.f; // per-sample decay slope (toward sustain)
+      Flt rSec = 0.1f; // release time in seconds (rate resolved at gateOff)
+      Flt rInc = 1.f; // per-sample release slope (toward 0)
+      Flt sr = 44100.f;
+    };
+
+    /**
+     *  @brief Virtual-analog + wavetable synthesiser voice.
+     *
+     *  Derives ``SYNTH::dspVoice`` and consumes the synth-core voice contract
+     *  (intent-driven lifecycle, ``clone()`` prototype, atomic note inputs).
+     *  All tone parameters live in a shared ``vaParams`` patch; construct one
+     *  prototype, dial in the patch, then hand it to ``synth::addVoices`` — the
+     *  clones share the patch and stay editable through ``patch()``.
+     *
+     *  Everything the audio thread needs is allocated up front (tables in the
+     *  patch, per-voice buffers/filter/LFO in the constructor), so ``process``
+     *  and ``clone``'s copy stay allocation-free on their respective threads.
+     */
+    class API vaVoice : public dspVoice {
+    public:
+      /** @brief Construct a voice with a fresh default patch. */
+      vaVoice(int outputChannels = 1);
+
+      /** @brief The shared, live-settable patch. Retain to keep editing after the prototype is
+       * gone. */
+      std::shared_ptr<vaParams> patch() const {
+        return params;
+      }
+
+      /** @brief Convenience reference to the shared patch. */
+      vaParams& parameters() {
+        return *params;
+      }
+
+      // ---- dspVoice contract -------------------------------------------------
+
+      /** @brief Render one block, honouring and settling ``intent``. Audio-thread only. */
+      void process(SOUND_STATUS& intent) override;
+
+      /** @brief Return a new voice sharing this voice's patch, with fresh DSP state. Setup-thread
+       * only. */
+      dspVoice* clone() override;
+
+    protected:
+      /** @brief Copy-construct: share the patch, rebuild independent DSP state. */
+      vaVoice(const vaVoice& other);
+
+    private:
+      // One oscillator sample at normalised phase (0..1) for oscillator index.
+      // Non-const because VA_NOISE advances the per-voice RNG state.
+      Flt renderOsc(int index, Dbl phase, Flt pulseWidth, Flt wtPos);
+      // Linear-interpolated read of a single-cycle table at normalised phase.
+      static Flt readTable(DSP::wavetable& t, Dbl phase);
+
+      std::shared_ptr<vaParams> params;
+
+      // ---- per-voice state (independent per clone) ---------------------------
+      Dbl oscPhase[vaParams::kNumOsc];
+      UInt noiseState;
+      DSP::lfo lfoOsc;
+      vaADSR ampEnv;
+      vaADSR filEnv;
+      DSP::ladderFilter filter;
+
+      enum Phase { IDLE, PLAYING, RELEASING };
+      Phase phase;
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_VAVOICE_HPP


### PR DESCRIPTION
## Summary

Adds a reusable Moog-style **ladder filter** DSP primitive and a
**virtual-analog + wavetable voice** (`SYNTH::vaVoice`) that consumes the
synth-core voice contract (`docs/design/synth_core.md` §3), covering the
classic subtractive/wavetable sound space with the engine's own DSP.

## Linked issue

Closes #175

## Changes

- **`YseEngine/dsp/ladderFilter.{hpp,cpp}`** — clean-room zero-delay-feedback
  (ZDF/TPT) Moog-style 4-pole resonant low-pass, derived from the
  freely-available Zavalishin *"The Art of VA Filter Design"* equations (no
  third-party code copied; deliberately **not** the LGPL Huovilainen model).
  Cutoff + resonance, an internal coefficient glide for click-free sweeps, a
  saturating loop for stability, and self-oscillation at the cutoff. Reusable
  standalone; attribution in the header.
- **`YseEngine/synth/vaVoice.{hpp,cpp}`** — a `dspVoice` subclass:
  - 3 oscillators: band-limited saw / PWM pulse / triangle / sine / white
    noise / wavetable-morph, with per-osc detune + mix.
  - Ladder LPF with cutoff, resonance, key-tracking, filter-envelope depth and
    velocity → cutoff.
  - Amplitude ADSR + independent filter ADSR + one LFO routable to
    pitch / cutoff / wavetable-position; velocity → amplitude.
  - All tone parameters live in a **live-settable shared `vaParams` patch**
    (atomics): every voice of a synth shares one patch, while per-voice DSP
    state (phases, filter, envelopes) stays independent — carried across
    `clone()` by shared pointer. RT-safe: `process()` allocates nothing, locks
    nothing, blocks on nothing.
- **Tests** (`Tests/dsp/`): ladder frequency response, self-oscillation
  frequency (FFT peak-bin) and RT audit; voice lifecycle, rendered pitch,
  detuned dual-saw "Minimoog-ish" harmonic content, click-free wavetable
  morph, 600-sample AKWF-length single-cycle load, velocity routing,
  clone/shared-patch semantics, and RT (no-allocation) audit.
- **Bench** (`Bench/dsp/bench_va_voice.cpp`): ladder filter block + single /
  dual-saw / wavetable voice render blocks.
- **`PROJECT_OVERVIEW.md`**: note the ladder filter and the VA voice.

### Notes / scope

- Envelopes use a lightweight, allocation-free linear ADSR inside the voice
  rather than `DSP::ADSRenvelope`, specifically so the shared patch's envelope
  times remain **live-settable without allocation** — the breakpoint envelope
  needs an allocating `generate()` on every parameter change, which conflicts
  with the "settable per-synth while playing" requirement.
- Loading AKWF **WAV files** and shipping CC0 tables stay in the content epic
  (per the issue); the voice's wavetable machinery accepts AKWF-shaped
  single-cycle data today (`vaParams::loadWavetable`), and the morph bank
  defaults to sine→triangle→saw→square so morph works out of the box.
- Out of scope per the issue's non-goals: no C-API for instruments (#178), no
  full modulation matrix, no unison/supersaw, no per-voice effects.

## Test plan

- [x] `clang-format --dry-run --Werror` clean on all new/changed files (gate pinned to 22.1.4).
- [x] `python yse.py analyze YseEngine/dsp/ladderFilter.cpp` / `.../synth/vaVoice.cpp` — no new user-code findings.
- [x] `python yse.py test` — **100% tests passed, 0 failed out of 23** ctest processes (the new cases run in the `dsp` suite: 17 new cases / 40 assertions, part of 327 dsp cases / 60520 assertions).
- [x] Benchmarks compile, link and run (`yse_benchmarks --benchmark_filter="Ladder|VaVoice"`).
- [n/a] Integration/e2e: this is engine-internal DSP (a filter primitive + a voice class) with no user-visible UI/flow; behaviour is exercised end-to-end by the DSP suite (render → FFT/RMS spectral assertions), which is the appropriate driver here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
