### PR TITLE
DSP: DX7 SysEx bank import (#177)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(YSE_TEST_SOURCES
   dsp/test_ladder_filter.cpp
   dsp/test_va_voice.cpp
   dsp/test_fm_voice.cpp
+  dsp/test_dx7_sysex.cpp
   patcher/test_graph.cpp
   patcher/test_nodes.cpp
   patcher/test_patcher_math.cpp

--- a/Tests/dsp/test_dx7_sysex.cpp
+++ b/Tests/dsp/test_dx7_sysex.cpp
@@ -1,0 +1,329 @@
+// Tests for YSE::SYNTH::dx7SysEx (issue #177) — the DX7 SysEx bank importer.
+//
+// Coverage:
+//   - a 32-voice packed bulk dump parses to 32 voices with correct names,
+//   - header-variant tolerance (arbitrary SysEx channel, leading/trailing
+//     junk around the F0…F7 block, bare unframed payloads),
+//   - checksum validation (a corrupted payload is rejected),
+//   - corrupt-input robustness (truncated / unrecognised length → no crash),
+//   - a single-voice unpacked dump round-trips,
+//   - ACCEPTANCE (#177): a parsed voice audibly matches its in-code #176
+//     equivalent — the fmVoice rendered from the parsed patch is sample-for-
+//     sample identical to the fmVoice rendered from fmPatch::fm2op().
+//
+// The fixtures are generated deterministically in-test by packing the #176
+// built-in voices into the documented DX7 SysEx layout — no copyrighted
+// factory bank is committed.
+
+#include <doctest/doctest.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "dsp/fm/dx7Sysex.hpp"
+#include "dsp/fm/fmPatch.hpp"
+#include "dsp/fm/fmVoice.hpp"
+#include "support/audio_helpers.hpp"
+
+TEST_SUITE("dsp") {
+
+  using YSE::SOUND_STATUS;
+  using YSE::SYNTH::dx7Bank;
+  using YSE::SYNTH::dx7SysEx;
+  using YSE::SYNTH::fmOperator;
+  using YSE::SYNTH::fmPatch;
+  using YSE::SYNTH::fmVoice;
+
+  // ─── in-test fixture generation (inverse of the importer's unpackers) ──────
+
+  // Pack one fmPatch into its 128-byte DX7 packed-voice representation.
+  static void packVoice(const fmPatch& p, uint8_t out[128]) {
+    std::memset(out, 0, 128);
+    for (int op = 0; op < 6; ++op) {
+      const fmOperator& o = p.op[op];
+      uint8_t* d = out + op * 17;
+      for (int i = 0; i < 4; ++i) {
+        d[i] = o.egRate[i];
+        d[4 + i] = o.egLevel[i];
+      }
+      d[8] = o.levelScaleBreakPoint;
+      d[9] = o.levelScaleLeftDepth;
+      d[10] = o.levelScaleRightDepth;
+      d[11] = (o.levelScaleLeftCurve & 0x03) | ((o.levelScaleRightCurve & 0x03) << 2);
+      d[12] = (o.rateScaling & 0x07) | ((o.detune & 0x0f) << 3);
+      d[13] = (o.ampModSens & 0x03) | ((o.keyVelSens & 0x07) << 2);
+      d[14] = o.outputLevel;
+      d[15] = (o.oscMode & 0x01) | ((o.freqCoarse & 0x1f) << 1);
+      d[16] = o.freqFine;
+    }
+    uint8_t* g = out + 102;
+    for (int i = 0; i < 4; ++i) {
+      g[i] = p.pitchEgRate[i];
+      g[4 + i] = p.pitchEgLevel[i];
+    }
+    g[8] = p.algorithm & 0x1f;
+    g[9] = (p.feedback & 0x07) | ((p.oscKeySync & 0x01) << 3);
+    g[10] = p.lfoSpeed;
+    g[11] = p.lfoDelay;
+    g[12] = p.lfoPitchModDepth;
+    g[13] = p.lfoAmpModDepth;
+    g[14] = (p.lfoSync & 0x01) | ((p.lfoWaveform & 0x07) << 1) | ((p.pitchModSens & 0x07) << 4);
+    g[15] = p.transpose;
+    for (int i = 0; i < 10; ++i)
+      g[16 + i] = static_cast<uint8_t>(p.name[i]);
+  }
+
+  // Pack one fmPatch into its 155-byte DX7 unpacked-voice representation.
+  static void packUnpackedVoice(const fmPatch& p, uint8_t out[155]) {
+    std::memset(out, 0, 155);
+    for (int op = 0; op < 6; ++op) {
+      const fmOperator& o = p.op[op];
+      uint8_t* s = out + op * 21;
+      for (int i = 0; i < 4; ++i) {
+        s[i] = o.egRate[i];
+        s[4 + i] = o.egLevel[i];
+      }
+      s[8] = o.levelScaleBreakPoint;
+      s[9] = o.levelScaleLeftDepth;
+      s[10] = o.levelScaleRightDepth;
+      s[11] = o.levelScaleLeftCurve;
+      s[12] = o.levelScaleRightCurve;
+      s[13] = o.rateScaling;
+      s[14] = o.ampModSens;
+      s[15] = o.keyVelSens;
+      s[16] = o.outputLevel;
+      s[17] = o.oscMode;
+      s[18] = o.freqCoarse;
+      s[19] = o.freqFine;
+      s[20] = o.detune;
+    }
+    for (int i = 0; i < 4; ++i) {
+      out[126 + i] = p.pitchEgRate[i];
+      out[130 + i] = p.pitchEgLevel[i];
+    }
+    out[134] = p.algorithm;
+    out[135] = p.feedback;
+    out[136] = p.oscKeySync;
+    out[137] = p.lfoSpeed;
+    out[138] = p.lfoDelay;
+    out[139] = p.lfoPitchModDepth;
+    out[140] = p.lfoAmpModDepth;
+    out[141] = p.lfoSync;
+    out[142] = p.lfoWaveform;
+    out[143] = p.pitchModSens;
+    out[144] = p.transpose;
+    for (int i = 0; i < 10; ++i)
+      out[145 + i] = static_cast<uint8_t>(p.name[i]);
+  }
+
+  static uint8_t sysexChecksum(const uint8_t* p, size_t n) {
+    unsigned sum = 0;
+    for (size_t i = 0; i < n; ++i)
+      sum += p[i];
+    return static_cast<uint8_t>((0x80u - (sum & 0x7fu)) & 0x7fu);
+  }
+
+  // Wrap a raw payload in the DX7 SysEx frame for the given format byte.
+  static std::vector<uint8_t> frame(uint8_t format, uint8_t channel, const uint8_t* payload,
+                                    size_t n) {
+    std::vector<uint8_t> msg;
+    msg.push_back(0xF0);
+    msg.push_back(0x43);
+    msg.push_back(static_cast<uint8_t>(channel & 0x0f));
+    msg.push_back(format);
+    msg.push_back(static_cast<uint8_t>((n >> 7) & 0x7f)); // byte-count MS
+    msg.push_back(static_cast<uint8_t>(n & 0x7f)); // byte-count LS
+    msg.insert(msg.end(), payload, payload + n);
+    msg.push_back(sysexChecksum(payload, n));
+    msg.push_back(0xF7);
+    return msg;
+  }
+
+  // Build a full 32-voice packed bulk-dump image. voices[i] fills slot i;
+  // remaining slots are filled with fmPatch::sine().
+  static std::vector<uint8_t> makeBank(const std::vector<fmPatch>& voices, uint8_t channel = 0) {
+    std::vector<uint8_t> payload(4096);
+    fmPatch filler = fmPatch::sine();
+    for (int i = 0; i < 32; ++i) {
+      const fmPatch& src = (static_cast<size_t>(i) < voices.size()) ? voices[i] : filler;
+      packVoice(src, payload.data() + i * 128);
+    }
+    return frame(0x09, channel, payload.data(), payload.size());
+  }
+
+  // Render N samples of the sustaining tone of a voice loaded with `patch`.
+  static void render(const fmPatch& patch, YSE::DSP::buffer& out, unsigned N) {
+    fmVoice v;
+    v.setPatch(patch);
+    v.frequency(57.f); // A3
+    v.velocity(1.f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 8; ++i)
+      v.process(intent); // warm-up
+    const unsigned block = YSE::STANDARD_BUFFERSIZE;
+    unsigned filled = 0;
+    while (filled + block <= N) {
+      v.process(intent);
+      out.copyFrom(v.samples[0], 0, filled, block);
+      filled += block;
+    }
+  }
+
+  // ─── parsing a full packed bank ────────────────────────────────────────────
+
+  TEST_CASE("dx7SysEx: 32-voice packed bank parses to 32 named voices") {
+    std::vector<fmPatch> v = {fmPatch::fm2op(), fmPatch::brass()};
+    std::vector<uint8_t> bank = makeBank(v);
+
+    dx7Bank out;
+    REQUIRE(dx7SysEx::parse(bank.data(), bank.size(), out));
+    CHECK(out.size() == 32);
+    CHECK_FALSE(out.empty());
+    CHECK(out.name(0) == "YSE 2opFM");
+    CHECK(out.name(1) == "YSE Brass");
+    CHECK(out.name(2) == "YSE Sine"); // filler
+    CHECK(out.indexOf("YSE Brass") == 1);
+    CHECK(out.indexOf("nope") == -1);
+    CHECK(out.name(99).empty()); // out of range
+  }
+
+  // ─── ACCEPTANCE: parsed patch matches its in-code #176 equivalent ─────────
+
+  TEST_CASE("dx7SysEx: parsed voice renders identically to the in-code fm2op patch") {
+    const fmPatch inCode = fmPatch::fm2op();
+    std::vector<uint8_t> bank = makeBank({inCode});
+
+    dx7Bank out;
+    REQUIRE(dx7SysEx::parse(bank.data(), bank.size(), out));
+    REQUIRE(out.size() == 32);
+
+    const unsigned N = 2048;
+    YSE::DSP::buffer ref(N), got(N);
+    ref = 0.f;
+    got = 0.f;
+    render(inCode, ref, N);
+    render(out.voices[0], got, N);
+
+    CHECK(TestHelpers::measureRms(ref) > 0.005f); // the reference actually sounds
+    float* r = ref.getPtr();
+    float* g = got.getPtr();
+    float maxDiff = 0.f;
+    for (unsigned i = 0; i < N; ++i)
+      maxDiff = std::max(maxDiff, std::abs(r[i] - g[i]));
+    // The DX7 round-trip is loss-free for in-range parameters, so the two
+    // voices are bit-identical DSP: the rendered blocks must match exactly.
+    CHECK(maxDiff == doctest::Approx(0.f));
+  }
+
+  // ─── header-variant tolerance ──────────────────────────────────────────────
+
+  TEST_CASE("dx7SysEx: tolerates an arbitrary SysEx channel in the sub-status byte") {
+    std::vector<uint8_t> bank = makeBank({fmPatch::brass()}, /*channel*/ 11);
+    dx7Bank out;
+    REQUIRE(dx7SysEx::parse(bank.data(), bank.size(), out));
+    CHECK(out.name(0) == "YSE Brass");
+  }
+
+  TEST_CASE("dx7SysEx: tolerates leading and trailing junk around the F0..F7 block") {
+    std::vector<uint8_t> bank = makeBank({fmPatch::fm2op()});
+    std::vector<uint8_t> padded;
+    padded.insert(padded.end(), {0x11, 0x22, 0x33}); // junk before
+    padded.insert(padded.end(), bank.begin(), bank.end());
+    padded.insert(padded.end(), {0x55, 0x66}); // junk after F7
+    dx7Bank out;
+    REQUIRE(dx7SysEx::parse(padded.data(), padded.size(), out));
+    CHECK(out.size() == 32);
+    CHECK(out.name(0) == "YSE 2opFM");
+  }
+
+  TEST_CASE("dx7SysEx: accepts a bare unframed 4096-byte packed payload") {
+    std::vector<uint8_t> payload(4096);
+    packVoice(fmPatch::brass(), payload.data());
+    for (int i = 1; i < 32; ++i)
+      packVoice(fmPatch::sine(), payload.data() + i * 128);
+    dx7Bank out;
+    REQUIRE(dx7SysEx::parse(payload.data(), payload.size(), out));
+    CHECK(out.size() == 32);
+    CHECK(out.name(0) == "YSE Brass");
+  }
+
+  // ─── single-voice unpacked dump ───────────────────────────────────────────
+
+  TEST_CASE("dx7SysEx: single-voice unpacked dump round-trips") {
+    uint8_t payload[155];
+    packUnpackedVoice(fmPatch::fm2op(), payload);
+    std::vector<uint8_t> msg = frame(0x00, 0, payload, 155);
+
+    dx7Bank out;
+    REQUIRE(dx7SysEx::parse(msg.data(), msg.size(), out));
+    REQUIRE(out.size() == 1);
+    CHECK(out.name(0) == "YSE 2opFM");
+
+    // Renders identically to the in-code patch.
+    const unsigned N = 1024;
+    YSE::DSP::buffer ref(N), got(N);
+    ref = 0.f;
+    got = 0.f;
+    render(fmPatch::fm2op(), ref, N);
+    render(out.voices[0], got, N);
+    float* r = ref.getPtr();
+    float* g = got.getPtr();
+    float maxDiff = 0.f;
+    for (unsigned i = 0; i < N; ++i)
+      maxDiff = std::max(maxDiff, std::abs(r[i] - g[i]));
+    CHECK(maxDiff == doctest::Approx(0.f));
+  }
+
+  TEST_CASE("dx7SysEx: bare 155-byte unpacked payload parses") {
+    uint8_t payload[155];
+    packUnpackedVoice(fmPatch::brass(), payload);
+    dx7Bank out;
+    REQUIRE(dx7SysEx::parse(payload, 155, out));
+    REQUIRE(out.size() == 1);
+    CHECK(out.name(0) == "YSE Brass");
+  }
+
+  // ─── corrupt-input robustness ──────────────────────────────────────────────
+
+  TEST_CASE("dx7SysEx: a corrupted payload fails the checksum and is rejected") {
+    std::vector<uint8_t> bank = makeBank({fmPatch::fm2op()});
+    bank[10] ^= 0x7f; // flip a payload byte; stored checksum no longer matches
+    dx7Bank out;
+    CHECK_FALSE(dx7SysEx::parse(bank.data(), bank.size(), out));
+    CHECK(out.empty()); // output left untouched on failure
+  }
+
+  TEST_CASE("dx7SysEx: a corrupted checksum byte is rejected") {
+    std::vector<uint8_t> bank = makeBank({fmPatch::brass()});
+    bank[bank.size() - 2] ^= 0x01; // the checksum byte sits just before F7
+    dx7Bank out;
+    CHECK_FALSE(dx7SysEx::parse(bank.data(), bank.size(), out));
+    CHECK(out.empty());
+  }
+
+  TEST_CASE("dx7SysEx: truncated input is rejected without crashing") {
+    std::vector<uint8_t> bank = makeBank({fmPatch::sine()});
+    bank.resize(2000); // drop the F7 and tail; length matches no known layout
+    dx7Bank out;
+    CHECK_FALSE(dx7SysEx::parse(bank.data(), bank.size(), out));
+    CHECK(out.empty());
+  }
+
+  TEST_CASE("dx7SysEx: empty and null input is rejected") {
+    dx7Bank out;
+    CHECK_FALSE(dx7SysEx::parse(nullptr, 0, out));
+    uint8_t dummy = 0;
+    CHECK_FALSE(dx7SysEx::parse(&dummy, 0, out));
+    CHECK(out.empty());
+  }
+
+  TEST_CASE("dx7SysEx: loadBank on a missing file is rejected without crashing") {
+    dx7Bank out;
+    CHECK_FALSE(dx7SysEx::loadBank("this/path/does/not/exist.syx", out));
+    CHECK(out.empty());
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -50,6 +50,7 @@ set(YSE_SRCS
   dsp/modules/sineWave.cpp
   dsp/fm/fmPatch.cpp
   dsp/fm/fmVoice.cpp
+  dsp/fm/dx7Sysex.cpp
   dsp/fm/msfa/sin.cc
   dsp/fm/msfa/exp2.cc
   dsp/fm/msfa/freqlut.cc

--- a/YseEngine/dsp/fm/dx7Sysex.cpp
+++ b/YseEngine/dsp/fm/dx7Sysex.cpp
@@ -1,0 +1,287 @@
+/*
+  ==============================================================================
+
+    dx7Sysex.cpp
+    DX7 SysEx bank importer — implementation. See dx7Sysex.hpp and issue #177.
+
+    The DX7 voice formats are the openly documented Yamaha System-Exclusive
+    layouts (``sysex-format.txt``). Two payloads are unpacked here:
+
+      - the 32-voice packed bulk dump (128 packed bytes per voice), and
+      - the single-voice unpacked dump (155 bytes, already in the MSFA order).
+
+    Both are mapped into the #176 ``fmPatch`` struct so that
+    ``fmPatch::toUnpacked`` reproduces exactly the 156-byte image the ported
+    MSFA core (``msfa::Dx7Note::init``) consumes: operator ``op`` at byte
+    offset ``op * 21`` with fields [R1..R4 L1..L4 BP LD RD LC RC RS AMS KVS OL
+    MODE COARSE FINE DET]. The importer therefore keeps operators in their
+    stored positional order — packed/unpacked operator block ``i`` becomes
+    ``fmPatch::op[i]`` — which is what MSFA's own unpack does.
+
+  ==============================================================================
+*/
+
+#include "dx7Sysex.hpp"
+
+#include <cstring>
+#include <fstream>
+
+#include "../../implementations/logImplementation.h"
+
+namespace YSE {
+  namespace SYNTH {
+
+    namespace {
+
+      // ─── format constants ────────────────────────────────────────────────
+      constexpr size_t kPackedVoiceSize = 128; // one packed voice
+      constexpr size_t kPackedBankSize = 4096; // 32 packed voices
+      constexpr size_t kPackedBankVoices = 32;
+      constexpr size_t kUnpackedVoiceSize = 155; // one DX7 unpacked voice
+      constexpr size_t kUnpackedFullSize = 156; // MSFA image (adds op on/off)
+
+      constexpr uint8_t kSysExStart = 0xF0;
+      constexpr uint8_t kSysExEnd = 0xF7;
+      constexpr uint8_t kYamahaId = 0x43;
+
+      // 7-bit two's-complement checksum over a run of data bytes: the value C
+      // for which (sum(bytes) + C) & 0x7f == 0.
+      uint8_t sysexChecksum(const uint8_t* p, size_t n) {
+        unsigned sum = 0;
+        for (size_t i = 0; i < n; ++i)
+          sum += p[i];
+        return static_cast<uint8_t>((0x80u - (sum & 0x7fu)) & 0x7fu);
+      }
+
+      void logError(const std::string& info) {
+        INTERNAL::LogImpl().emit(E_FILE_ERROR, "DX7 SysEx: " + info);
+      }
+
+      // ─── voice unpackers ─────────────────────────────────────────────────
+
+      // Unpack one 128-byte packed voice into a patch. `src` must hold at least
+      // kPackedVoiceSize bytes. Bit-packed fields are split per the DX7 spec.
+      void unpackPacked(const uint8_t* src, fmPatch& p) {
+        std::memset(&p, 0, sizeof(p));
+        for (int op = 0; op < 6; ++op) {
+          const uint8_t* s = src + op * 17;
+          fmOperator& o = p.op[op];
+          for (int i = 0; i < 4; ++i) {
+            o.egRate[i] = s[i];
+            o.egLevel[i] = s[4 + i];
+          }
+          o.levelScaleBreakPoint = s[8];
+          o.levelScaleLeftDepth = s[9];
+          o.levelScaleRightDepth = s[10];
+          o.levelScaleLeftCurve = s[11] & 0x03;
+          o.levelScaleRightCurve = (s[11] >> 2) & 0x03;
+          o.rateScaling = s[12] & 0x07;
+          o.detune = (s[12] >> 3) & 0x0f;
+          o.ampModSens = s[13] & 0x03;
+          o.keyVelSens = (s[13] >> 2) & 0x07;
+          o.outputLevel = s[14];
+          o.oscMode = s[15] & 0x01;
+          o.freqCoarse = (s[15] >> 1) & 0x1f;
+          o.freqFine = s[16];
+        }
+        const uint8_t* g = src + 102; // global block: bytes 102..127
+        for (int i = 0; i < 4; ++i) {
+          p.pitchEgRate[i] = g[i];
+          p.pitchEgLevel[i] = g[4 + i];
+        }
+        p.algorithm = g[8] & 0x1f;
+        p.feedback = g[9] & 0x07;
+        p.oscKeySync = (g[9] >> 3) & 0x01;
+        p.lfoSpeed = g[10];
+        p.lfoDelay = g[11];
+        p.lfoPitchModDepth = g[12];
+        p.lfoAmpModDepth = g[13];
+        p.lfoSync = g[14] & 0x01;
+        p.lfoWaveform = (g[14] >> 1) & 0x07;
+        p.pitchModSens = (g[14] >> 4) & 0x07;
+        p.transpose = g[15];
+        for (int i = 0; i < 10; ++i)
+          p.name[i] = static_cast<char>(g[16 + i]);
+        p.opEnabled = 0x3f; // not carried in the DX7 voice; default all on
+      }
+
+      // Unpack one unpacked-format voice (155 or 156 bytes) into a patch. The
+      // unpacked byte order already matches the MSFA image, so this is a
+      // field-for-field copy with defensive masking on the bit-width fields.
+      void unpackUnpacked(const uint8_t* v, fmPatch& p) {
+        std::memset(&p, 0, sizeof(p));
+        for (int op = 0; op < 6; ++op) {
+          const uint8_t* s = v + op * 21;
+          fmOperator& o = p.op[op];
+          for (int i = 0; i < 4; ++i) {
+            o.egRate[i] = s[i];
+            o.egLevel[i] = s[4 + i];
+          }
+          o.levelScaleBreakPoint = s[8];
+          o.levelScaleLeftDepth = s[9];
+          o.levelScaleRightDepth = s[10];
+          o.levelScaleLeftCurve = s[11] & 0x03;
+          o.levelScaleRightCurve = s[12] & 0x03;
+          o.rateScaling = s[13] & 0x07;
+          o.ampModSens = s[14] & 0x03;
+          o.keyVelSens = s[15] & 0x07;
+          o.outputLevel = s[16];
+          o.oscMode = s[17] & 0x01;
+          o.freqCoarse = s[18] & 0x1f;
+          o.freqFine = s[19];
+          o.detune = s[20] & 0x0f;
+        }
+        for (int i = 0; i < 4; ++i) {
+          p.pitchEgRate[i] = v[126 + i];
+          p.pitchEgLevel[i] = v[130 + i];
+        }
+        p.algorithm = v[134] & 0x1f;
+        p.feedback = v[135] & 0x07;
+        p.oscKeySync = v[136] & 0x01;
+        p.lfoSpeed = v[137];
+        p.lfoDelay = v[138];
+        p.lfoPitchModDepth = v[139];
+        p.lfoAmpModDepth = v[140];
+        p.lfoSync = v[141] & 0x01;
+        p.lfoWaveform = v[142] & 0x07;
+        p.pitchModSens = v[143] & 0x07;
+        p.transpose = v[144];
+        for (int i = 0; i < 10; ++i)
+          p.name[i] = static_cast<char>(v[145 + i]);
+        p.opEnabled = 0x3f;
+      }
+
+      // Fill `out` from a raw (unframed) payload identified purely by length.
+      // No checksum is available for raw payloads. Returns false if the length
+      // matches no known layout.
+      bool parseRawPayload(const uint8_t* data, size_t length, dx7Bank& out) {
+        std::vector<fmPatch> voices;
+        if (length == kPackedBankSize) {
+          voices.resize(kPackedBankVoices);
+          for (size_t i = 0; i < kPackedBankVoices; ++i)
+            unpackPacked(data + i * kPackedVoiceSize, voices[i]);
+        } else if (length == kPackedVoiceSize) {
+          voices.resize(1);
+          unpackPacked(data, voices[0]);
+        } else if (length == kUnpackedVoiceSize || length == kUnpackedFullSize) {
+          voices.resize(1);
+          unpackUnpacked(data, voices[0]);
+        } else {
+          logError("unrecognised payload length (" + std::to_string(length) + " bytes)");
+          return false;
+        }
+        out.voices = std::move(voices);
+        return true;
+      }
+
+    } // namespace
+
+    // ─── dx7Bank helpers ─────────────────────────────────────────────────────
+
+    std::string dx7Bank::name(size_t index) const {
+      if (index >= voices.size()) return std::string();
+      const char* n = voices[index].name;
+      size_t len = 10; // DX7 names are 10 chars, space-padded, not terminated
+      while (len > 0 && (n[len - 1] == ' ' || n[len - 1] == '\0'))
+        --len;
+      return std::string(n, n + len);
+    }
+
+    int dx7Bank::indexOf(const char* voiceName) const {
+      if (voiceName == nullptr) return -1;
+      for (size_t i = 0; i < voices.size(); ++i)
+        if (name(i) == voiceName) return static_cast<int>(i);
+      return -1;
+    }
+
+    // ─── dx7SysEx ────────────────────────────────────────────────────────────
+
+    bool dx7SysEx::parse(const uint8_t* data, size_t length, dx7Bank& out) {
+      if (data == nullptr || length == 0) {
+        logError("empty input");
+        return false;
+      }
+
+      // 1. Locate an F0 … F7 SysEx block (tolerating leading/trailing junk).
+      size_t start = length;
+      for (size_t i = 0; i < length; ++i) {
+        if (data[i] == kSysExStart) {
+          start = i;
+          break;
+        }
+      }
+      if (start != length && start + 1 < length && data[start + 1] == kYamahaId) {
+        size_t end = length;
+        for (size_t j = start + 1; j < length; ++j) {
+          if (data[j] == kSysExEnd) {
+            end = j;
+            break;
+          }
+        }
+        if (end != length) {
+          // A framed Yamaha message: [F0][43][sub/chan][fmt][cMS][cLS][payload…][cksum][F7].
+          // Trust the actual framing length over the declared count so common
+          // header variants (any channel, off-by-one count) still parse.
+          const size_t msgLen = end - start + 1;
+          if (msgLen < 8) {
+            logError("truncated SysEx header");
+            return false;
+          }
+          const uint8_t* payload = data + start + 6;
+          const size_t payloadLen = msgLen - 8; // minus F0,43,sub,fmt,cMS,cLS,cksum,F7
+          const uint8_t declaredCk = data[end - 1];
+          if (sysexChecksum(payload, payloadLen) != declaredCk) {
+            logError("checksum mismatch");
+            return false;
+          }
+          std::vector<fmPatch> voices;
+          if (payloadLen == kUnpackedVoiceSize) {
+            voices.resize(1);
+            unpackUnpacked(payload, voices[0]);
+          } else if (payloadLen == kPackedVoiceSize) {
+            voices.resize(1);
+            unpackPacked(payload, voices[0]);
+          } else if (payloadLen == kPackedBankSize) {
+            voices.resize(kPackedBankVoices);
+            for (size_t i = 0; i < kPackedBankVoices; ++i)
+              unpackPacked(payload + i * kPackedVoiceSize, voices[i]);
+          } else {
+            logError("unrecognised SysEx payload length (" + std::to_string(payloadLen) +
+                     " bytes)");
+            return false;
+          }
+          out.voices = std::move(voices);
+          return true;
+        }
+      }
+
+      // 2. No usable frame — treat the input as a raw payload keyed by length.
+      return parseRawPayload(data, length, out);
+    }
+
+    bool dx7SysEx::loadBank(const char* path, dx7Bank& out) {
+      if (path == nullptr) {
+        logError("null path");
+        return false;
+      }
+      std::ifstream in(path, std::ios::binary | std::ios::ate);
+      if (!in.is_open()) {
+        logError(std::string("cannot open file: ") + path);
+        return false;
+      }
+      const std::streamsize size = in.tellg();
+      if (size <= 0) {
+        logError(std::string("empty file: ") + path);
+        return false;
+      }
+      in.seekg(0, std::ios::beg);
+      std::vector<uint8_t> bytes(static_cast<size_t>(size));
+      if (!in.read(reinterpret_cast<char*>(bytes.data()), size)) {
+        logError(std::string("read error: ") + path);
+        return false;
+      }
+      return parse(bytes.data(), bytes.size(), out);
+    }
+
+  } // namespace SYNTH
+} // namespace YSE

--- a/YseEngine/dsp/fm/dx7Sysex.hpp
+++ b/YseEngine/dsp/fm/dx7Sysex.hpp
@@ -1,0 +1,106 @@
+/*
+  ==============================================================================
+
+    dx7Sysex.hpp
+    DX7 SysEx bank importer for YSE::synth (issue #177).
+
+    Parses the openly documented Yamaha DX7 System-Exclusive voice formats and
+    unpacks each voice into the #176 ``fmPatch`` struct (the explicit data
+    contract between the FM engine and this importer). Two formats are handled:
+
+      - the 32-voice packed bulk dump (header ``F0 43 0n 09 20 00`` + 4096
+        payload bytes + checksum + ``F7``; 128 packed bytes per voice), and
+      - the single-voice unpacked dump (header ``F0 43 0n 00 01 1B`` + 155
+        payload bytes + checksum + ``F7``).
+
+    The parser is tolerant of the header variants found in the wild: any
+    SysEx channel in the sub-status byte, leading/trailing junk around the
+    ``F0 … F7`` block, and unwrapped raw payloads (a bare 4096-byte packed
+    bank, a bare 128-byte packed voice, or a bare 155-byte unpacked voice).
+    A present checksum is validated and a mismatch rejects the input.
+
+    Offline only — call from the setup / slow-pool thread, never from the audio
+    callback (it reads files and allocates). On failure it logs
+    ``E_FILE_ERROR`` and returns false, leaving the output untouched.
+
+    Non-goals (see issue #177): SysEx *output* / device dumps, DX7II/TX802
+    extended formats, and the instrument C-API (that is #178).
+
+  ==============================================================================
+*/
+
+#ifndef YSE_DSP_FM_DX7SYSEX_HPP
+#define YSE_DSP_FM_DX7SYSEX_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "fmPatch.hpp"
+#include "../../headers/defines.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /**
+     *  @brief A parsed DX7 bank: the voices plus name lookup helpers.
+     *
+     *  A packed bulk dump yields 32 voices; a single-voice dump yields one.
+     *  Plain data — safe to copy and hand across the setup boundary.
+     */
+    struct API dx7Bank {
+      std::vector<fmPatch> voices; ///< Parsed voices, in bank order.
+
+      /// @brief Number of voices in the bank.
+      size_t size() const {
+        return voices.size();
+      }
+      /// @brief True when no voice was parsed.
+      bool empty() const {
+        return voices.empty();
+      }
+
+      /**
+       *  @brief Voice name at @p index, trimmed of trailing spaces.
+       *  @return The name, or an empty string if @p index is out of range.
+       */
+      std::string name(size_t index) const;
+
+      /**
+       *  @brief First voice whose (trimmed) name equals @p voiceName.
+       *  @return The voice index, or -1 if no voice matches.
+       */
+      int indexOf(const char* voiceName) const;
+    };
+
+    /**
+     *  @brief Stateless DX7 SysEx parser. Offline / setup-thread only.
+     */
+    class API dx7SysEx {
+    public:
+      /**
+       *  @brief Parse a DX7 SysEx image from memory.
+       *  @param data   Raw bytes (a ``.syx`` file image or an in-memory dump).
+       *  @param length Number of bytes at @p data.
+       *  @param out    Filled with the parsed voices on success; untouched on
+       *                failure.
+       *  @return true on success. On failure logs ``E_FILE_ERROR`` and returns
+       *          false (bad header, wrong length, or checksum mismatch).
+       */
+      static bool parse(const uint8_t* data, size_t length, dx7Bank& out);
+
+      /**
+       *  @brief Load and parse a DX7 ``.syx`` file.
+       *  @param path UTF-8 path to the SysEx file.
+       *  @param out  Filled with the parsed voices on success.
+       *  @return true on success; on failure logs ``E_FILE_ERROR`` (file not
+       *          found / unreadable, or a parse error) and returns false.
+       */
+      static bool loadBank(const char* path, dx7Bank& out);
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_DSP_FM_DX7SYSEX_HPP


### PR DESCRIPTION
## Summary

Adds a DX7 SysEx bank importer (`YSE::SYNTH::dx7SysEx`) that parses Yamaha
DX7 System-Exclusive voice dumps into the #176 `fmPatch` struct, so real
DX7 patch banks (40 years of them) load straight into the FM voice.

## Linked issue

Closes #177 (part of #148; unblocked by #176, now on `dev`).

## Changes

- **Parser** (`YseEngine/dsp/fm/dx7Sysex.{hpp,cpp}`):
  - 32-voice packed bulk dump (128 packed bytes/voice) and single-voice
    155-byte unpacked dump.
  - Voices unpack 1:1 onto the MSFA 156-byte image `fmPatch::toUnpacked`
    produces (operator block `i` -> `op[i]`; bit-packed operator params,
    algorithm, feedback, LFO, name), verified against `msfa::Dx7Note::init`.
  - 7-bit two's-complement checksum validation; a mismatch rejects the
    input and leaves the output untouched.
  - Tolerant of common header variants: any SysEx channel in the
    sub-status byte, leading/trailing junk around the `F0..F7` block, and
    bare unframed payloads (4096 / 128 / 155 / 156 bytes).
  - `dx7Bank` enumeration: space-trimmed voice names + index-by-name.
  - Offline only (`loadBank` reads a file on the setup/slow-pool thread);
    logs `E_FILE_ERROR` and returns false on any failure.
- **Tests** (`Tests/dsp/test_dx7_sysex.cpp`): `.syx` fixtures generated
  deterministically in-test from the #176 built-in voices — no
  copyrighted factory bank committed.

## Non-goals (per the issue)

Instrument/synth-side C-API load call (#178), SysEx *output* / device
dumps, and DX7II/TX802 extended formats.

## Test plan

- [x] `python yse.py build` — clean
- [x] `python yse.py analyze` on changed files — no new findings (only
  pre-existing header warnings, all suppressed in non-user code)
- [x] `python yse.py test` — 23/23 ctest suites pass
- [x] New `dsp` cases: 12 test cases / 39 assertions pass, including the
  **acceptance** bar — a parsed voice renders sample-for-sample
  identically to `fmPatch::fm2op()` (rendered-buffer comparison), plus
  checksum-rejection, truncation, and header-variant robustness cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)