### PR TITLE
DSP: 6-operator FM engine (MSFA port) (#176)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,48 @@
+YSE Sound Engine
+Copyright (c) the YSE Sound Engine contributors.
+
+This product includes software developed by third parties, listed below.
+
+================================================================================
+music-synthesizer-for-android (MSFA)
+================================================================================
+
+The DX7-class 6-operator FM engine under YseEngine/dsp/fm/msfa/ is derived from
+music-synthesizer-for-android:
+
+    https://github.com/google/music-synthesizer-for-android
+
+    Copyright 2012-2014 Google Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use these files except in compliance with the License. You may obtain a
+    copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+The following files are ported from that project (the Apache-2.0 core; none of
+Dexed's GPL-licensed wrapper code is used). Each retains its upstream Apache-2.0
+license header. Changes made for this port: the sources were wrapped in the
+YSE::DSP::msfa namespace, Android/JNI and ARM-NEON scaffolding was removed
+(leaving the portable scalar kernels), and debug-only helpers were dropped.
+
+    YseEngine/dsp/fm/msfa/synth.h
+    YseEngine/dsp/fm/msfa/aligned_buf.h
+    YseEngine/dsp/fm/msfa/controllers.h
+    YseEngine/dsp/fm/msfa/sin.h,          sin.cc
+    YseEngine/dsp/fm/msfa/exp2.h,         exp2.cc
+    YseEngine/dsp/fm/msfa/freqlut.h,      freqlut.cc
+    YseEngine/dsp/fm/msfa/lfo.h,          lfo.cc
+    YseEngine/dsp/fm/msfa/env.h,          env.cc
+    YseEngine/dsp/fm/msfa/pitchenv.h,     pitchenv.cc
+    YseEngine/dsp/fm/msfa/fm_op_kernel.h, fm_op_kernel.cc
+    YseEngine/dsp/fm/msfa/fm_core.h,      fm_core.cc
+    YseEngine/dsp/fm/msfa/dx7note.h,      dx7note.cc
+
+A copy of the Apache License, Version 2.0 is available at the URL above.

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(YSE_TEST_SOURCES
   dsp/test_synth_voice.cpp
   dsp/test_ladder_filter.cpp
   dsp/test_va_voice.cpp
+  dsp/test_fm_voice.cpp
   patcher/test_graph.cpp
   patcher/test_nodes.cpp
   patcher/test_patcher_math.cpp

--- a/Tests/dsp/test_fm_voice.cpp
+++ b/Tests/dsp/test_fm_voice.cpp
@@ -1,0 +1,310 @@
+// Tests for YSE::SYNTH::fmVoice (issue #176) — the DX7-class 6-operator FM
+// voice ported from music-synthesizer-for-android, and its fmPatch contract.
+//
+// Coverage:
+//   - intent-driven lifecycle (WANTSTOPLAY -> PLAYING -> release -> STOPPED),
+//   - the built-in sine patch renders a clean tone at the requested pitch
+//     (FFT peak-bin),
+//   - the 2-operator FM patch generates sidebands the sine patch does not
+//     (carrier + sideband spectrum),
+//   - all 32 algorithms instantiate and render finite, non-silent audio
+//     (algorithm routing + feedback stability),
+//   - clone() shares the patch but keeps independent per-voice state,
+//   - process() does not allocate after warm-up,
+//   - fmPatch::toUnpacked lays fields out at the byte offsets #177 depends on.
+//
+// No audio device required; SAMPLERATE is initialised by the
+// portaudioDeviceManager translation unit at static-initialisation time (44100
+// by default; CI also forces 48000). Tones and windows are derived from the
+// actual SAMPLERATE so the tests hold at any rate.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include <vector>
+
+#include "dsp/fm/fmVoice.hpp"
+#include "dsp/fm/fmPatch.hpp"
+#include "dsp/fourier/fft.hpp"
+#include "dsp/math.hpp"
+#include "support/audio_helpers.hpp"
+#include "support/alloc_probe.hpp"
+
+TEST_SUITE("dsp") {
+
+  using YSE::SOUND_STATUS;
+  using YSE::SYNTH::fmPatch;
+  using YSE::SYNTH::fmVoice;
+
+  // Drive a voice to note-on, let it settle, then capture N samples of the
+  // sustaining tone in STANDARD_BUFFERSIZE blocks.
+  static unsigned captureSustain(fmVoice & v, YSE::DSP::buffer & out, unsigned N, int warm = 8) {
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < warm; ++i)
+      v.process(intent);
+    const unsigned block = YSE::STANDARD_BUFFERSIZE;
+    unsigned filled = 0;
+    while (filled + block <= N) {
+      v.process(intent); // stays PLAYING
+      out.copyFrom(v.samples[0], 0, filled, block);
+      filled += block;
+    }
+    return filled;
+  }
+
+  // Summed magnitude-squared energy in a small window around `hz`.
+  static float binEnergy(float* re, float* im, unsigned N, float hz) {
+    const float binHz = static_cast<float>(YSE::SAMPLERATE) / static_cast<float>(N);
+    int bin = static_cast<int>(std::lround(hz / binHz));
+    float e = 0.f;
+    for (int k = bin - 1; k <= bin + 1; ++k) {
+      if (k < 1 || k > static_cast<int>(N / 2)) continue;
+      e += re[k] * re[k] + im[k] * im[k];
+    }
+    return e;
+  }
+
+  // ─── lifecycle ──────────────────────────────────────────────────────────────
+
+  TEST_CASE("fmVoice: WANTSTOPLAY settles the intent to PLAYING and sounds") {
+    fmVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    CHECK(intent == YSE::SS_PLAYING);
+    for (int i = 0; i < 20; ++i)
+      v.process(intent);
+    CHECK(TestHelpers::measureRms(v.samples[0]) > 0.005f);
+  }
+
+  TEST_CASE("fmVoice: WANTSTOSTOP releases and settles to STOPPED") {
+    fmVoice v;
+    v.frequency(69.f);
+    v.velocity(1.f);
+
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 20; ++i)
+      v.process(intent);
+
+    intent = YSE::SS_WANTSTOSTOP;
+    int blocks = 0;
+    const int kMax = 2000;
+    while (intent != YSE::SS_STOPPED && blocks < kMax) {
+      v.process(intent);
+      ++blocks;
+    }
+    CHECK(intent == YSE::SS_STOPPED);
+    CHECK(blocks < kMax);
+  }
+
+  TEST_CASE("fmVoice: released before it ever attacked settles immediately") {
+    fmVoice v;
+    v.frequency(60.f);
+    v.velocity(1.f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOSTOP; // note-off with no prior note-on
+    v.process(intent);
+    CHECK(intent == YSE::SS_STOPPED);
+  }
+
+  // ─── pitch (sine patch) ───────────────────────────────────────────────────
+
+  TEST_CASE("fmVoice: sine patch renders a tone at the requested pitch") {
+    fmVoice v; // constructs with the sine patch by default
+    const float note = 69.f; // A4
+    v.frequency(note);
+    v.velocity(1.f);
+    const float noteHz = YSE::DSP::MidiToFreq(note);
+
+    const unsigned N = 2048;
+    YSE::DSP::buffer re(N), im(N);
+    re = 0.f;
+    im = 0.f;
+    unsigned filled = captureSustain(v, re, N);
+    REQUIRE(filled == N);
+    CHECK(TestHelpers::measureRms(re) > 0.005f);
+
+    YSE::DSP::fft f;
+    f(re, im);
+    unsigned peak = TestHelpers::peakBinIndex(f.getReal().getPtr(), f.getImaginary().getPtr(), N);
+    const float binHz = static_cast<float>(YSE::SAMPLERATE) / static_cast<float>(N);
+    const float peakHz = static_cast<float>(peak) * binHz;
+    CHECK(std::abs(peakHz - noteHz) < 3.f * binHz);
+  }
+
+  // ─── FM sidebands (carrier + sideband structure) ─────────────────────────
+
+  TEST_CASE("fmVoice: 2-operator FM patch generates sidebands the sine patch lacks") {
+    const float note = 57.f; // A3, ~220 Hz — fundamental + 2nd well resolved
+    const float noteHz = YSE::DSP::MidiToFreq(note);
+    const unsigned N = 4096;
+
+    // Sine reference: essentially no energy at 2f.
+    fmVoice sine;
+    sine.setPatch(fmPatch::sine());
+    sine.frequency(note);
+    sine.velocity(1.f);
+    YSE::DSP::buffer sre(N), sim(N);
+    sre = 0.f;
+    sim = 0.f;
+    REQUIRE(captureSustain(sine, sre, N) == N);
+    YSE::DSP::fft sf;
+    sf(sre, sim);
+    float sineFund = binEnergy(sf.getReal().getPtr(), sf.getImaginary().getPtr(), N, noteHz);
+    float sineHarm = binEnergy(sf.getReal().getPtr(), sf.getImaginary().getPtr(), N, 2.f * noteHz);
+
+    // 2-op FM: carrier plus real sideband energy at 2f.
+    fmVoice fm;
+    fm.setPatch(fmPatch::fm2op());
+    fm.frequency(note);
+    fm.velocity(1.f);
+    YSE::DSP::buffer fre(N), fim(N);
+    fre = 0.f;
+    fim = 0.f;
+    REQUIRE(captureSustain(fm, fre, N) == N);
+    CHECK(TestHelpers::measureRms(fre) > 0.005f);
+    YSE::DSP::fft ff;
+    ff(fre, fim);
+    float fmFund = binEnergy(ff.getReal().getPtr(), ff.getImaginary().getPtr(), N, noteHz);
+    float fmHarm = binEnergy(ff.getReal().getPtr(), ff.getImaginary().getPtr(), N, 2.f * noteHz);
+
+    // The carrier is present in both.
+    CHECK(fmFund > 0.f);
+    CHECK(sineFund > 0.f);
+    // The FM patch has substantial sideband energy at 2f...
+    CHECK(fmHarm > 0.05f * fmFund);
+    // ...far more than the near-pure sine reference.
+    CHECK(fmHarm > 10.f * sineHarm);
+  }
+
+  // ─── all 32 algorithms (routing + feedback stability) ────────────────────
+
+  TEST_CASE("fmVoice: all 32 algorithms instantiate and render finite audio") {
+    for (int alg = 0; alg < 32; ++alg) {
+      fmPatch p = fmPatch::brass();
+      p.algorithm = static_cast<uint8_t>(alg);
+      // Ensure every operator can sound so each algorithm's carriers are lit.
+      for (int i = 0; i < 6; ++i)
+        p.op[i].outputLevel = 99;
+
+      fmVoice v;
+      v.setPatch(p);
+      v.frequency(60.f);
+      v.velocity(1.f);
+
+      const unsigned N = 512;
+      YSE::DSP::buffer buf(N);
+      buf = 0.f;
+      unsigned filled = captureSustain(v, buf, N, /*warm*/ 4);
+      REQUIRE(filled == N);
+
+      float* d = buf.getPtr();
+      bool allFinite = true;
+      for (unsigned i = 0; i < N; ++i)
+        if (!std::isfinite(d[i])) allFinite = false;
+
+      INFO("algorithm index = " << alg);
+      CHECK(allFinite);
+      CHECK(TestHelpers::measureRms(buf) > 0.f);
+    }
+  }
+
+  // ─── clone semantics ──────────────────────────────────────────────────────
+
+  TEST_CASE("fmVoice: clone shares the patch but keeps independent state") {
+    fmVoice proto;
+    proto.parameters().feedback = 3;
+    std::unique_ptr<YSE::SYNTH::dspVoice> a(proto.clone());
+    std::unique_ptr<YSE::SYNTH::dspVoice> b(proto.clone());
+
+    auto* fa = dynamic_cast<fmVoice*>(a.get());
+    auto* fb = dynamic_cast<fmVoice*>(b.get());
+    REQUIRE(fa != nullptr);
+    REQUIRE(fb != nullptr);
+
+    // Same shared patch object.
+    CHECK(fa->patch().get() == proto.patch().get());
+    CHECK(fb->patch().get() == proto.patch().get());
+
+    // Independent DSP state: play A only; B stays silent.
+    fa->frequency(69.f);
+    fa->velocity(1.f);
+    fb->frequency(69.f);
+    fb->velocity(1.f);
+    SOUND_STATUS ia = YSE::SS_WANTSTOPLAY;
+    for (int i = 0; i < 20; ++i)
+      fa->process(ia);
+    SOUND_STATUS ib = YSE::SS_STOPPED;
+    fb->process(ib);
+    CHECK(TestHelpers::measureRms(fa->samples[0]) > 0.005f);
+    CHECK(TestHelpers::measureRms(fb->samples[0]) == doctest::Approx(0.f));
+  }
+
+  // ─── real-time discipline ─────────────────────────────────────────────────
+
+  TEST_CASE("fmVoice: process() does not allocate after warm-up") {
+    fmVoice v;
+    v.setPatch(fmPatch::fm2op());
+    v.frequency(64.f);
+    v.velocity(0.9f);
+
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 8; ++i)
+      v.process(intent);
+
+    {
+      TestHelpers::ProbeScope probe;
+      for (int i = 0; i < 64; ++i)
+        v.process(intent);
+      // Drive a note-off/settle cycle too — no allocation on any control edge.
+      SOUND_STATUS off = YSE::SS_WANTSTOSTOP;
+      for (int i = 0; i < 8; ++i)
+        v.process(off);
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+  }
+
+  // ─── fmPatch contract (#177 byte-layout) ─────────────────────────────────
+
+  TEST_CASE("fmPatch: toUnpacked lays fields at the DX7 156-byte offsets") {
+    fmPatch p = fmPatch::sine();
+    // Distinct, checkable values across an operator and the global block.
+    p.op[0].egRate[0] = 11;
+    p.op[0].egLevel[3] = 22;
+    p.op[0].detune = 14;
+    p.op[2].outputLevel = 77;
+    p.op[5].freqCoarse = 5;
+    p.pitchEgRate[1] = 33;
+    p.pitchEgLevel[3] = 44;
+    p.algorithm = 17;
+    p.feedback = 5;
+    p.lfoWaveform = 4;
+    p.pitchModSens = 6;
+    p.transpose = 30;
+    p.name[0] = 'F';
+    p.name[9] = 'M';
+    p.opEnabled = 0x3f;
+
+    char u[156];
+    p.toUnpacked(u);
+
+    CHECK(u[0 * 21 + 0] == 11); // op0 EG rate 1
+    CHECK(u[0 * 21 + 7] == 22); // op0 EG level 4
+    CHECK(u[0 * 21 + 20] == 14); // op0 detune
+    CHECK(u[2 * 21 + 16] == 77); // op2 output level
+    CHECK(u[5 * 21 + 18] == 5); // op5 coarse freq
+    CHECK(u[127] == 33); // pitch EG rate 2
+    CHECK(u[133] == 44); // pitch EG level 4
+    CHECK(u[134] == 17); // algorithm
+    CHECK(u[135] == 5); // feedback
+    CHECK(u[142] == 4); // LFO waveform
+    CHECK(u[143] == 6); // pitch mod sensitivity
+    CHECK(u[144] == 30); // transpose
+    CHECK(u[145] == 'F'); // name[0]
+    CHECK(u[154] == 'M'); // name[9]
+    CHECK(static_cast<unsigned char>(u[155]) == 0x3f); // operator on/off
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -48,6 +48,17 @@ set(YSE_SRCS
   dsp/modules/plateReverb.cpp
   dsp/modules/ringModulator.cpp
   dsp/modules/sineWave.cpp
+  dsp/fm/fmPatch.cpp
+  dsp/fm/fmVoice.cpp
+  dsp/fm/msfa/sin.cc
+  dsp/fm/msfa/exp2.cc
+  dsp/fm/msfa/freqlut.cc
+  dsp/fm/msfa/lfo.cc
+  dsp/fm/msfa/env.cc
+  dsp/fm/msfa/pitchenv.cc
+  dsp/fm/msfa/fm_op_kernel.cc
+  dsp/fm/msfa/fm_core.cc
+  dsp/fm/msfa/dx7note.cc
   dsp/oscillators.cpp
   dsp/ramp.cpp
   dsp/rawFilters.cpp
@@ -183,6 +194,24 @@ endif()
 # ── Source-file-scoped warning suppressions ───────────────────────────────────
 # cJSON is a vendored C file; suppress all its warnings rather than patching it.
 set_source_files_properties(json/cJSON.cpp
+  PROPERTIES COMPILE_FLAGS "-w"
+)
+
+# The dsp/fm/msfa/ files are ported verbatim from music-synthesizer-for-android
+# (Apache-2.0, see NOTICE). They are treated like vendored third-party code:
+# suppress compiler warnings rather than patching upstream style, and they are
+# kept out of the clang-tidy pass (yse.py analyze globs *.cpp only, and these
+# are *.cc). Issue #176.
+set_source_files_properties(
+  dsp/fm/msfa/sin.cc
+  dsp/fm/msfa/exp2.cc
+  dsp/fm/msfa/freqlut.cc
+  dsp/fm/msfa/lfo.cc
+  dsp/fm/msfa/env.cc
+  dsp/fm/msfa/pitchenv.cc
+  dsp/fm/msfa/fm_op_kernel.cc
+  dsp/fm/msfa/fm_core.cc
+  dsp/fm/msfa/dx7note.cc
   PROPERTIES COMPILE_FLAGS "-w"
 )
 

--- a/YseEngine/dsp/fm/fmPatch.cpp
+++ b/YseEngine/dsp/fm/fmPatch.cpp
@@ -1,0 +1,162 @@
+/*
+  ==============================================================================
+
+    fmPatch.cpp
+    Serialisation + built-in voices for the DX7 FM patch — see fmPatch.hpp and
+    issue #176.
+
+  ==============================================================================
+*/
+
+#include "fmPatch.hpp"
+
+#include <cstring>
+
+namespace YSE {
+  namespace SYNTH {
+
+    void fmPatch::toUnpacked(char dest[156]) const {
+      for (int i = 0; i < 6; i++) {
+        const fmOperator& o = op[i];
+        char* d = dest + i * 21;
+        d[0] = static_cast<char>(o.egRate[0]);
+        d[1] = static_cast<char>(o.egRate[1]);
+        d[2] = static_cast<char>(o.egRate[2]);
+        d[3] = static_cast<char>(o.egRate[3]);
+        d[4] = static_cast<char>(o.egLevel[0]);
+        d[5] = static_cast<char>(o.egLevel[1]);
+        d[6] = static_cast<char>(o.egLevel[2]);
+        d[7] = static_cast<char>(o.egLevel[3]);
+        d[8] = static_cast<char>(o.levelScaleBreakPoint);
+        d[9] = static_cast<char>(o.levelScaleLeftDepth);
+        d[10] = static_cast<char>(o.levelScaleRightDepth);
+        d[11] = static_cast<char>(o.levelScaleLeftCurve);
+        d[12] = static_cast<char>(o.levelScaleRightCurve);
+        d[13] = static_cast<char>(o.rateScaling);
+        d[14] = static_cast<char>(o.ampModSens);
+        d[15] = static_cast<char>(o.keyVelSens);
+        d[16] = static_cast<char>(o.outputLevel);
+        d[17] = static_cast<char>(o.oscMode);
+        d[18] = static_cast<char>(o.freqCoarse);
+        d[19] = static_cast<char>(o.freqFine);
+        d[20] = static_cast<char>(o.detune);
+      }
+      dest[126] = static_cast<char>(pitchEgRate[0]);
+      dest[127] = static_cast<char>(pitchEgRate[1]);
+      dest[128] = static_cast<char>(pitchEgRate[2]);
+      dest[129] = static_cast<char>(pitchEgRate[3]);
+      dest[130] = static_cast<char>(pitchEgLevel[0]);
+      dest[131] = static_cast<char>(pitchEgLevel[1]);
+      dest[132] = static_cast<char>(pitchEgLevel[2]);
+      dest[133] = static_cast<char>(pitchEgLevel[3]);
+      dest[134] = static_cast<char>(algorithm);
+      dest[135] = static_cast<char>(feedback);
+      dest[136] = static_cast<char>(oscKeySync);
+      dest[137] = static_cast<char>(lfoSpeed);
+      dest[138] = static_cast<char>(lfoDelay);
+      dest[139] = static_cast<char>(lfoPitchModDepth);
+      dest[140] = static_cast<char>(lfoAmpModDepth);
+      dest[141] = static_cast<char>(lfoSync);
+      dest[142] = static_cast<char>(lfoWaveform);
+      dest[143] = static_cast<char>(pitchModSens);
+      dest[144] = static_cast<char>(transpose);
+      for (int i = 0; i < 10; i++)
+        dest[145 + i] = name[i];
+      dest[155] = static_cast<char>(opEnabled);
+    }
+
+    // ─── built-in voices ─────────────────────────────────────────────────────
+
+    namespace {
+
+      // A fully-sustaining operator: envelope snaps to full and holds, no key
+      // scaling, no velocity sensitivity (so tests are level-deterministic),
+      // frequency ratio 1.0 (coarse 1 / fine 0 / detune centred).
+      fmOperator makeOp(uint8_t outputLevel, uint8_t coarse = 1) {
+        fmOperator o{};
+        o.egRate[0] = o.egRate[1] = o.egRate[2] = o.egRate[3] = 99;
+        o.egLevel[0] = o.egLevel[1] = o.egLevel[2] = 99;
+        o.egLevel[3] = 0; // L4 is the release floor
+        o.levelScaleBreakPoint = 39;
+        o.levelScaleLeftDepth = 0;
+        o.levelScaleRightDepth = 0;
+        o.levelScaleLeftCurve = 0;
+        o.levelScaleRightCurve = 0;
+        o.rateScaling = 0;
+        o.ampModSens = 0;
+        o.keyVelSens = 0;
+        o.outputLevel = outputLevel;
+        o.oscMode = 0;
+        o.freqCoarse = coarse;
+        o.freqFine = 0;
+        o.detune = 7;
+        return o;
+      }
+
+      // Fill the global (non-operator) fields of a sustaining voice: flat pitch
+      // envelope (level 50 = centre), LFO present but with zero modulation
+      // depth, no transpose.
+      void fillGlobals(fmPatch& p, uint8_t algorithm, uint8_t feedback, const char* name) {
+        p.pitchEgRate[0] = p.pitchEgRate[1] = p.pitchEgRate[2] = p.pitchEgRate[3] = 99;
+        p.pitchEgLevel[0] = p.pitchEgLevel[1] = p.pitchEgLevel[2] = p.pitchEgLevel[3] = 50;
+        p.algorithm = algorithm;
+        p.feedback = feedback;
+        p.oscKeySync = 1;
+        p.lfoSpeed = 35;
+        p.lfoDelay = 0;
+        p.lfoPitchModDepth = 0;
+        p.lfoAmpModDepth = 0;
+        p.lfoSync = 1;
+        p.lfoWaveform = 0;
+        p.pitchModSens = 0;
+        p.transpose = 24;
+        std::memset(p.name, ' ', sizeof(p.name));
+        for (int i = 0; i < 10 && name[i]; i++)
+          p.name[i] = name[i];
+        p.opEnabled = 0x3f;
+      }
+
+    } // namespace
+
+    fmPatch fmPatch::sine() {
+      fmPatch p{};
+      // Algorithm 32 (index 31): six parallel carriers. Only OP1 sounds.
+      p.op[0] = makeOp(99);
+      for (int i = 1; i < 6; i++)
+        p.op[i] = makeOp(0);
+      fillGlobals(p, 31, 0, "YSE Sine");
+      return p;
+    }
+
+    fmPatch fmPatch::fm2op() {
+      fmPatch p{};
+      // Algorithm 5 (index 4): three 2-op stacks. In the first stack OP1 (op[0],
+      // routed to modulation bus 1) modulates OP2 (op[1], the carrier that
+      // reaches the output); both run at ratio 1.0. A moderate modulator level
+      // gives a clear carrier plus a handful of FM sidebands rather than a
+      // saturated, noise-like spectrum. The other stacks are silent.
+      p.op[0] = makeOp(72); // modulator (modulation index)
+      p.op[1] = makeOp(99); // carrier
+      for (int i = 2; i < 6; i++)
+        p.op[i] = makeOp(0);
+      fillGlobals(p, 4, 0, "YSE 2opFM");
+      return p;
+    }
+
+    fmPatch fmPatch::brass() {
+      fmPatch p{};
+      // Algorithm 1 (index 0) with all six operators active and operator
+      // feedback engaged — a bright, harmonically rich voice that exercises the
+      // full operator set.
+      p.op[0] = makeOp(99, 1);
+      p.op[1] = makeOp(90, 1);
+      p.op[2] = makeOp(90, 1);
+      p.op[3] = makeOp(85, 1);
+      p.op[4] = makeOp(90, 1);
+      p.op[5] = makeOp(85, 1);
+      fillGlobals(p, 0, 6, "YSE Brass");
+      return p;
+    }
+
+  } // namespace SYNTH
+} // namespace YSE

--- a/YseEngine/dsp/fm/fmPatch.hpp
+++ b/YseEngine/dsp/fm/fmPatch.hpp
@@ -1,0 +1,117 @@
+/*
+  ==============================================================================
+
+    fmPatch.hpp
+    DX7-class 6-operator FM voice parameter set for YSE::synth (issue #176).
+
+    This struct is the explicit data contract between the FM engine (this
+    issue, #176) and the DX7 SysEx importer (#177). #177 parses a DX7 voice
+    out of a SysEx dump and fills an ``fmPatch``; ``fmVoice`` consumes it. The
+    field set is the full DX7 155-parameter voice (6 operators + global pitch
+    envelope, algorithm, feedback, LFO, transpose, name), laid out so it maps
+    one-to-one onto the 156-byte "unpacked voice" the ported MSFA core
+    (``msfa::Dx7Note::init``) expects — see ``toUnpacked``.
+
+    Ranges follow the DX7 hardware (the values a SysEx voice already carries):
+    most parameters are 0..99, curves 0..3, algorithm 0..31 (the DX7 front
+    panel shows 1..32), feedback 0..7, detune 0..14 (7 = centre), transpose
+    0..48 (24 = C3, i.e. no transpose). #177 is responsible for range-checking
+    what it imports; ``fmVoice`` clamps defensively where a bad value could
+    index out of bounds.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_DSP_FM_FMPATCH_HPP
+#define YSE_DSP_FM_FMPATCH_HPP
+
+#include <cstdint>
+
+#include "../../headers/defines.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /**
+     *  @brief One DX7 operator's parameters (21 fields).
+     *
+     *  Maps to bytes ``[op*21 .. op*21+20]`` of the 156-byte unpacked voice.
+     *  Operators are stored in DX7 voice order: ``op[0]`` is OP1 … ``op[5]``
+     *  is OP6, matching the algorithm routing tables in the ported core.
+     */
+    struct fmOperator {
+      uint8_t egRate[4]; ///< Envelope rates R1..R4 (0..99).           [+0..3]
+      uint8_t egLevel[4]; ///< Envelope levels L1..L4 (0..99).          [+4..7]
+
+      uint8_t levelScaleBreakPoint; ///< Keyboard level-scaling break point.   [+8]
+      uint8_t levelScaleLeftDepth; ///< Level scaling, left depth (0..99).     [+9]
+      uint8_t levelScaleRightDepth; ///< Level scaling, right depth (0..99).    [+10]
+      uint8_t levelScaleLeftCurve; ///< Left curve (0..3: -lin,-exp,+exp,+lin).[+11]
+      uint8_t levelScaleRightCurve; ///< Right curve (0..3).                    [+12]
+
+      uint8_t rateScaling; ///< Keyboard rate scaling (0..7).                   [+13]
+      uint8_t ampModSens; ///< Amplitude-modulation sensitivity (0..3).       [+14]
+      uint8_t keyVelSens; ///< Key-velocity sensitivity (0..7).               [+15]
+      uint8_t outputLevel; ///< Operator output level (0..99).                 [+16]
+
+      uint8_t oscMode; ///< 0 = frequency ratio, 1 = fixed frequency.       [+17]
+      uint8_t freqCoarse; ///< Coarse frequency (0..31).                       [+18]
+      uint8_t freqFine; ///< Fine frequency (0..99).                         [+19]
+      uint8_t detune; ///< Detune (0..14, 7 = centre).                     [+20]
+    };
+
+    /**
+     *  @brief A complete DX7 6-operator voice.
+     *
+     *  Plain data — no behaviour, no atomics — so it is trivially copyable and
+     *  cheap to hand across the setup boundary. ``fmVoice`` snapshots one of
+     *  these at construction and serialises it to the MSFA core on each
+     *  note-on via ``toUnpacked``; the shared, live-editable copy the voice
+     *  keeps is the ``fmVoice`` patch (see fmVoice.hpp).
+     */
+    struct API fmPatch {
+      fmOperator op[6]; ///< OP1..OP6.                                    [0..125]
+
+      uint8_t pitchEgRate[4]; ///< Pitch envelope rates R1..R4 (0..99).  [126..129]
+      uint8_t pitchEgLevel[4]; ///< Pitch envelope levels L1..L4 (0..99). [130..133]
+
+      uint8_t algorithm; ///< FM algorithm (0..31; DX7 shows 1..32).      [134]
+      uint8_t feedback; ///< Feedback amount (0..7).                     [135]
+      uint8_t oscKeySync; ///< Oscillator key sync (0/1).                 [136]
+
+      uint8_t lfoSpeed; ///< LFO speed (0..99).                    [137]
+      uint8_t lfoDelay; ///< LFO delay (0..99).                    [138]
+      uint8_t lfoPitchModDepth; ///< LFO pitch-mod depth PMD (0..99).     [139]
+      uint8_t lfoAmpModDepth; ///< LFO amp-mod depth AMD (0..99).        [140]
+      uint8_t lfoSync; ///< LFO key sync (0/1).                   [141]
+      uint8_t lfoWaveform; ///< LFO waveform (0..5: tri,saw-d,saw-u,sqr,sine,s&h). [142]
+      uint8_t pitchModSens; ///< Pitch-mod sensitivity (0..7).         [143]
+
+      uint8_t transpose; ///< Transpose in semitones (0..48, 24 = none).  [144]
+      char name[10]; ///< Voice name, ASCII, space-padded.            [145..154]
+      uint8_t opEnabled; ///< Operator on/off bitmask (bit n = OPn+1); 0x3f = all on. [155]
+
+      /**
+       *  @brief Serialise into the 156-byte unpacked voice the MSFA core reads.
+       *
+       *  ``dest`` must point to at least 156 bytes. This is the exact layout
+       *  ``msfa::Dx7Note::init`` consumes; ``fmVoice`` calls it on note-on.
+       */
+      void toUnpacked(char dest[156]) const;
+
+      /// @name Built-in test voices (defined in code; #176 acceptance).
+      /// @{
+      /** @brief A single unmodulated carrier — a pure sine (algorithm 32). */
+      static fmPatch sine();
+      /** @brief A textbook 2-operator FM patch: OP1 modulated by OP2 at a 1:1
+       *  ratio (algorithm 5), producing a carrier plus FM sidebands. */
+      static fmPatch fm2op();
+      /** @brief A fuller, brass-like patch exercising all six operators. */
+      static fmPatch brass();
+      /// @}
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_DSP_FM_FMPATCH_HPP

--- a/YseEngine/dsp/fm/fmVoice.cpp
+++ b/YseEngine/dsp/fm/fmVoice.cpp
@@ -1,0 +1,215 @@
+/*
+  ==============================================================================
+
+    fmVoice.cpp
+    DX7-class 6-operator FM voice — see fmVoice.hpp and issue #176.
+
+  ==============================================================================
+*/
+
+#include "fmVoice.hpp"
+
+#include <cmath>
+#include <cstring>
+#include <mutex>
+
+#include "../math.hpp"
+#include "../../headers/constants.hpp"
+
+#include "msfa/synth.h"
+#include "msfa/sin.h"
+#include "msfa/exp2.h"
+#include "msfa/freqlut.h"
+#include "msfa/pitchenv.h"
+#include "msfa/lfo.h"
+#include "msfa/controllers.h"
+#include "msfa/dx7note.h"
+
+namespace YSE {
+  namespace SYNTH {
+
+    namespace msfa = ::YSE::DSP::msfa;
+
+    // Convert the FM core's fixed-point output to float. MSFA maps a note's
+    // int32 sample to a signed 16-bit value by `(sample >> 4) >> 9` with full
+    // scale at 1<<24, i.e. 1<<28 in the raw domain maps to unity.
+    static const Flt kOutputScale = 1.0f / static_cast<Flt>(1 << 28);
+
+    // Raw-domain peak below which a releasing voice is considered silent. The
+    // envelopes decay toward zero after key-up, so a couple of consecutive
+    // quiet blocks means the release tail has finished.
+    static const int32_t kSilenceThreshold = 512;
+    static const int kQuietBlocksToStop = 2;
+
+    // ─── one-time, rate-dependent global table init ──────────────────────────
+    // The MSFA sine / exp2 tables are rate-independent; the freqlut, LFO and
+    // pitch-envelope tables depend on the sample rate. Built once per rate on
+    // the setup thread (never the audio thread) — voices are cloned there after
+    // the device has locked SAMPLERATE. Guarded by a mutex because the prototype
+    // may be constructed on a different (non-audio) thread than the clones.
+    static void ensureTablesInited() {
+      static std::mutex mutex;
+      static double initedRate = 0.0;
+      std::lock_guard<std::mutex> lock(mutex);
+      const double sr = static_cast<double>(SAMPLERATE);
+      if (initedRate == sr) return;
+      msfa::Sin::init();
+      msfa::Exp2::init();
+      msfa::Freqlut::init(sr);
+      msfa::Lfo::init(sr);
+      msfa::PitchEnv::init(sr);
+      initedRate = sr;
+    }
+
+    // ─── PIMPL audio-thread state ────────────────────────────────────────────
+    struct fmVoiceState {
+      msfa::Dx7Note note;
+      msfa::Lfo lfo;
+      msfa::Controllers ctrls;
+      int32_t scratch[64];
+      int scratchPos = 64; // >= 64 forces a refill on the first sample
+      enum Phase { IDLE, PLAYING, RELEASING } phase = IDLE;
+      int quietBlocks = 0;
+      SOUND_STATUS settleStatus = SS_STOPPED;
+
+      fmVoiceState() {
+        for (int i = 0; i < 129; i++)
+          ctrls.values_[i] = 0;
+        ctrls.values_[msfa::kControllerPitch] = 0x2000; // pitch-wheel centre
+        for (int i = 0; i < 64; i++)
+          scratch[i] = 0;
+      }
+    };
+
+    // ─── fmVoice ─────────────────────────────────────────────────────────────
+
+    fmVoice::fmVoice(int outputChannels)
+      : dspVoice(outputChannels),
+        params(std::make_shared<fmPatch>(fmPatch::sine())),
+        state(std::make_unique<fmVoiceState>()) {
+      ensureTablesInited();
+    }
+
+    fmVoice::fmVoice(const fmVoice& other)
+      : dspVoice(other),
+        params(other.params), // share the patch — all voices track one sound
+        state(std::make_unique<fmVoiceState>()) {
+      ensureTablesInited();
+    }
+
+    fmVoice::~fmVoice() = default;
+
+    dspVoice* fmVoice::clone() {
+      return new fmVoice(*this);
+    }
+
+    void fmVoice::startNote() {
+      const fmPatch& p = *params;
+
+      // MIDI note number: the base stores frequency as Hz, so round-trip it
+      // back to a note number and apply the patch transpose (24 = no shift).
+      int midinote = static_cast<int>(std::lround(DSP::FreqToMidi(getFrequency())));
+      midinote += static_cast<int>(p.transpose) - 24;
+      if (midinote < 0) midinote = 0;
+      if (midinote > 127) midinote = 127;
+
+      int velocity = static_cast<int>(std::lround(getVelocity() * 127.f));
+      if (velocity < 0) velocity = 0;
+      if (velocity > 127) velocity = 127;
+
+      char unpacked[156];
+      p.toUnpacked(unpacked);
+      state->note.init(unpacked, midinote, velocity);
+
+      // LFO parameter block: {speed, delay, pmd, amd, sync, waveform}.
+      char lfoParams[6];
+      lfoParams[0] = static_cast<char>(p.lfoSpeed);
+      lfoParams[1] = static_cast<char>(p.lfoDelay);
+      lfoParams[2] = static_cast<char>(p.lfoPitchModDepth);
+      lfoParams[3] = static_cast<char>(p.lfoAmpModDepth);
+      lfoParams[4] = static_cast<char>(p.lfoSync);
+      lfoParams[5] = static_cast<char>(p.lfoWaveform);
+      state->lfo.reset(lfoParams);
+      state->lfo.keydown();
+
+      state->scratchPos = 64; // force a fresh core block
+    }
+
+    void fmVoice::process(SOUND_STATUS& intent) {
+      if (samples.empty()) return; // degenerate 0-channel voice
+      const UInt n = samples[0].getLength();
+      fmVoiceState& s = *state;
+
+      // ---- lifecycle / gates -------------------------------------------------
+      if (intent == SS_WANTSTOPLAY || intent == SS_WANTSTORESTART) {
+        startNote();
+        s.phase = fmVoiceState::PLAYING;
+        intent = SS_PLAYING;
+      } else if (intent == SS_WANTSTOSTOP || intent == SS_WANTSTOPAUSE) {
+        const SOUND_STATUS settled = (intent == SS_WANTSTOPAUSE) ? SS_PAUSED : SS_STOPPED;
+        if (s.phase == fmVoiceState::IDLE) {
+          // Released before it ever attacked — nothing is sounding.
+          intent = settled;
+          for (UInt ch = 0; ch < samples.size(); ch++)
+            samples[ch] = 0.f;
+          return;
+        }
+        if (s.phase != fmVoiceState::RELEASING) {
+          s.note.keyup();
+          s.phase = fmVoiceState::RELEASING;
+          s.settleStatus = settled;
+          s.quietBlocks = 0;
+        }
+      } else if (intent == SS_PLAYING || intent == SS_PLAYING_FULL_VOLUME) {
+        // keep rendering
+      } else {
+        // SS_STOPPED / SS_PAUSED: emit silence.
+        for (UInt ch = 0; ch < samples.size(); ch++)
+          samples[ch] = 0.f;
+        return;
+      }
+
+      // Deliver the channel pitch-wheel (±1 → ±8192 around the 0x2000 centre;
+      // the core maps this to a hardcoded ±3-semitone bend).
+      int pb = 0x2000 + static_cast<int>(std::lround(getPitchWheel() * 8192.f));
+      if (pb < 0) pb = 0;
+      if (pb > 16383) pb = 16383;
+      s.ctrls.values_[msfa::kControllerPitch] = pb;
+
+      // ---- per-sample render -------------------------------------------------
+      Flt* out = samples[0].getPtr();
+      int32_t blockMax = 0;
+      for (UInt i = 0; i < n; i++) {
+        if (s.scratchPos >= 64) {
+          int32_t lfoVal = s.lfo.getsample();
+          int32_t lfoDelay = s.lfo.getdelay();
+          for (int k = 0; k < 64; k++)
+            s.scratch[k] = 0;
+          s.note.compute(s.scratch, lfoVal, lfoDelay, &s.ctrls);
+          s.scratchPos = 0;
+        }
+        int32_t raw = s.scratch[s.scratchPos++];
+        int32_t mag = raw < 0 ? -raw : raw;
+        if (mag > blockMax) blockMax = mag;
+        out[i] = static_cast<Flt>(raw) * kOutputScale;
+      }
+
+      // Mirror the mono voice signal to any extra output channels.
+      for (UInt ch = 1; ch < samples.size(); ch++)
+        samples[ch] = samples[0];
+
+      // Release tail finished (envelopes decayed to silence) — free the slot.
+      if (s.phase == fmVoiceState::RELEASING) {
+        if (blockMax < kSilenceThreshold) {
+          if (++s.quietBlocks >= kQuietBlocksToStop) {
+            intent = s.settleStatus;
+            s.phase = fmVoiceState::IDLE;
+          }
+        } else {
+          s.quietBlocks = 0;
+        }
+      }
+    }
+
+  } // namespace SYNTH
+} // namespace YSE

--- a/YseEngine/dsp/fm/fmVoice.hpp
+++ b/YseEngine/dsp/fm/fmVoice.hpp
@@ -1,0 +1,95 @@
+/*
+  ==============================================================================
+
+    fmVoice.hpp
+    DX7-class 6-operator FM synthesiser voice for YSE::synth (issue #176).
+
+    A SYNTH::dspVoice subclass that renders one DX7 voice by driving the FM
+    core ported from music-synthesizer-for-android (see dsp/fm/msfa/). The tone
+    is described by a shared, live-editable fmPatch (the same contract the DX7
+    SysEx importer #177 targets); all voices of one synth share one patch and
+    each keeps its own independent operator / envelope / LFO state.
+
+    The MSFA core is held behind a PIMPL so its fixed-point macros (N, LG_N, …)
+    never leak into this header or into consumers/tests. All allocation happens
+    in the constructor / clone() (setup thread); process() is allocation-free.
+
+    See docs/design/synth_core.md §3 for the voice contract.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_DSP_FM_FMVOICE_HPP
+#define YSE_DSP_FM_FMVOICE_HPP
+
+#include <memory>
+
+#include "fmPatch.hpp"
+#include "../../synth/dspVoice.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /// @cond INTERNAL
+    // Opaque audio-thread state (MSFA Dx7Note + Lfo + controllers + scratch).
+    // Defined in fmVoice.cpp so the fixed-point core stays out of this header.
+    struct fmVoiceState;
+    /// @endcond
+
+    /**
+     *  @brief DX7-class 6-operator FM voice.
+     *
+     *  Construct one, dial in its ``fmPatch`` (or load a DX7 voice into it via
+     *  #177), then hand it to ``synth::addVoices``. Clones share the patch and
+     *  stay editable through ``patch()``. Patch edits take effect on the next
+     *  note-on (the FM core bakes operator parameters at key-down, exactly like
+     *  the hardware reacting to a program change between notes).
+     */
+    class API fmVoice : public dspVoice {
+    public:
+      /** @brief Construct a voice with the built-in sine test patch. */
+      fmVoice(int outputChannels = 1);
+
+      ~fmVoice() override;
+
+      /** @brief The shared, live-editable patch. Retain to keep editing after the prototype is
+       * gone. */
+      std::shared_ptr<fmPatch> patch() const {
+        return params;
+      }
+
+      /** @brief Convenience reference to the shared patch. */
+      fmPatch& parameters() {
+        return *params;
+      }
+
+      /** @brief Overwrite the shared patch; applied on the next note-on. */
+      fmVoice& setPatch(const fmPatch& p) {
+        *params = p;
+        return *this;
+      }
+
+      // ---- dspVoice contract -------------------------------------------------
+
+      /** @brief Render one block, honouring and settling ``intent``. Audio-thread only. */
+      void process(SOUND_STATUS& intent) override;
+
+      /** @brief Return a new voice sharing this voice's patch, with fresh DSP state. Setup-thread
+       * only. */
+      dspVoice* clone() override;
+
+    protected:
+      /** @brief Copy-construct: share the patch, build fresh independent core state. */
+      fmVoice(const fmVoice& other);
+
+    private:
+      void startNote();
+
+      std::shared_ptr<fmPatch> params;
+      std::unique_ptr<fmVoiceState> state;
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_DSP_FM_FMVOICE_HPP

--- a/YseEngine/dsp/fm/msfa/aligned_buf.h
+++ b/YseEngine/dsp/fm/msfa/aligned_buf.h
@@ -1,0 +1,51 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// A convenient wrapper for buffers with alignment constraints
+
+#ifndef YSE_DSP_FM_MSFA_ALIGNED_BUF_H
+#define YSE_DSP_FM_MSFA_ALIGNED_BUF_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      template <typename T, size_t size, size_t alignment = 16> class AlignedBuf {
+      public:
+        T* get() {
+          return (T*)((((intptr_t)storage_) + alignment - 1) & -alignment);
+        }
+
+      private:
+        unsigned char storage_[size * sizeof(T) + alignment];
+      };
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_ALIGNED_BUF_H

--- a/YseEngine/dsp/fm/msfa/controllers.h
+++ b/YseEngine/dsp/fm/msfa/controllers.h
@@ -1,0 +1,45 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// State of MIDI controllers
+
+#ifndef YSE_DSP_FM_MSFA_CONTROLLERS_H
+#define YSE_DSP_FM_MSFA_CONTROLLERS_H
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      const int kControllerPitch = 128;
+
+      class Controllers {
+      public:
+        int values_[129];
+      };
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_CONTROLLERS_H

--- a/YseEngine/dsp/fm/msfa/dx7note.cc
+++ b/YseEngine/dsp/fm/msfa/dx7note.cc
@@ -1,0 +1,196 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; the VERBOSE debug printing and the unused patch.h
+ * include were removed. Upstream Apache-2.0 license header preserved below;
+ * see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <math.h>
+#include "synth.h"
+#include "freqlut.h"
+#include "exp2.h"
+#include "controllers.h"
+#include "dx7note.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      int32_t midinote_to_logfreq(int midinote) {
+        const int base = 50857777; // (1 << 24) * (log(440) / log(2) - 69/12)
+        const int step = (1 << 24) / 12;
+        return base + step * midinote;
+      }
+
+      const int32_t coarsemul[] = {
+          -16777216, 0,        16777216, 26591258, 33554432, 38955489, 43368474, 47099600,
+          50331648,  53182516, 55732705, 58039632, 60145690, 62083076, 63876816, 65546747,
+          67108864,  68576247, 69959732, 71268397, 72509921, 73690858, 74816848, 75892776,
+          76922906,  77910978, 78860292, 79773775, 80654032, 81503396, 82323963, 83117622};
+
+      int32_t osc_freq(int midinote, int mode, int coarse, int fine, int detune) {
+        // TODO: pitch randomization
+        int32_t logfreq;
+        if (mode == 0) {
+          logfreq = midinote_to_logfreq(midinote);
+          logfreq += coarsemul[coarse & 31];
+          if (fine) {
+            // (1 << 24) / log(2)
+            logfreq += (int32_t)floor(24204406.323123 * log(1 + 0.01 * fine) + 0.5);
+          }
+          // This was measured at 7.213Hz per count at 9600Hz, but the exact
+          // value is somewhat dependent on midinote. Close enough for now.
+          logfreq += 12606 * (detune - 7);
+        } else {
+          // ((1 << 24) * log(10) / log(2) * .01) << 3
+          logfreq = (4458616 * ((coarse & 3) * 100 + fine)) >> 3;
+          logfreq += detune > 7 ? 13457 * (detune - 7) : 0;
+        }
+        return logfreq;
+      }
+
+      const uint8_t velocity_data[64] = {
+          0,   70,  86,  97,  106, 114, 121, 126, 132, 138, 142, 148, 152, 156, 160, 163,
+          166, 170, 173, 174, 178, 181, 184, 186, 189, 190, 194, 196, 198, 200, 202, 205,
+          206, 209, 211, 214, 216, 218, 220, 222, 224, 225, 227, 229, 230, 232, 233, 235,
+          237, 238, 240, 241, 242, 243, 244, 246, 246, 248, 249, 250, 251, 252, 253, 254};
+
+      // See "velocity" section of notes. Returns velocity delta in microsteps.
+      int ScaleVelocity(int velocity, int sensitivity) {
+        int clamped_vel = max(0, min(127, velocity));
+        int vel_value = velocity_data[clamped_vel >> 1] - 239;
+        int scaled_vel = ((sensitivity * vel_value + 7) >> 3) << 4;
+        return scaled_vel;
+      }
+
+      int ScaleRate(int midinote, int sensitivity) {
+        int x = min(31, max(0, midinote / 3 - 7));
+        int qratedelta = (sensitivity * x) >> 3;
+        return qratedelta;
+      }
+
+      const uint8_t exp_scale_data[] = {0,  1,  2,  3,  4,  5,   6,   7,   8,   9,   11,
+                                        14, 16, 19, 23, 27, 33,  39,  47,  56,  66,  80,
+                                        94, 110, 126, 142, 158, 174, 190, 206, 222, 238, 250};
+
+      int ScaleCurve(int group, int depth, int curve) {
+        int scale;
+        if (curve == 0 || curve == 3) {
+          // linear
+          scale = (group * depth * 329) >> 12;
+        } else {
+          // exponential
+          int n_scale_data = sizeof(exp_scale_data);
+          int raw_exp = exp_scale_data[min(group, n_scale_data - 1)];
+          scale = (raw_exp * depth * 329) >> 15;
+        }
+        if (curve < 2) {
+          scale = -scale;
+        }
+        return scale;
+      }
+
+      int ScaleLevel(int midinote, int break_pt, int left_depth, int right_depth, int left_curve,
+                     int right_curve) {
+        int offset = midinote - break_pt - 17;
+        if (offset >= 0) {
+          return ScaleCurve(offset / 3, right_depth, right_curve);
+        } else {
+          return ScaleCurve((-offset) / 3, left_depth, left_curve);
+        }
+      }
+
+      static const uint8_t pitchmodsenstab[] = {0, 10, 20, 33, 55, 92, 153, 255};
+
+      void Dx7Note::init(const char patch[156], int midinote, int velocity) {
+        int rates[4];
+        int levels[4];
+        for (int op = 0; op < 6; op++) {
+          int off = op * 21;
+          for (int i = 0; i < 4; i++) {
+            rates[i] = patch[off + i];
+            levels[i] = patch[off + 4 + i];
+          }
+          int outlevel = patch[off + 16];
+          outlevel = Env::scaleoutlevel(outlevel);
+          int level_scaling = ScaleLevel(midinote, patch[off + 8], patch[off + 9], patch[off + 10],
+                                         patch[off + 11], patch[off + 12]);
+          outlevel += level_scaling;
+          outlevel = min(127, outlevel);
+          outlevel = outlevel << 5;
+          outlevel += ScaleVelocity(velocity, patch[off + 15]);
+          outlevel = max(0, outlevel);
+          int rate_scaling = ScaleRate(midinote, patch[off + 13]);
+          env_[op].init(rates, levels, outlevel, rate_scaling);
+
+          int mode = patch[off + 17];
+          int coarse = patch[off + 18];
+          int fine = patch[off + 19];
+          int detune = patch[off + 20];
+          int32_t freq = osc_freq(midinote, mode, coarse, fine, detune);
+          basepitch_[op] = freq;
+          params_[op].phase = 0;
+          params_[op].gain[1] = 0;
+        }
+        for (int i = 0; i < 4; i++) {
+          rates[i] = patch[126 + i];
+          levels[i] = patch[130 + i];
+        }
+        pitchenv_.set(rates, levels);
+        algorithm_ = patch[134];
+        int feedback = patch[135];
+        fb_shift_ = feedback != 0 ? 8 - feedback : 16;
+        pitchmoddepth_ = (patch[139] * 165) >> 6;
+        pitchmodsens_ = pitchmodsenstab[patch[143] & 7];
+      }
+
+      void Dx7Note::compute(int32_t* buf, int32_t lfo_val, int32_t lfo_delay,
+                            const Controllers* ctrls) {
+        int32_t pitchmod = pitchenv_.getsample();
+        uint32_t pmd = pitchmoddepth_ * lfo_delay; // Q32
+        // TODO: add modulation sources (mod wheel, etc)
+        int32_t senslfo = pitchmodsens_ * (lfo_val - (1 << 23));
+        pitchmod += (((int64_t)pmd) * (int64_t)senslfo) >> 39;
+
+        // hardcodes a pitchbend range of 3 semitones, TODO make configurable
+        int pitchbend = ctrls->values_[kControllerPitch];
+        int32_t pb = (pitchbend - 0x2000) << 9;
+        pitchmod += pb;
+        for (int op = 0; op < 6; op++) {
+          params_[op].gain[0] = params_[op].gain[1];
+          int32_t level = env_[op].getsample();
+          int32_t gain = Exp2::lookup(level - (14 * (1 << 24)));
+          params_[op].freq = Freqlut::lookup(basepitch_[op] + pitchmod);
+          params_[op].gain[1] = gain;
+        }
+        core_.compute(buf, params_, algorithm_, fb_buf_, fb_shift_);
+      }
+
+      void Dx7Note::keyup() {
+        for (int op = 0; op < 6; op++) {
+          env_[op].keydown(false);
+          pitchenv_.keydown(false);
+        }
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/fm/msfa/dx7note.h
+++ b/YseEngine/dsp/fm/msfa/dx7note.h
@@ -1,0 +1,69 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; the init() parameter is spelled patch[156] to
+ * match the unpacked-voice length the implementation actually reads. Upstream
+ * Apache-2.0 license header preserved below; see the repository NOTICE file
+ * for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YSE_DSP_FM_MSFA_DX7NOTE_H
+#define YSE_DSP_FM_MSFA_DX7NOTE_H
+
+// This is the logic to put together a note from the MIDI description
+// and run the low-level modules.
+
+#include "env.h"
+#include "pitchenv.h"
+#include "fm_core.h"
+#include "controllers.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      class Dx7Note {
+      public:
+        void init(const char patch[156], int midinote, int velocity);
+
+        // Note: this _adds_ to the buffer.
+        void compute(int32_t* buf, int32_t lfo_val, int32_t lfo_delay, const Controllers* ctrls);
+
+        void keyup();
+
+      private:
+        FmCore core_;
+        Env env_[6];
+        FmOpParams params_[6];
+        PitchEnv pitchenv_;
+        int32_t basepitch_[6];
+        int32_t fb_buf_[2];
+        int32_t fb_shift_;
+
+        int algorithm_;
+        int pitchmoddepth_;
+        int pitchmodsens_;
+      };
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_DX7NOTE_H

--- a/YseEngine/dsp/fm/msfa/env.cc
+++ b/YseEngine/dsp/fm/msfa/env.cc
@@ -1,0 +1,113 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "synth.h"
+#include "env.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      void Env::init(const int r[4], const int l[4], int32_t ol, int rate_scaling) {
+        for (int i = 0; i < 4; i++) {
+          rates_[i] = r[i];
+          levels_[i] = l[i];
+        }
+        outlevel_ = ol;
+        rate_scaling_ = rate_scaling;
+        level_ = 0;
+        down_ = true;
+        advance(0);
+      }
+
+      int32_t Env::getsample() {
+        if (ix_ < 3 || ((ix_ < 4) && !down_)) {
+          if (rising_) {
+            const int jumptarget = 1716;
+            if (level_ < (jumptarget << 16)) {
+              level_ = jumptarget << 16;
+            }
+            level_ += (((17 << 24) - level_) >> 24) * inc_;
+            // TODO: should probably be more accurate when inc is large
+            if (level_ >= targetlevel_) {
+              level_ = targetlevel_;
+              advance(ix_ + 1);
+            }
+          } else { // !rising
+            level_ -= inc_;
+            if (level_ <= targetlevel_) {
+              level_ = targetlevel_;
+              advance(ix_ + 1);
+            }
+          }
+        }
+        // TODO: this would be a good place to set level to 0 when under threshold
+        return level_;
+      }
+
+      void Env::keydown(bool d) {
+        if (down_ != d) {
+          down_ = d;
+          advance(d ? 0 : 3);
+        }
+      }
+
+      void Env::setparam(int param, int value) {
+        if (param < 4) {
+          rates_[param] = value;
+        } else if (param < 8) {
+          levels_[param - 4] = value;
+        }
+        // Unknown parameter, ignore for now
+      }
+
+      const int levellut[] = {0, 5, 9, 13, 17, 20, 23, 25, 27, 29,
+                              31, 33, 35, 37, 39, 41, 42, 43, 45, 46};
+
+      int Env::scaleoutlevel(int outlevel) {
+        return outlevel >= 20 ? 28 + outlevel : levellut[outlevel];
+      }
+
+      void Env::advance(int newix) {
+        ix_ = newix;
+        if (ix_ < 4) {
+          int newlevel = levels_[ix_];
+          int actuallevel = scaleoutlevel(newlevel) >> 1;
+          actuallevel = (actuallevel << 6) + outlevel_ - 4256;
+          actuallevel = actuallevel < 16 ? 16 : actuallevel;
+          // level here is same as Java impl
+          targetlevel_ = actuallevel << 16;
+          rising_ = (targetlevel_ > level_);
+
+          // rate
+          int qrate = (rates_[ix_] * 41) >> 6;
+          qrate += rate_scaling_;
+          qrate = min(qrate, 63);
+          inc_ = (4 + (qrate & 3)) << (2 + LG_N + (qrate >> 2));
+        }
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/fm/msfa/env.h
+++ b/YseEngine/dsp/fm/msfa/env.h
@@ -1,0 +1,75 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YSE_DSP_FM_MSFA_ENV_H
+#define YSE_DSP_FM_MSFA_ENV_H
+
+#include <stdint.h>
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      // DX7 envelope generation
+
+      class Env {
+      public:
+        // The rates and levels arrays are calibrated to match the Dx7 parameters
+        // (ie, value 0..99). The outlevel parameter is calibrated in microsteps
+        // (ie units of approx .023 dB), with 99 * 32 = nominal full scale. The
+        // rate_scaling parameter is in qRate units (ie 0..63).
+        void init(const int rates[4], const int levels[4], int outlevel, int rate_scaling);
+
+        // Result is in Q24/doubling log format. Also, result is subsampled
+        // for every N samples.
+        int32_t getsample();
+
+        void keydown(bool down);
+        void setparam(int param, int value);
+        static int scaleoutlevel(int outlevel);
+
+      private:
+        int rates_[4];
+        int levels_[4];
+        int outlevel_;
+        int rate_scaling_;
+        // Level is stored so that 2^24 is one doubling, ie 16 more bits than
+        // the DX7 itself (fraction is stored in level rather than separate
+        // counter)
+        int32_t level_;
+        int targetlevel_;
+        bool rising_;
+        int ix_;
+        int inc_;
+
+        bool down_;
+
+        void advance(int newix);
+      };
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_ENV_H

--- a/YseEngine/dsp/fm/msfa/exp2.cc
+++ b/YseEngine/dsp/fm/msfa/exp2.cc
@@ -1,0 +1,52 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; the upstream Tanh table (resonant-filter only) was
+ * dropped. Upstream Apache-2.0 license header preserved below; see the
+ * repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <math.h>
+
+#include "synth.h"
+#include "exp2.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      int32_t exp2tab[EXP2_N_SAMPLES << 1];
+
+      void Exp2::init() {
+        double inc = exp2(1.0 / EXP2_N_SAMPLES);
+        double y = 1 << 30;
+        for (int i = 0; i < EXP2_N_SAMPLES; i++) {
+          exp2tab[(i << 1) + 1] = (int32_t)floor(y + 0.5);
+          y *= inc;
+        }
+        for (int i = 0; i < EXP2_N_SAMPLES - 1; i++) {
+          exp2tab[i << 1] = exp2tab[(i << 1) + 3] - exp2tab[(i << 1) + 1];
+        }
+        exp2tab[(EXP2_N_SAMPLES << 1) - 2] = (1U << 31) - exp2tab[(EXP2_N_SAMPLES << 1) - 1];
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/fm/msfa/exp2.h
+++ b/YseEngine/dsp/fm/msfa/exp2.h
@@ -1,0 +1,70 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; the upstream Tanh table (used only by the
+ * resonant-filter module, which this port does not include) was dropped.
+ * Upstream Apache-2.0 license header preserved below; see the repository
+ * NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YSE_DSP_FM_MSFA_EXP2_H
+#define YSE_DSP_FM_MSFA_EXP2_H
+
+#include <stdint.h>
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      class Exp2 {
+      public:
+        Exp2();
+
+        static void init();
+
+        // Q24 in, Q24 out
+        static int32_t lookup(int32_t x);
+      };
+
+#define EXP2_LG_N_SAMPLES 10
+#define EXP2_N_SAMPLES (1 << EXP2_LG_N_SAMPLES)
+
+#define EXP2_INLINE
+
+      extern int32_t exp2tab[EXP2_N_SAMPLES << 1];
+
+#ifdef EXP2_INLINE
+      inline int32_t Exp2::lookup(int32_t x) {
+        const int SHIFT = 24 - EXP2_LG_N_SAMPLES;
+        int lowbits = x & ((1 << SHIFT) - 1);
+        int x_int = (x >> (SHIFT - 1)) & ((EXP2_N_SAMPLES - 1) << 1);
+        int dy = exp2tab[x_int];
+        int y0 = exp2tab[x_int + 1];
+
+        int y = y0 + (((int64_t)dy * (int64_t)lowbits) >> SHIFT);
+        return y >> (6 - (x >> 24));
+      }
+#endif
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_EXP2_H

--- a/YseEngine/dsp/fm/msfa/fm_core.cc
+++ b/YseEngine/dsp/fm/msfa/fm_core.cc
@@ -1,0 +1,124 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; the debug-only FmCore::dump() / n_out() helpers
+ * were removed. The 32 DX7 algorithm routing tables are preserved verbatim.
+ * Upstream Apache-2.0 license header preserved below; see the repository
+ * NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "synth.h"
+#include "fm_op_kernel.h"
+#include "fm_core.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      enum FmOperatorFlags {
+        OUT_BUS_ONE = 1 << 0,
+        OUT_BUS_TWO = 1 << 1,
+        OUT_BUS_ADD = 1 << 2,
+        IN_BUS_ONE = 1 << 4,
+        IN_BUS_TWO = 1 << 5,
+        FB_IN = 1 << 6,
+        FB_OUT = 1 << 7
+      };
+
+      struct FmAlgorithm {
+        int ops[6];
+      };
+
+      const FmAlgorithm algorithms[32] = {
+          {{0xc1, 0x11, 0x11, 0x14, 0x01, 0x14}}, // 1
+          {{0x01, 0x11, 0x11, 0x14, 0xc1, 0x14}}, // 2
+          {{0xc1, 0x11, 0x14, 0x01, 0x11, 0x14}}, // 3
+          {{0x41, 0x11, 0x94, 0x01, 0x11, 0x14}}, // 4
+          {{0xc1, 0x14, 0x01, 0x14, 0x01, 0x14}}, // 5
+          {{0x41, 0x94, 0x01, 0x14, 0x01, 0x14}}, // 6
+          {{0xc1, 0x11, 0x05, 0x14, 0x01, 0x14}}, // 7
+          {{0x01, 0x11, 0xc5, 0x14, 0x01, 0x14}}, // 8
+          {{0x01, 0x11, 0x05, 0x14, 0xc1, 0x14}}, // 9
+          {{0x01, 0x05, 0x14, 0xc1, 0x11, 0x14}}, // 10
+          {{0xc1, 0x05, 0x14, 0x01, 0x11, 0x14}}, // 11
+          {{0x01, 0x05, 0x05, 0x14, 0xc1, 0x14}}, // 12
+          {{0xc1, 0x05, 0x05, 0x14, 0x01, 0x14}}, // 13
+          {{0xc1, 0x05, 0x11, 0x14, 0x01, 0x14}}, // 14
+          {{0x01, 0x05, 0x11, 0x14, 0xc1, 0x14}}, // 15
+          {{0xc1, 0x11, 0x02, 0x25, 0x05, 0x14}}, // 16
+          {{0x01, 0x11, 0x02, 0x25, 0xc5, 0x14}}, // 17
+          {{0x01, 0x11, 0x11, 0xc5, 0x05, 0x14}}, // 18
+          {{0xc1, 0x14, 0x14, 0x01, 0x11, 0x14}}, // 19
+          {{0x01, 0x05, 0x14, 0xc1, 0x14, 0x14}}, // 20
+          {{0x01, 0x14, 0x14, 0xc1, 0x14, 0x14}}, // 21
+          {{0xc1, 0x14, 0x14, 0x14, 0x01, 0x14}}, // 22
+          {{0xc1, 0x14, 0x14, 0x01, 0x14, 0x04}}, // 23
+          {{0xc1, 0x14, 0x14, 0x14, 0x04, 0x04}}, // 24
+          {{0xc1, 0x14, 0x14, 0x04, 0x04, 0x04}}, // 25
+          {{0xc1, 0x05, 0x14, 0x01, 0x14, 0x04}}, // 26
+          {{0x01, 0x05, 0x14, 0xc1, 0x14, 0x04}}, // 27
+          {{0x04, 0xc1, 0x11, 0x14, 0x01, 0x14}}, // 28
+          {{0xc1, 0x14, 0x01, 0x14, 0x04, 0x04}}, // 29
+          {{0x04, 0xc1, 0x11, 0x14, 0x04, 0x04}}, // 30
+          {{0xc1, 0x14, 0x04, 0x04, 0x04, 0x04}}, // 31
+          {{0xc4, 0x04, 0x04, 0x04, 0x04, 0x04}}, // 32
+      };
+
+      void FmCore::compute(int32_t* output, FmOpParams* params, int algorithm, int32_t* fb_buf,
+                           int feedback_shift) {
+        const int kLevelThresh = 1120;
+        const FmAlgorithm alg = algorithms[algorithm];
+        bool has_contents[3] = {true, false, false};
+        for (int op = 0; op < 6; op++) {
+          int flags = alg.ops[op];
+          bool add = (flags & OUT_BUS_ADD) != 0;
+          FmOpParams& param = params[op];
+          int inbus = (flags >> 4) & 3;
+          int outbus = flags & 3;
+          int32_t* outptr = (outbus == 0) ? output : buf_[outbus - 1].get();
+          int32_t gain1 = param.gain[0];
+          int32_t gain2 = param.gain[1];
+          if (gain1 >= kLevelThresh || gain2 >= kLevelThresh) {
+            if (!has_contents[outbus]) {
+              add = false;
+            }
+            if (inbus == 0 || !has_contents[inbus]) {
+              // todo: more than one op in a feedback loop
+              if ((flags & 0xc0) == 0xc0 && feedback_shift < 16) {
+                FmOpKernel::compute_fb(outptr, param.phase, param.freq, gain1, gain2, fb_buf,
+                                       feedback_shift, add);
+              } else {
+                FmOpKernel::compute_pure(outptr, param.phase, param.freq, gain1, gain2, add);
+              }
+            } else {
+              FmOpKernel::compute(outptr, buf_[inbus - 1].get(), param.phase, param.freq, gain1,
+                                  gain2, add);
+            }
+            has_contents[outbus] = true;
+          } else if (!add) {
+            has_contents[outbus] = false;
+          }
+          param.phase += param.freq << LG_N;
+        }
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/fm/msfa/fm_core.h
+++ b/YseEngine/dsp/fm/msfa/fm_core.h
@@ -1,0 +1,62 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; the debug-only dump() method was removed.
+ * Upstream Apache-2.0 license header preserved below; see the repository
+ * NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YSE_DSP_FM_MSFA_FM_CORE_H
+#define YSE_DSP_FM_MSFA_FM_CORE_H
+
+#include <stdint.h>
+
+#include "synth.h"
+#include "aligned_buf.h"
+#include "fm_op_kernel.h"
+#include "controllers.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      struct FmOpParams {
+        int32_t gain[2];
+        int32_t freq;
+        int32_t phase;
+      };
+
+      class FmCore {
+      public:
+        void compute(int32_t* output, FmOpParams* params, int algorithm, int32_t* fb_buf,
+                     int32_t feedback_gain);
+
+      private:
+        AlignedBuf<int32_t, N> buf_[2];
+      };
+
+      // Number of DX7 FM algorithms.
+      const int kNumAlgorithms = 32;
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_FM_CORE_H

--- a/YseEngine/dsp/fm/msfa/fm_op_kernel.cc
+++ b/YseEngine/dsp/fm/msfa/fm_op_kernel.cc
@@ -1,0 +1,116 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; the upstream ARM-NEON fast path and the disabled
+ * (#if 0) experimental sine generators were removed, leaving the portable
+ * scalar kernels. Upstream Apache-2.0 license header preserved below; see the
+ * repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <math.h>
+
+#include "synth.h"
+
+#include "sin.h"
+#include "fm_op_kernel.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      void FmOpKernel::compute(int32_t* output, const int32_t* input, int32_t phase0, int32_t freq,
+                               int32_t gain1, int32_t gain2, bool add) {
+        int32_t dgain = (gain2 - gain1 + (N >> 1)) >> LG_N;
+        int32_t gain = gain1;
+        int32_t phase = phase0;
+        if (add) {
+          for (int i = 0; i < N; i++) {
+            gain += dgain;
+            int32_t y = Sin::lookup(phase + input[i]);
+            output[i] += ((int64_t)y * (int64_t)gain) >> 24;
+            phase += freq;
+          }
+        } else {
+          for (int i = 0; i < N; i++) {
+            gain += dgain;
+            int32_t y = Sin::lookup(phase + input[i]);
+            output[i] = ((int64_t)y * (int64_t)gain) >> 24;
+            phase += freq;
+          }
+        }
+      }
+
+      void FmOpKernel::compute_pure(int32_t* output, int32_t phase0, int32_t freq, int32_t gain1,
+                                    int32_t gain2, bool add) {
+        int32_t dgain = (gain2 - gain1 + (N >> 1)) >> LG_N;
+        int32_t gain = gain1;
+        int32_t phase = phase0;
+        if (add) {
+          for (int i = 0; i < N; i++) {
+            gain += dgain;
+            int32_t y = Sin::lookup(phase);
+            output[i] += ((int64_t)y * (int64_t)gain) >> 24;
+            phase += freq;
+          }
+        } else {
+          for (int i = 0; i < N; i++) {
+            gain += dgain;
+            int32_t y = Sin::lookup(phase);
+            output[i] = ((int64_t)y * (int64_t)gain) >> 24;
+            phase += freq;
+          }
+        }
+      }
+
+      void FmOpKernel::compute_fb(int32_t* output, int32_t phase0, int32_t freq, int32_t gain1,
+                                  int32_t gain2, int32_t* fb_buf, int fb_shift, bool add) {
+        int32_t dgain = (gain2 - gain1 + (N >> 1)) >> LG_N;
+        int32_t gain = gain1;
+        int32_t phase = phase0;
+        int32_t y0 = fb_buf[0];
+        int32_t y = fb_buf[1];
+        if (add) {
+          for (int i = 0; i < N; i++) {
+            gain += dgain;
+            int32_t scaled_fb = (y0 + y) >> (fb_shift + 1);
+            y0 = y;
+            y = Sin::lookup(phase + scaled_fb);
+            y = ((int64_t)y * (int64_t)gain) >> 24;
+            output[i] += y;
+            phase += freq;
+          }
+        } else {
+          for (int i = 0; i < N; i++) {
+            gain += dgain;
+            int32_t scaled_fb = (y0 + y) >> (fb_shift + 1);
+            y0 = y;
+            y = Sin::lookup(phase + scaled_fb);
+            y = ((int64_t)y * (int64_t)gain) >> 24;
+            output[i] = y;
+            phase += freq;
+          }
+        }
+        fb_buf[0] = y0;
+        fb_buf[1] = y;
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/fm/msfa/fm_op_kernel.h
+++ b/YseEngine/dsp/fm/msfa/fm_op_kernel.h
@@ -1,0 +1,56 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YSE_DSP_FM_MSFA_FM_OP_KERNEL_H
+#define YSE_DSP_FM_MSFA_FM_OP_KERNEL_H
+
+#include <stdint.h>
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      class FmOpKernel {
+      public:
+        // gain1 and gain2 represent linear step: gain for sample i is
+        // gain1 + (1 + i) / 64 * (gain2 - gain1)
+
+        // This is the basic FM operator. No feedback.
+        static void compute(int32_t* output, const int32_t* input, int32_t phase0, int32_t freq,
+                            int32_t gain1, int32_t gain2, bool add);
+
+        // This is a sine generator, no feedback.
+        static void compute_pure(int32_t* output, int32_t phase0, int32_t freq, int32_t gain1,
+                                 int32_t gain2, bool add);
+
+        // One op with feedback, no add.
+        static void compute_fb(int32_t* output, int32_t phase0, int32_t freq, int32_t gain1,
+                               int32_t gain2, int32_t* fb_buf, int fb_gain, bool add);
+      };
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_FM_OP_KERNEL_H

--- a/YseEngine/dsp/fm/msfa/freqlut.cc
+++ b/YseEngine/dsp/fm/msfa/freqlut.cc
@@ -1,0 +1,69 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace (the module-global lookup table is now namespaced);
+ * otherwise unchanged. Upstream Apache-2.0 license header preserved below; see
+ * the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Resolve frequency signal (1.0 in Q24 format = 1 octave) to phase delta.
+
+#include <stdint.h>
+#include <math.h>
+
+#include "freqlut.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+#define LG_N_SAMPLES 10
+#define N_SAMPLES (1 << LG_N_SAMPLES)
+#define SAMPLE_SHIFT (24 - LG_N_SAMPLES)
+
+#define MAX_LOGFREQ_INT 20
+
+      static int32_t lut[N_SAMPLES + 1];
+
+      void Freqlut::init(double sample_rate) {
+        double y = (1LL << (24 + MAX_LOGFREQ_INT)) / sample_rate;
+        double inc = pow(2, 1.0 / N_SAMPLES);
+        for (int i = 0; i < N_SAMPLES + 1; i++) {
+          lut[i] = (int32_t)floor(y + 0.5);
+          y *= inc;
+        }
+      }
+
+      // Note: if logfreq is more than 20.0, the results will be inaccurate. However,
+      // that will be many times the Nyquist rate.
+      int32_t Freqlut::lookup(int32_t logfreq) {
+        int ix = (logfreq & 0xffffff) >> SAMPLE_SHIFT;
+
+        int32_t y0 = lut[ix];
+        int32_t y1 = lut[ix + 1];
+        int lowbits = logfreq & ((1 << SAMPLE_SHIFT) - 1);
+        int32_t y = y0 + ((((int64_t)(y1 - y0) * (int64_t)lowbits)) >> SAMPLE_SHIFT);
+        int hibits = logfreq >> 24;
+        return y >> (MAX_LOGFREQ_INT - hibits);
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/fm/msfa/freqlut.h
+++ b/YseEngine/dsp/fm/msfa/freqlut.h
@@ -1,0 +1,44 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YSE_DSP_FM_MSFA_FREQLUT_H
+#define YSE_DSP_FM_MSFA_FREQLUT_H
+
+#include <stdint.h>
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      class Freqlut {
+      public:
+        static void init(double sample_rate);
+        static int32_t lookup(int32_t logfreq);
+      };
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_FREQLUT_H

--- a/YseEngine/dsp/fm/msfa/lfo.cc
+++ b/YseEngine/dsp/fm/msfa/lfo.cc
@@ -1,0 +1,113 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Low frequency oscillator, compatible with DX7
+
+#include "synth.h"
+
+#include "sin.h"
+#include "lfo.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      uint32_t Lfo::unit_;
+
+      void Lfo::init(double sample_rate) {
+        // constant is 1 << 32 / 15.5s / 11
+        Lfo::unit_ = (int32_t)(N * 25190424 / sample_rate + 0.5);
+      }
+
+      void Lfo::reset(const char params[6]) {
+        int rate = params[0]; // 0..99
+        int sr = rate == 0 ? 1 : (165 * rate) >> 6;
+        sr *= sr < 160 ? 11 : (11 + ((sr - 160) >> 4));
+        delta_ = unit_ * sr;
+        int a = 99 - params[1]; // LFO delay
+        if (a == 99) {
+          delayinc_ = ~0u;
+          delayinc2_ = ~0u;
+        } else {
+          a = (16 + (a & 15)) << (1 + (a >> 4));
+          delayinc_ = unit_ * a;
+          a &= 0xff80;
+          a = max(0x80, a);
+          delayinc2_ = unit_ * a;
+        }
+        waveform_ = params[5];
+        sync_ = params[4] != 0;
+      }
+
+      int32_t Lfo::getsample() {
+        phase_ += delta_;
+        int32_t x;
+        switch (waveform_) {
+        case 0: // triangle
+          x = phase_ >> 7;
+          x ^= -(phase_ >> 31);
+          x &= (1 << 24) - 1;
+          return x;
+        case 1: // sawtooth down
+          return (~phase_ ^ (1U << 31)) >> 8;
+        case 2: // sawtooth up
+          return (phase_ ^ (1U << 31)) >> 8;
+        case 3: // square
+          return ((~phase_) >> 7) & (1 << 24);
+        case 4: // sine
+          return (1 << 23) + (Sin::lookup(phase_ >> 8) >> 1);
+        case 5: // s&h
+          if (phase_ < delta_) {
+            randstate_ = (randstate_ * 179 + 17) & 0xff;
+          }
+          x = randstate_ ^ 0x80;
+          return (x + 1) << 16;
+        }
+        return 1 << 23;
+      }
+
+      int32_t Lfo::getdelay() {
+        uint32_t delta = delaystate_ < (1U << 31) ? delayinc_ : delayinc2_;
+        uint32_t d = delaystate_ + delta;
+        if (d < delayinc_) {
+          return 1 << 24;
+        }
+        delaystate_ = d;
+        if (d < (1U << 31)) {
+          return 0;
+        } else {
+          return (d >> 7) & ((1 << 24) - 1);
+        }
+      }
+
+      void Lfo::keydown() {
+        if (sync_) {
+          phase_ = (1U << 31) - 1;
+        }
+        delaystate_ = 0;
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/fm/msfa/lfo.h
+++ b/YseEngine/dsp/fm/msfa/lfo.h
@@ -1,0 +1,67 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Low frequency oscillator, compatible with DX7
+
+#ifndef YSE_DSP_FM_MSFA_LFO_H
+#define YSE_DSP_FM_MSFA_LFO_H
+
+#include <stdint.h>
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      class Lfo {
+      public:
+        static void init(double sample_rate);
+        void reset(const char params[6]);
+
+        // result is 0..1 in Q24
+        int32_t getsample();
+
+        // result is 0..1 in Q24
+        int32_t getdelay();
+
+        void keydown();
+
+      private:
+        static uint32_t unit_;
+
+        uint32_t phase_; // Q32
+        uint32_t delta_;
+        uint8_t waveform_;
+        uint8_t randstate_;
+        bool sync_;
+
+        uint32_t delaystate_;
+        uint32_t delayinc_;
+        uint32_t delayinc2_;
+      };
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_LFO_H

--- a/YseEngine/dsp/fm/msfa/pitchenv.cc
+++ b/YseEngine/dsp/fm/msfa/pitchenv.cc
@@ -1,0 +1,104 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "synth.h"
+#include "pitchenv.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      int PitchEnv::unit_;
+
+      void PitchEnv::init(double sample_rate) {
+        unit_ = N * (1 << 24) / (21.3 * sample_rate) + 0.5;
+      }
+
+      static uint8_t ratetab[] = {
+          1,   2,   3,   3,   4,   4,   5,   5,   6,   6,   7,   7,   8,   8,   9,   9,   10,
+          10,  11,  11,  12,  12,  13,  13,  14,  14,  15,  16,  16,  17,  18,  18,  19,  20,
+          21,  22,  23,  24,  25,  26,  27,  28,  30,  31,  33,  34,  36,  37,  38,  39,  41,
+          42,  44,  46,  47,  49,  51,  53,  54,  56,  58,  60,  62,  64,  66,  68,  70,  72,
+          74,  76,  79,  82,  85,  88,  91,  94,  98,  102, 106, 110, 115, 120, 125, 130, 135,
+          141, 147, 153, 159, 165, 171, 178, 185, 193, 202, 211, 232, 243, 254, 255};
+
+      static int8_t pitchtab[] = {
+          -128, -116, -104, -95, -85, -76, -68, -61, -56, -52, -49, -46, -43, -41, -39, -37,
+          -35,  -33,  -32,  -31, -30, -29, -28, -27, -26, -25, -24, -23, -22, -21, -20, -19,
+          -18,  -17,  -16,  -15, -14, -13, -12, -11, -10, -9,  -8,  -7,  -6,  -5,  -4,  -3,
+          -2,   -1,   0,    1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,
+          14,   15,   16,   17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
+          30,   31,   32,   33,  34,  35,  38,  40,  43,  46,  49,  53,  58,  65,  73,  82,
+          92,   103,  115,  127};
+
+      void PitchEnv::set(const int r[4], const int l[4]) {
+        for (int i = 0; i < 4; i++) {
+          rates_[i] = r[i];
+          levels_[i] = l[i];
+        }
+        level_ = pitchtab[l[3]] << 19;
+        down_ = true;
+        advance(0);
+      }
+
+      int32_t PitchEnv::getsample() {
+        if (ix_ < 3 || ((ix_ < 4) && !down_)) {
+          if (rising_) {
+            level_ += inc_;
+            if (level_ >= targetlevel_) {
+              level_ = targetlevel_;
+              advance(ix_ + 1);
+            }
+          } else { // !rising
+            level_ -= inc_;
+            if (level_ <= targetlevel_) {
+              level_ = targetlevel_;
+              advance(ix_ + 1);
+            }
+          }
+        }
+        return level_;
+      }
+
+      void PitchEnv::keydown(bool d) {
+        if (down_ != d) {
+          down_ = d;
+          advance(d ? 0 : 3);
+        }
+      }
+
+      void PitchEnv::advance(int newix) {
+        ix_ = newix;
+        if (ix_ < 4) {
+          int newlevel = levels_[ix_];
+          targetlevel_ = pitchtab[newlevel] << 19;
+          rising_ = (targetlevel_ > level_);
+
+          inc_ = ratetab[rates_[ix_]] * unit_;
+        }
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/fm/msfa/pitchenv.h
+++ b/YseEngine/dsp/fm/msfa/pitchenv.h
@@ -1,0 +1,68 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YSE_DSP_FM_MSFA_PITCHENV_H
+#define YSE_DSP_FM_MSFA_PITCHENV_H
+
+#include <stdint.h>
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      // Computation of the DX7 pitch envelope
+
+      class PitchEnv {
+      public:
+        static void init(double sample_rate);
+
+        // The rates and levels arrays are calibrated to match the Dx7 parameters
+        // (ie, value 0..99).
+        void set(const int rates[4], const int levels[4]);
+
+        // Result is in Q24/octave
+        int32_t getsample();
+
+        void keydown(bool down);
+
+      private:
+        static int unit_;
+        int rates_[4];
+        int levels_[4];
+        int32_t level_;
+        int targetlevel_;
+        bool rising_;
+        int ix_;
+        int inc_;
+
+        bool down_;
+
+        void advance(int newix);
+      };
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_PITCHENV_H

--- a/YseEngine/dsp/fm/msfa/sin.cc
+++ b/YseEngine/dsp/fm/msfa/sin.cc
@@ -1,0 +1,140 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; the disabled (#if 0) experimental table-free sine
+ * generators of the upstream file were dropped. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <math.h>
+
+#include "synth.h"
+#include "sin.h"
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+#define R (1 << 29)
+
+#ifdef SIN_DELTA
+      int32_t sintab[SIN_N_SAMPLES << 1];
+#else
+      int32_t sintab[SIN_N_SAMPLES + 1];
+#endif
+
+      void Sin::init() {
+        double dphase = 2 * M_PI / SIN_N_SAMPLES;
+        int32_t c = (int32_t)floor(cos(dphase) * (1 << 30) + 0.5);
+        int32_t s = (int32_t)floor(sin(dphase) * (1 << 30) + 0.5);
+        int32_t u = 1 << 30;
+        int32_t v = 0;
+        for (int i = 0; i < SIN_N_SAMPLES / 2; i++) {
+#ifdef SIN_DELTA
+          sintab[(i << 1) + 1] = (v + 32) >> 6;
+          sintab[((i + SIN_N_SAMPLES / 2) << 1) + 1] = -((v + 32) >> 6);
+#else
+          sintab[i] = (v + 32) >> 6;
+          sintab[i + SIN_N_SAMPLES / 2] = -((v + 32) >> 6);
+#endif
+          int32_t t = ((int64_t)u * (int64_t)s + (int64_t)v * (int64_t)c + R) >> 30;
+          u = ((int64_t)u * (int64_t)c - (int64_t)v * (int64_t)s + R) >> 30;
+          v = t;
+        }
+#ifdef SIN_DELTA
+        for (int i = 0; i < SIN_N_SAMPLES - 1; i++) {
+          sintab[i << 1] = sintab[(i << 1) + 3] - sintab[(i << 1) + 1];
+        }
+        sintab[(SIN_N_SAMPLES << 1) - 2] = -sintab[(SIN_N_SAMPLES << 1) - 1];
+#else
+        sintab[SIN_N_SAMPLES] = 0;
+#endif
+      }
+
+#ifndef SIN_INLINE
+      int32_t Sin::lookup(int32_t phase) {
+        const int SHIFT = 24 - SIN_LG_N_SAMPLES;
+        int lowbits = phase & ((1 << SHIFT) - 1);
+#ifdef SIN_DELTA
+        int phase_int = (phase >> (SHIFT - 1)) & ((SIN_N_SAMPLES - 1) << 1);
+        int dy = sintab[phase_int];
+        int y0 = sintab[phase_int + 1];
+
+        return y0 + (((int64_t)dy * (int64_t)lowbits) >> SHIFT);
+#else
+        int phase_int = (phase >> SHIFT) & (SIN_N_SAMPLES - 1);
+        int y0 = sintab[phase_int];
+        int y1 = sintab[phase_int + 1];
+
+        return y0 + (((int64_t)(y1 - y0) * (int64_t)lowbits) >> SHIFT);
+#endif
+      }
+#endif
+
+// coefficients are Chebyshev polynomial, computed by compute_cos_poly.py
+#define C8_0 16777216
+#define C8_2 -331168742
+#define C8_4 1089453524
+#define C8_6 -1430910663
+#define C8_8 950108533
+
+      int32_t Sin::compute(int32_t phase) {
+        int32_t x = (phase & ((1 << 23) - 1)) - (1 << 22);
+        int32_t x2 = ((int64_t)x * (int64_t)x) >> 16;
+        int32_t y = (((((((((((((int64_t)C8_8 * (int64_t)x2) >> 32) + C8_6) * (int64_t)x2) >> 32) +
+                            C8_4) *
+                           (int64_t)x2) >>
+                          32) +
+                         C8_2) *
+                        (int64_t)x2) >>
+                       32) +
+                      C8_0);
+        y ^= -((phase >> 23) & 1);
+        return y;
+      }
+
+#define C10_0 (1 << 30)
+#define C10_2 -1324675874 // scaled * 4
+#define C10_4 1089501821
+#define C10_6 -1433689867
+#define C10_8 1009356886
+#define C10_10 -421101352
+      int32_t Sin::compute10(int32_t phase) {
+        int32_t x = (phase & ((1 << 29) - 1)) - (1 << 28);
+        int32_t x2 = ((int64_t)x * (int64_t)x) >> 26;
+        int32_t y =
+            ((((((((((((((((int64_t)C10_10 * (int64_t)x2) >> 34) + C10_8) * (int64_t)x2) >> 34) +
+                       C10_6) *
+                      (int64_t)x2) >>
+                     34) +
+                    C10_4) *
+                   (int64_t)x2) >>
+                  32) +
+                 C10_2) *
+                (int64_t)x2) >>
+               30) +
+              C10_0);
+        y ^= -((phase >> 29) & 1);
+        return y;
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/fm/msfa/sin.h
+++ b/YseEngine/dsp/fm/msfa/sin.h
@@ -1,0 +1,84 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Wrapped in the
+ * YSE::DSP::msfa namespace; otherwise unchanged. Upstream Apache-2.0 license
+ * header preserved below; see the repository NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YSE_DSP_FM_MSFA_SIN_H
+#define YSE_DSP_FM_MSFA_SIN_H
+
+#include <stdint.h>
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+      class Sin {
+      public:
+        Sin();
+
+        static void init();
+        static int32_t lookup(int32_t phase);
+        static int32_t compute(int32_t phase);
+
+        // A more accurate sine, both input and output Q30
+        static int32_t compute10(int32_t phase);
+      };
+
+#define SIN_LG_N_SAMPLES 10
+#define SIN_N_SAMPLES (1 << SIN_LG_N_SAMPLES)
+
+#define SIN_INLINE
+
+// Use twice as much RAM for the LUT but avoid a little computation
+#define SIN_DELTA
+
+#ifdef SIN_DELTA
+      extern int32_t sintab[SIN_N_SAMPLES << 1];
+#else
+      extern int32_t sintab[SIN_N_SAMPLES + 1];
+#endif
+
+#ifdef SIN_INLINE
+      inline int32_t Sin::lookup(int32_t phase) {
+        const int SHIFT = 24 - SIN_LG_N_SAMPLES;
+        int lowbits = phase & ((1 << SHIFT) - 1);
+#ifdef SIN_DELTA
+        int phase_int = (phase >> (SHIFT - 1)) & ((SIN_N_SAMPLES - 1) << 1);
+        int dy = sintab[phase_int];
+        int y0 = sintab[phase_int + 1];
+
+        return y0 + (((int64_t)dy * (int64_t)lowbits) >> SHIFT);
+#else
+        int phase_int = (phase >> SHIFT) & (SIN_N_SAMPLES - 1);
+        int y0 = sintab[phase_int];
+        int y1 = sintab[phase_int + 1];
+
+        return y0 + (((int64_t)(y1 - y0) * (int64_t)lowbits) >> SHIFT);
+#endif
+      }
+#endif
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_SIN_H

--- a/YseEngine/dsp/fm/msfa/synth.h
+++ b/YseEngine/dsp/fm/msfa/synth.h
@@ -1,0 +1,59 @@
+/*
+ * Derived from music-synthesizer-for-android (MSFA):
+ *   https://github.com/google/music-synthesizer-for-android
+ * Ported into the YSE sound engine for issue #176. Adapted for engine
+ * integration: wrapped in the YSE::DSP::msfa namespace; the Android/Apple
+ * memory-barrier and ARM-NEON scaffolding of the upstream synth.h has been
+ * removed (the desktop/engine build uses the scalar kernels only). The
+ * upstream Apache-2.0 license header is preserved below; see the repository
+ * NOTICE file for attribution.
+ */
+
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YSE_DSP_FM_MSFA_SYNTH_H
+#define YSE_DSP_FM_MSFA_SYNTH_H
+
+#include <stdint.h>
+
+namespace YSE {
+  namespace DSP {
+    namespace msfa {
+
+// The FM core processes in fixed blocks of N = 64 samples.
+#define LG_N 6
+#define N (1 << LG_N)
+
+      template <typename T> inline static T min(const T& a, const T& b) {
+        return a < b ? a : b;
+      }
+
+      template <typename T> inline static T max(const T& a, const T& b) {
+        return a > b ? a : b;
+      }
+
+      // The engine build ships the portable scalar kernels; the upstream
+      // ARM-NEON fast path is intentionally not compiled in.
+      inline static bool hasNeon() {
+        return false;
+      }
+
+    } // namespace msfa
+  } // namespace DSP
+} // namespace YSE
+
+#endif // YSE_DSP_FM_MSFA_SYNTH_H


### PR DESCRIPTION
## Summary

Adds a DX7-class 6-operator FM synthesiser voice, ported from
**music-synthesizer-for-android** (MSFA, Apache-2.0), as a `SYNTH::dspVoice`
subclass. Covers 6 operators, the 32 DX7 algorithms, per-operator rate/level
envelopes, feedback, key/velocity scaling, the pitch envelope and the DX7 LFO.

## Linked issue

Closes #176

## Provenance & licensing (Apache-2.0)

- The FM core under `YseEngine/dsp/fm/msfa/` is derived from MSFA
  (https://github.com/google/music-synthesizer-for-android), the Apache-2.0
  core only. **None of Dexed's GPL wrapper code is used.**
- Each ported file keeps its upstream Apache-2.0 header; adaptations
  (wrapped in the `YSE::DSP::msfa` namespace, Android/JNI + ARM-NEON
  scaffolding removed, debug helpers dropped) are noted at the top of each
  file. Attribution added to a new top-level `NOTICE`.
- The ported files use the upstream `.cc`/`.h` extensions and are treated like
  vendored code: compiler warnings suppressed per-file in CMake, and they fall
  outside the `yse.py analyze` glob (`*.cpp` only).

## The `#177` contract

`fmPatch` (`dsp/fm/fmPatch.hpp`) is the explicit data contract the DX7 SysEx
importer (#177) will populate: the full DX7 155-parameter voice as **named
fields** (6 operators × 21 params + global pitch EG, algorithm, feedback, LFO,
transpose, name, op-enable mask). `fmPatch::toUnpacked(char[156])` serialises
it to the exact byte layout `msfa::Dx7Note::init` consumes; a test locks those
offsets so #177 can rely on them.

## Real-time discipline

`fmVoice` holds the fixed-point core behind a PIMPL (so its macros never leak
into headers/tests). All allocation is in the constructor / `clone()` (setup
thread); `process()` allocates nothing, locks nothing, blocks on nothing.
Rate-dependent global tables are built once on the setup thread, guarded by a
mutex, never on the audio thread.

## Changes

- `YseEngine/dsp/fm/msfa/` — ported MSFA core (sin/exp2/freqlut/lfo/env/
  pitchenv/fm_op_kernel/fm_core/dx7note + support headers).
- `YseEngine/dsp/fm/fmPatch.{hpp,cpp}` — DX7 patch struct + `toUnpacked` +
  three built-in voices (sine, 2-op FM, brass).
- `YseEngine/dsp/fm/fmVoice.{hpp,cpp}` — the `dspVoice` FM voice.
- `NOTICE` — Apache-2.0 attribution.
- `Tests/dsp/test_fm_voice.cpp` — new tests; wired into CMake.

## Non-goals (untouched)

DX7 SysEx import (#177), instrument C-API (#178).

## Test plan

- [x] `clang-format --dry-run --Werror` clean on the gated new files (`.h/.hpp/.cpp`; clang-format 22.1.4)
- [x] `python yse.py analyze YseEngine/dsp/fm` + test file — no findings in user code (ported `.cc` are outside the glob; MSFA header warnings suppressed via HeaderFilterRegex)
- [x] `python yse.py test` — **23/23 ctest suites pass, 0 failed**; the `dsp` suite is 336 cases / 60653 assertions. New FM tests: lifecycle (play→release→stop), rendered pitch (FFT peak within 3 bins), carrier+sideband spectrum (2-op FM has ~250× the 2f energy of the sine reference), all 32 algorithms render finite non-silent audio, clone independence, no-alloc-in-`process()`, and the `fmPatch` byte-layout contract.
