### PR TITLE
c-api: channel DSP inserts, effect modules, and send/return surface (#166)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(YSE_TEST_SOURCES
   channel/test_channel_layout.cpp
   channel/test_channel_dsp.cpp
   channel/test_channel_sends.cpp
+  channel/test_c_api_channel.cpp
   sound/test_sound_state.cpp
   sound/test_sound_streaming.cpp
   sound/test_sound_bufferrace.cpp
@@ -205,7 +206,10 @@ add_test(
   # `sendstress` is excluded too: like the lifecycle suites it drives
   # System::initOffline() (process-global engine state), so it must run in its
   # own process (yse_tests_sendstress) rather than in this shared one.
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthcapi,midisynth,playersynth,playercapi,sendstress "--test-case-exclude=* concurrency: *" --duration=true
+  # `channelcapi` (issue #166 C-API channel-DSP/send surface) is excluded for
+  # the same reason — it drives yse_system_init_offline() and runs in its own
+  # process (yse_tests_channelcapi).
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthcapi,midisynth,playersynth,playercapi,sendstress,channelcapi "--test-case-exclude=* concurrency: *" --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -422,6 +426,18 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_sendstress PROPERTIES LABELS "channel;concurrency" TIMEOUT 300)
+
+# C-API channel-DSP, effect-module, and send/return surface (issue #166). Drives
+# the channel insert + send-to-plate-return graph entirely through the flat C
+# ABI under an offline engine (yse_system_init_offline), so it runs on headless
+# CI. Isolated in its own process for the same reason as yse_tests_sendstress:
+# it drives process-global engine state via init_offline().
+add_test(
+  NAME    yse_tests_channelcapi
+  COMMAND yse_tests --test-suite=channelcapi
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_channelcapi PROPERTIES LABELS "channel;c-api" TIMEOUT 300)
 endif()  # NOT ANDROID — close the CTest registration block
 
 if(ANDROID)

--- a/Tests/channel/test_c_api_channel.cpp
+++ b/Tests/channel/test_c_api_channel.cpp
@@ -1,0 +1,320 @@
+// C-API channel-DSP, effect-module, and send/return surface tests (issue #166,
+// part of epic #146). Exercises the surface added in #166 entirely through the
+// flat C ABI (no engine C++ headers), mirroring the C++ coverage in
+// test_channel_dsp.cpp / test_channel_sends.cpp and the module suites at the C
+// surface.
+//
+// Two things are proven here:
+//   1. A C-only end-to-end render: a channel with a parametric-EQ insert sends
+//      into a plate-reverb return under an offline engine (no audio hardware),
+//      and the whole graph renders block after block with finite output. This
+//      is the issue's headline acceptance item.
+//   2. Parameter parity: every new C++ module parameter (feedbackDelay, chorus,
+//      plateReverb, parametricEQ, compressor) is reachable and round-trips
+//      through the C setters/getters, and the channel insert get/set + send
+//      wiring mirror the engine semantics from docs/design/send_return_buses.md.
+//
+// The engine is driven offline (yse_system_init_offline + render_offline), so
+// it runs on headless CI. It lives in its own TEST_SUITE("channelcapi") and its
+// own ctest process (see Tests/CMakeLists.txt) because init_offline() drives
+// process-global engine state — the same isolation the sendstress / synthcapi
+// suites use.
+
+#include <doctest/doctest.h>
+
+#include <chrono>
+#include <cmath>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "yse_c/yse_channel.h"
+#include "yse_c/yse_dsp.h"
+#include "yse_c/yse_dsp_modules.h"
+#include "yse_c/yse_enums.h"
+#include "yse_c/yse_sound.h"
+#include "yse_c/yse_system.h"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+  // Init the offline engine once for the whole channelcapi process. Mirrors the
+  // sendstress suite's ensureOffline(); no audio hardware needed.
+  bool ensureOffline() {
+    static bool done = false;
+    static bool ok = false;
+    if (!done) {
+      YseSystem* sys = yse_system_get();
+      yse_system_close(sys); // normalize regardless of starting state
+      ok = (yse_system_init_offline(sys) == YSE_OK);
+      done = true;
+    }
+    return ok;
+  }
+
+  // Offline analogue of the channel suite's drainChannels(): update() flags the
+  // control-plane work the audio callback body runs, render_offline() runs
+  // blocks, and a short sleep lets the slow pool execute queued setup() jobs so
+  // freshly created channels / returns / sounds reach OBJECT_READY.
+  void pump(int iterations = 20) {
+    YseSystem* sys = yse_system_get();
+    for (int i = 0; i < iterations; ++i) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 2);
+      std::this_thread::sleep_for(2ms);
+    }
+  }
+
+  // A looping in-memory sine tone loaded through the C buffer API — a real AC
+  // signal source built entirely from C (no dspSourceObject subclassing, which
+  // is out of scope for #166). File-scope so it outlives every sound built from
+  // it (the load_buffer lifetime contract).
+  YseDspBuffer* makeToneBuffer() {
+    const unsigned int len = 2048;
+    YseDspBuffer* buf = yse_dsp_buffer_create(len, 0);
+    if (!buf) return nullptr;
+    std::vector<float> tone(len);
+    for (unsigned int i = 0; i < len; ++i)
+      tone[i] = 0.25f * std::sin(2.0f * 3.14159265f * 4.0f * static_cast<float>(i) /
+                                 static_cast<float>(len));
+    yse_dsp_buffer_write(buf, 0, tone.data(), len);
+    return buf;
+  }
+
+} // namespace
+
+TEST_SUITE("channelcapi") {
+
+  // ─── Headline acceptance: C-only insert + send-to-plate-return render ────────
+
+  TEST_CASE("c-api channel: insert chain + send to a plate return renders end to end") {
+    REQUIRE(ensureOffline());
+
+    // A source channel with a parametric-EQ insert (the DAW insert slot).
+    YseChannel* src = yse_channel_create("capi_src", yse_channel_master());
+    REQUIRE(src != nullptr);
+    CHECK(yse_channel_is_return(src) == 0);
+
+    YseDspObject* eq = yse_dsp_eq_create();
+    REQUIRE(eq != nullptr);
+    yse_dsp_eq_set_gain(eq, YSE_EQ_LOW_SHELF, 6.0f);
+    yse_channel_set_dsp(src, eq);
+    CHECK(yse_channel_get_dsp(src) == eq); // insert round-trips through the C handle
+
+    // A plate-reverb return bus (excluded from the mix tree; folds into master).
+    YseChannel* verb = yse_channel_create_return("capi_verb", 4);
+    REQUIRE(verb != nullptr);
+    CHECK(yse_channel_is_return(verb) == 1);
+    YseDspObject* plate = yse_dsp_plate_reverb_create();
+    REQUIRE(plate != nullptr);
+    yse_dsp_plate_reverb_set_decay(plate, 0.7f);
+    yse_channel_set_dsp(verb, plate);
+
+    // Drive the channel/return lifecycle to READY, then attach a looping tone
+    // and start it (create/load does not auto-play).
+    pump();
+    YseDspBuffer* tone = makeToneBuffer();
+    REQUIRE(tone != nullptr);
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_sound_load_buffer(snd, tone, src, /*loop*/ 1, /*volume*/ 1.0f) == YSE_OK);
+    pump();
+    yse_sound_play(snd);
+    pump();
+
+    // Wire a post-fader send from the source into the plate return.
+    yse_channel_send(src, 0, verb, 0.5f, /*pre_fader*/ 0);
+    CHECK(yse_channel_get_send_level(src, 0) == doctest::Approx(0.5f));
+
+    // Render enough blocks to build the plate tail. The whole graph must render
+    // without crashing and stay finite.
+    pump();
+    for (int i = 0; i < 8; ++i)
+      yse_system_render_offline(yse_system_get(), 16);
+
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(src)));
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(verb)));
+    CHECK(yse_channel_get_peak_linear_post(verb) >= 0.f);
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(yse_channel_master())));
+
+    // A send level is a modulation target — continuous writes must be accepted.
+    for (int t = 0; t < 16; ++t)
+      yse_channel_set_send_level(src, 0, 0.3f + 0.2f * std::sin(0.2f * static_cast<float>(t)));
+    pump(2);
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(verb)));
+
+    // Tear down: detach the inserts before the returns/channels fall away, stop
+    // and free the sound, then let the delete jobs drain before the buffer dies.
+    yse_channel_clear_send(src, 0);
+    yse_sound_stop(snd);
+    pump();
+    yse_channel_set_dsp(src, nullptr);
+    yse_channel_set_dsp(verb, nullptr);
+    yse_sound_destroy(snd);
+    yse_channel_destroy(verb);
+    yse_channel_destroy(src);
+    pump();
+    yse_dsp_object_destroy(eq);
+    yse_dsp_object_destroy(plate);
+    yse_dsp_buffer_destroy(tone);
+  }
+
+  // ─── Send/return wiring validation through the C surface ─────────────────────
+
+  TEST_CASE("c-api channel: send wiring validation mirrors the engine rules") {
+    REQUIRE(ensureOffline());
+
+    YseChannel* src = yse_channel_create("capi_wsrc", yse_channel_master());
+    YseChannel* notReturn = yse_channel_create("capi_notret", yse_channel_master());
+    YseChannel* ret = yse_channel_create_return("capi_wret", 4);
+    REQUIRE(src);
+    REQUIRE(notReturn);
+    REQUIRE(ret);
+    pump();
+
+    // Send to a non-return target is rejected (level stays 0).
+    yse_channel_send(src, 0, notReturn, 0.5f, 0);
+    CHECK(yse_channel_get_send_level(src, 0) == doctest::Approx(0.f));
+
+    // An out-of-range slot is rejected.
+    yse_channel_send(src, 99, ret, 0.5f, 0);
+    CHECK(yse_channel_get_send_level(src, 99) == doctest::Approx(0.f));
+
+    // A valid send reports its level; set_send_level updates it; clear detaches.
+    yse_channel_send(src, 0, ret, 0.4f, 0);
+    CHECK(yse_channel_get_send_level(src, 0) == doctest::Approx(0.4f));
+    yse_channel_set_send_level(src, 0, 0.7f);
+    CHECK(yse_channel_get_send_level(src, 0) == doctest::Approx(0.7f));
+    yse_channel_clear_send(src, 0);
+    CHECK(yse_channel_get_send_level(src, 0) == doctest::Approx(0.f));
+
+    // return→return is allowed (DAG); a cycle is rejected at wiring time.
+    YseChannel* ret2 = yse_channel_create_return("capi_wret2", 4);
+    REQUIRE(ret2);
+    pump();
+    yse_channel_send(ret, 0, ret2, 0.5f, 0); // legal edge
+    CHECK(yse_channel_get_send_level(ret, 0) == doctest::Approx(0.5f));
+    yse_channel_send(ret2, 0, ret, 0.5f, 0); // would close a cycle
+    CHECK(yse_channel_get_send_level(ret2, 0) == doctest::Approx(0.f));
+
+    yse_channel_clear_send(ret, 0);
+    pump();
+    yse_channel_destroy(ret2);
+    yse_channel_destroy(ret);
+    yse_channel_destroy(notReturn);
+    yse_channel_destroy(src);
+    pump();
+  }
+
+  // Null-safety: every void mutator is a no-op and every getter a zero on NULL.
+  TEST_CASE("c-api channel: send/insert surface is null-safe") {
+    CHECK(yse_channel_is_return(nullptr) == 0);
+    CHECK(yse_channel_get_send_level(nullptr, 0) == doctest::Approx(0.f));
+    CHECK(yse_channel_get_dsp(nullptr) == nullptr);
+    // No crash:
+    yse_channel_send(nullptr, 0, nullptr, 1.f, 0);
+    yse_channel_set_send_level(nullptr, 0, 1.f);
+    yse_channel_clear_send(nullptr, 0);
+    yse_channel_set_dsp(nullptr, nullptr);
+    CHECK(yse_channel_create_return(nullptr, 4) == nullptr);
+    CHECK(yse_channel_create_with_sends(nullptr, nullptr, 4) == nullptr);
+  }
+
+  // ─── Module parameter parity (every new C++ param reachable from C) ──────────
+
+  TEST_CASE("c-api dsp: feedback delay parameters round-trip (#160)") {
+    YseDspObject* d = yse_dsp_feedback_delay_create();
+    REQUIRE(d != nullptr);
+    yse_dsp_feedback_delay_set_time(d, 120.0f);
+    CHECK(yse_dsp_feedback_delay_get_time(d) == doctest::Approx(120.0f));
+    yse_dsp_feedback_delay_set_feedback(d, 0.6f);
+    CHECK(yse_dsp_feedback_delay_get_feedback(d) == doctest::Approx(0.6f));
+    yse_dsp_feedback_delay_set_damping(d, 3000.0f);
+    CHECK(yse_dsp_feedback_delay_get_damping(d) == doctest::Approx(3000.0f));
+    yse_dsp_feedback_delay_set_crossfeed(d, 0.5f);
+    CHECK(yse_dsp_feedback_delay_get_crossfeed(d) == doctest::Approx(0.5f));
+    // inherited dspObject surface reaches the same handle
+    yse_dsp_object_set_impact(d, 0.8f);
+    CHECK(yse_dsp_object_get_impact(d) == doctest::Approx(0.8f));
+    yse_dsp_object_destroy(d);
+  }
+
+  TEST_CASE("c-api dsp: chorus/flanger parameters round-trip (#161)") {
+    YseDspObject* c = yse_dsp_chorus_create();
+    REQUIRE(c != nullptr);
+    yse_dsp_chorus_set_mode(c, YSE_CHORUS_MODE_FLANGER);
+    CHECK(yse_dsp_chorus_get_mode(c) == YSE_CHORUS_MODE_FLANGER);
+    yse_dsp_chorus_set_rate(c, 0.8f);
+    CHECK(yse_dsp_chorus_get_rate(c) == doctest::Approx(0.8f));
+    yse_dsp_chorus_set_depth(c, 0.5f);
+    CHECK(yse_dsp_chorus_get_depth(c) == doctest::Approx(0.5f));
+    yse_dsp_chorus_set_feedback(c, -0.4f);
+    CHECK(yse_dsp_chorus_get_feedback(c) == doctest::Approx(-0.4f));
+    yse_dsp_chorus_set_spread(c, 0.7f);
+    CHECK(yse_dsp_chorus_get_spread(c) == doctest::Approx(0.7f));
+    yse_dsp_object_destroy(c);
+  }
+
+  TEST_CASE("c-api dsp: plate reverb parameters round-trip (#162)") {
+    YseDspObject* p = yse_dsp_plate_reverb_create();
+    REQUIRE(p != nullptr);
+    yse_dsp_plate_reverb_set_decay(p, 0.85f);
+    CHECK(yse_dsp_plate_reverb_get_decay(p) == doctest::Approx(0.85f));
+    yse_dsp_plate_reverb_set_damping(p, 4000.0f);
+    CHECK(yse_dsp_plate_reverb_get_damping(p) == doctest::Approx(4000.0f));
+    yse_dsp_plate_reverb_set_predelay(p, 20.0f);
+    CHECK(yse_dsp_plate_reverb_get_predelay(p) == doctest::Approx(20.0f));
+    yse_dsp_object_destroy(p);
+  }
+
+  TEST_CASE("c-api dsp: parametric EQ parameters round-trip, per band (#163)") {
+    YseDspObject* e = yse_dsp_eq_create();
+    REQUIRE(e != nullptr);
+    const YseEqBand bands[] = {YSE_EQ_LOW_SHELF, YSE_EQ_PEAK_1, YSE_EQ_PEAK_2, YSE_EQ_HIGH_SHELF};
+    for (YseEqBand b : bands) {
+      yse_dsp_eq_set_frequency(e, b, 1000.0f);
+      CHECK(yse_dsp_eq_get_frequency(e, b) == doctest::Approx(1000.0f));
+      yse_dsp_eq_set_gain(e, b, 3.0f);
+      CHECK(yse_dsp_eq_get_gain(e, b) == doctest::Approx(3.0f));
+      yse_dsp_eq_set_q(e, b, 1.2f);
+      CHECK(yse_dsp_eq_get_q(e, b) == doctest::Approx(1.2f));
+    }
+    yse_dsp_object_destroy(e);
+  }
+
+  TEST_CASE("c-api dsp: compressor parameters round-trip (#163)") {
+    YseDspObject* c = yse_dsp_compressor_create();
+    REQUIRE(c != nullptr);
+    yse_dsp_compressor_set_detector(c, YSE_COMPRESSOR_DETECT_RMS);
+    CHECK(yse_dsp_compressor_get_detector(c) == YSE_COMPRESSOR_DETECT_RMS);
+    yse_dsp_compressor_set_threshold(c, -18.0f);
+    CHECK(yse_dsp_compressor_get_threshold(c) == doctest::Approx(-18.0f));
+    yse_dsp_compressor_set_ratio(c, 4.0f);
+    CHECK(yse_dsp_compressor_get_ratio(c) == doctest::Approx(4.0f));
+    yse_dsp_compressor_set_attack(c, 10.0f);
+    CHECK(yse_dsp_compressor_get_attack(c) == doctest::Approx(10.0f));
+    yse_dsp_compressor_set_release(c, 120.0f);
+    CHECK(yse_dsp_compressor_get_release(c) == doctest::Approx(120.0f));
+    yse_dsp_compressor_set_makeup(c, 6.0f);
+    CHECK(yse_dsp_compressor_get_makeup(c) == doctest::Approx(6.0f));
+    // read-only meter is reachable and finite
+    CHECK(std::isfinite(yse_dsp_compressor_get_gain_reduction_db(c)));
+    yse_dsp_object_destroy(c);
+  }
+
+  // Module setters/getters are null-safe like the rest of the module surface.
+  TEST_CASE("c-api dsp: new module setters/getters are null-safe") {
+    yse_dsp_feedback_delay_set_time(nullptr, 1.f);
+    yse_dsp_chorus_set_rate(nullptr, 1.f);
+    yse_dsp_plate_reverb_set_decay(nullptr, 1.f);
+    yse_dsp_eq_set_gain(nullptr, YSE_EQ_PEAK_1, 1.f);
+    yse_dsp_compressor_set_ratio(nullptr, 1.f);
+    CHECK(yse_dsp_feedback_delay_get_time(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_dsp_chorus_get_mode(nullptr) == YSE_CHORUS_MODE_CHORUS);
+    CHECK(yse_dsp_plate_reverb_get_decay(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_dsp_eq_get_gain(nullptr, YSE_EQ_PEAK_1) == doctest::Approx(0.f));
+    CHECK(yse_dsp_compressor_get_gain_reduction_db(nullptr) == doctest::Approx(0.f));
+  }
+
+} // TEST_SUITE("channelcapi")

--- a/YseEngine/c_api/include/yse_c/yse_channel.h
+++ b/YseEngine/c_api/include/yse_c/yse_channel.h
@@ -18,10 +18,15 @@
 extern "C" {
 #endif
 
-/* Owned via yse_channel_create — release with yse_channel_destroy.
-   Borrowed via the yse_channel_master / _fx / _music / _ambient /
-   _voice / _gui pre-built accessors — never destroy those. */
+/* Owned via yse_channel_create / _create_with_sends / _create_return —
+   release with yse_channel_destroy. Borrowed via the yse_channel_master /
+   _fx / _music / _ambient / _voice / _gui pre-built accessors — never
+   destroy those. */
 typedef struct YseChannel YseChannel;
+
+/* Forward declaration — see yse_dsp_modules.h for ownership (a channel
+   insert effect is owned by the caller, never by the channel). */
+typedef struct YseDspObject YseDspObject;
 
 /* Pre-built channels — borrowed pointers, never destroy. */
 YSE_C_API YseChannel* yse_channel_master(void);
@@ -31,9 +36,66 @@ YSE_C_API YseChannel* yse_channel_ambient(void);
 YSE_C_API YseChannel* yse_channel_voice(void);
 YSE_C_API YseChannel* yse_channel_gui(void);
 
-/* User-created channels. */
+/* User-created channels. yse_channel_create allocates a channel with the
+   default 4 aux-send slots; yse_channel_create_with_sends chooses the slot
+   count (sized once off the audio thread and never resized — raise it for a
+   channel that fans out to many return buses). Both return NULL and set
+   yse_last_error() on a NULL name/parent. */
 YSE_C_API YseChannel* yse_channel_create(const char* name, YseChannel* parent);
+YSE_C_API YseChannel* yse_channel_create_with_sends(const char* name, YseChannel* parent,
+                                                    int send_slots);
 YSE_C_API void yse_channel_destroy(YseChannel* ch);
+
+/* ─── send/return buses (issue #165; design docs/design/send_return_buses.md) ──
+ *
+ * A return bus is an ordinary channel (it keeps set_dsp inserts, attach_reverb,
+ * set_volume, and metering) excluded from the normal mix tree; other channels
+ * route scaled copies of their signal into it and its output folds into the
+ * master mix after the source tree — the classic aux-send topology. A return
+ * may itself send into another return (an acyclic delay→reverb chain); cycles
+ * are rejected at wiring time.
+ *
+ * yse_channel_create_return allocates and flags a return in one call (the C
+ * mirror of makeReturn) — call it INSTEAD of yse_channel_create. Destroy it
+ * with yse_channel_destroy like any channel. */
+YSE_C_API YseChannel* yse_channel_create_return(const char* name, int send_slots);
+
+/* 1 if the channel is a send/return bus, else 0 (also 0 on NULL). */
+YSE_C_API int yse_channel_is_return(YseChannel* ch);
+
+/* Wire send slot `slot` (in [0, send_slots)) of `ch` to `return_bus` at
+ * `level`. Post-fader by default; pass pre_fader != 0 for a cue-style send
+ * independent of the channel fader. Illegal wirings (target not a return, a
+ * self-send, a return→return edge that would close a cycle, an out-of-range
+ * slot) are rejected on the calling thread and logged — never reaching the
+ * audio thread. Null-safe no-op. */
+YSE_C_API void yse_channel_send(YseChannel* ch, int slot, YseChannel* return_bus, float level,
+                                int pre_fader);
+
+/* Set a send slot's level, ramped and click-free. Safe to call every control
+ * tick — send levels are designed as modulation targets, so continuous writes
+ * fuse into the per-block ramp without zippering. Null-safe no-op. */
+YSE_C_API void yse_channel_set_send_level(YseChannel* ch, int slot, float level);
+
+/* Detach send slot `slot`, fully disconnecting it from its return. Null-safe
+ * no-op. */
+YSE_C_API void yse_channel_clear_send(YseChannel* ch, int slot);
+
+/* Current target level of send slot `slot`, or 0 if unset/invalid/NULL. */
+YSE_C_API float yse_channel_get_send_level(YseChannel* ch, int slot);
+
+/* ─── channel insert DSP (issue #159) ─────────────────────────────────────
+ *
+ * Attach a pre-fader insert effect chain to this channel — the DAW "insert"
+ * slot, mirroring yse_sound_set_dsp at the channel level. The effect processes
+ * the channel's summed output in place, before reverb and the channel volume.
+ * Chain effects with yse_dsp_object_link. Pass NULL to detach. The channel
+ * takes no ownership: the YseDspObject must outlive the channel or be detached
+ * first. Null-safe no-op. */
+YSE_C_API void yse_channel_set_dsp(YseChannel* ch, YseDspObject* dsp);
+
+/* The currently attached insert effect chain head, or NULL if none/NULL. */
+YSE_C_API YseDspObject* yse_channel_get_dsp(YseChannel* ch);
 
 YSE_C_API void yse_channel_set_volume(YseChannel* ch, float value);
 YSE_C_API float yse_channel_get_volume(YseChannel* ch);

--- a/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
@@ -41,6 +41,16 @@ YSE_C_API YseDspObject* yse_dsp_ring_modulator_create(void);
 YSE_C_API YseDspObject* yse_dsp_difference_create(void);
 YSE_C_API YseDspObject* yse_dsp_granulator_create(unsigned int pool_size, unsigned int max_grains);
 
+/* Mix-grade effect modules (issues #160-#163). Each is a chainable insert or
+   send-return effect; drop one on a channel with yse_channel_set_dsp() or a
+   sound with yse_sound_set_dsp(). Their wet/dry balance is the inherited
+   yse_dsp_object_set_impact(). */
+YSE_C_API YseDspObject* yse_dsp_feedback_delay_create(void); /* #160 */
+YSE_C_API YseDspObject* yse_dsp_chorus_create(void); /* #161 */
+YSE_C_API YseDspObject* yse_dsp_plate_reverb_create(void); /* #162 */
+YSE_C_API YseDspObject* yse_dsp_eq_create(void); /* #163 */
+YSE_C_API YseDspObject* yse_dsp_compressor_create(void); /* #163 */
+
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj);
 
 /* ─── inherited dspObject control surface ─────────────────────────────── */
@@ -111,6 +121,71 @@ YSE_C_API void yse_dsp_granulator_set_grain_transpose(YseDspObject* obj, float p
 YSE_C_API float yse_dsp_granulator_get_grain_transpose(YseDspObject* obj);
 YSE_C_API void yse_dsp_granulator_set_gain(YseDspObject* obj, float value);
 YSE_C_API float yse_dsp_granulator_get_gain(YseDspObject* obj);
+
+/* ─── feedback delay (#160) ──────────────────────────────────────────────
+ * A recirculating delay for a channel insert or a send return: per-channel
+ * delay line, a damping low-pass in the feedback path, and cross-feed between
+ * channel pairs for ping-pong. impact(1) is echoes only (send use). */
+YSE_C_API void yse_dsp_feedback_delay_set_time(YseDspObject* obj, float ms);
+YSE_C_API float yse_dsp_feedback_delay_get_time(YseDspObject* obj);
+YSE_C_API void yse_dsp_feedback_delay_set_feedback(YseDspObject* obj, float amount);
+YSE_C_API float yse_dsp_feedback_delay_get_feedback(YseDspObject* obj);
+YSE_C_API void yse_dsp_feedback_delay_set_damping(YseDspObject* obj, float hz);
+YSE_C_API float yse_dsp_feedback_delay_get_damping(YseDspObject* obj);
+YSE_C_API void yse_dsp_feedback_delay_set_crossfeed(YseDspObject* obj, float amount);
+YSE_C_API float yse_dsp_feedback_delay_get_crossfeed(YseDspObject* obj);
+
+/* ─── chorus / flanger (#161) ────────────────────────────────────────────
+ * One modulated-delay module with a mode() switch between chorus and flanger.
+ * spread() fans a per-channel LFO phase offset for stereo width. */
+YSE_C_API void yse_dsp_chorus_set_mode(YseDspObject* obj, YseChorusMode mode);
+YSE_C_API YseChorusMode yse_dsp_chorus_get_mode(YseDspObject* obj);
+YSE_C_API void yse_dsp_chorus_set_rate(YseDspObject* obj, float hz);
+YSE_C_API float yse_dsp_chorus_get_rate(YseDspObject* obj);
+YSE_C_API void yse_dsp_chorus_set_depth(YseDspObject* obj, float value);
+YSE_C_API float yse_dsp_chorus_get_depth(YseDspObject* obj);
+YSE_C_API void yse_dsp_chorus_set_feedback(YseDspObject* obj, float value);
+YSE_C_API float yse_dsp_chorus_get_feedback(YseDspObject* obj);
+YSE_C_API void yse_dsp_chorus_set_spread(YseDspObject* obj, float value);
+YSE_C_API float yse_dsp_chorus_get_spread(YseDspObject* obj);
+
+/* ─── plate reverb (#162) ────────────────────────────────────────────────
+ * Dattorro plate reverb for a channel insert or a send return. Distinct from
+ * the engine's global spatial reverb; impact(0.25) is a natural insert mix,
+ * impact(1) is fully wet (send-return use). */
+YSE_C_API void yse_dsp_plate_reverb_set_decay(YseDspObject* obj, float value);
+YSE_C_API float yse_dsp_plate_reverb_get_decay(YseDspObject* obj);
+YSE_C_API void yse_dsp_plate_reverb_set_damping(YseDspObject* obj, float hz);
+YSE_C_API float yse_dsp_plate_reverb_get_damping(YseDspObject* obj);
+YSE_C_API void yse_dsp_plate_reverb_set_predelay(YseDspObject* obj, float ms);
+YSE_C_API float yse_dsp_plate_reverb_get_predelay(YseDspObject* obj);
+
+/* ─── parametric EQ (#163) ───────────────────────────────────────────────
+ * Four cascaded bands (low shelf, two peaks, high shelf); each parameter is
+ * addressed by a YseEqBand. Gain is in dB (0 = flat / band bypass). */
+YSE_C_API void yse_dsp_eq_set_frequency(YseDspObject* obj, YseEqBand band, float hz);
+YSE_C_API float yse_dsp_eq_get_frequency(YseDspObject* obj, YseEqBand band);
+YSE_C_API void yse_dsp_eq_set_gain(YseDspObject* obj, YseEqBand band, float db);
+YSE_C_API float yse_dsp_eq_get_gain(YseDspObject* obj, YseEqBand band);
+YSE_C_API void yse_dsp_eq_set_q(YseDspObject* obj, YseEqBand band, float value);
+YSE_C_API float yse_dsp_eq_get_q(YseDspObject* obj, YseEqBand band);
+
+/* ─── compressor (#163) ──────────────────────────────────────────────────
+ * Feed-forward, stereo-linked dynamics. gain_reduction_db is a read-only
+ * meter of the reduction on the last processed sample (<= 0 dB). */
+YSE_C_API void yse_dsp_compressor_set_detector(YseDspObject* obj, YseCompressorDetector mode);
+YSE_C_API YseCompressorDetector yse_dsp_compressor_get_detector(YseDspObject* obj);
+YSE_C_API void yse_dsp_compressor_set_threshold(YseDspObject* obj, float db);
+YSE_C_API float yse_dsp_compressor_get_threshold(YseDspObject* obj);
+YSE_C_API void yse_dsp_compressor_set_ratio(YseDspObject* obj, float value);
+YSE_C_API float yse_dsp_compressor_get_ratio(YseDspObject* obj);
+YSE_C_API void yse_dsp_compressor_set_attack(YseDspObject* obj, float ms);
+YSE_C_API float yse_dsp_compressor_get_attack(YseDspObject* obj);
+YSE_C_API void yse_dsp_compressor_set_release(YseDspObject* obj, float ms);
+YSE_C_API float yse_dsp_compressor_get_release(YseDspObject* obj);
+YSE_C_API void yse_dsp_compressor_set_makeup(YseDspObject* obj, float db);
+YSE_C_API float yse_dsp_compressor_get_makeup(YseDspObject* obj);
+YSE_C_API float yse_dsp_compressor_get_gain_reduction_db(YseDspObject* obj);
 
 #ifdef __cplusplus
 }

--- a/YseEngine/c_api/include/yse_c/yse_enums.h
+++ b/YseEngine/c_api/include/yse_c/yse_enums.h
@@ -70,6 +70,30 @@ typedef enum YseDspDelayTap {
   YSE_DELAY_TAP_THIRD = 2
 } YseDspDelayTap;
 
+/* Mirrors YSE::DSP::MODULES::chorusMode (chorus.hpp) — the chorus/flanger
+   topology switch. */
+typedef enum YseChorusMode {
+  YSE_CHORUS_MODE_CHORUS = 0, /* Longer base delay, wide slow sweep. */
+  YSE_CHORUS_MODE_FLANGER = 1 /* Short base delay, feedback comb. */
+} YseChorusMode;
+
+/* Mirrors YSE::DSP::MODULES::eqBand (parametricEQ.hpp) — the four fixed
+   bands of the parametric EQ. YSE_EQ_BAND_COUNT is the sentinel count. */
+typedef enum YseEqBand {
+  YSE_EQ_LOW_SHELF = 0,
+  YSE_EQ_PEAK_1 = 1,
+  YSE_EQ_PEAK_2 = 2,
+  YSE_EQ_HIGH_SHELF = 3,
+  YSE_EQ_BAND_COUNT = 4
+} YseEqBand;
+
+/* Mirrors YSE::DSP::MODULES::compressorDetector (compressor.hpp) — the
+   level-detector mode. */
+typedef enum YseCompressorDetector {
+  YSE_COMPRESSOR_DETECT_PEAK = 0, /* Instantaneous linked peak. */
+  YSE_COMPRESSOR_DETECT_RMS = 1 /* Short mean-square window. */
+} YseCompressorDetector;
+
 /* Mirrors YSE::PATCHER::pCategory in patcher/pEnums.h. The patcher
    registry exposes this through the metadata API so binding-side
    documentation generators can group objects without inspecting the

--- a/YseEngine/c_api/yse_channel.cpp
+++ b/YseEngine/c_api/yse_channel.cpp
@@ -2,6 +2,7 @@
 #include "yse_c_internal.hpp"
 
 #include "../channel/channelInterface.hpp"
+#include "../dsp/dspObject.hpp"
 
 #include <exception>
 
@@ -54,9 +55,82 @@ YSE_C_API YseChannel* yse_channel_create(const char* name, YseChannel* parent) {
   }
 }
 
+YSE_C_API YseChannel* yse_channel_create_with_sends(const char* name, YseChannel* parent,
+                                                    int send_slots) {
+  if (!name || !parent) {
+    yse_c::set_last_error("yse_channel_create_with_sends: name and parent must be non-null");
+    return nullptr;
+  }
+  try {
+    auto* ch = new YSE::channel();
+    ch->create(name, *to_cpp(parent), send_slots);
+    return reinterpret_cast<YseChannel*>(ch);
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("unknown C++ exception in yse_channel_create_with_sends");
+    return nullptr;
+  }
+}
+
+YSE_C_API YseChannel* yse_channel_create_return(const char* name, int send_slots) {
+  if (!name) {
+    yse_c::set_last_error("yse_channel_create_return: name must be non-null");
+    return nullptr;
+  }
+  try {
+    auto* ch = new YSE::channel();
+    ch->makeReturn(name, send_slots);
+    return reinterpret_cast<YseChannel*>(ch);
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("unknown C++ exception in yse_channel_create_return");
+    return nullptr;
+  }
+}
+
 YSE_C_API void yse_channel_destroy(YseChannel* ch) {
   if (!ch) return;
   delete to_cpp(ch);
+}
+
+YSE_C_API int yse_channel_is_return(YseChannel* ch) {
+  if (!ch) return 0;
+  return to_cpp(ch)->isReturn() ? 1 : 0;
+}
+
+YSE_C_API void yse_channel_send(YseChannel* ch, int slot, YseChannel* return_bus, float level,
+                                int pre_fader) {
+  if (!ch || !return_bus) return;
+  to_cpp(ch)->send(slot, *to_cpp(return_bus), level, pre_fader != 0);
+}
+
+YSE_C_API void yse_channel_set_send_level(YseChannel* ch, int slot, float level) {
+  if (!ch) return;
+  to_cpp(ch)->setSendLevel(slot, level);
+}
+
+YSE_C_API void yse_channel_clear_send(YseChannel* ch, int slot) {
+  if (!ch) return;
+  to_cpp(ch)->clearSend(slot);
+}
+
+YSE_C_API float yse_channel_get_send_level(YseChannel* ch, int slot) {
+  if (!ch) return 0.0f;
+  return to_cpp(ch)->getSendLevel(slot);
+}
+
+YSE_C_API void yse_channel_set_dsp(YseChannel* ch, YseDspObject* dsp) {
+  if (!ch) return;
+  to_cpp(ch)->setDSP(reinterpret_cast<YSE::DSP::dspObject*>(dsp));
+}
+
+YSE_C_API YseDspObject* yse_channel_get_dsp(YseChannel* ch) {
+  if (!ch) return nullptr;
+  return reinterpret_cast<YseDspObject*>(to_cpp(ch)->getDSP());
 }
 
 YSE_C_API void yse_channel_set_volume(YseChannel* ch, float value) {

--- a/YseEngine/c_api/yse_dsp_modules.cpp
+++ b/YseEngine/c_api/yse_dsp_modules.cpp
@@ -14,6 +14,11 @@
 #include "../dsp/modules/ringModulator.hpp"
 #include "../dsp/modules/granulator.hpp"
 #include "../dsp/modules/fm/difference.hpp"
+#include "../dsp/modules/delay/feedbackDelay.hpp"
+#include "../dsp/modules/chorus.hpp"
+#include "../dsp/modules/plateReverb.hpp"
+#include "../dsp/modules/parametricEQ.hpp"
+#include "../dsp/modules/compressor.hpp"
 
 #include <exception>
 
@@ -96,6 +101,22 @@ YSE_C_API YseDspObject* yse_dsp_granulator_create(unsigned int pool_size, unsign
     yse_c::set_last_error("granulator_create: unknown C++ exception");
     return nullptr;
   }
+}
+
+YSE_C_API YseDspObject* yse_dsp_feedback_delay_create(void) {
+  return mk<YSE::DSP::MODULES::feedbackDelay>();
+}
+YSE_C_API YseDspObject* yse_dsp_chorus_create(void) {
+  return mk<YSE::DSP::MODULES::chorus>();
+}
+YSE_C_API YseDspObject* yse_dsp_plate_reverb_create(void) {
+  return mk<YSE::DSP::MODULES::plateReverb>();
+}
+YSE_C_API YseDspObject* yse_dsp_eq_create(void) {
+  return mk<YSE::DSP::MODULES::parametricEQ>();
+}
+YSE_C_API YseDspObject* yse_dsp_compressor_create(void) {
+  return mk<YSE::DSP::MODULES::compressor>();
 }
 
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj) {
@@ -306,6 +327,193 @@ YSE_C_API void yse_dsp_granulator_set_gain(YseDspObject* o, float v) {
 YSE_C_API float yse_dsp_granulator_get_gain(YseDspObject* o) {
   auto* g = as<YSE::DSP::MODULES::granulator>(o);
   return g ? g->gain() : 0.0f;
+}
+
+// ─── feedback delay (#160) ────────────────────────────────────────────
+
+YSE_C_API void yse_dsp_feedback_delay_set_time(YseDspObject* o, float ms) {
+  auto* d = as<YSE::DSP::MODULES::feedbackDelay>(o);
+  if (d) d->time(ms);
+}
+YSE_C_API float yse_dsp_feedback_delay_get_time(YseDspObject* o) {
+  auto* d = as<YSE::DSP::MODULES::feedbackDelay>(o);
+  return d ? d->time() : 0.0f;
+}
+YSE_C_API void yse_dsp_feedback_delay_set_feedback(YseDspObject* o, float amount) {
+  auto* d = as<YSE::DSP::MODULES::feedbackDelay>(o);
+  if (d) d->feedback(amount);
+}
+YSE_C_API float yse_dsp_feedback_delay_get_feedback(YseDspObject* o) {
+  auto* d = as<YSE::DSP::MODULES::feedbackDelay>(o);
+  return d ? d->feedback() : 0.0f;
+}
+YSE_C_API void yse_dsp_feedback_delay_set_damping(YseDspObject* o, float hz) {
+  auto* d = as<YSE::DSP::MODULES::feedbackDelay>(o);
+  if (d) d->damping(hz);
+}
+YSE_C_API float yse_dsp_feedback_delay_get_damping(YseDspObject* o) {
+  auto* d = as<YSE::DSP::MODULES::feedbackDelay>(o);
+  return d ? d->damping() : 0.0f;
+}
+YSE_C_API void yse_dsp_feedback_delay_set_crossfeed(YseDspObject* o, float amount) {
+  auto* d = as<YSE::DSP::MODULES::feedbackDelay>(o);
+  if (d) d->crossfeed(amount);
+}
+YSE_C_API float yse_dsp_feedback_delay_get_crossfeed(YseDspObject* o) {
+  auto* d = as<YSE::DSP::MODULES::feedbackDelay>(o);
+  return d ? d->crossfeed() : 0.0f;
+}
+
+// ─── chorus / flanger (#161) ──────────────────────────────────────────
+
+YSE_C_API void yse_dsp_chorus_set_mode(YseDspObject* o, YseChorusMode mode) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  if (c) c->mode(static_cast<YSE::DSP::MODULES::chorusMode>(mode));
+}
+YSE_C_API YseChorusMode yse_dsp_chorus_get_mode(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  return c ? static_cast<YseChorusMode>(c->mode()) : YSE_CHORUS_MODE_CHORUS;
+}
+YSE_C_API void yse_dsp_chorus_set_rate(YseDspObject* o, float hz) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  if (c) c->rate(hz);
+}
+YSE_C_API float yse_dsp_chorus_get_rate(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  return c ? c->rate() : 0.0f;
+}
+YSE_C_API void yse_dsp_chorus_set_depth(YseDspObject* o, float value) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  if (c) c->depth(value);
+}
+YSE_C_API float yse_dsp_chorus_get_depth(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  return c ? c->depth() : 0.0f;
+}
+YSE_C_API void yse_dsp_chorus_set_feedback(YseDspObject* o, float value) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  if (c) c->feedback(value);
+}
+YSE_C_API float yse_dsp_chorus_get_feedback(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  return c ? c->feedback() : 0.0f;
+}
+YSE_C_API void yse_dsp_chorus_set_spread(YseDspObject* o, float value) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  if (c) c->spread(value);
+}
+YSE_C_API float yse_dsp_chorus_get_spread(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::chorus>(o);
+  return c ? c->spread() : 0.0f;
+}
+
+// ─── plate reverb (#162) ──────────────────────────────────────────────
+
+YSE_C_API void yse_dsp_plate_reverb_set_decay(YseDspObject* o, float value) {
+  auto* p = as<YSE::DSP::MODULES::plateReverb>(o);
+  if (p) p->decay(value);
+}
+YSE_C_API float yse_dsp_plate_reverb_get_decay(YseDspObject* o) {
+  auto* p = as<YSE::DSP::MODULES::plateReverb>(o);
+  return p ? p->decay() : 0.0f;
+}
+YSE_C_API void yse_dsp_plate_reverb_set_damping(YseDspObject* o, float hz) {
+  auto* p = as<YSE::DSP::MODULES::plateReverb>(o);
+  if (p) p->damping(hz);
+}
+YSE_C_API float yse_dsp_plate_reverb_get_damping(YseDspObject* o) {
+  auto* p = as<YSE::DSP::MODULES::plateReverb>(o);
+  return p ? p->damping() : 0.0f;
+}
+YSE_C_API void yse_dsp_plate_reverb_set_predelay(YseDspObject* o, float ms) {
+  auto* p = as<YSE::DSP::MODULES::plateReverb>(o);
+  if (p) p->preDelay(ms);
+}
+YSE_C_API float yse_dsp_plate_reverb_get_predelay(YseDspObject* o) {
+  auto* p = as<YSE::DSP::MODULES::plateReverb>(o);
+  return p ? p->preDelay() : 0.0f;
+}
+
+// ─── parametric EQ (#163) ─────────────────────────────────────────────
+
+YSE_C_API void yse_dsp_eq_set_frequency(YseDspObject* o, YseEqBand band, float hz) {
+  auto* e = as<YSE::DSP::MODULES::parametricEQ>(o);
+  if (e) e->frequency(static_cast<YSE::DSP::MODULES::eqBand>(band), hz);
+}
+YSE_C_API float yse_dsp_eq_get_frequency(YseDspObject* o, YseEqBand band) {
+  auto* e = as<YSE::DSP::MODULES::parametricEQ>(o);
+  return e ? e->frequency(static_cast<YSE::DSP::MODULES::eqBand>(band)) : 0.0f;
+}
+YSE_C_API void yse_dsp_eq_set_gain(YseDspObject* o, YseEqBand band, float db) {
+  auto* e = as<YSE::DSP::MODULES::parametricEQ>(o);
+  if (e) e->gain(static_cast<YSE::DSP::MODULES::eqBand>(band), db);
+}
+YSE_C_API float yse_dsp_eq_get_gain(YseDspObject* o, YseEqBand band) {
+  auto* e = as<YSE::DSP::MODULES::parametricEQ>(o);
+  return e ? e->gain(static_cast<YSE::DSP::MODULES::eqBand>(band)) : 0.0f;
+}
+YSE_C_API void yse_dsp_eq_set_q(YseDspObject* o, YseEqBand band, float value) {
+  auto* e = as<YSE::DSP::MODULES::parametricEQ>(o);
+  if (e) e->q(static_cast<YSE::DSP::MODULES::eqBand>(band), value);
+}
+YSE_C_API float yse_dsp_eq_get_q(YseDspObject* o, YseEqBand band) {
+  auto* e = as<YSE::DSP::MODULES::parametricEQ>(o);
+  return e ? e->q(static_cast<YSE::DSP::MODULES::eqBand>(band)) : 0.0f;
+}
+
+// ─── compressor (#163) ────────────────────────────────────────────────
+
+YSE_C_API void yse_dsp_compressor_set_detector(YseDspObject* o, YseCompressorDetector mode) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  if (c) c->detector(static_cast<YSE::DSP::MODULES::compressorDetector>(mode));
+}
+YSE_C_API YseCompressorDetector yse_dsp_compressor_get_detector(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  return c ? static_cast<YseCompressorDetector>(c->detector()) : YSE_COMPRESSOR_DETECT_PEAK;
+}
+YSE_C_API void yse_dsp_compressor_set_threshold(YseDspObject* o, float db) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  if (c) c->threshold(db);
+}
+YSE_C_API float yse_dsp_compressor_get_threshold(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  return c ? c->threshold() : 0.0f;
+}
+YSE_C_API void yse_dsp_compressor_set_ratio(YseDspObject* o, float value) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  if (c) c->ratio(value);
+}
+YSE_C_API float yse_dsp_compressor_get_ratio(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  return c ? c->ratio() : 0.0f;
+}
+YSE_C_API void yse_dsp_compressor_set_attack(YseDspObject* o, float ms) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  if (c) c->attack(ms);
+}
+YSE_C_API float yse_dsp_compressor_get_attack(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  return c ? c->attack() : 0.0f;
+}
+YSE_C_API void yse_dsp_compressor_set_release(YseDspObject* o, float ms) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  if (c) c->release(ms);
+}
+YSE_C_API float yse_dsp_compressor_get_release(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  return c ? c->release() : 0.0f;
+}
+YSE_C_API void yse_dsp_compressor_set_makeup(YseDspObject* o, float db) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  if (c) c->makeup(db);
+}
+YSE_C_API float yse_dsp_compressor_get_makeup(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  return c ? c->makeup() : 0.0f;
+}
+YSE_C_API float yse_dsp_compressor_get_gain_reduction_db(YseDspObject* o) {
+  auto* c = as<YSE::DSP::MODULES::compressor>(o);
+  return c ? c->gainReductionDb() : 0.0f;
 }
 
 } // extern "C"

--- a/YseEngine/c_api/yse_enums_check.cpp
+++ b/YseEngine/c_api/yse_enums_check.cpp
@@ -13,6 +13,9 @@
 #include "../dsp/lfo.hpp"
 #include "../dsp/modules/filters/sweep.hpp"
 #include "../dsp/modules/delay/basicDelay.hpp"
+#include "../dsp/modules/chorus.hpp"
+#include "../dsp/modules/parametricEQ.hpp"
+#include "../dsp/modules/compressor.hpp"
 #include "../patcher/pEnums.h"
 
 namespace {
@@ -66,6 +69,21 @@ namespace {
   YSE_ASSERT_ENUM(YSE_DELAY_TAP_FIRST, YSE::DSP::MODULES::basicDelay::FIRST);
   YSE_ASSERT_ENUM(YSE_DELAY_TAP_SECOND, YSE::DSP::MODULES::basicDelay::SECOND);
   YSE_ASSERT_ENUM(YSE_DELAY_TAP_THIRD, YSE::DSP::MODULES::basicDelay::THIRD);
+
+  // YseChorusMode ↔ YSE::DSP::MODULES::chorusMode
+  YSE_ASSERT_ENUM(YSE_CHORUS_MODE_CHORUS, YSE::DSP::MODULES::MODE_CHORUS);
+  YSE_ASSERT_ENUM(YSE_CHORUS_MODE_FLANGER, YSE::DSP::MODULES::MODE_FLANGER);
+
+  // YseEqBand ↔ YSE::DSP::MODULES::eqBand
+  YSE_ASSERT_ENUM(YSE_EQ_LOW_SHELF, YSE::DSP::MODULES::EQ_LOW_SHELF);
+  YSE_ASSERT_ENUM(YSE_EQ_PEAK_1, YSE::DSP::MODULES::EQ_PEAK_1);
+  YSE_ASSERT_ENUM(YSE_EQ_PEAK_2, YSE::DSP::MODULES::EQ_PEAK_2);
+  YSE_ASSERT_ENUM(YSE_EQ_HIGH_SHELF, YSE::DSP::MODULES::EQ_HIGH_SHELF);
+  YSE_ASSERT_ENUM(YSE_EQ_BAND_COUNT, YSE::DSP::MODULES::EQ_BAND_COUNT);
+
+  // YseCompressorDetector ↔ YSE::DSP::MODULES::compressorDetector
+  YSE_ASSERT_ENUM(YSE_COMPRESSOR_DETECT_PEAK, YSE::DSP::MODULES::DETECT_PEAK);
+  YSE_ASSERT_ENUM(YSE_COMPRESSOR_DETECT_RMS, YSE::DSP::MODULES::DETECT_RMS);
 
   // YsePCategory ↔ YSE::PATCHER::pCategory
   YSE_ASSERT_ENUM(YSE_PCAT_UNSET, YSE::PATCHER::pCategory::UNSET);


### PR DESCRIPTION
## Summary

Mirrors the effects-epic engine surface — channel inserts (#159), send/return
buses (#165), and the five DAW-baseline modules (#160–#163) — through the flat
C ABI for ffigen (dart-yse) consumers. Follows the `c-api-extend` conventions
(opaque handles, null-safe no-op voids, enum drift guard, ffigen-friendly
documented headers) and the #165 semantics in
`docs/design/send_return_buses.md`.

## Linked issue

Closes #166

## Changes

**Effect-module constructors + per-parameter setters/getters** (`yse_dsp_modules.h/.cpp`):
- `yse_dsp_feedback_delay_create` (#160): time, feedback, damping, crossfeed
- `yse_dsp_chorus_create` (#161): mode, rate, depth, feedback, spread
- `yse_dsp_plate_reverb_create` (#162): decay, damping, predelay
- `yse_dsp_eq_create` (#163): per-band frequency / gain / q
- `yse_dsp_compressor_create` (#163): detector, threshold, ratio, attack, release, makeup, gain_reduction_db (read-only meter)

Each inherits the existing `yse_dsp_object_*` control surface (bypass/impact/lfo/link).

**Enums** mirrored + drift-guarded (`yse_enums.h` / `yse_enums_check.cpp`):
`YseChorusMode`, `YseEqBand`, `YseCompressorDetector`.

**Channel surface** (`yse_channel.h/.cpp`):
- `yse_channel_set_dsp` / `yse_channel_get_dsp` — the channel insert slot (#159)
- `yse_channel_create_return` / `yse_channel_is_return` — return-bus create/destroy (destroy via `yse_channel_destroy`)
- `yse_channel_create_with_sends` — send-slot count exposed at creation (default 4; `yse_channel_create` unchanged for ABI)
- `yse_channel_send` / `_set_send_level` / `_clear_send` / `_get_send_level` — per-slot, pre/post-fader sends; return→return allowed as a DAG, cycles/self-sends/non-return targets rejected at wiring time. Send levels documented as click-free control-rate modulation targets.

## Non-goal

Wrapping `dspObject` subclassing from C is deliberately deferred (same as
`dspSourceObject`) and noted in `yse_dsp.h`. The C-only render test drives a
real signal through the C buffer API instead.

## Test plan

- [x] `clang-format` 22.1.4 clean on all changed files
- [x] `clang-tidy` (`python yse.py analyze`) clean on the changed `.cpp` files — no new user-code findings
- [x] Full suite green: **26/26 ctest entries pass** (`python yse.py test`)
- [x] New C-only integration test `Tests/channel/test_c_api_channel.cpp` (suite `channelcapi`, isolated ctest process `yse_tests_channelcapi`): builds a channel with a parametric-EQ insert sending into a plate-reverb return under an offline engine and renders block-after-block with finite output; send-wiring validation parity (non-return target / self / cycle / out-of-range rejected); round-trip parity for every new module parameter; null-safety of the new surface.
- [x] Enum drift guard compiles (build fails loudly on drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
