### PR TITLE
ENGINE: Send/return buses (#165)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -290,10 +290,10 @@
     },
     {
       "name": "tests-asan",
-      "displayName": "ASan patcher concurrency test",
+      "displayName": "ASan concurrency tests (patcher + send/return)",
       "configurePreset": "tests-asan",
       "output": { "outputOnFailure": true },
-      "filter": { "include": { "name": "yse_tests_patcher_concurrency" } },
+      "filter": { "include": { "name": "yse_tests_patcher_concurrency|yse_tests_sendstress" } },
       "environment": {
         "ASAN_OPTIONS": "detect_leaks=0"
       },
@@ -305,10 +305,10 @@
     },
     {
       "name": "tests-tsan",
-      "displayName": "TSan patcher concurrency test",
+      "displayName": "TSan concurrency tests (patcher + send/return)",
       "configurePreset": "tests-tsan",
       "output": { "outputOnFailure": true },
-      "filter": { "include": { "name": "yse_tests_patcher_concurrency" } },
+      "filter": { "include": { "name": "yse_tests_patcher_concurrency|yse_tests_sendstress" } },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(YSE_TEST_SOURCES
   channel/test_channel_bus.cpp
   channel/test_channel_layout.cpp
   channel/test_channel_dsp.cpp
+  channel/test_channel_sends.cpp
   sound/test_sound_state.cpp
   sound/test_sound_streaming.cpp
   sound/test_sound_bufferrace.cpp
@@ -199,7 +200,10 @@ add_test(
   # suite exclusions above and loses no coverage: yse_tests_concurrency plus the
   # per-suite entries still run every case. Tracked in #304; the root fix is
   # #41/#298 engine work.
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthcapi,midisynth,playersynth,playercapi "--test-case-exclude=* concurrency: *" --duration=true
+  # `sendstress` is excluded too: like the lifecycle suites it drives
+  # System::initOffline() (process-global engine state), so it must run in its
+  # own process (yse_tests_sendstress) rather than in this shared one.
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthcapi,midisynth,playersynth,playercapi,sendstress "--test-case-exclude=* concurrency: *" --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -390,6 +394,19 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_concurrency PROPERTIES LABELS concurrency)
+
+# Send/return offline-render + threading gate (issue #165). Runs under an
+# offline engine (no audio device), so it executes on headless CI and under the
+# TSan/ASan sanitizer legs — the `tests-tsan` / `tests-asan` presets include
+# this entry by name (see CMakePresets.json). Isolated in its own process
+# because it drives System::initOffline(); shares the `concurrency` label with
+# the other stress suites.
+add_test(
+  NAME    yse_tests_sendstress
+  COMMAND yse_tests --test-suite=sendstress --duration=true
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_sendstress PROPERTIES LABELS "channel;concurrency" TIMEOUT 300)
 endif()  # NOT ANDROID — close the CTest registration block
 
 if(ANDROID)

--- a/Tests/channel/test_channel_sends.cpp
+++ b/Tests/channel/test_channel_sends.cpp
@@ -1,0 +1,686 @@
+// Tests for the channel send/return buses (issue #165, part of epic #146).
+//
+// Design contract: docs/design/send_return_buses.md. The feature adds aux
+// send/return routing on top of the channel tree: any channel can send a
+// ramped, scaled copy of its output into a return bus; the return applies its
+// own insert chain (e.g. a plate reverb) and folds into MainMix after the
+// source tree, before the master fader. Return→return sends are allowed as an
+// acyclic DAG; cycles are rejected at wiring time on the control thread.
+//
+// Three layers of coverage:
+//   1. Deterministic impl-level tests of the send accumulation math — the
+//      ramped multiply-accumulate is click-free and sample-accurate. Driven
+//      directly on CHANNEL::implementationObject (the pattern test_channel_dsp
+//      uses), engineInit()-guarded because setup() sizes buffers from the
+//      device layout.
+//   2. Control-thread wiring-graph tests — generation indexing and cycle
+//      rejection, driven through the manager's public graph API. These need no
+//      audio device, so they run on headless CI.
+//   3. Interface-level wiring tests — makeReturn / send / getSendLevel and the
+//      wiring-validation rejections through the public YSE::channel surface.
+//
+// The concurrent render / TSan gate lives in the separate "sendstress" suite at
+// the bottom (offline engine, its own ctest process — see Tests/CMakeLists.txt).
+
+#include <doctest/doctest.h>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "channel/channelInterface.hpp"
+#include "channel/channelImplementation.h"
+#include "channel/channelManager.h"
+#include "channel/channelMessage.h"
+#include "dsp/dspObject.hpp"
+#include "dsp/modules/plateReverb.hpp"
+#include "sound/soundInterface.hpp"
+#include "sound/soundManager.h"
+#include "implementations/logImplementation.h"
+#include "internal/time.h"
+#include "support/null_device.hpp"
+
+namespace {
+
+  using YSE::CHANNEL::implementationObject;
+
+  // ─── impl-level helpers (mirror test_channel_dsp.cpp) ──────────────────────
+
+  // Size an impl's `out` (and `sends`) to the device layout, then mark it READY.
+  // Requires a live engine (setup() reads CHANNEL::Manager().getNumberOfOutputs()).
+  // The READY promotion stands in for the audio thread's readyCheck (SETUP ->
+  // READY) so a send taps into it: accumulateSend gates on the target reaching
+  // OBJECT_READY (issue #165), which a directly-driven impl would otherwise never
+  // reach.
+  void primeImpl(implementationObject& impl) {
+    impl.setStatus(YSE::OBJECT_CREATED);
+    impl.setup();
+    impl.setStatus(YSE::OBJECT_READY);
+  }
+
+  void fill(std::vector<YSE::DSP::buffer>& bufs, float value) {
+    for (auto& b : bufs) {
+      float* p = b.getPtr();
+      const UInt n = b.getLength();
+      for (UInt i = 0; i < n; ++i)
+        p[i] = value;
+    }
+  }
+
+  bool allEqual(std::vector<YSE::DSP::buffer>& bufs, float value) {
+    for (auto& b : bufs) {
+      float* p = b.getPtr();
+      const UInt n = b.getLength();
+      for (UInt i = 0; i < n; ++i)
+        if (p[i] != doctest::Approx(value)) return false;
+    }
+    return true;
+  }
+
+  // Wire src's slot at `target` via the ADD_SEND message the interface posts.
+  void wireSend(implementationObject& src, implementationObject* target, int slot, bool preFader) {
+    YSE::CHANNEL::messageObject m;
+    m.ID = YSE::CHANNEL::ADD_SEND;
+    m.send.target = target;
+    m.send.slot = slot;
+    m.send.preFader = preFader;
+    src.parseMessage(m);
+  }
+
+  void setSendLevelMsg(implementationObject& src, int slot, float level) {
+    YSE::CHANNEL::messageObject m;
+    m.ID = YSE::CHANNEL::SEND_LEVEL;
+    m.sendLevel.slot = slot;
+    m.sendLevel.level = level;
+    src.parseMessage(m);
+  }
+
+  void removeSendMsg(implementationObject& src, int slot) {
+    YSE::CHANNEL::messageObject m;
+    m.ID = YSE::CHANNEL::REMOVE_SEND;
+    m.uintValue = (UInt)slot;
+    src.parseMessage(m);
+  }
+
+  // Run one post-fader tap and let the ramp settle so a subsequent tap runs at a
+  // constant level (lastLevel == newLevel).
+  void settlePostFader(implementationObject& src, implementationObject& target) {
+    src.runSendTaps(false);
+    target.clearBuffers();
+    src.runSendTaps(false);
+  }
+
+  void drainChannels(int iterations = 12) {
+    for (int i = 0; i < iterations; ++i) {
+      YSE::INTERNAL::Time().update();
+      YSE::SOUND::Manager().update();
+      YSE::CHANNEL::Manager().update();
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("channel") {
+
+  // ─── Message ids ───────────────────────────────────────────────────────────
+
+  TEST_CASE("channel sends: the new send message ids are all distinct") {
+    using namespace YSE::CHANNEL;
+    CHECK(ADD_SEND != SEND_LEVEL);
+    CHECK(ADD_SEND != REMOVE_SEND);
+    CHECK(ADD_SEND != SET_GENERATION);
+    CHECK(SEND_LEVEL != REMOVE_SEND);
+    CHECK(SEND_LEVEL != SET_GENERATION);
+    CHECK(REMOVE_SEND != SET_GENERATION);
+    // and distinct from the pre-existing ids
+    CHECK(ADD_SEND != VOLUME);
+    CHECK(ADD_SEND != ATTACH_DSP);
+    CHECK(SET_GENERATION != ATTACH_REVERB);
+  }
+
+  // ─── Send accumulation math (acceptance: click-free, sample-accurate) ───────
+
+  TEST_CASE("channel sends: post-fader send accumulates a scaled copy at a steady level") {
+    if (!TestHelpers::engineInit()) return;
+    implementationObject src(nullptr), ret(nullptr);
+    primeImpl(src);
+    primeImpl(ret);
+    REQUIRE(src.GetBuffers().size() > 0);
+
+    wireSend(src, &ret, 0, false);
+    setSendLevelMsg(src, 0, 0.5f);
+
+    fill(src.GetBuffers(), 1.0f);
+    ret.clearBuffers();
+    settlePostFader(src, ret); // ramp 0->0.5 then run at steady 0.5
+    // src is 1.0 everywhere, level 0.5 -> return holds 0.5.
+    CHECK(allEqual(ret.GetBuffers(), 0.5f));
+  }
+
+  TEST_CASE("channel sends: a fresh send ramps up from silence, sample-accurately (click-free)") {
+    if (!TestHelpers::engineInit()) return;
+    implementationObject src(nullptr), ret(nullptr);
+    primeImpl(src);
+    primeImpl(ret);
+    REQUIRE(src.GetBuffers().size() > 0);
+
+    wireSend(src, &ret, 0, false);
+    setSendLevelMsg(src, 0, 0.5f); // lastLevel = 0, newLevel = 0.5
+
+    fill(src.GetBuffers(), 1.0f);
+    ret.clearBuffers();
+    src.runSendTaps(false); // first block: ramp 0 -> 0.5
+
+    // The ramp is fused into the MAC exactly like adjustVolume(): sample j gets
+    // src[j] * (lastLevel + step*j), step = (newLevel-lastLevel)/BUFSIZE.
+    const float step = 0.5f / static_cast<float>(YSE::STANDARD_BUFFERSIZE);
+    float* p = ret.GetBuffers()[0].getPtr();
+    CHECK(p[0] == doctest::Approx(0.f)); // starts at silence — no click
+    CHECK(p[1] == doctest::Approx(step));
+    CHECK(p[64] == doctest::Approx(step * 64.f));
+    CHECK(p[YSE::STANDARD_BUFFERSIZE - 1] ==
+          doctest::Approx(step * static_cast<float>(YSE::STANDARD_BUFFERSIZE - 1)));
+  }
+
+  TEST_CASE("channel sends: a level change ramps linearly across the block, never steps (no zipper)") {
+    if (!TestHelpers::engineInit()) return;
+    implementationObject src(nullptr), ret(nullptr);
+    primeImpl(src);
+    primeImpl(ret);
+    REQUIRE(src.GetBuffers().size() > 0);
+
+    wireSend(src, &ret, 0, false);
+    setSendLevelMsg(src, 0, 0.2f);
+    fill(src.GetBuffers(), 1.0f);
+    ret.clearBuffers();
+    settlePostFader(src, ret); // settle at 0.2 (lastLevel becomes 0.2)
+
+    // Now move the target to 0.8 and tap once: the whole block is a single
+    // linear ramp 0.2 -> 0.8, so consecutive samples differ by a constant step
+    // (a zipper/step would show a discontinuity somewhere).
+    setSendLevelMsg(src, 0, 0.8f);
+    fill(src.GetBuffers(), 1.0f);
+    ret.clearBuffers();
+    src.runSendTaps(false);
+
+    const float step = (0.8f - 0.2f) / static_cast<float>(YSE::STANDARD_BUFFERSIZE);
+    float* p = ret.GetBuffers()[0].getPtr();
+    CHECK(p[0] == doctest::Approx(0.2f));
+    for (UInt j = 1; j < YSE::STANDARD_BUFFERSIZE; ++j) {
+      CHECK((p[j] - p[j - 1]) == doctest::Approx(step)); // constant slope: no zipper
+    }
+  }
+
+  TEST_CASE("channel sends: continuous setSendLevel writes stay click-free block to block") {
+    if (!TestHelpers::engineInit()) return;
+    implementationObject src(nullptr), ret(nullptr);
+    primeImpl(src);
+    primeImpl(ret);
+    REQUIRE(src.GetBuffers().size() > 0);
+    wireSend(src, &ret, 0, false);
+
+    // Drive a new target level every block (the modulation-target usage pattern)
+    // and assert every block's first sample continues smoothly from the previous
+    // block's last sample — i.e. the multiplier never jumps.
+    fill(src.GetBuffers(), 1.0f);
+    float prevLast = 0.f;
+    float target = 0.f;
+    for (int block = 0; block < 32; ++block) {
+      target = 0.5f + 0.4f * std::sin(0.3f * static_cast<float>(block));
+      setSendLevelMsg(src, 0, target);
+      ret.clearBuffers();
+      src.runSendTaps(false);
+      float* p = ret.GetBuffers()[0].getPtr();
+      // src is a constant 1.0, so p[] is exactly the gain envelope. The first
+      // sample equals the previous block's ending multiplier (continuity), and
+      // within a block the slope is bounded by one block's worth of change.
+      CHECK(p[0] == doctest::Approx(prevLast));
+      prevLast = p[YSE::STANDARD_BUFFERSIZE - 1] +
+                 (target - prevLast) / static_cast<float>(YSE::STANDARD_BUFFERSIZE);
+    }
+  }
+
+  TEST_CASE("channel sends: pre-fader and post-fader slots tap only on their own phase") {
+    if (!TestHelpers::engineInit()) return;
+    implementationObject src(nullptr), retPre(nullptr), retPost(nullptr);
+    primeImpl(src);
+    primeImpl(retPre);
+    primeImpl(retPost);
+    REQUIRE(src.GetBuffers().size() > 0);
+
+    wireSend(src, &retPre, 0, /*preFader*/ true);
+    setSendLevelMsg(src, 0, 1.0f);
+    wireSend(src, &retPost, 1, /*preFader*/ false);
+    setSendLevelMsg(src, 1, 1.0f);
+
+    // Pre-fader phase: only the pre slot taps.
+    fill(src.GetBuffers(), 1.0f);
+    retPre.clearBuffers();
+    retPost.clearBuffers();
+    src.runSendTaps(true);
+    CHECK_FALSE(allEqual(retPre.GetBuffers(), 0.f));  // pre got signal (ramped)
+    CHECK(allEqual(retPost.GetBuffers(), 0.f));       // post untouched
+
+    // Post-fader phase: only the post slot taps.
+    retPre.clearBuffers();
+    retPost.clearBuffers();
+    src.runSendTaps(false);
+    CHECK(allEqual(retPre.GetBuffers(), 0.f));        // pre untouched this phase
+    CHECK_FALSE(allEqual(retPost.GetBuffers(), 0.f)); // post got signal
+  }
+
+  TEST_CASE("channel sends: REMOVE_SEND stops a slot from accumulating") {
+    if (!TestHelpers::engineInit()) return;
+    implementationObject src(nullptr), ret(nullptr);
+    primeImpl(src);
+    primeImpl(ret);
+    REQUIRE(src.GetBuffers().size() > 0);
+
+    wireSend(src, &ret, 0, false);
+    setSendLevelMsg(src, 0, 0.5f);
+    fill(src.GetBuffers(), 1.0f);
+    ret.clearBuffers();
+    settlePostFader(src, ret);
+    CHECK_FALSE(allEqual(ret.GetBuffers(), 0.f)); // active: it accumulates
+
+    removeSendMsg(src, 0);
+    ret.clearBuffers();
+    src.runSendTaps(false);
+    CHECK(allEqual(ret.GetBuffers(), 0.f)); // detached: nothing added
+  }
+
+  // ─── Control-thread wiring graph: generations + cycle rejection ─────────────
+  // (No audio device needed — the graph is pure control-thread bookkeeping.)
+
+  TEST_CASE("channel sends: the return graph layers generations and rejects cycles") {
+    auto& M = YSE::CHANNEL::Manager();
+    // Three bare impls used only as graph nodes (identity by pointer).
+    implementationObject a(nullptr), b(nullptr), c(nullptr);
+    M.registerReturnGraph(&a);
+    M.registerReturnGraph(&b);
+    M.registerReturnGraph(&c);
+
+    // Fresh returns are generation 0.
+    CHECK(M.returnGenerationOf(&a) == 0);
+    CHECK(M.returnGenerationOf(&b) == 0);
+
+    // a -> b : b is now fed by a generation-0 return, so it is generation 1.
+    CHECK(M.tryAddReturnEdge(&a, &b) == true);
+    CHECK(M.returnGenerationOf(&a) == 0);
+    CHECK(M.returnGenerationOf(&b) == 1);
+
+    // b -> c : the chain a -> b -> c makes c generation 2.
+    CHECK(M.tryAddReturnEdge(&b, &c) == true);
+    CHECK(M.returnGenerationOf(&c) == 2);
+
+    // c -> a would close the cycle a->b->c->a: rejected, graph unchanged.
+    CHECK(M.tryAddReturnEdge(&c, &a) == false);
+    CHECK(M.returnGenerationOf(&a) == 0);
+    CHECK(M.returnGenerationOf(&c) == 2);
+
+    // Removing a -> b drops b (and the chain) back to generation 0.
+    M.removeReturnEdge(&a, &b);
+    CHECK(M.returnGenerationOf(&b) == 0);
+    CHECK(M.returnGenerationOf(&c) == 1); // still fed by b
+
+    // Cleanup: never leave dangling stack-impl pointers in the shared graph.
+    M.unregisterReturnGraph(&a);
+    M.unregisterReturnGraph(&b);
+    M.unregisterReturnGraph(&c);
+    CHECK(M.returnGenerationOf(&a) == -1);
+  }
+
+  TEST_CASE("channel sends: a self-send edge is treated as a cycle by the graph") {
+    auto& M = YSE::CHANNEL::Manager();
+    implementationObject a(nullptr);
+    M.registerReturnGraph(&a);
+    CHECK(M.tryAddReturnEdge(&a, &a) == false); // reflexive edge = cycle
+    M.unregisterReturnGraph(&a);
+  }
+
+  // ─── Interface-level wiring + validation ────────────────────────────────────
+
+  TEST_CASE("channel sends: makeReturn flags a return, create() does not") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::channel normal;
+    normal.create("send_normal", YSE::ChannelMaster());
+    YSE::channel ret;
+    ret.makeReturn("send_ret");
+    drainChannels();
+    CHECK_FALSE(normal.isReturn());
+    CHECK(ret.isReturn());
+    drainChannels();
+  }
+
+  TEST_CASE("channel sends: send to a non-return target is rejected") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::channel src, notReturn;
+    src.create("send_src_a", YSE::ChannelMaster());
+    notReturn.create("send_notret", YSE::ChannelMaster());
+    drainChannels();
+    src.send(0, notReturn, 0.5f);
+    CHECK(src.getSendLevel(0) == doctest::Approx(0.f)); // wiring not accepted
+    drainChannels();
+  }
+
+  TEST_CASE("channel sends: a self-send is rejected") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::channel ret;
+    ret.makeReturn("send_selfret");
+    drainChannels();
+    ret.send(0, ret, 0.5f);
+    CHECK(ret.getSendLevel(0) == doctest::Approx(0.f));
+    drainChannels();
+  }
+
+  TEST_CASE("channel sends: an out-of-range slot index is rejected") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::channel src, ret;
+    src.create("send_src_b", YSE::ChannelMaster());
+    ret.makeReturn("send_ret_b");
+    drainChannels();
+    src.send(99, ret, 0.5f); // only slots [0,4) exist by default
+    CHECK(src.getSendLevel(99) == doctest::Approx(0.f));
+    CHECK(src.getSendLevel(0) == doctest::Approx(0.f));
+    drainChannels();
+  }
+
+  TEST_CASE("channel sends: an accepted send reports its level; clearSend detaches it") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::channel src, ret;
+    src.create("send_src_c", YSE::ChannelMaster());
+    ret.makeReturn("send_ret_c");
+    drainChannels();
+
+    src.send(0, ret, 0.4f);
+    CHECK(src.getSendLevel(0) == doctest::Approx(0.4f));
+    src.setSendLevel(0, 0.7f);
+    CHECK(src.getSendLevel(0) == doctest::Approx(0.7f));
+    src.clearSend(0);
+    CHECK(src.getSendLevel(0) == doctest::Approx(0.f));
+    drainChannels();
+  }
+
+  TEST_CASE("channel sends: return->return is allowed but a cycle is rejected at wiring time") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::channel delayRet, reverbRet;
+    delayRet.makeReturn("send_delay");
+    reverbRet.makeReturn("send_reverb");
+    drainChannels();
+
+    // delay -> reverb: a legal DAG edge (the delay tail washes into the reverb).
+    delayRet.send(0, reverbRet, 0.5f);
+    CHECK(delayRet.getSendLevel(0) == doctest::Approx(0.5f));
+
+    // reverb -> delay would close a cycle: rejected, left unset.
+    reverbRet.send(0, delayRet, 0.5f);
+    CHECK(reverbRet.getSendLevel(0) == doctest::Approx(0.f));
+    drainChannels();
+  }
+
+} // TEST_SUITE("channel")
+
+// ════════════════════════════════════════════════════════════════════════════
+//  sendstress — offline-render + concurrency gate (issue #165)
+//
+//  Runs under an offline engine (no audio device), so it executes on headless
+//  CI and under the TSan/ASan sanitizer legs. Isolated in its own ctest process
+//  (Tests/CMakeLists.txt) and excluded from the combined yse_unit_tests run,
+//  because initOffline() drives process-global engine state.
+//
+//  doctest's assertion macros are not thread-safe, so the worker threads call
+//  none of them (a race/UAF is caught by the sanitizer aborting; logical
+//  post-conditions are asserted on the main thread after the workers join). The
+//  logger writes a shared stream without a lock, so it is silenced for the
+//  duration.
+// ════════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+  // A steady tone source: every source channel produces a real, band-limited AC
+  // signal into its `out`, so the send taps have something to accumulate AND the
+  // plate reverb on the return produces a genuine wet tail. (A pure-DC source
+  // must NOT be used here: a plate reverb's comb/allpass network rejects DC, so
+  // the return's wet output would read ~0 and the "signal reaches the return"
+  // assertions would be measuring reverb buildup noise rather than the send
+  // path.) File-scope so it outlives every sound built from it (the
+  // create(dspSourceObject) contract).
+  struct ToneSource : YSE::DSP::dspSourceObject {
+    float ph = 0.f;
+    void process(YSE::SOUND_STATUS& intent) override {
+      for (UInt c = 0; c < samples.size(); ++c) {
+        float* p = samples[c].getPtr();
+        const UInt len = samples[c].getLength();
+        float local = ph;
+        for (UInt i = 0; i < len; ++i) {
+          p[i] = 0.25f * std::sin(local);
+          local += 0.12f;
+        }
+      }
+      ph += 0.12f * (float)samples[0].getLength();
+      intent = YSE::SS_PLAYING;
+    }
+    void frequency(float) override {}
+  };
+
+  ToneSource g_tone[8];
+  YSE::DSP::MODULES::plateReverb g_plateA;
+  YSE::DSP::MODULES::plateReverb g_plateB;
+
+  struct LogSilencer {
+    YSE::ERROR_LEVEL previous;
+    LogSilencer() : previous(YSE::INTERNAL::LogImpl().getLevel()) {
+      YSE::INTERNAL::LogImpl().setLevel(YSE::EL_NONE);
+    }
+    ~LogSilencer() {
+      YSE::INTERNAL::LogImpl().setLevel(previous);
+    }
+  };
+
+  // Init the offline engine once for the whole sendstress process.
+  bool ensureOffline() {
+    static bool done = false;
+    static bool ok = false;
+    if (!done) {
+      YSE::System().close(); // normalize regardless of starting state
+      ok = YSE::System().initOffline();
+      done = true;
+    }
+    return ok;
+  }
+
+  // Drive the engine to quiescence: System().update() flags the control-plane
+  // work (so the audio callback body actually runs the manager updates), then
+  // renderOffline() runs blocks; a short sleep lets the single-threaded slow
+  // pool execute the queued setup() jobs. This is the offline analogue of the
+  // channel suite's drainChannels(). Needed so freshly created channels /
+  // returns / sounds reach OBJECT_READY (and get linked into the returns list)
+  // before the render is expected to carry signal.
+  void pump(int iterations = 20) {
+    for (int i = 0; i < iterations; ++i) {
+      YSE::System().update();
+      YSE::System().renderOffline(2);
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+  }
+
+  bool anyNonFinite(YSE::channel& ch) {
+    const int n = ch.getNumOutputs();
+    for (int i = 0; i < n; ++i) {
+      const float v = ch.getPeakLinearPost(i);
+      if (!std::isfinite(v)) return true;
+    }
+    return false;
+  }
+
+} // namespace
+
+TEST_SUITE("sendstress") {
+
+  TEST_CASE("sends stress: 8 senders into 2 reverb returns render race-free under live level moves") {
+    if (!ensureOffline()) return;
+    LogSilencer silence;
+
+    YSE::channel retA, retB;
+    retA.makeReturn("stress_retA");
+    retB.makeReturn("stress_retB");
+    retA.setDSP(&g_plateA);
+    retB.setDSP(&g_plateB);
+
+    YSE::channel src[8];
+    YSE::sound snd[8];
+    for (int i = 0; i < 8; ++i)
+      src[i].create(("stress_src_" + std::to_string(i)).c_str(), YSE::ChannelMaster());
+
+    // Drive lifecycle to READY, then attach a steady tone to each channel and
+    // start it playing (create() does not auto-play).
+    pump();
+    for (int i = 0; i < 8; ++i)
+      snd[i].create(g_tone[i], &src[i], 1.0f);
+    pump();
+    for (int i = 0; i < 8; ++i)
+      snd[i].play();
+    pump();
+
+    // Every source fans out to both returns at distinct levels (the canonical
+    // aux topology: 8 channels sharing 2 reverb returns).
+    for (int i = 0; i < 8; ++i) {
+      src[i].send(0, retA, 0.3f);
+      src[i].send(1, retB, 0.2f);
+    }
+    pump(); // apply the wiring + warm the reverb tanks
+
+    // Sanity before the race: the send path delivers to both returns and to the
+    // master mix (dry sources + wet returns).
+    CHECK(src[0].getPeakLinearPost() > 0.f);
+    CHECK(YSE::ChannelMaster().getPeakLinearPost() > 0.f);
+    CHECK(retA.getPeakLinearPost() > 0.f);
+    CHECK(retB.getPeakLinearPost() > 0.f);
+
+    // ── Concurrent phase (the TSan/ASan gate) ──
+    // One render thread IS the audio thread: it renders blocks in a tight loop,
+    // draining the per-channel message inboxes in sync() and running the send
+    // accumulation + returns phase. One control thread hammers setSendLevel() on
+    // every slot every iteration — the modulation-target usage pattern the design
+    // mandates (§11) — and flags the manager update the render thread consumes.
+    // Send levels are the shared state written by control and read (via the ramp)
+    // by audio; the design's claim is that this hand-off is race-free because it
+    // is a bounded lfQueue message applied in sync(), never a direct write to
+    // render state. No doctest macro runs off the main thread (they are not
+    // thread-safe); a race/UAF is caught by the sanitizer aborting the process,
+    // and the logical post-conditions are asserted on the main thread after join.
+    std::atomic<bool> stop{false};
+    std::atomic<std::uint64_t> blocks{0};
+
+    std::thread render([&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        YSE::System().renderOffline(1);
+        blocks.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+
+    std::thread control([&] {
+      for (int t = 0; t < 6000; ++t) {
+        for (int i = 0; i < 8; ++i) {
+          const float a = 0.3f + 0.2f * std::sin(0.013f * static_cast<float>(t) + i);
+          const float b = 0.2f + 0.15f * std::sin(0.017f * static_cast<float>(t) + i);
+          src[i].setSendLevel(0, a);
+          src[i].setSendLevel(1, b);
+        }
+        YSE::System().update(); // flag the update the render thread applies
+        std::this_thread::sleep_for(std::chrono::microseconds(50));
+      }
+    });
+
+    control.join();
+    stop.store(true, std::memory_order_relaxed);
+    render.join();
+
+    // The audio thread kept rendering throughout the storm.
+    CHECK(blocks.load() > 0);
+
+    // Post-conditions on the main thread: both returns still carry signal and the
+    // accumulation stayed bounded (no NaN/Inf reached the render path).
+    pump(4);
+    CHECK(retA.getPeakLinearPost() > 0.f);
+    CHECK(retB.getPeakLinearPost() > 0.f);
+    CHECK_FALSE(anyNonFinite(retA));
+    CHECK_FALSE(anyNonFinite(retB));
+
+    // Detach the module inserts before the returns fall out of scope.
+    retA.setDSP(nullptr);
+    retB.setDSP(nullptr);
+    pump(4);
+  }
+
+  TEST_CASE("sends stress: a return->return (delay->reverb) chain carries signal end to end") {
+    if (!ensureOffline()) return;
+    LogSilencer silence;
+
+    // reverbRet is fed only by delayRet (generation 0 -> 1). A source drives
+    // delayRet; if the generation ordering is correct, the reverb return sees
+    // signal (delayRet accumulates into reverbRet before reverbRet is folded).
+    YSE::channel delayRet, reverbRet;
+    delayRet.makeReturn("chain_delay");
+    reverbRet.makeReturn("chain_reverb");
+    reverbRet.setDSP(&g_plateA); // reuse a plate as the reverb payload
+
+    YSE::channel src;
+    YSE::sound snd;
+    src.create("chain_src", YSE::ChannelMaster());
+    pump();
+    snd.create(g_tone[0], &src, 1.0f);
+    pump();
+    snd.play();
+    pump();
+
+    src.send(0, delayRet, 0.8f);      // source -> delay return (gen 0)
+    delayRet.send(0, reverbRet, 0.8f); // delay -> reverb return (gen 1)
+    CHECK(delayRet.getSendLevel(0) == doctest::Approx(0.8f));
+
+    pump(); // apply wiring
+    for (int i = 0; i < 8; ++i)
+      YSE::System().renderOffline(16); // let the plate tail build
+    CHECK(reverbRet.getPeakLinearPost() > 0.f); // the chain delivered end to end
+    CHECK_FALSE(anyNonFinite(reverbRet));
+
+    reverbRet.setDSP(nullptr);
+    pump(4);
+  }
+
+  TEST_CASE("sends stress: destroying a return while senders are live is UAF-safe") {
+    if (!ensureOffline()) return;
+    LogSilencer silence;
+
+    YSE::channel src[4];
+    YSE::sound snd[4];
+    for (int i = 0; i < 4; ++i)
+      src[i].create(("td_src_" + std::to_string(i)).c_str(), YSE::ChannelMaster());
+    pump();
+    for (int i = 0; i < 4; ++i)
+      snd[i].create(g_tone[i], &src[i], 1.0f);
+    pump();
+    for (int i = 0; i < 4; ++i)
+      snd[i].play();
+    pump();
+
+    {
+      YSE::channel ret;
+      ret.makeReturn("td_ret");
+      for (int i = 0; i < 4; ++i)
+        src[i].send(0, ret, 0.5f);
+      pump(); // sends live into the return
+    } // ~ret: OBJECT_RELEASE -> detachSends() severs every sender's slot on the
+      // audio thread before the impl is freed. The senders still hold slot 0.
+
+    // Keep rendering: the severed slots must not dereference the freed return.
+    // ASan/TSan catch a use-after-free here; a plain build must not crash.
+    pump(32);
+    CHECK(YSE::ChannelMaster().getPeakLinearPost() >= 0.f);
+  }
+
+} // TEST_SUITE("sendstress")

--- a/Tests/channel/test_channel_sends.cpp
+++ b/Tests/channel/test_channel_sends.cpp
@@ -186,7 +186,8 @@ TEST_SUITE("channel") {
           doctest::Approx(step * static_cast<float>(YSE::STANDARD_BUFFERSIZE - 1)));
   }
 
-  TEST_CASE("channel sends: a level change ramps linearly across the block, never steps (no zipper)") {
+  TEST_CASE(
+      "channel sends: a level change ramps linearly across the block, never steps (no zipper)") {
     if (!TestHelpers::engineInit()) return;
     implementationObject src(nullptr), ret(nullptr);
     primeImpl(src);
@@ -262,14 +263,14 @@ TEST_SUITE("channel") {
     retPre.clearBuffers();
     retPost.clearBuffers();
     src.runSendTaps(true);
-    CHECK_FALSE(allEqual(retPre.GetBuffers(), 0.f));  // pre got signal (ramped)
-    CHECK(allEqual(retPost.GetBuffers(), 0.f));       // post untouched
+    CHECK_FALSE(allEqual(retPre.GetBuffers(), 0.f)); // pre got signal (ramped)
+    CHECK(allEqual(retPost.GetBuffers(), 0.f)); // post untouched
 
     // Post-fader phase: only the post slot taps.
     retPre.clearBuffers();
     retPost.clearBuffers();
     src.runSendTaps(false);
-    CHECK(allEqual(retPre.GetBuffers(), 0.f));        // pre untouched this phase
+    CHECK(allEqual(retPre.GetBuffers(), 0.f)); // pre untouched this phase
     CHECK_FALSE(allEqual(retPost.GetBuffers(), 0.f)); // post got signal
   }
 
@@ -521,7 +522,8 @@ namespace {
 
 TEST_SUITE("sendstress") {
 
-  TEST_CASE("sends stress: 8 senders into 2 reverb returns render race-free under live level moves") {
+  TEST_CASE(
+      "sends stress: 8 senders into 2 reverb returns render race-free under live level moves") {
     if (!ensureOffline()) return;
     LogSilencer silence;
 
@@ -638,7 +640,7 @@ TEST_SUITE("sendstress") {
     snd.play();
     pump();
 
-    src.send(0, delayRet, 0.8f);      // source -> delay return (gen 0)
+    src.send(0, delayRet, 0.8f); // source -> delay return (gen 0)
     delayRet.send(0, reverbRet, 0.8f); // delay -> reverb return (gen 1)
     CHECK(delayRet.getSendLevel(0) == doctest::Approx(0.8f));
 

--- a/YseEngine/channel/channel.hpp
+++ b/YseEngine/channel/channel.hpp
@@ -28,6 +28,15 @@ namespace YSE {
       VIRTUAL,
       ATTACH_REVERB,
       ATTACH_DSP,
+      // Send/return bus wiring (issue #165, design docs/design/send_return_buses.md).
+      // All applied on the audio thread in parseMessage() as pointer/scalar
+      // writes — no allocation, no locking. Wiring-time validation (cycle
+      // rejection, generation indexing) runs on the control thread before these
+      // are posted.
+      ADD_SEND, // (re)point a send slot at a return + link its back-reference
+      SEND_LEVEL, // set a slot's target level (ramped, click-free)
+      REMOVE_SEND, // detach a send slot and unlink its back-reference
+      SET_GENERATION, // update a return's processing-order generation index
     };
   } // namespace CHANNEL
 } // namespace YSE

--- a/YseEngine/channel/channelImplementation.cpp
+++ b/YseEngine/channel/channelImplementation.cpp
@@ -87,7 +87,14 @@ Bool YSE::CHANNEL::implementationObject::disconnect(YSE::SOUND::implementationOb
 }
 
 void YSE::CHANNEL::implementationObject::run() {
-  dsp();
+  // A return bus is dispatched to the fast pool from processReturns() to run its
+  // insert chain over the already-accumulated `out`; an ordinary channel runs
+  // the normal source-tree dsp(). Both write only this impl's own `out`
+  // (single-writer discipline, issue #165).
+  if (isReturn)
+    processReturnInsert();
+  else
+    dsp();
 }
 
 void YSE::CHANNEL::implementationObject::dsp() {
@@ -149,10 +156,34 @@ void YSE::CHANNEL::implementationObject::removeInterface() {
 void YSE::CHANNEL::implementationObject::buffersToParent() {
   join();
 
-  // call this recursively on all child channels
+  // The master channel drives the send/return phases (issue #165). It is the
+  // only channel with no parent, and its body runs after the whole source tree
+  // has been recursed — the point where every source send has landed in the
+  // return buffers.
+  const bool isMaster = (parent == nullptr);
+
+  // (0) Zero every return buffer before any source send taps into it. Runs after
+  //     the parallel dsp() phase (which never touches returns), so it races
+  //     nothing, and before the recursion below where sends accumulate.
+  if (isMaster) CHANNEL::Manager().zeroReturnBuffers();
+
+  // (1) call this recursively on all child channels. Each source channel taps
+  //     its sends into the return buffers during its own buffersToParent().
   for (auto i = children.begin(); i != children.end(); ++i) {
     (*i)->buffersToParent();
   }
+
+  // (2) generation-ordered returns phase: each return's insert chain runs on the
+  //     fast pool, then folds into master — after all source sends, before the
+  //     master fader.
+  if (isMaster) CHANNEL::Manager().processReturns(this);
+
+  // A channel with no sounds or subchannels never filled `out` this block, so
+  // its buffer is stale; it must neither tap sends nor sum into its parent.
+  const bool hasWork = !(children.empty() && sounds.empty());
+
+  // Pre-fader send taps read `out` before adjustVolume() scales it.
+  if (hasWork && !sends.empty()) runSendTaps(true);
 
   // apply channel volume
   adjustVolume();
@@ -167,9 +198,12 @@ void YSE::CHANNEL::implementationObject::buffersToParent() {
     }
   }
 
+  // Post-fader send taps read the faded `out` (the default aux-send behaviour).
+  if (hasWork && !sends.empty()) runSendTaps(false);
+
   // if this is the main channel, we're done here
-  if (parent == nullptr) return;
-  if (children.empty() && sounds.empty()) return;
+  if (isMaster) return;
+  if (!hasWork) return;
 
   // if not the main channel, add output to parent channel
   for (UInt i = 0; i < out.size(); ++i) {
@@ -208,6 +242,128 @@ void YSE::CHANNEL::implementationObject::processInsertDSP() {
   }
 }
 
+void YSE::CHANNEL::implementationObject::accumulateSend(sendSlot& s) {
+  // src is this channel's finalized `out`; dst is the target return's `out`.
+  // Runs on the audio thread only, after this channel's dsp() job is joined, so
+  // `out` is complete and the return buffer receives from many senders strictly
+  // in sequence on one thread — no lock, no atomic (design §8). The ramp is
+  // fused into the multiply-accumulate exactly like adjustVolume().
+  implementationObject* tgt = s.target;
+  // A send may be wired (ADD_SEND applied on the audio thread) before its target
+  // return has finished setup() on the slow pool: the source impl is already
+  // live, so its next block would read/write the return's `out` while the slow
+  // pool is still resizing it — a data race (issue #165). Gate on the target
+  // reaching OBJECT_READY, the same acquire/release handshake readyCheck uses to
+  // publish the resized buffers; until then the return is not rendering anyway,
+  // so skipping loses nothing. A single atomic load, no lock or allocation.
+  if (tgt->objectStatus.load(std::memory_order_acquire) != OBJECT_READY) return;
+  const UInt n = (UInt)std::min(out.size(), tgt->out.size());
+  if (s.lastLevel == s.newLevel) {
+    const Flt level = s.newLevel;
+    if (level == 0.f) return; // soft-muted send: nothing to add
+    for (UInt i = 0; i < n; ++i) {
+      Flt* dst = tgt->out[i].getPtr();
+      const Flt* src = out[i].getPtr();
+      for (UInt j = 0; j < STANDARD_BUFFERSIZE; ++j)
+        dst[j] += src[j] * level;
+    }
+  } else {
+    const Flt step = (s.newLevel - s.lastLevel) / STANDARD_BUFFERSIZE;
+    for (UInt i = 0; i < n; ++i) {
+      Flt* dst = tgt->out[i].getPtr();
+      const Flt* src = out[i].getPtr();
+      Flt level = s.lastLevel;
+      for (UInt j = 0; j < STANDARD_BUFFERSIZE; ++j) {
+        dst[j] += src[j] * level;
+        level += step;
+      }
+    }
+    s.lastLevel = s.newLevel;
+  }
+}
+
+void YSE::CHANNEL::implementationObject::runSendTaps(bool preFaderPhase) {
+  for (auto& s : sends) {
+    if (s.target != nullptr && s.preFader == preFaderPhase) accumulateSend(s);
+  }
+}
+
+void YSE::CHANNEL::implementationObject::processReturnInsert() {
+  // `out` already holds the accumulated sends (zeroed at block start by the
+  // master, summed by the source tree and any earlier-generation returns). Run
+  // the return's own DSP in place — its insert chain is the effect (e.g. a plate
+  // reverb on a send return), plus any attached global reverb / underwater FX —
+  // mirroring the tail of dsp(). Single-writer over this return's own `out`.
+  if (insert_dsp != nullptr) processInsertDSP();
+
+  REVERB::Manager().process(this);
+
+  if (INTERNAL::UnderWaterEffect().channel() == this) {
+    INTERNAL::UnderWaterEffect().apply(out);
+  }
+
+  // Publish pre-volume peak (mirrors dsp()).
+  const UInt n = (UInt)std::min(out.size(), lastPeakLinearPre.size());
+  for (UInt i = 0; i < n; ++i) {
+    lastPeakLinearPre[i].v.store(out[i].maxValue(), std::memory_order_release);
+  }
+}
+
+void YSE::CHANNEL::implementationObject::finalizeReturn(implementationObject* master) {
+  // Serial audio-thread finalize, run after this return's processReturnInsert()
+  // job has been joined (design §7). Pre-fader taps read the return's `out`
+  // before its own fader; post-fader taps read it after. A return's send targets
+  // are always a strictly-higher generation, whose buffers have not yet been
+  // dispatched, so this accumulation is safe.
+  if (!sends.empty()) runSendTaps(true);
+
+  adjustVolume(); // the return's own fader
+
+  {
+    const UInt n = (UInt)std::min(out.size(), lastPeakLinearPost.size());
+    for (UInt i = 0; i < n; ++i) {
+      lastPeakLinearPost[i].v.store(out[i].maxValue(), std::memory_order_release);
+    }
+  }
+
+  if (!sends.empty()) runSendTaps(false);
+
+  // Fold the return into the master mix. A return always contributes (its insert
+  // chain may still be ringing out a reverb tail after its senders fell silent),
+  // so there is no hasWork guard here.
+  const UInt n = (UInt)std::min(out.size(), master->out.size());
+  for (UInt i = 0; i < n; ++i) {
+    master->out[i] += out[i];
+  }
+}
+
+void YSE::CHANNEL::implementationObject::detachSends() {
+  // Audio-thread teardown at OBJECT_RELEASE, before the impl can be freed by the
+  // slow pool (design §9). Two directions:
+  //
+  // 1. This channel's own outgoing sends: unlink each active slot from its
+  //    target return's registry so the target never dangles.
+  for (auto& s : sends) {
+    if (s.target != nullptr) {
+      s.target->sendRegistry.remove(&s);
+      s.target = nullptr;
+    }
+  }
+
+  // 2. If this is a return, sever every slot that still points at us (the
+  //    many-to-one case) and unlink from the manager's returns list, so no live
+  //    send slot can write into our freed `out` next block.
+  if (isReturn) {
+    for (auto i = sendRegistry.begin(); i != sendRegistry.end();) {
+      sendSlot* s = *i;
+      ++i; // advance (reads s->regNext) BEFORE mutating the slot
+      s->target = nullptr; // disable the sender's slot
+    }
+    sendRegistry.clear(); // detach every regNext link
+    CHANNEL::Manager().unlinkReturn(this);
+  }
+}
+
 void YSE::CHANNEL::implementationObject::setup() {
   if (objectStatus >= OBJECT_CREATED) {
     if (objectStatus == OBJECT_READY) return;
@@ -222,6 +378,17 @@ void YSE::CHANNEL::implementationObject::setup() {
       outConf[i].isLFE = CHANNEL::Manager().getOutputIsLFE(i);
     }
     computeEffectiveSpeakerWeights(outConf);
+
+    // Size the send-slot vector exactly once, here on the slow pool, before the
+    // channel ever reaches the render path (issue #165). Never resized
+    // afterwards, so `&sends[i]` stays a stable back-reference node. Guarded so a
+    // repeated setup() (e.g. readyCheck bouncing the status back to CREATED)
+    // cannot reallocate it.
+    if (!sendsSized) {
+      sends.resize(sendSlotCount > 0 ? (std::size_t)sendSlotCount : 0);
+      sendsSized = true;
+    }
+
     objectStatus = OBJECT_SETUP;
   }
 }
@@ -287,6 +454,17 @@ Bool YSE::CHANNEL::implementationObject::readyCheck() {
 }
 
 void YSE::CHANNEL::implementationObject::doThisWhenReady() {
+  // A return bus is excluded from the source dsp tree: it is NOT linked into any
+  // parent's `children`, so dsp() never dispatches it and buffersToParent()'s
+  // recursion never visits it. Instead it joins the manager's audio-thread
+  // `returns` list and is processed in the explicit returns phase (issue #165).
+  // connectedToParent stays false, so the release/destructor parent-disconnect
+  // path is skipped for returns (they tear down via detachSends()).
+  if (isReturn) {
+    CHANNEL::Manager().linkReturn(this);
+    return;
+  }
+
   parent->connect(this);
   // Audio thread now owns the link into parent->children. Mark it so the
   // release path can disconnect us before the slow-pool deleteJob frees us.
@@ -335,6 +513,48 @@ void YSE::CHANNEL::implementationObject::parseMessage(const messageObject& messa
     break;
   case VOLUME:
     newVolume = message.floatValue;
+    break;
+  case ADD_SEND: {
+    // (Re)point a send slot at a return and link its back-reference. By the time
+    // this arrives, setup() has already sized `sends` (a channel reaches sync()
+    // only after readyCheck, which follows setup()), but bounds-check defensively.
+    const Int slot = message.send.slot;
+    if (slot >= 0 && (std::size_t)slot < sends.size()) {
+      sendSlot& s = sends[slot];
+      // Detach the slot's previous target from its registry before repointing.
+      if (s.target != nullptr) s.target->sendRegistry.remove(&s);
+      s.target = (implementationObject*)message.send.target;
+      s.preFader = message.send.preFader;
+      // Start the ramp from silence so a freshly-wired send fades in click-free;
+      // the SEND_LEVEL message that follows sets the target level.
+      s.lastLevel = 0.f;
+      s.newLevel = 0.f;
+      if (s.target != nullptr) s.target->sendRegistry.push_front(&s);
+    }
+    break;
+  }
+  case SEND_LEVEL: {
+    const Int slot = message.sendLevel.slot;
+    if (slot >= 0 && (std::size_t)slot < sends.size()) {
+      sends[slot].newLevel = message.sendLevel.level;
+    }
+    break;
+  }
+  case REMOVE_SEND: {
+    const Int slot = (Int)message.uintValue;
+    if (slot >= 0 && (std::size_t)slot < sends.size()) {
+      sendSlot& s = sends[slot];
+      if (s.target != nullptr) {
+        s.target->sendRegistry.remove(&s);
+        s.target = nullptr;
+      }
+      s.lastLevel = 0.f;
+      s.newLevel = 0.f;
+    }
+    break;
+  }
+  case SET_GENERATION:
+    generation = (Int)message.uintValue;
     break;
   }
 }

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -39,6 +39,25 @@ namespace YSE {
       }
     };
 
+    // One aux-send slot on a channel (issue #165; design
+    // docs/design/send_return_buses.md §6). A channel owns a fixed vector of
+    // these, sized once at setup() on the slow pool and never resized on the
+    // render path, so `&sends[i]` is a stable node address. A slot is active
+    // when `target != nullptr`; the send then accumulates a ramped, scaled copy
+    // of the channel's `out` into `target->out` during the serial summation
+    // walk. `regNext` is the intrusive back-reference link: the slot is threaded
+    // into `target`'s sendRegistry so a return teardown can sever every slot
+    // pointing at it before the impl is freed (the many-to-one generalization of
+    // the insert chain's `calledfrom` guard). All fields are touched only on the
+    // audio thread.
+    struct sendSlot {
+      implementationObject* target = nullptr; // a return, or nullptr = empty
+      Flt newLevel = 0.f; // control-thread target level (via SEND_LEVEL)
+      Flt lastLevel = 0.f; // audio-thread ramp state
+      Bool preFader = false; // tap point for this slot
+      sendSlot* regNext = nullptr; // next slot in target's back-reference registry
+    };
+
     /**
       This is the implementation side of a channel. It should only be used internally.
     */
@@ -218,6 +237,53 @@ namespace YSE {
       void processInsertDSP();
 
       /////////////////////////////////////////////////////
+      // Send / return buses (issue #165)
+      /////////////////////////////////////////////////////
+      /**
+        Accumulate a ramped, scaled copy of this channel's `out` into every
+        active send slot whose tap point matches @p preFaderPhase. Runs on the
+        audio callback thread only, from the serial summation walk
+        (buffersToParent) for source channels and from finalizeReturn() for
+        returns — never on a parallel worker. The ramp is fused into the
+        multiply-accumulate exactly like adjustVolume(), so live send-level moves
+        are click-free. Public so tests can drive it after populating `out`.
+      */
+      void runSendTaps(bool preFaderPhase);
+
+      /**
+        The fast-pool job body for a return bus: runs the return's own DSP
+        (insert chain + optional reverb / underwater FX) in place over the
+        already-accumulated `out`, then publishes the pre-fader peak. Mirrors the
+        tail of dsp(); dispatched from CHANNEL::Manager::processReturns() exactly
+        like a source channel's dsp(). Single-writer over this return's own `out`.
+      */
+      void processReturnInsert();
+
+      /**
+        Serial finalize step for a return, run on the audio thread after its
+        processReturnInsert() job is joined: applies the return fader, publishes
+        the post-fader peak, runs the return's own send taps (targets are always
+        a strictly higher generation), then folds the return into @p master. See
+        design §7.
+      */
+      void finalizeReturn(implementationObject* master);
+
+      /**
+        Audio-thread teardown of every send this impl participates in, run at
+        OBJECT_RELEASE before the impl becomes eligible for the slow-pool delete.
+        Unlinks this channel's own active slots from their targets' registries,
+        and — if this is a return — severs every slot pointing at it and unlinks
+        it from the manager's returns list. Guarantees no live send slot
+        dereferences a freed return (design §9).
+      */
+      void detachSends();
+
+      /** @brief True when this channel is a send/return bus (issue #165). */
+      bool getIsReturn() const {
+        return isReturn;
+      }
+
+      /////////////////////////////////////////////////////
       // Output peak metering (control-thread readers)
       /////////////////////////////////////////////////////
       /** @brief Number of output channels currently allocated for this implementation. */
@@ -276,6 +342,11 @@ namespace YSE {
       // replacing the std::forward_list<T*> nodes without per-tick heap churn.
       implementationObject* _mgrNext = nullptr;
       implementationObject* _childNext = nullptr;
+      // Threads a return bus through the CHANNEL manager's audio-thread `returns`
+      // list (issue #165). Only returns use it; a return is in `returns` (render
+      // phase) in addition to `inUse` (lifecycle/sync), so it needs a link
+      // distinct from `_mgrNext`. nullptr for ordinary channels.
+      implementationObject* _returnNext = nullptr;
 
       std::atomic<channel*> head; // < The interface connected to this object
       std::atomic<OBJECT_IMPLEMENTATION_STATE> objectStatus; // < the status of this object
@@ -320,6 +391,29 @@ namespace YSE {
 
       Bool userChannel = true; // channel is created by user and not crucial for the system
       Bool allowVirtual;
+
+      // ─── Send / return bus state (issue #165) ───
+      // `isReturn`, `sendSlotCount` are control-thread writes applied before the
+      // impl is handed to the slow/audio threads (mirrors `parent`), then treated
+      // as immutable — published once via the setup/ready handshake, read after.
+      // `generation` and `sends` are mutated only on the audio thread.
+      Bool isReturn = false; // this channel is a return bus (excluded from the dsp tree)
+      Int generation = 0; // return processing-order layer (SET_GENERATION); audio thread only
+      Int sendSlotCount = 4; // number of send slots; sized once in setup()
+      Bool sendsSized = false; // guards the one-time setup() sizing of `sends`
+
+      // Fixed vector of send slots, sized once at setup() and never resized on
+      // the render path (so slot addresses stay stable as registry nodes).
+      std::vector<sendSlot> sends;
+
+      // Back-reference registry: the send slots currently targeting THIS return.
+      // Mutated only on the audio thread (ADD_SEND / REMOVE_SEND / detachSends).
+      // Empty for non-return channels.
+      IntrusiveForwardList<sendSlot, &sendSlot::regNext> sendRegistry;
+
+      /** Accumulate one active slot's ramped, scaled `out` into its target
+          return's `out`. Audio thread only; no allocation or locking. */
+      void accumulateSend(sendSlot& slot);
 
       friend class SOUND::implementationObject;
       friend class YSE::channel;

--- a/YseEngine/channel/channelInterface.cpp
+++ b/YseEngine/channel/channelInterface.cpp
@@ -52,20 +52,62 @@ YSE::channel::channel() : volume(1.f), allowVirtual(true), pimpl(nullptr) {}
 
 YSE::channel::~channel() {
   unregisterFromBus();
+  // Drop this return from the control-thread wiring graph so cycle checks and
+  // generation indexing for the surviving returns stay correct. Guarded on the
+  // active engine (like unregisterFromBus): after System::close() the graph is
+  // already torn down and the peer impls are gone, so recomputing/posting would
+  // be unsafe. The impl-side teardown (unlink from the returns list, sever the
+  // back-reference registry) runs separately on the audio thread via the
+  // OBJECT_RELEASE path once removeInterface() nulls the head. (issue #165)
+  if (_isReturn && pimpl != nullptr && INTERNAL::Global().isActive()) {
+    CHANNEL::Manager().unregisterReturnGraph(pimpl);
+  }
   if (pimpl != nullptr) {
     pimpl->removeInterface();
     pimpl = nullptr;
   }
 }
 
-YSE::channel& YSE::channel::create(const char* name, channel& parent) {
+YSE::channel& YSE::channel::create(const char* name, channel& parent, int sendSlots) {
   assert(pimpl == nullptr); // make sure we don't get called twice
   this->logName = name;
 
+  _sendSlots = sendSlots < 0 ? 0 : sendSlots;
+  _sends.assign((std::size_t)_sendSlots, SendMirror{});
+
   pimpl = CHANNEL::Manager().addImplementation(this);
   pimpl->parent = parent.pimpl;
+  // Control-thread writes applied before the impl is handed to the slow/audio
+  // threads (mirrors `parent`); setup() reads sendSlotCount on the slow pool.
+  pimpl->sendSlotCount = _sendSlots;
   CHANNEL::Manager().setup(pimpl);
   return *this;
+}
+
+YSE::channel& YSE::channel::makeReturn(const char* name, int sendSlots) {
+  assert(pimpl == nullptr); // make sure we don't get called twice
+  this->logName = name;
+
+  _isReturn = true;
+  _sendSlots = sendSlots < 0 ? 0 : sendSlots;
+  _sends.assign((std::size_t)_sendSlots, SendMirror{});
+
+  pimpl = CHANNEL::Manager().addImplementation(this);
+  // A return folds into master and is excluded from the source tree. Setting
+  // parent to master keeps the impl's release/destructor guards well-defined
+  // (they short-circuit on connectedToParent, which stays false for returns).
+  pimpl->parent = CHANNEL::Manager().master().pimpl;
+  pimpl->isReturn = true;
+  pimpl->sendSlotCount = _sendSlots;
+  CHANNEL::Manager().setup(pimpl);
+  // Register as a node in the control-thread wiring graph so return→return
+  // cycle checks and generation indexing can see it.
+  CHANNEL::Manager().registerReturnGraph(pimpl);
+  return *this;
+}
+
+bool YSE::channel::isReturn() const {
+  return _isReturn;
 }
 
 void YSE::channel::createGlobal() {
@@ -183,6 +225,98 @@ YSE::channel& YSE::channel::setDSP(YSE::DSP::dspObject* value) {
 
 YSE::DSP::dspObject* YSE::channel::getDSP() {
   return _dsp;
+}
+
+YSE::channel& YSE::channel::send(int slot, channel& returnBus, float level, bool preFader) {
+  if (pimpl == nullptr) return *this;
+  if (slot < 0 || slot >= _sendSlots) {
+    INTERNAL::LogImpl().emit(E_ERROR, "channel send: slot index out of range; ignored");
+    return *this;
+  }
+  if (!returnBus._isReturn || returnBus.pimpl == nullptr) {
+    INTERNAL::LogImpl().emit(E_ERROR, "channel send: target is not a return bus; ignored");
+    return *this;
+  }
+  if (returnBus.pimpl == pimpl) {
+    INTERNAL::LogImpl().emit(E_ERROR, "channel send: a channel cannot send to itself; ignored");
+    return *this;
+  }
+
+  // A return→return edge must keep the routing acyclic. Validate BEFORE the old
+  // edge for this slot is removed, so a rejected wiring leaves the graph
+  // untouched (the temporary presence of both the old and new edge is legal —
+  // a return may send to several returns).
+  bool newGraphEdge = false;
+  if (_isReturn) {
+    if (!CHANNEL::Manager().tryAddReturnEdge(pimpl, returnBus.pimpl)) {
+      INTERNAL::LogImpl().emit(
+          E_ERROR, "channel send: rejected — would create a cycle in the return graph");
+      return *this;
+    }
+    newGraphEdge = true;
+  }
+
+  // Accepted. Drop the slot's previous return→return edge, if any.
+  SendMirror& m = _sends[slot];
+  if (m.graphEdge && m.targetImpl != nullptr) {
+    CHANNEL::Manager().removeReturnEdge(pimpl, m.targetImpl);
+  }
+  m.target = &returnBus;
+  m.targetImpl = returnBus.pimpl;
+  m.level = level;
+  m.preFader = preFader;
+  m.graphEdge = newGraphEdge;
+
+  // Post the wiring to the audio thread: ADD_SEND links the slot + back-reference
+  // (ramp reset to silence), then SEND_LEVEL sets the target level so it fades in.
+  {
+    CHANNEL::messageObject msg;
+    msg.ID = CHANNEL::ADD_SEND;
+    msg.send.target = returnBus.pimpl;
+    msg.send.slot = slot;
+    msg.send.preFader = preFader;
+    pimpl->sendMessage(msg);
+  }
+  {
+    CHANNEL::messageObject msg;
+    msg.ID = CHANNEL::SEND_LEVEL;
+    msg.sendLevel.slot = slot;
+    msg.sendLevel.level = level;
+    pimpl->sendMessage(msg);
+  }
+  return *this;
+}
+
+YSE::channel& YSE::channel::setSendLevel(int slot, float level) {
+  if (pimpl == nullptr) return *this;
+  if (slot < 0 || slot >= _sendSlots) return *this;
+  _sends[slot].level = level;
+  CHANNEL::messageObject msg;
+  msg.ID = CHANNEL::SEND_LEVEL;
+  msg.sendLevel.slot = slot;
+  msg.sendLevel.level = level;
+  pimpl->sendMessage(msg);
+  return *this;
+}
+
+YSE::channel& YSE::channel::clearSend(int slot) {
+  if (pimpl == nullptr) return *this;
+  if (slot < 0 || slot >= _sendSlots) return *this;
+  SendMirror& m = _sends[slot];
+  if (m.graphEdge && m.targetImpl != nullptr) {
+    CHANNEL::Manager().removeReturnEdge(pimpl, m.targetImpl);
+  }
+  m = SendMirror{};
+  CHANNEL::messageObject msg;
+  msg.ID = CHANNEL::REMOVE_SEND;
+  msg.uintValue = (UInt)slot;
+  pimpl->sendMessage(msg);
+  return *this;
+}
+
+float YSE::channel::getSendLevel(int slot) const {
+  if (slot < 0 || slot >= _sendSlots) return 0.f;
+  return _sends[slot].level;
 }
 
 int YSE::channel::getNumOutputs() {

--- a/YseEngine/channel/channelInterface.cpp
+++ b/YseEngine/channel/channelInterface.cpp
@@ -249,8 +249,8 @@ YSE::channel& YSE::channel::send(int slot, channel& returnBus, float level, bool
   bool newGraphEdge = false;
   if (_isReturn) {
     if (!CHANNEL::Manager().tryAddReturnEdge(pimpl, returnBus.pimpl)) {
-      INTERNAL::LogImpl().emit(
-          E_ERROR, "channel send: rejected — would create a cycle in the return graph");
+      INTERNAL::LogImpl().emit(E_ERROR,
+                               "channel send: rejected — would create a cycle in the return graph");
       return *this;
     }
     newGraphEdge = true;

--- a/YseEngine/channel/channelInterface.hpp
+++ b/YseEngine/channel/channelInterface.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 #include "../classes.hpp"
 #include "../headers/defines.hpp"
 #include "../headers/types.hpp"
@@ -62,8 +63,77 @@ namespace YSE {
      *  @param name   Channel name, used for log output.
      *  @param parent Existing channel to attach to. Use ``ChannelMaster()`` for a
      *                top-level channel.
+     *  @param sendSlots Number of aux-send slots to allocate for this channel
+     *                (issue #165). Sized once off the audio thread and never
+     *                resized. Default 4; raise it for a channel that fans out to
+     *                many return buses.
      */
-    channel& create(const char* name, channel& parent);
+    channel& create(const char* name, channel& parent, int sendSlots = 4);
+
+    /**
+     *  @brief Create this channel as a send/return bus.
+     *
+     *  A return bus is an ordinary channel (it keeps ``setDSP`` inserts,
+     *  ``attachReverb``, ``setVolume``, and metering) with two differences: it is
+     *  excluded from the normal mix tree, and other channels route scaled copies
+     *  of their signal into it via ``send``. Its output folds into ``MainMix``
+     *  after the source tree, so a single reverb or delay on a return can serve
+     *  many channels (the classic aux-send topology). A return may itself
+     *  ``send`` into another return (an acyclic delay→reverb chain, for example);
+     *  cycles are rejected at wiring time.
+     *
+     *  Call this instead of ``create`` — not after it. The engine takes no
+     *  ownership of any effect attached with ``setDSP``.
+     *
+     *  @param name      Channel name, used for log output.
+     *  @param sendSlots Number of aux-send slots on the return itself (for
+     *                   return→return routing). Default 4.
+     *  @return ``*this`` for fluent chaining (e.g. ``r.makeReturn("verb").setDSP(&plate)``).
+     */
+    channel& makeReturn(const char* name = "return", int sendSlots = 4);
+
+    /** @brief Whether this channel is a send/return bus (issue #165). */
+    bool isReturn() const;
+
+    /**
+     *  @brief Route a scaled copy of this channel into a return bus.
+     *
+     *  Wires send slot @p slot (in ``[0, sendSlots)``) to @p returnBus at the
+     *  given @p level. The send is **post-fader** by default (it follows this
+     *  channel's own volume); pass ``preFader = true`` for a cue-style send
+     *  independent of the fader. Re-calling ``send`` on the same slot re-points
+     *  it. The level ramps in, so wiring a live send never clicks.
+     *
+     *  Illegal wirings are rejected on the calling (control) thread and logged,
+     *  never reaching the audio thread: a target that is not a return, a
+     *  self-send, or a return→return edge that would close a cycle.
+     *
+     *  @param slot      Send-slot index in ``[0, sendSlots)``.
+     *  @param returnBus A channel created with ``makeReturn``.
+     *  @param level     Send gain (typically ``[0, 1]``).
+     *  @param preFader  Tap before this channel's fader when true (default false).
+     *  @return ``*this`` for fluent chaining.
+     */
+    channel& send(int slot, channel& returnBus, float level, bool preFader = false);
+
+    /**
+     *  @brief Set a send slot's level, ramped and click-free.
+     *
+     *  Safe to call every control tick — send levels are designed as modulation
+     *  targets (a patcher outlet, a live-coded expression, a proximity rule), so
+     *  continuous writes fuse into the per-block ramp without zippering.
+     *
+     *  @param slot  Send-slot index in ``[0, sendSlots)``.
+     *  @param level New send gain.
+     *  @return ``*this`` for fluent chaining.
+     */
+    channel& setSendLevel(int slot, float level);
+
+    /** @brief Detach send slot @p slot (fully disconnects it from its return). */
+    channel& clearSend(int slot);
+
+    /** @brief Current target level of send slot @p slot, or 0 if unset/invalid. */
+    float getSendLevel(int slot) const;
 
     /** @brief Set the channel volume in the range [0.0, 1.0]. */
     channel& setVolume(float value);
@@ -216,6 +286,23 @@ namespace YSE {
     std::string busName;
     std::uint64_t busVolumeHandle{0};
     bool busOwner{false};
+
+    // ─── Send/return state (issue #165) ───
+    // Control-thread mirror of this channel's send wiring. Lets the interface
+    // validate slots, report getSendLevel(), and maintain the control-thread
+    // return→return graph (remove the old edge when a slot is re-pointed). None
+    // of this is touched on the audio thread — the impl carries its own copy,
+    // updated via messages.
+    bool _isReturn{false};
+    int _sendSlots{0};
+    struct SendMirror {
+      channel* target{nullptr}; // interface identity of the target return
+      CHANNEL::implementationObject* targetImpl{nullptr}; // graph key (value only; never dereferenced)
+      float level{0.f};
+      bool preFader{false};
+      bool graphEdge{false}; // this slot contributed a return→return graph edge
+    };
+    std::vector<SendMirror> _sends;
 
     friend class CHANNEL::implementationObject;
     friend class SOUND::implementationObject;

--- a/YseEngine/channel/channelInterface.hpp
+++ b/YseEngine/channel/channelInterface.hpp
@@ -297,7 +297,8 @@ namespace YSE {
     int _sendSlots{0};
     struct SendMirror {
       channel* target{nullptr}; // interface identity of the target return
-      CHANNEL::implementationObject* targetImpl{nullptr}; // graph key (value only; never dereferenced)
+      CHANNEL::implementationObject* targetImpl{
+          nullptr}; // graph key (value only; never dereferenced)
       float level{0.f};
       bool preFader{false};
       bool graphEdge{false}; // this slot contributed a return→return graph edge

--- a/YseEngine/channel/channelManager.cpp
+++ b/YseEngine/channel/channelManager.cpp
@@ -38,6 +38,13 @@ YSE::CHANNEL::managerObject::~managerObject() noexcept {
     // remove all objects that are still in memory
     toLoad.clear();
     inUse.clear();
+    returns.clear();
+    {
+      std::scoped_lock lk(returnGraphMutex);
+      returnNodes.clear();
+      returnEdges.clear();
+      returnGenPosted.clear();
+    }
     implementations.clear();
     delete[] outputAngles;
     delete[] outputIsLFE;
@@ -122,6 +129,11 @@ void YSE::CHANNEL::managerObject::update() {
               false, std::memory_order_release); // NOSONAR S8417: intentional release — publishes
                                                  // audio-thread disconnect before slow-pool delete
         }
+        // Sever every send this impl participates in (both directions) and, if
+        // it is a return, unlink it from the `returns` list — on the audio
+        // thread, BEFORE OBJECT_DELETE makes it eligible for the slow-pool free.
+        // Guarantees no live send slot dereferences the freed impl (issue #165 §9).
+        ptr->detachSends();
         ptr->setStatus(OBJECT_DELETE);
         runDelete = true;
         continue; // c already refers to the successor after erase()
@@ -168,6 +180,13 @@ void YSE::CHANNEL::managerObject::destroy() {
   }
   toLoad.clear();
   inUse.clear();
+  returns.clear();
+  {
+    std::scoped_lock lk(returnGraphMutex);
+    returnNodes.clear();
+    returnEdges.clear();
+    returnGenPosted.clear();
+  }
   {
     std::scoped_lock lk(implementationsMutex);
     // Each impl destructor nulls its interface's pimpl, clearing the persistent
@@ -380,4 +399,161 @@ void YSE::CHANNEL::managerObject::set71() {
   setAngle(5, 135.0f); // back right
   setAngle(6, -90.0f); // side left
   setAngle(7, 90.0f); // side right
+}
+
+/////////////////////////////////////////////////////
+// Send / return buses (issue #165)
+/////////////////////////////////////////////////////
+
+// ─── Audio-thread render helpers ───
+
+void YSE::CHANNEL::managerObject::zeroReturnBuffers() {
+  for (auto i = returns.begin(); i != returns.end(); ++i) {
+    (*i)->clearBuffers();
+  }
+}
+
+void YSE::CHANNEL::managerObject::processReturns(implementationObject* master) {
+  if (returns.empty()) return;
+
+  // Returns are few, so a per-block scan for the max generation is trivial and
+  // avoids having to track a running maximum across teardown.
+  Int maxGen = 0;
+  for (auto i = returns.begin(); i != returns.end(); ++i) {
+    if ((*i)->generation > maxGen) maxGen = (*i)->generation;
+  }
+
+  // Process generation by generation, ascending. Within a generation returns are
+  // mutually independent (their sends only target strictly-higher generations,
+  // enforced at wiring time), so all can be dispatched to the fast pool at once
+  // and then joined + finalized serially in list order (deterministic += order).
+  for (Int g = 0; g <= maxGen; ++g) {
+    for (auto i = returns.begin(); i != returns.end(); ++i) {
+      if ((*i)->generation == g) INTERNAL::Global().addFastJob(*i);
+    }
+    for (auto i = returns.begin(); i != returns.end(); ++i) {
+      if ((*i)->generation == g) {
+        (*i)->join();
+        (*i)->finalizeReturn(master);
+      }
+    }
+  }
+}
+
+void YSE::CHANNEL::managerObject::linkReturn(implementationObject* r) {
+  returns.push_front(r);
+}
+
+void YSE::CHANNEL::managerObject::unlinkReturn(implementationObject* r) {
+  returns.remove(r);
+}
+
+// ─── Control-thread wiring graph ───
+
+bool YSE::CHANNEL::managerObject::returnReachable(implementationObject* from,
+                                                  implementationObject* to) {
+  // Depth-first walk from `from` over return→return edges; true if `to` is
+  // reachable. Bounded by the (small) number of returns. Control thread, under
+  // returnGraphMutex.
+  if (from == to) return true;
+  std::vector<implementationObject*> stack;
+  std::unordered_set<implementationObject*> seen;
+  stack.push_back(from);
+  seen.insert(from);
+  while (!stack.empty()) {
+    implementationObject* n = stack.back();
+    stack.pop_back();
+    auto it = returnEdges.find(n);
+    if (it == returnEdges.end()) continue;
+    for (auto& [next, cnt] : it->second) {
+      if (cnt <= 0) continue;
+      if (next == to) return true;
+      if (seen.insert(next).second) stack.push_back(next);
+    }
+  }
+  return false;
+}
+
+void YSE::CHANNEL::managerObject::recomputeAndPostGenerations() {
+  // Longest-path layering over the return→return DAG (returns are few; a simple
+  // relaxation to a fixpoint is ample). generation(n) = 0 for a return with no
+  // incoming return→return edge, else 1 + max(generation(pred)).
+  std::unordered_map<implementationObject*, Int> gen;
+  gen.reserve(returnNodes.size());
+  for (auto* n : returnNodes)
+    gen[n] = 0;
+
+  for (std::size_t pass = 0; pass < returnNodes.size(); ++pass) {
+    bool changed = false;
+    for (auto& [from, tos] : returnEdges) {
+      if (returnNodes.find(from) == returnNodes.end()) continue;
+      const Int gf = gen[from];
+      for (auto& [to, cnt] : tos) {
+        if (cnt <= 0 || returnNodes.find(to) == returnNodes.end()) continue;
+        if (gen[to] < gf + 1) {
+          gen[to] = gf + 1;
+          changed = true;
+        }
+      }
+    }
+    if (!changed) break;
+  }
+
+  // Message only the returns whose generation actually changed — a single scalar
+  // write applied in sync() on the audio thread.
+  for (auto* n : returnNodes) {
+    const Int g = gen[n];
+    auto it = returnGenPosted.find(n);
+    if (it == returnGenPosted.end() || it->second != g) {
+      returnGenPosted[n] = g;
+      messageObject m;
+      m.ID = SET_GENERATION;
+      m.uintValue = (UInt)g;
+      n->sendMessage(m);
+    }
+  }
+}
+
+void YSE::CHANNEL::managerObject::registerReturnGraph(implementationObject* r) {
+  std::scoped_lock lk(returnGraphMutex);
+  returnNodes.insert(r);
+  returnGenPosted[r] = 0; // matches the impl's default generation (0)
+}
+
+void YSE::CHANNEL::managerObject::unregisterReturnGraph(implementationObject* r) {
+  std::scoped_lock lk(returnGraphMutex);
+  returnNodes.erase(r);
+  returnEdges.erase(r); // outgoing edges
+  for (auto& [from, tos] : returnEdges) // incoming edges
+    tos.erase(r);
+  returnGenPosted.erase(r);
+  recomputeAndPostGenerations();
+}
+
+bool YSE::CHANNEL::managerObject::tryAddReturnEdge(implementationObject* from,
+                                                   implementationObject* to) {
+  std::scoped_lock lk(returnGraphMutex);
+  // Adding from→to closes a cycle iff `to` can already reach `from`.
+  if (returnReachable(to, from)) return false;
+  returnEdges[from][to]++;
+  recomputeAndPostGenerations();
+  return true;
+}
+
+void YSE::CHANNEL::managerObject::removeReturnEdge(implementationObject* from,
+                                                   implementationObject* to) {
+  std::scoped_lock lk(returnGraphMutex);
+  auto it = returnEdges.find(from);
+  if (it == returnEdges.end()) return;
+  auto jt = it->second.find(to);
+  if (jt == it->second.end()) return;
+  if (jt->second > 0) --jt->second;
+  if (jt->second <= 0) it->second.erase(jt);
+  recomputeAndPostGenerations();
+}
+
+Int YSE::CHANNEL::managerObject::returnGenerationOf(implementationObject* r) {
+  std::scoped_lock lk(returnGraphMutex);
+  auto it = returnGenPosted.find(r);
+  return it == returnGenPosted.end() ? -1 : it->second;
 }

--- a/YseEngine/channel/channelManager.h
+++ b/YseEngine/channel/channelManager.h
@@ -13,6 +13,8 @@
 
 #include <forward_list>
 #include <mutex>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include "channelImplementation.h"
 #include "../headers/enums.hpp"
@@ -74,7 +76,46 @@ namespace YSE {
 
       void setMaster(implementationObject* impl);
 
+      /////////////////////////////////////////////////////
+      // Send / return buses (issue #165)
+      /////////////////////////////////////////////////////
+      // Audio-thread render helpers, driven from the master's buffersToParent().
+      /** Zero every return's `out` buffer once per block, before any send taps. */
+      void zeroReturnBuffers();
+      /** Generation-ordered returns phase: each return's insert chain runs on the
+          fast pool, then folds into @p master. Audio thread only. */
+      void processReturns(implementationObject* master);
+      /** Link/unlink a return into the audio-thread `returns` render list. Called
+          from the impl's doThisWhenReady() / detachSends(). */
+      void linkReturn(implementationObject* r);
+      void unlinkReturn(implementationObject* r);
+
+      // Control-thread wiring-graph operations (issue #165 §10). These run on the
+      // setup/control thread only (from the channel interface), never on the
+      // audio thread. They validate acyclicity, maintain the return→return edge
+      // graph, and post SET_GENERATION messages when a wiring change alters the
+      // longest-path generation of any return. Guarded by returnGraphMutex.
+      /** Register/unregister a return as a node in the wiring graph. */
+      void registerReturnGraph(implementationObject* r);
+      void unregisterReturnGraph(implementationObject* r);
+      /** Add a return→return edge iff it keeps the graph acyclic. Returns false
+          (edge NOT added) if it would create a cycle. Recomputes generations. */
+      bool tryAddReturnEdge(implementationObject* from, implementationObject* to);
+      /** Remove one return→return edge (by multiplicity). Recomputes generations. */
+      void removeReturnEdge(implementationObject* from, implementationObject* to);
+      /** The generation the wiring graph currently assigns to return @p r, or -1
+          if it is not a registered return. Control-thread diagnostic (tests). */
+      Int returnGenerationOf(implementationObject* r);
+
     private:
+      // Recompute the longest-path generation of every return over the current
+      // return→return DAG and post SET_GENERATION to any whose value changed.
+      // Control thread, called under returnGraphMutex.
+      void recomputeAndPostGenerations();
+      // True if `to` can already reach `from` over return→return edges (so adding
+      // from→to would close a cycle). Control thread, called under the mutex.
+      bool returnReachable(implementationObject* from, implementationObject* to);
+
       // Once an object is ready for use, it is linked into this container. The
       // manager updates and syncs all these objects during the dsp callback.
       // Intrusive (link embedded via `_mgrNext`) — allocation-free (issue #194).
@@ -90,6 +131,26 @@ namespace YSE {
       // Audio-thread-owned working list of impls awaiting OBJECT_READY. Shares
       // the `_mgrNext` link with `inUse` (an impl is only ever in one of them).
       IntrusiveForwardList<implementationObject, &implementationObject::_mgrNext> toLoad;
+
+      // Audio-thread-owned list of return buses (issue #165). Threaded on the
+      // impl's `_returnNext` link — distinct from `_mgrNext` because a return is
+      // in BOTH `inUse` (lifecycle/sync) and `returns` (render phase). Walked
+      // only in zeroReturnBuffers()/processReturns() and mutated only via
+      // linkReturn()/unlinkReturn(), all on the audio callback thread.
+      IntrusiveForwardList<implementationObject, &implementationObject::_returnNext> returns;
+
+      // ─── Control-thread return→return wiring graph (issue #165 §10) ───
+      // Touched ONLY on the setup/control thread, never on the audio thread, so
+      // its mutex never reaches the render path. `returnEdges[from][to]` is the
+      // multiplicity of send slots wiring return `from` into return `to`; an edge
+      // is present while the count is > 0. `returnGenPosted` caches the last
+      // generation posted to each return so recomputes only message the ones that
+      // changed.
+      std::mutex returnGraphMutex;
+      std::unordered_set<implementationObject*> returnNodes;
+      std::unordered_map<implementationObject*, std::unordered_map<implementationObject*, int>>
+          returnEdges;
+      std::unordered_map<implementationObject*, Int> returnGenPosted;
 
       // Canonical list of all implementationObjects. Touched by main thread
       // (addImplementation emplace_front) and the slow-pool worker (setupJob

--- a/YseEngine/channel/channelMessage.h
+++ b/YseEngine/channel/channelMessage.h
@@ -16,6 +16,21 @@
 namespace YSE {
   namespace CHANNEL {
 
+    // Send/return message payloads (issue #165). Named (not anonymous nested)
+    // so the shared messageObject union stays -Wpedantic clean. Both fit inside
+    // the existing union footprint (max member Flt[3] = 12 bytes; the void*
+    // alignment already rounds the union to 16 bytes on a 64-bit ABI), so the
+    // shared message size does not grow.
+    struct sendPayload {
+      void* target; // CHANNEL::implementationObject* of the return
+      Int slot;
+      Bool preFader;
+    };
+    struct sendLevelPayload {
+      Int slot;
+      Flt level;
+    };
+
     /*
        Message objects are used to send messages from interface to implementation. In this
        case, a message will be sent from a channelInterfaceObject to a
@@ -39,6 +54,12 @@ namespace YSE {
         Flt floatValue;
         UInt uintValue;
         void* ptrValue;
+
+        // Send/return payloads (issue #165). `send` carries an ADD_SEND (target
+        // return + slot index + tap point); `sendLevel` carries a SEND_LEVEL
+        // (slot + level). REMOVE_SEND / SET_GENERATION reuse uintValue.
+        sendPayload send;
+        sendLevelPayload sendLevel;
       };
     };
   } // namespace CHANNEL

--- a/YseEngine/utils/atomicOps.hpp
+++ b/YseEngine/utils/atomicOps.hpp
@@ -257,6 +257,26 @@ namespace YSE {
 #endif
 #include <utility>
 
+// ThreadSanitizer cannot model standalone `std::atomic_thread_fence`, which is
+// exactly how this SPSC queue publishes non-atomic element data (a relaxed
+// index store guarded by a release fence, observed via a relaxed index load
+// guarded by an acquire fence — see lfQueue.hpp). The algorithm is correct, but
+// TSan reports a false-positive data race on the element move because it cannot
+// see the fence-established happens-before. When (and only when) building under
+// TSan, promote the weak_atomic index load/store to seq_cst so the
+// synchronisation rides on the atomic accesses themselves — which TSan does
+// model — instead of the standalone fences. This is a sanitizer-only visibility
+// change: normal debug/release builds keep the original relaxed+fence fast path
+// byte-for-byte, so there is no runtime cost off the TSan leg. (issue #165)
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define YSE_WEAK_ATOMIC_TSAN 1
+#endif
+#endif
+#if !defined(YSE_WEAK_ATOMIC_TSAN) && defined(__SANITIZE_THREAD__)
+#define YSE_WEAK_ATOMIC_TSAN 1
+#endif
+
 // WARNING: *NOT* A REPLACEMENT FOR std::atomic. READ CAREFULLY:
 // Provides basic support for atomic variables -- no memory ordering guarantees are provided.
 // The guarantee of atomicity is only made for types that already have atomic load and store
@@ -294,18 +314,23 @@ namespace YSE {
       return value;
     }
 #else
+#ifdef YSE_WEAK_ATOMIC_TSAN
+    static constexpr std::memory_order weak_order = std::memory_order_seq_cst;
+#else
+    static constexpr std::memory_order weak_order = std::memory_order_relaxed;
+#endif
     template <typename U> AE_FORCEINLINE weak_atomic const& operator=(U&& x) {
-      value.store(std::forward<U>(x), std::memory_order_relaxed);
+      value.store(std::forward<U>(x), weak_order);
       return *this;
     }
 
     AE_FORCEINLINE weak_atomic const& operator=(weak_atomic const& other) {
-      value.store(other.value.load(std::memory_order_relaxed), std::memory_order_relaxed);
+      value.store(other.value.load(weak_order), weak_order);
       return *this;
     }
 
     AE_FORCEINLINE T load() const {
-      return value.load(std::memory_order_relaxed);
+      return value.load(weak_order);
     }
 #endif
 


### PR DESCRIPTION
## Summary

Implements aux **send/return buses** per the settled design in
[`docs/design/send_return_buses.md`](docs/design/send_return_buses.md) (issue #164).
Any channel can route a ramped, scaled copy of its output into a **return bus**;
the return runs its own insert chain (e.g. a plate reverb) and folds into
`MainMix` after the source tree, before the master fader. Return→return sends
form an acyclic DAG; cycles are rejected at wiring time on the control thread.

C API is intentionally **out of scope** (that is #166).

## Linked issue

Closes #165

## Design conformance (docs/design/send_return_buses.md)

- **§5 return = flagged channel** — `isReturn` impl, excluded from the source
  `dsp()` tree, owned by a master-level `returns` list, folded into master.
- **§6 send slots** — fixed vector sized **once in `setup()`** on the slow pool
  (default 4, per-channel), never resized on the render path; ramp-fused
  multiply-accumulate (pre/post-fader tap points), click-free.
- **§7 block cycle** — `zeroReturnBuffers()` → source recursion (taps sends) →
  `processReturns()` **generation-by-generation**, each return's insert chain
  dispatched to the **fast pool** and help-joined, accumulation serial on the
  audio thread. No render-path lock/atomic/allocation.
- **§9 lifecycle** — wiring via `lfQueue` messages applied in `sync()`;
  intrusive back-reference registry; teardown severs both send directions at
  `OBJECT_RELEASE` before the slow pool frees the impl.
- **§10 cycle prevention** — bounded control-thread DFS rejects cycles at wiring
  time (logged, never posted to the audio thread); longest-path generation
  indexing via `SET_GENERATION`.
- **§11 modulation targets** — `setSendLevel()` is safe to call every control
  tick (bounded inbox message + one-block ramp).

Extra RT-safety fix found during TSan bring-up: `accumulateSend()` gates on the
target return reaching `OBJECT_READY`. A send can be wired before its target
finishes `setup()` on the slow pool; touching the return's `out` before then
races the resize. One atomic acquire-load, no lock/allocation.

## Note on `atomicOps.hpp` (shared infra, TSan-only)

The 8-senders→2-returns gate races a control thread calling `setSendLevel()`
against the render thread — the wiring hand-off goes through the per-channel
`lfQueue` (moodycamel SPSC). That queue publishes non-atomic element data via
relaxed indices guarded by standalone fences, which **ThreadSanitizer cannot
model** — a false positive on every `lfQueue` producer/consumer split (used by
*every* channel control op, not just sends; the patcher TSan gate never
exercised it because the patcher uses a different queue). Under TSan **only**,
`weak_atomic` load/store is promoted to seq_cst so the synchronisation rides on
the atomic accesses TSan does model. Normal debug/release builds keep the
relaxed+fence fast path **byte-for-byte** — sanitizer-only visibility change.

## Test plan

Tests in `Tests/channel/test_channel_sends.cpp` (+ `sendstress` suite in its own
ctest process, wired into the `tests-tsan`/`tests-asan` presets):

- [x] `python yse.py format` clean (format gate)
- [x] `python yse.py analyze` clean on modified files (no new findings)
- [x] Full unit suite: **24/24 ctest entries pass** on Windows (`python yse.py test`)
- [x] Deterministic impl-level accumulation math: click-free ramp-in,
      sample-accurate, no zipper on level change, pre/post-fader phase
      isolation, `REMOVE_SEND` detach
- [x] Control-thread wiring graph: generation layering + cycle/self-send rejection
- [x] Interface wiring + validation rejections
- [x] **TSan-clean** (0 races) via `tools/ci-linux` sanitizer image: 8 senders →
      2 plate-reverb returns with a control thread hammering `setSendLevel`;
      return→return (gen 0→1) chain end-to-end; destroy-return-while-senders-live
- [x] **ASan-clean** via the same image

### Pre-existing issue observed (not from this PR)

The pre-existing `test_channel_concurrency` "two-thread create/destroy churn"
test is flaky in the local `tools/ci-linux` **audio-enabled** Docker image
(hangs ~22/30 on `dev`, ~19/30 on this branch — roughly equal, driven by an
audio-callback lifecycle race, issue #41 / #298 territory). It does **not**
reproduce on the deviceless GitHub Linux runner (dev's SonarQube leg is green),
so it is not a CI blocker and is unrelated to send/return. Flagging for the
backlog rather than fixing in this PR (scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)