### PR TITLE
ENGINE: position handler interface + built-in handlers (#170)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -78,6 +78,7 @@ set(YSE_TEST_SOURCES
   synth/test_synth_keyboard.cpp
   synth/test_synth_close.cpp
   synth/test_synth_positioning.cpp
+  synth/test_synth_handlers.cpp
   synth/test_c_api_synth.cpp
   dsp/test_panner.cpp
   reverb/test_reverb_dsp.cpp
@@ -209,7 +210,7 @@ add_test(
   # `channelcapi` (issue #166 C-API channel-DSP/send surface) is excluded for
   # the same reason — it drives yse_system_init_offline() and runs in its own
   # process (yse_tests_channelcapi).
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthcapi,midisynth,playersynth,playercapi,sendstress,channelcapi "--test-case-exclude=* concurrency: *" --duration=true
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,midisynth,playersynth,playercapi,sendstress,channelcapi "--test-case-exclude=* concurrency: *" --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -308,6 +309,18 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_synthpositioning PROPERTIES LABELS "synth;lifecycle")
+
+# Position handlers (issue #170). Isolated in its own process for the same reason
+# as yse_tests_synthpositioning: the lifecycle / steal cases drive
+# System::initOffline()/close(). This process also runs under ASan/TSan in
+# tools/ci-linux/ to catch handler-lifetime races. initOffline() needs no audio
+# hardware, so it runs in CI.
+add_test(
+  NAME    yse_tests_synthhandlers
+  COMMAND yse_tests --test-suite=synthhandlers
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_synthhandlers PROPERTIES LABELS "synth;lifecycle")
 
 # C-API synth surface (issue #157). Drives the synth entirely through the flat
 # C ABI under an offline engine (yse_system_init_offline), then yse_system_close().

--- a/Tests/synth/test_synth_handlers.cpp
+++ b/Tests/synth/test_synth_handlers.cpp
@@ -1,0 +1,452 @@
+// Position-handler tests (issue #170, §8/§10/§11 of
+// docs/design/per_note_positioning.md).
+//
+// Covers the three things the issue names for tests:
+//   * handler lifecycle vs voice lifecycle (including stealing) — a note keeps
+//     being steered through its release tail, a stolen slot re-inits its
+//     handler, and heavy overcommit never crashes or grows the pool;
+//   * position trajectories deterministic under seeded random — two synths with
+//     the same seed scatter their notes identically, a different seed differs;
+//   * controller / aftertouch / handler-param forwarding — the synth hands the
+//     live values to the handler through voiceContext, which the built-in orbit
+//     handler (aftertouch widens the swarm) and a probe handler read back.
+// Plus the epic's acceptance check: N notes trace distinct, moving orbits.
+//
+// ISOLATION: like `synthpositioning` these drive System::initOffline()/close()
+// and so run in their own ctest process (`synthhandlers`), excluded from the
+// combined `yse_unit_tests` run. initOffline() needs no audio hardware, so they
+// run in CI; a host where it returns false bails the case out as a pass. The
+// steal / lifecycle cases are written to run under ASan/TSan via tools/ci-linux/.
+
+#include <doctest/doctest.h>
+#include <chrono>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "sound/soundInterface.hpp"
+#include "synth/positionHandler.hpp"
+#include "synth/positionHandlers.hpp"
+#include "synth/sineVoice.hpp"
+#include "synth/synthInterface.hpp"
+
+namespace {
+
+  // Bring a synth (behind a sound) to READY by pumping the offline engine until
+  // its voices are cloned on the slow pool, or a deadline passes.
+  bool bringToReady(YSE::synth& syn, int expectVoices) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+      if (syn.getNumVoices() == expectVoices) return true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return syn.getNumVoices() == expectVoices;
+  }
+
+  // Advance the offline engine by n blocks.
+  void pump(int n) {
+    for (int b = 0; b < n; ++b) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+    }
+  }
+
+  // Horizontal (x,z) radius of a position from the origin.
+  double planarRadius(const YSE::Pos& p) {
+    return std::sqrt(static_cast<double>(p.x) * p.x + static_cast<double>(p.z) * p.z);
+  }
+
+  // A handler that echoes voiceContext fields straight into a position, so a
+  // test can assert exactly which live value reached the handler. It is also the
+  // minimal "write your own handler" example (steers position only, RT-safe).
+  class ProbeHandler : public YSE::SYNTH::positionHandler {
+  public:
+    YSE::SYNTH::positionHandler* clone() override {
+      return new ProbeHandler(*this);
+    }
+    YSE::Pos noteOn(const YSE::SYNTH::voiceContext& ctx) override {
+      return probe(ctx);
+    }
+    YSE::Pos update(const YSE::SYNTH::voiceContext& ctx, Flt) override {
+      return probe(ctx);
+    }
+
+  private:
+    // x <- CC1 (controller forwarding), y <- handler-param 5, z <- aftertouch.
+    static YSE::Pos probe(const YSE::SYNTH::voiceContext& ctx) {
+      return YSE::Pos(ctx.controller(1) * 10.f, ctx.handlerParam(5), ctx.aftertouch * 4.f);
+    }
+  };
+
+} // namespace
+
+TEST_SUITE("synthhandlers") {
+
+  // ── Acceptance: N notes trace distinct orbits, and each orbit moves over
+  //    time (positions differ per note and advance per block). ──
+  TEST_CASE("synthhandlers: swarm notes trace distinct, moving orbits") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice voiceProto;
+    voiceProto.attack(0.005f).sustain(0.8f).release(0.2f);
+    YSE::SYNTH::orbitHandler orbitProto;
+    orbitProto.radius(2.f).velocityRadius(0.f).rate(4.f); // fixed radius so phase alone separates
+    {
+      YSE::synth syn;
+      syn.create().addVoices(voiceProto, 16).positionHandler(orbitProto);
+      YSE::sound snd;
+      snd.create(syn);
+      REQUIRE(bringToReady(syn, 16));
+      snd.play();
+
+      const int base = 48;
+      const int n = 8;
+      for (int i = 0; i < n; ++i)
+        syn.noteOn(1, base + i, 0.8f);
+      pump(2);
+
+      // Distinct per note: sample each note's position; all pairwise different.
+      std::vector<YSE::Pos> first;
+      for (int i = 0; i < n; ++i)
+        first.push_back(syn.getVoicePosition(1, base + i));
+      for (int i = 0; i < n; ++i) {
+        for (int j = i + 1; j < n; ++j) {
+          CHECK(first[static_cast<size_t>(i)] != first[static_cast<size_t>(j)]);
+        }
+        // On a fixed-radius orbit every note sits on the same ring.
+        CHECK(planarRadius(first[static_cast<size_t>(i)]) == doctest::Approx(2.0).epsilon(0.05));
+      }
+
+      // Moving over time: after more blocks each note has advanced its orbit.
+      pump(30);
+      int moved = 0;
+      for (int i = 0; i < n; ++i) {
+        if (syn.getVoicePosition(1, base + i) != first[static_cast<size_t>(i)]) ++moved;
+      }
+      CHECK(moved == n);
+
+      snd.stop();
+      pump(4);
+    }
+    pump(4);
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ── Deterministic seeded random spread: two synths seeded the same scatter
+  //    their notes identically; a different seed differs. ──
+  TEST_CASE("synthhandlers: random spread is deterministic under a seed") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice voiceProto;
+    voiceProto.attack(0.005f).sustain(0.8f).release(0.05f);
+
+    YSE::SYNTH::randomSpreadHandler protoA;
+    protoA.radius(5.f).seed(1234u);
+    YSE::SYNTH::randomSpreadHandler protoB;
+    protoB.radius(5.f).seed(1234u); // same seed as A
+    YSE::SYNTH::randomSpreadHandler protoC;
+    protoC.radius(5.f).seed(9999u); // different seed
+    {
+      YSE::synth a, b, c;
+      a.create().addVoices(voiceProto, 8).positionHandler(protoA);
+      b.create().addVoices(voiceProto, 8).positionHandler(protoB);
+      c.create().addVoices(voiceProto, 8).positionHandler(protoC);
+      YSE::sound sa, sb, sc;
+      sa.create(a);
+      sb.create(b);
+      sc.create(c);
+      REQUIRE(bringToReady(a, 8));
+      REQUIRE(bringToReady(b, 8));
+      REQUIRE(bringToReady(c, 8));
+      sa.play();
+      sb.play();
+      sc.play();
+
+      const int base = 60;
+      const int n = 6;
+      for (int i = 0; i < n; ++i) {
+        a.noteOn(1, base + i, 0.7f);
+        b.noteOn(1, base + i, 0.7f);
+        c.noteOn(1, base + i, 0.7f);
+      }
+      pump(2);
+
+      int differsFromC = 0;
+      for (int i = 0; i < n; ++i) {
+        YSE::Pos pa = a.getVoicePosition(1, base + i);
+        YSE::Pos pb = b.getVoicePosition(1, base + i);
+        YSE::Pos pc = c.getVoicePosition(1, base + i);
+        // Same seed -> identical scatter (same computation, exact match).
+        CHECK(pa.x == doctest::Approx(pb.x));
+        CHECK(pa.y == doctest::Approx(pb.y));
+        CHECK(pa.z == doctest::Approx(pb.z));
+        // Draw is inside the radius sphere around the origin centre.
+        CHECK(std::sqrt(pa.x * pa.x + pa.y * pa.y + pa.z * pa.z) <= 5.0f * 1.7321f + 1e-3f);
+        if (pa != pc) ++differsFromC;
+      }
+      CHECK(differsFromC > 0); // a different seed produces a different scatter
+
+      a.allNotesOff(0);
+      b.allNotesOff(0);
+      c.allNotesOff(0);
+      pump(4);
+    }
+    pump(4);
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ── Steerable centre: writing handler-params 0..2 recentres the whole spread
+  //    on the next block (the swarm-centre use case, §9). ──
+  TEST_CASE("synthhandlers: handlerParam recentres the spread") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice voiceProto;
+    voiceProto.attack(0.005f).sustain(0.8f).release(0.05f);
+    YSE::SYNTH::randomSpreadHandler proto;
+    proto.radius(1.f).seed(42u);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(voiceProto, 8).positionHandler(proto);
+      YSE::sound snd;
+      snd.create(syn);
+      REQUIRE(bringToReady(syn, 8));
+      snd.play();
+
+      for (int i = 0; i < 4; ++i)
+        syn.noteOn(1, 60 + i, 0.7f);
+      pump(2);
+      YSE::Pos before = syn.getVoicePosition(1, 60);
+
+      // Shift the shared centre far along +X; the held note tracks it next block.
+      syn.handlerParam(YSE::SYNTH::HP_CENTER_X, 100.f);
+      pump(2);
+      YSE::Pos after = syn.getVoicePosition(1, 60);
+
+      CHECK(after.x > before.x + 90.f); // moved by ~the centre shift, radius aside
+
+      snd.stop();
+      pump(4);
+    }
+    pump(4);
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ── Controller / aftertouch / handler-param forwarding through voiceContext.
+  //    A probe handler echoes each live value into a coordinate. ──
+  TEST_CASE("synthhandlers: synth forwards controller/aftertouch to the handler") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice voiceProto;
+    voiceProto.attack(0.005f).sustain(0.8f).release(0.05f);
+    ProbeHandler probeProto;
+    {
+      YSE::synth syn;
+      syn.create().addVoices(voiceProto, 4).positionHandler(probeProto);
+      YSE::sound snd;
+      snd.create(syn);
+      REQUIRE(bringToReady(syn, 4));
+      snd.play();
+
+      syn.noteOn(1, 64, 0.9f);
+      pump(2); // establish the voice; live values still at defaults (~0)
+      YSE::Pos base = syn.getVoicePosition(1, 64);
+      CHECK(base.x == doctest::Approx(0.f).epsilon(0.01));
+      CHECK(base.z == doctest::Approx(0.f).epsilon(0.01));
+
+      // CC1 -> x (controller forwarding).
+      syn.controller(1, 1, 0.5f);
+      // Channel aftertouch -> z (aftertouch forwarding).
+      syn.aftertouch(1, -1, 1.0f);
+      // Shared handler-param 5 -> y.
+      syn.handlerParam(5, 3.f);
+      pump(2);
+
+      YSE::Pos p = syn.getVoicePosition(1, 64);
+      CHECK(p.x == doctest::Approx(5.f).epsilon(0.01)); // 0.5 * 10
+      CHECK(p.y == doctest::Approx(3.f).epsilon(0.01)); // handlerParam(5)
+      CHECK(p.z == doctest::Approx(4.f).epsilon(0.01)); // 1.0 * 4
+
+      snd.stop();
+      pump(4);
+    }
+    pump(4);
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ── Orbit widens under aftertouch: the built-in handler reads the live value
+  //    the synth forwards and spreads the swarm outward. ──
+  TEST_CASE("synthhandlers: aftertouch widens the orbit radius") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice voiceProto;
+    voiceProto.attack(0.005f).sustain(0.8f).release(0.05f);
+    YSE::SYNTH::orbitHandler proto;
+    proto.radius(2.f).velocityRadius(0.f).aftertouchWiden(1.f).rate(1.f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(voiceProto, 4).positionHandler(proto);
+      YSE::sound snd;
+      snd.create(syn);
+      REQUIRE(bringToReady(syn, 4));
+      snd.play();
+
+      syn.noteOn(1, 60, 0.5f);
+      pump(2);
+      double r0 = planarRadius(syn.getVoicePosition(1, 60));
+      CHECK(r0 == doctest::Approx(2.0).epsilon(0.05));
+
+      syn.aftertouch(1, 60, 1.0f); // full pressure doubles the radius (widen 1.0)
+      pump(2);
+      double r1 = planarRadius(syn.getVoicePosition(1, 60));
+      CHECK(r1 > r0 + 1.0); // ~4 vs ~2
+
+      snd.stop();
+      pump(4);
+    }
+    pump(4);
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ── Handler lifecycle vs voice lifecycle: a released note keeps being steered
+  //    through its decay tail (position moves after note-off), then the slot
+  //    frees. ──
+  TEST_CASE("synthhandlers: handler steers through the release tail") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice voiceProto;
+    voiceProto.attack(0.005f).sustain(0.8f).release(0.05f); // audible tail to observe
+    YSE::SYNTH::orbitHandler proto;
+    proto.radius(3.f).velocityRadius(0.f).rate(6.f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(voiceProto, 4).positionHandler(proto);
+      YSE::sound snd;
+      snd.create(syn);
+      REQUIRE(bringToReady(syn, 4));
+      snd.play();
+
+      syn.noteOn(1, 55, 0.8f);
+      pump(2);
+      YSE::Pos held = syn.getVoicePosition(1, 55);
+      CHECK(planarRadius(held) == doctest::Approx(3.0).epsilon(0.05));
+
+      // Release: the note enters its tail but keeps orbiting (still sounding).
+      syn.noteOff(1, 55);
+      pump(1);
+      YSE::Pos releasing = syn.getVoicePosition(1, 55);
+      CHECK(releasing != held); // moved through the tail
+      CHECK(planarRadius(releasing) == doctest::Approx(3.0).epsilon(0.1)); // still on the ring
+
+      // Let the tail finish; the slot then frees (no voice reports that note).
+      bool freed = false;
+      for (int i = 0; i < 200 && !freed; ++i) {
+        pump(1);
+        if (syn.getVoicePosition(1, 55) == YSE::Pos(0.f)) freed = true;
+      }
+      CHECK(freed);
+
+      snd.stop();
+      pump(4);
+    }
+    pump(4);
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ── Voice stealing re-inits the handler: a tiny pool massively overcommitted
+  //    steals every block; handlers re-seed per steal, the pool never grows, and
+  //    positions stay finite. The ASan/TSan target for handler lifetime. ──
+  TEST_CASE("synthhandlers: stealing re-inits handlers without leaks") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice voiceProto;
+    voiceProto.attack(0.001f).decay(0.002f).sustain(0.8f).release(0.05f);
+    YSE::SYNTH::orbitHandler proto;
+    proto.radius(1.f).velocityRadius(3.f).rate(5.f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(voiceProto, 4).positionHandler(proto); // tiny pool
+      YSE::sound snd;
+      snd.create(syn);
+      REQUIRE(bringToReady(syn, 4));
+      snd.play();
+
+      for (int n = 40; n < 64; ++n) // 24 keys vs 4 voices -> constant stealing
+        syn.noteOn(1, n, 0.8f);
+      for (int b = 0; b < 64; ++b) {
+        YSE::System().update();
+        YSE::System().renderOffline(1);
+        CHECK(syn.getNumVoices() == 4);
+        if (b % 8 == 0) {
+          for (int n = 40; n < 64; ++n)
+            syn.noteOn(1, n, 0.7f);
+        }
+        // Whatever note currently owns a slot must have a finite position.
+        for (int n = 40; n < 64; ++n) {
+          YSE::Pos p = syn.getVoicePosition(1, n);
+          CHECK(std::isfinite(p.x));
+          CHECK(std::isfinite(p.y));
+          CHECK(std::isfinite(p.z));
+        }
+      }
+      syn.allNotesOff(0);
+      pump(8);
+      snd.stop();
+      pump(4);
+    }
+    pump(8);
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ── No handler attached: the synth is unchanged — every voice stays at the
+  //    aggregate origin (strictly additive, §8). ──
+  TEST_CASE("synthhandlers: no handler leaves voices at the aggregate position") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice voiceProto;
+    voiceProto.attack(0.005f).sustain(0.8f).release(0.05f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(voiceProto, 4); // no positionHandler()
+      YSE::sound snd;
+      snd.create(syn);
+      REQUIRE(bringToReady(syn, 4));
+      snd.play();
+
+      syn.noteOn(1, 60, 0.8f);
+      pump(4);
+      CHECK(syn.getVoicePosition(1, 60) == YSE::Pos(0.f));
+
+      // notePosition() still works with no handler (app-driven placement).
+      syn.notePosition(1, 60, YSE::Pos(7.f, 0.f, -3.f));
+      pump(2);
+      YSE::Pos p = syn.getVoicePosition(1, 60);
+      CHECK(p.x == doctest::Approx(7.f));
+      CHECK(p.z == doctest::Approx(-3.f));
+
+      snd.stop();
+      pump(4);
+    }
+    pump(4);
+    YSE::System().close();
+    CHECK(true);
+  }
+
+} // TEST_SUITE("synthhandlers")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -150,6 +150,7 @@ set(YSE_SRCS
   sound/soundManager.cpp
   synth/sineVoice.cpp
   synth/vaVoice.cpp
+  synth/positionHandlers.cpp
   synth/synthImplementation.cpp
   synth/synthInterface.cpp
   synth/synthManager.cpp

--- a/YseEngine/synth/positionHandler.hpp
+++ b/YseEngine/synth/positionHandler.hpp
@@ -1,0 +1,175 @@
+/*
+  ==============================================================================
+
+    positionHandler.hpp
+    Per-note 3D position behaviour for the YSE::synth subsystem.
+
+    Implements §8 ("The positionHandler contract") of
+    docs/design/per_note_positioning.md (issue #170). A positionHandler is the
+    positional analogue of SYNTH::dspVoice: the user derives from it, the engine
+    owns polyphony and lifetime, one instance is clone()-d per voice slot, and
+    its hooks run on the audio thread under the same real-time discipline as a
+    voice process(). A handler steers a voice's POSITION only — it never
+    produces audio, never touches keyboard state, and never forwards
+    controllers; the synth owns all of that and hands the live values to the
+    handler through the read-only voiceContext for it to react to.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_POSITIONHANDLER_HPP
+#define YSE_SYNTH_POSITIONHANDLER_HPP
+
+#include "../headers/defines.hpp" // API
+#include "../headers/types.hpp" // Flt, Int
+#include "../utils/vector.hpp" // Pos
+
+namespace YSE {
+  namespace SYNTH {
+
+    /// @cond INTERNAL
+    // The audio-thread implementation object that owns and drives handlers. It
+    // is friended so it can fill the private backing pointers of a voiceContext
+    // it hands to a handler; the handler code itself only reads the public
+    // scalars and the const accessors.
+    class implementationObject;
+    /// @endcond
+
+    /**
+     *  @brief Read-only view of one voice's live note state, handed to a
+     *         positionHandler on every hook.
+     *
+     *  The synth fills a fresh voiceContext on the stack for each hook call —
+     *  it is never a heap object and the handler never owns it. Everything on
+     *  it is a value or a same-thread read; nothing here allocates or locks.
+     *  Read it to modulate position (e.g. velocity -> orbit radius, aftertouch
+     *  -> swarm width, a control-change -> height); you cannot write note state
+     *  through it.
+     */
+    class voiceContext {
+    public:
+      Flt frequency = 0.f; ///< The sounding pitch, in Hz.
+      Flt velocity = 0.f; ///< Note-on velocity, normalised to [0, 1].
+      Flt aftertouch = 0.f; ///< Live aftertouch pressure for this voice, [0, 1].
+      Flt pitchWheel = 0.f; ///< Live pitch-wheel position for the channel, [-1, 1].
+      Int channel = 0; ///< MIDI channel that triggered the note (1..16).
+      Int note = 0; ///< MIDI note number.
+
+      /** @brief Live value of control-change ``number`` on this voice's channel,
+       *  normalised to [0, 1]. Out-of-range numbers read 0. This is the synth
+       *  forwarding a controller to the handler — same-thread read, no atomics. */
+      Flt controller(int number) const {
+        if (controllers_ == nullptr || number < 0 || number > 127) return 0.f;
+        return controllers_[number];
+      }
+
+      /** @brief Shared handler parameter ``index``, written by
+       *  ``synth::handlerParam()`` on the audio thread (§9). All of a synth's
+       *  live handlers read the same block, so it is the natural home for a
+       *  steerable swarm centre / radius. Out-of-range indices read 0. */
+      Flt handlerParam(int index) const {
+        if (handlerParams_ == nullptr || index < 0 || index >= numHandlerParams_) return 0.f;
+        return handlerParams_[index];
+      }
+
+    private:
+      // Filled by the engine immediately before a hook; handler code must not
+      // touch these directly (use the accessors above).
+      const Flt* controllers_ = nullptr; // -> channelState.controller[128]
+      const Flt* handlerParams_ = nullptr; // -> the synth's shared param block
+      int numHandlerParams_ = 0;
+      friend class implementationObject;
+    };
+
+    /**
+     *  @brief Base class for user-subclassable per-note position behaviours.
+     *
+     *  Derive from ``positionHandler`` to decide where every note of a synth
+     *  lives and how it moves — a static offset, a random scatter, a swarm
+     *  orbiting a moving centre — without writing engine code per note. The
+     *  returned ``Pos`` is the voice's position in the same coordinate frame as
+     *  a ``YSE::sound`` position; the engine feeds it straight into that voice's
+     *  panner (see docs/design/per_note_positioning.md §6/§7).
+     *
+     *  **Lifecycle (mirrors the voice slot, §8/§10/§11).** Attach a prototype
+     *  with ``synth::positionHandler(proto)``. The engine clones it once per
+     *  voice slot on the setup pool (via ``clone()``) and reuses that one
+     *  instance for every note the slot ever plays. When the allocator lands a
+     *  note on a slot it calls ``noteOn()``; every audio block until the voice's
+     *  release tail ends it calls ``update()``; on the note-off edge it calls
+     *  ``onRelease()`` once. The instance is never freed at note rate — it is
+     *  re-seeded by the next ``noteOn()``.
+     *
+     *  **Stealing (§11).** Because one instance is permanently paired with a
+     *  slot and reused, a stolen slot simply gets a fresh ``noteOn()`` for the
+     *  new note. Therefore **``noteOn()`` must establish the note's COMPLETE
+     *  initial state** (reset every phase / counter / RNG draw) — the instance
+     *  may have just finished another note. Do not assume construction state.
+     *
+     *  **Real-time discipline.** ``noteOn()``, ``update()`` and ``onRelease()``
+     *  run on the audio thread. They must not allocate, lock, block on I/O, or
+     *  log — identical rules to a voice ``process()``. Allocate everything the
+     *  hooks touch in the constructor / ``clone()`` (which run only on the setup
+     *  pool). Any state shared with another thread must arrive through the
+     *  handler-param block or be atomic.
+     *
+     *  The shipped reference implementations are ``SYNTH::staticHandler``,
+     *  ``SYNTH::randomSpreadHandler`` and ``SYNTH::orbitHandler`` (the last is
+     *  the swarm workhorse and the template for a custom handler).
+     *
+     *  @see YSE::SYNTH::orbitHandler  The swarm reference handler.
+     *  @see YSE::synth::positionHandler  To attach a prototype.
+     */
+    class API positionHandler {
+    public:
+      virtual ~positionHandler() {}
+
+      /**
+       *  @brief Return a new, fully-allocated heap clone of your derived type.
+       *         **You must implement this.**
+       *
+       *  The typical body is ``return new MyHandler(*this);``. Everything the
+       *  hooks will touch must already exist in the returned object, so the
+       *  hooks stay allocation-free. Called only on the setup pool (never the
+       *  audio thread); allocation here is fine.
+       */
+      virtual positionHandler* clone() = 0;
+
+      /**
+       *  @brief A note begins on this handler's slot. Return its initial
+       *         position. **You must implement this.**
+       *
+       *  Runs on the audio thread; allocation-free. Because the instance is
+       *  reused across notes (and across voice steals), this hook **must fully
+       *  reinitialise** every piece of per-note state it keeps.
+       */
+      virtual Pos noteOn(const voiceContext& ctx) = 0;
+
+      /**
+       *  @brief Control-rate steer, called once per audio block while the note
+       *         sounds (through its release tail). Return the new position.
+       *         **You must implement this.**
+       *
+       *  ``delta`` is the block's duration in seconds (buffer length /
+       *  samplerate), so advancing state by ``rate * delta`` is frame-rate
+       *  independent. Runs on the audio thread; allocation-free.
+       */
+      virtual Pos update(const voiceContext& ctx, Flt delta) = 0;
+
+      /**
+       *  @brief The note entered its release tail (key up / note-off edge).
+       *         Optional — the default is a no-op.
+       *
+       *  Position control CONTINUES through the tail (``update()`` keeps being
+       *  called until the voice stops), so a handler that ignores release keeps
+       *  moving. Override to change behaviour for the fade (e.g. drift outward,
+       *  slow an orbit). Called exactly once, on the edge. Audio thread;
+       *  allocation-free.
+       */
+      virtual void onRelease(const voiceContext& /*ctx*/) {}
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_POSITIONHANDLER_HPP

--- a/YseEngine/synth/positionHandlers.cpp
+++ b/YseEngine/synth/positionHandlers.cpp
@@ -1,0 +1,120 @@
+/*
+  ==============================================================================
+
+    positionHandlers.cpp
+    Definitions for the three built-in position handlers (issue #170). Kept out
+    of line so each concrete handler's vtable is anchored in one translation
+    unit and exported under the API macro, exactly like SYNTH::sineVoice.
+
+    All hook bodies are allocation-free, lock-free and non-blocking: they run on
+    the audio thread. The only non-trivial cost is orbitHandler's two trig calls
+    and randomSpreadHandler's xorshift draw — both a handful of FLOPs.
+
+  ==============================================================================
+*/
+
+#include "positionHandlers.hpp"
+
+#include <cmath>
+
+namespace YSE {
+  namespace SYNTH {
+
+    // ---- staticHandler ----------------------------------------------------
+
+    positionHandler* staticHandler::clone() {
+      return new staticHandler(*this);
+    }
+
+    Pos staticHandler::noteOn(const voiceContext& /*ctx*/) {
+      return position_;
+    }
+
+    Pos staticHandler::update(const voiceContext& /*ctx*/, Flt /*delta*/) {
+      return position_;
+    }
+
+    // ---- randomSpreadHandler ----------------------------------------------
+
+    Flt randomSpreadHandler::nextRandom() {
+      // xorshift32 — a fixed-size, allocation-free PRNG safe to draw from on the
+      // audio thread. State is seeded non-zero in clone().
+      uint32_t x = rngState_;
+      x ^= x << 13;
+      x ^= x >> 17;
+      x ^= x << 5;
+      rngState_ = x;
+      return static_cast<Flt>(x & 0xFFFFFFu) / static_cast<Flt>(0x1000000u);
+    }
+
+    Pos randomSpreadHandler::center(const voiceContext& ctx) const {
+      return Pos(ctx.handlerParam(HP_CENTER_X), ctx.handlerParam(HP_CENTER_Y),
+                 ctx.handlerParam(HP_CENTER_Z));
+    }
+
+    positionHandler* randomSpreadHandler::clone() {
+      auto* h = new randomSpreadHandler(*this);
+      // Derive a distinct, deterministic stream for this slot. cloneCounter_
+      // lives on the prototype and advances per clone(), so slots created in
+      // order on the setup pool get reproducible, non-overlapping seeds.
+      uint32_t s = baseSeed_ + 0x9E3779B9u * (++cloneCounter_);
+      if (s == 0) s = 0x1u; // xorshift must never be seeded with 0
+      h->rngState_ = s;
+      h->cloneCounter_ = 0;
+      return h;
+    }
+
+    Pos randomSpreadHandler::noteOn(const voiceContext& ctx) {
+      // Draw a fresh offset for THIS note (full reinit — the slot may have just
+      // finished another note, §11). Three draws mapped to [-radius, +radius].
+      offset_.x = (nextRandom() * 2.f - 1.f) * radius_;
+      offset_.y = (nextRandom() * 2.f - 1.f) * radius_;
+      offset_.z = (nextRandom() * 2.f - 1.f) * radius_;
+      return center(ctx) + offset_;
+    }
+
+    Pos randomSpreadHandler::update(const voiceContext& ctx, Flt /*delta*/) {
+      // Static per note: hold the note-on draw, but track the live centre so a
+      // steered centre carries the whole scatter with it.
+      return center(ctx) + offset_;
+    }
+
+    // ---- orbitHandler -----------------------------------------------------
+
+    // Golden angle (rad): spacing successive note phases by it scatters notes
+    // evenly around the ring, so distinct notes trace visibly distinct orbits.
+    static const Flt kGoldenAngle = 2.399963229f;
+
+    Pos orbitHandler::positionAt(const voiceContext& ctx, Flt phase) const {
+      Pos c(ctx.handlerParam(HP_CENTER_X), ctx.handlerParam(HP_CENTER_Y),
+            ctx.handlerParam(HP_CENTER_Z));
+      // Radius chosen for this note (from velocity, set in noteOn) widened live
+      // by aftertouch, so leaning on a key spreads the swarm outward — the synth
+      // forwarding a live value to the handler.
+      Flt r = noteRadius_ * (1.f + aftertouchWiden_ * ctx.aftertouch);
+      return Pos(c.x + r * std::cos(phase), c.y + height_, c.z + r * std::sin(phase));
+    }
+
+    positionHandler* orbitHandler::clone() {
+      return new orbitHandler(*this);
+    }
+
+    Pos orbitHandler::noteOn(const voiceContext& ctx) {
+      // FULL reinit — the instance may have just finished another note (§11).
+      phase_ = static_cast<Flt>(ctx.note) * kGoldenAngle; // distinct per note
+      speed_ = rate_;
+      noteRadius_ = radius_ + velocityRadius_ * ctx.velocity; // velocity -> radius
+      return positionAt(ctx, phase_);
+    }
+
+    Pos orbitHandler::update(const voiceContext& ctx, Flt delta) {
+      phase_ += speed_ * delta; // frame-rate independent advance
+      return positionAt(ctx, phase_);
+    }
+
+    void orbitHandler::onRelease(const voiceContext& /*ctx*/) {
+      speed_ *= releaseSlow_; // slow the orbit through the decay tail
+    }
+
+  } // namespace SYNTH
+} // namespace YSE

--- a/YseEngine/synth/positionHandlers.hpp
+++ b/YseEngine/synth/positionHandlers.hpp
@@ -1,0 +1,186 @@
+/*
+  ==============================================================================
+
+    positionHandlers.hpp
+    The three built-in position handlers shipped by issue #170.
+
+    - staticHandler       : a fixed position (or offset). The trivial default.
+    - randomSpreadHandler : a random point in a radius around a centre, drawn
+                            once per note-on (so voice steals re-randomise). Its
+                            RNG is seeded deterministically, so a given seed
+                            reproduces the same scatter every run.
+    - orbitHandler        : the swarm workhorse — each note orbits a shared,
+                            steerable centre with a per-note phase and a radius
+                            derived from velocity and aftertouch. Doubles as the
+                            reference for writing a custom handler.
+
+    All three keep their configuration in members set (chainably) on the
+    prototype before attach; clone() copies that configuration to every slot.
+    The centre is read live from the synth's shared handler-param block
+    (indices 0..2), so it can be steered at runtime with synth::handlerParam().
+    See docs/design/per_note_positioning.md §8 and §15 (the worked swarm).
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_POSITIONHANDLERS_HPP
+#define YSE_SYNTH_POSITIONHANDLERS_HPP
+
+#include <cstdint>
+
+#include "../headers/defines.hpp" // API
+#include "../headers/types.hpp"
+#include "../utils/vector.hpp" // Pos
+#include "positionHandler.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /** Shared handler-param indices the built-in handlers read for their
+        steerable centre (written with ``synth::handlerParam(index, value)``). */
+    enum HandlerParamIndex {
+      HP_CENTER_X = 0,
+      HP_CENTER_Y = 1,
+      HP_CENTER_Z = 2,
+    };
+
+    /**
+     *  @brief Places every note at one fixed position. The trivial default.
+     *
+     *  Ignores the shared centre and all live values — a genuinely static
+     *  source. Use ``synth::notePosition()`` for app-driven trajectories when
+     *  no movement behaviour is wanted.
+     */
+    class API staticHandler : public positionHandler {
+    public:
+      /** @brief Set the fixed position (same frame as a YSE::sound position). */
+      staticHandler& position(const Pos& p) {
+        position_ = p;
+        return *this;
+      }
+      /** @brief Current fixed position. */
+      Pos position() const {
+        return position_;
+      }
+
+      positionHandler* clone() override;
+      Pos noteOn(const voiceContext& ctx) override;
+      Pos update(const voiceContext& ctx, Flt delta) override;
+
+    private:
+      Pos position_{0.f};
+    };
+
+    /**
+     *  @brief Scatters each note to a random point within ``radius`` of the
+     *         shared centre, drawn once at note-on and held for the note.
+     *
+     *  The draw uses a small deterministic PRNG seeded from ``seed()`` plus a
+     *  per-slot offset, so the same seed reproduces the same scatter every run
+     *  (the basis of the seeded-trajectory tests). A voice steal re-draws in
+     *  ``noteOn()``, so a stolen slot re-randomises correctly.
+     */
+    class API randomSpreadHandler : public positionHandler {
+    public:
+      /** @brief Radius of the spread sphere around the centre. */
+      randomSpreadHandler& radius(Flt r) {
+        radius_ = r;
+        return *this;
+      }
+      Flt radius() const {
+        return radius_;
+      }
+      /** @brief Base RNG seed. Each cloned slot derives a distinct stream from
+       *  it, so the whole synth is reproducible for a given seed. */
+      randomSpreadHandler& seed(uint32_t s) {
+        baseSeed_ = s;
+        return *this;
+      }
+
+      positionHandler* clone() override;
+      Pos noteOn(const voiceContext& ctx) override;
+      Pos update(const voiceContext& ctx, Flt delta) override;
+
+    private:
+      // xorshift32: allocation-free, lock-free, deterministic — RT-safe to draw
+      // from on the audio thread. Returns [0, 1).
+      Flt nextRandom();
+      Pos center(const voiceContext& ctx) const;
+
+      Flt radius_ = 1.f;
+      uint32_t baseSeed_ = 0x9E3779B9u; // golden-ratio constant; non-zero
+      uint32_t cloneCounter_ = 0; // advanced on the prototype, per clone()
+      uint32_t rngState_ = 0x9E3779B9u; // per-instance stream state (non-zero)
+      Pos offset_{0.f}; // the per-note draw, set in noteOn()
+    };
+
+    /**
+     *  @brief The swarm handler — each note orbits a shared, steerable centre.
+     *
+     *  This is the epic's showcase and the template for a user handler. Each
+     *  note gets a distinct starting phase (from its note number), a radius
+     *  derived from velocity (and widened live by aftertouch), and advances its
+     *  phase at ``rate`` rad/s. The centre is read live from handler-params
+     *  0..2, so ``synth::handlerParam()`` recentres the whole swarm from the
+     *  main thread with one bounded message. On release the orbit slows, so a
+     *  released note keeps moving — audibly correct — through its decay tail.
+     */
+    class API orbitHandler : public positionHandler {
+    public:
+      /** @brief Base orbit radius (added to the velocity-scaled term). */
+      orbitHandler& radius(Flt r) {
+        radius_ = r;
+        return *this;
+      }
+      /** @brief Extra radius added at full velocity. */
+      orbitHandler& velocityRadius(Flt r) {
+        velocityRadius_ = r;
+        return *this;
+      }
+      /** @brief Fraction of extra radius added at full aftertouch (swarm
+       *  widening). */
+      orbitHandler& aftertouchWiden(Flt frac) {
+        aftertouchWiden_ = frac;
+        return *this;
+      }
+      /** @brief Orbit angular speed in radians per second. */
+      orbitHandler& rate(Flt radiansPerSecond) {
+        rate_ = radiansPerSecond;
+        return *this;
+      }
+      /** @brief Vertical offset of the orbit plane from the centre. */
+      orbitHandler& height(Flt h) {
+        height_ = h;
+        return *this;
+      }
+      /** @brief Multiplier applied to ``rate`` once the note is released. */
+      orbitHandler& releaseSlow(Flt factor) {
+        releaseSlow_ = factor;
+        return *this;
+      }
+
+      positionHandler* clone() override;
+      Pos noteOn(const voiceContext& ctx) override;
+      Pos update(const voiceContext& ctx, Flt delta) override;
+      void onRelease(const voiceContext& ctx) override;
+
+    private:
+      Pos positionAt(const voiceContext& ctx, Flt phase) const;
+
+      // config (copied to every clone)
+      Flt radius_ = 1.f;
+      Flt velocityRadius_ = 2.f;
+      Flt aftertouchWiden_ = 1.f;
+      Flt rate_ = 2.f;
+      Flt height_ = 0.f;
+      Flt releaseSlow_ = 0.5f;
+      // per-note state (fully reset in noteOn)
+      Flt phase_ = 0.f; ///< current orbit angle
+      Flt speed_ = 2.f; ///< current angular speed (rate_, halved on release)
+      Flt noteRadius_ = 1.f; ///< radius chosen for the current note
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_POSITIONHANDLERS_HPP

--- a/YseEngine/synth/synth.hpp
+++ b/YseEngine/synth/synth.hpp
@@ -26,6 +26,7 @@ namespace YSE {
     class messageObject;
     class managerObject;
     class dspVoice;
+    class positionHandler;
 
     /** The control events the interface can push onto an implementation's
         lock-free inbox. #153 wires up the note ops (NOTE_ON / NOTE_OFF /
@@ -43,6 +44,10 @@ namespace YSE {
       SUSTAIN,
       SOSTENUTO,
       SOFTPEDAL,
+      // Per-note positioning (#170). HANDLER_PARAM updates the synth's shared
+      // handler-param block; NOTE_POSITION imperatively places sounding notes.
+      HANDLER_PARAM,
+      NOTE_POSITION,
     };
   } // namespace SYNTH
 

--- a/YseEngine/synth/synthImplementation.cpp
+++ b/YseEngine/synth/synthImplementation.cpp
@@ -71,6 +71,18 @@ namespace YSE {
       pendingGroups.push_back({prototype, numVoices, channel, lowestNote, highestNote});
     }
 
+    void implementationObject::setPositionHandler(positionHandler* prototype) {
+      std::scoped_lock lk(buildMutex);
+      if (objectStatus.load(std::memory_order_acquire) >= OBJECT_SETUP) {
+        // Handlers, like voice groups, are immutable once built: the audio
+        // thread reads them lock-free. Reject rather than race the reader (§8).
+        INTERNAL::LogImpl().emit(E_WARNING,
+                                 "SYNTH: positionHandler() after setup is not supported");
+        return;
+      }
+      handlerPrototype = prototype; // caller-owned; cloned per slot in setup()
+    }
+
     void implementationObject::setNoteCallback(NoteCallback func) {
       // Release-store so the audio thread's acquire-load sees a fully-published
       // function pointer. nullptr simply disables the hook.
@@ -106,6 +118,19 @@ namespace YSE {
       return channels[channelIndex(channel)].softPedal;
     }
 
+    Pos implementationObject::getVoicePosition(int channel, int note) const {
+      // Best-effort audio-thread snapshot (like the keyboard getters above): the
+      // first voice sounding (channel, note) reports its current position.
+      for (const auto& g : groups) {
+        for (const auto& slot : g.slots) {
+          if (slot.channel == channel && slot.note == note && slot.intent != SS_STOPPED) {
+            return slot.position;
+          }
+        }
+      }
+      return Pos(0.f);
+    }
+
     DSP::dspSourceObject& implementationObject::getOutputSource() {
       return output;
     }
@@ -130,6 +155,15 @@ namespace YSE {
         g.voices.reserve(static_cast<size_t>(req.numVoices));
         for (int k = 0; k < req.numVoices; ++k) {
           g.voices.emplace_back(req.prototype->clone());
+        }
+        // Clone one position handler per voice slot (#170), parallel to voices.
+        // With no handler attached the vector stays empty and every voice falls
+        // back to the aggregate position (the epic is strictly additive).
+        if (handlerPrototype != nullptr) {
+          g.handlers.reserve(static_cast<size_t>(req.numVoices));
+          for (int k = 0; k < req.numVoices; ++k) {
+            g.handlers.emplace_back(handlerPrototype->clone());
+          }
         }
         groups.push_back(std::move(g));
       }
@@ -271,15 +305,26 @@ namespace YSE {
       // 4. Render each active voice, then spread its mono output across the
       //    device-width bed at its own position (issue #169, design §7).
       const int blockLen = static_cast<int>(output.samples[0].getLength());
+      // Per-block wall time in seconds, fed to handler update(delta). Derived
+      // from the block length so trajectories are deterministic and frame-rate
+      // independent (design §8), not tied to the control-thread clock.
+      const Flt delta =
+          SAMPLERATE > 0 ? static_cast<Flt>(blockLen) / static_cast<Flt>(SAMPLERATE) : 0.f;
       for (auto& g : groups) {
         for (size_t i = 0; i < g.slots.size(); ++i) {
           voiceSlot& slot = g.slots[i];
           dspVoice* v = g.voices[i].get();
 
+          positionHandler* handler = handlerFor(g, i);
+
           if (slot.stealing) {
             // Keep rendering the OLD note, force-faded to silence over the steal
             // window, then spread it at its current position so a stolen note
-            // fades cleanly along whatever direction it currently occupies.
+            // fades cleanly along whatever direction it currently occupies. The
+            // OLD handler keeps steering it through the fade (design §11).
+            if (handler != nullptr) {
+              slot.position = handler->update(buildContext(g, i), delta);
+            }
             v->process(slot.intent);
             fillStealFader(slot, blockLen);
             slot.panner.update(slot.position);
@@ -296,10 +341,18 @@ namespace YSE {
               slot.keyDown = true; // the new note's key is down
               slot.heldBySustain = false;
               slot.heldBySostenuto = false;
-              slot.position = Pos(0.f); // no handler yet — re-seed to the aggregate (#170)
+              slot.releaseNotified = false;
               v->frequency(static_cast<Flt>(slot.pendNote));
               v->velocity(slot.pendVelocity);
               primeVoicePitchWheel(*v, slot.pendChannel); // start in tune (§5)
+              // Re-seed the position: the handler fully re-inits for the new note
+              // (§11), else fall back to the aggregate. buildContext now reads the
+              // new note's freq/velocity set just above.
+              if (handler != nullptr) {
+                slot.position = handler->noteOn(buildContext(g, i));
+              } else {
+                slot.position = Pos(0.f);
+              }
               // The panner's smoothing ramp starts from the faded-to-zero gain,
               // so the new note fades up from silence at its own direction — no
               // positional glide from the stolen note (design §11).
@@ -307,8 +360,20 @@ namespace YSE {
               slot.intent = SS_WANTSTOPLAY;
             }
           } else if (slot.intent != SS_STOPPED) {
+            // Signal the release edge exactly once so a handler can react to the
+            // note dying (design §10). Position control continues through the
+            // tail via update() below.
+            if (handler != nullptr && slot.intent == SS_WANTSTOSTOP && !slot.releaseNotified) {
+              handler->onRelease(buildContext(g, i));
+              slot.releaseNotified = true;
+            }
             v->process(slot.intent); // may settle the intent to SS_STOPPED
             fillUnitFader(blockLen);
+            // Steer the voice's position for this block (design §7). Skip once the
+            // voice has just stopped — the slot is about to free.
+            if (handler != nullptr && slot.intent != SS_STOPPED) {
+              slot.position = handler->update(buildContext(g, i), delta);
+            }
             slot.panner.update(slot.position);
             slot.panner.spread(v->samples, voiceFader.data(), output.samples);
             if (slot.intent == SS_STOPPED) {
@@ -351,6 +416,47 @@ namespace YSE {
       }
     }
 
+    // ---- position handlers (#170) -----------------------------------------
+
+    voiceContext implementationObject::buildContext(voiceGroup& group, size_t i) {
+      // A fresh stack view of the voice's live note state for the handler hooks.
+      // Reads the voice's own atomics (frequency/velocity/aftertouch/wheel) and
+      // points at the channel's controller row + the shared handler-param block.
+      const voiceSlot& s = group.slots[i];
+      const dspVoice* v = group.voices[i].get();
+      voiceContext ctx;
+      ctx.frequency = v->getFrequency();
+      ctx.velocity = v->getVelocity();
+      ctx.aftertouch = v->getAftertouch();
+      ctx.pitchWheel = v->getPitchWheel();
+      ctx.channel = s.channel;
+      ctx.note = s.note;
+      ctx.controllers_ = channelFor(s.channel).controller.data();
+      ctx.handlerParams_ = handlerParams.data();
+      ctx.numHandlerParams_ = kMaxHandlerParams;
+      return ctx;
+    }
+
+    void implementationObject::handleHandlerParam(int index, Flt value) {
+      if (index >= 0 && index < kMaxHandlerParams) {
+        handlerParams[static_cast<size_t>(index)] = value; // read by handlers next block
+      }
+    }
+
+    void implementationObject::handleNotePosition(int channel, int note, const Pos& pos) {
+      // Imperative override for app-driven trajectories: place every voice
+      // sounding (channel, note) at pos. When a handler is attached its next
+      // update() re-steers the voice, so this is primarily for the no-handler
+      // case (the main thread owning the trajectory). §9.
+      for (auto& g : groups) {
+        for (auto& slot : g.slots) {
+          if (slot.channel == channel && slot.note == note && slot.intent != SS_STOPPED) {
+            slot.position = pos;
+          }
+        }
+      }
+    }
+
     // ---- keyboard / allocator ---------------------------------------------
 
     void implementationObject::parseMessage(const messageObject& message) {
@@ -381,6 +487,14 @@ namespace YSE {
         break;
       case SOFTPEDAL:
         handleSoftPedal(message.pedal.channel, message.pedal.down);
+        break;
+      case HANDLER_PARAM:
+        handleHandlerParam(message.handlerParam.index, message.handlerParam.value);
+        break;
+      case NOTE_POSITION:
+        handleNotePosition(
+            message.notePosition.channel, message.notePosition.note,
+            Pos(message.notePosition.x, message.notePosition.y, message.notePosition.z));
         break;
       }
     }
@@ -576,9 +690,19 @@ namespace YSE {
           s.keyDown = true;
           s.heldBySustain = false;
           s.heldBySostenuto = false;
+          s.releaseNotified = false;
           group.voices[i]->frequency(static_cast<Flt>(note));
           group.voices[i]->velocity(velocity);
           primeVoicePitchWheel(*group.voices[i], channel); // start in tune (§5)
+          // Seed the note's position from its handler (#170) — a full re-init,
+          // since this slot may have played before; else the aggregate origin.
+          // Reset the panner so the new note pans clean from its own direction.
+          if (positionHandler* h = handlerFor(group, i)) {
+            s.position = h->noteOn(buildContext(group, i));
+            s.panner.reset();
+          } else {
+            s.position = Pos(0.f);
+          }
           s.intent = SS_WANTSTOPLAY;
           return;
         }

--- a/YseEngine/synth/synthImplementation.h
+++ b/YseEngine/synth/synthImplementation.h
@@ -39,6 +39,7 @@
 #include "../utils/lfQueue.hpp"
 #include "../utils/vector.hpp"
 #include "dspVoice.hpp"
+#include "positionHandler.hpp"
 #include "synth.hpp"
 #include "synthMessage.h"
 
@@ -83,6 +84,12 @@ namespace YSE {
       void addVoiceGroup(dspVoice* prototype, int numVoices, int channel, int lowestNote,
                          int highestNote);
 
+      /** Record the position-handler prototype to clone once per voice slot in
+          setup() (#170). nullptr clears it. Rejected (with a warning) after
+          setup, like addVoiceGroup — the audio thread reads the handlers
+          lock-free once built. Control thread; guarded by buildMutex. */
+      void setPositionHandler(positionHandler* prototype);
+
       /** Total allocated voices across every group. Thread-safe. */
       int getNumVoices() const;
 
@@ -96,6 +103,10 @@ namespace YSE {
       bool getSustain(int channel) const;
       bool getSostenuto(int channel) const;
       bool getSoftPedal(int channel) const;
+      // Current position of a voice sounding (channel, note), or the origin if
+      // none is. Best-effort audio-thread snapshot (like the getters above);
+      // intended for tests and future C-API/metering readback (#170/#171).
+      Pos getVoicePosition(int channel, int note) const;
 
       // ---- attachment -----------------------------------------------------
 
@@ -165,6 +176,10 @@ namespace YSE {
         bool keyDown = false; // physical key is down (NOTE_ON..NOTE_OFF)
         bool heldBySustain = false; // sustain pedal is deferring this release
         bool heldBySostenuto = false; // captured + deferred by the sostenuto pedal
+        // Position handler edge tracking (#170): set once onRelease() has fired
+        // for this note's release, cleared when the slot is (re-)armed. Keeps
+        // onRelease a single edge call however many times the slot is scanned.
+        bool releaseNotified = false;
         // engine-owned declick for click-free stealing
         bool stealing = false; // fading the OLD note out before re-arming
         int stealPos = 0; // samples elapsed into the steal fade
@@ -187,6 +202,10 @@ namespace YSE {
       struct voiceGroup {
         std::vector<std::unique_ptr<dspVoice>> voices;
         std::vector<voiceSlot> slots; // parallel to voices
+        // Per-slot position handler (#170). Either empty (no handler attached —
+        // every voice uses the aggregate position) or exactly one clone per
+        // voice slot, parallel to voices/slots. Built on the setup pool.
+        std::vector<std::unique_ptr<positionHandler>> handlers;
         int channel = 0; // 0 = omni
         int lowNote = 0;
         int highNote = 127;
@@ -242,6 +261,16 @@ namespace YSE {
       void handlePitchWheel(int channel, Flt value);
       void handleController(int channel, int number, Flt value);
       void handleAftertouch(int channel, int note, Flt value);
+      // per-note positioning ops (#170)
+      void handleHandlerParam(int index, Flt value);
+      void handleNotePosition(int channel, int note, const Pos& pos);
+      // Fill a voiceContext for the handler paired with slot i of `group`.
+      // Reads the voice's live note atomics and the channel/handler-param state.
+      voiceContext buildContext(voiceGroup& group, size_t i);
+      // The handler paired with slot i, or nullptr when no handler is attached.
+      static positionHandler* handlerFor(voiceGroup& group, size_t i) {
+        return group.handlers.empty() ? nullptr : group.handlers[i].get();
+      }
       void handleSustain(int channel, bool down);
       void handleSostenuto(int channel, bool down);
       void handleSoftPedal(int channel, bool down);
@@ -278,7 +307,17 @@ namespace YSE {
       // the container is immutable for the impl's lifetime.
       std::vector<voiceGroup> groups;
       std::vector<groupRequest> pendingGroups; // control -> setup pool
-      std::mutex buildMutex; // guards pendingGroups / groups build
+      // Position-handler prototype recorded by setPositionHandler(), cloned once
+      // per voice slot in setup() (#170). Raw, caller-owned (like a voice
+      // prototype); nullptr = no handler attached.
+      positionHandler* handlerPrototype = nullptr;
+      std::mutex buildMutex; // guards pendingGroups / groups / handlerPrototype
+
+      // Shared handler-param block (#170, §9). Written by HANDLER_PARAM on the
+      // audio thread, read by every live handler through voiceContext the same
+      // block. Audio thread only — no atomics needed (same-thread access).
+      static constexpr int kMaxHandlerParams = 16;
+      std::array<Flt, kMaxHandlerParams> handlerParams{};
 
       std::atomic<int> numVoicesTotal{0};
       uint64_t ageCounter = 0; // audio thread only

--- a/YseEngine/synth/synthInterface.cpp
+++ b/YseEngine/synth/synthInterface.cpp
@@ -12,6 +12,7 @@
 #include "synthInterface.hpp"
 #include "../internalHeaders.h"
 #include "../music/note.hpp"
+#include "positionHandler.hpp"
 #include "synthManager.h"
 
 #include <cmath>
@@ -143,6 +144,41 @@ namespace YSE {
       m.pedal.down = down;
       pimpl->sendMessage(m);
       return *this;
+    }
+
+    interfaceObject& interfaceObject::positionHandler(YSE::SYNTH::positionHandler& prototype) {
+      // Records the prototype under buildMutex; cloned per voice slot in setup().
+      // Like addVoices/onNoteEvent, harmless before create() has an impl.
+      if (pimpl == nullptr) create();
+      pimpl->setPositionHandler(&prototype);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::handlerParam(int index, float value) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = HANDLER_PARAM;
+      m.handlerParam.index = index;
+      m.handlerParam.value = value;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    interfaceObject& interfaceObject::notePosition(int channel, int noteNumber, const Pos& pos) {
+      if (pimpl == nullptr) return *this;
+      messageObject m;
+      m.ID = NOTE_POSITION;
+      m.notePosition.channel = channel;
+      m.notePosition.note = noteNumber;
+      m.notePosition.x = pos.x;
+      m.notePosition.y = pos.y;
+      m.notePosition.z = pos.z;
+      pimpl->sendMessage(m);
+      return *this;
+    }
+
+    Pos interfaceObject::getVoicePosition(int channel, int noteNumber) const {
+      return pimpl != nullptr ? pimpl->getVoicePosition(channel, noteNumber) : Pos(0.f);
     }
 
     interfaceObject& interfaceObject::onNoteEvent(void (*func)(bool, float*, float*)) {

--- a/YseEngine/synth/synthInterface.hpp
+++ b/YseEngine/synth/synthInterface.hpp
@@ -17,6 +17,7 @@
 
 #include "../classes.hpp"
 #include "../headers/defines.hpp"
+#include "../utils/vector.hpp" // Pos (notePosition / getVoicePosition)
 #include "synth.hpp"
 
 namespace YSE {
@@ -119,6 +120,38 @@ namespace YSE {
       /** @brief Soft pedal (CC 67). While down, notes that START scale their
        *  velocity down; sounding voices are unaffected. */
       interfaceObject& softPedal(int channel, bool down);
+
+      // ---- per-note 3D positioning (§14, issue #170) -----------------------
+
+      /** @brief Clone ``prototype`` once per voice slot as this synth's position
+       *  handler, giving every note its own 3D position and movement.
+       *
+       *  With no handler attached, every voice uses the synth's aggregate
+       *  position — so this call is purely additive. Ship-in handlers are
+       *  ``SYNTH::staticHandler`` / ``SYNTH::randomSpreadHandler`` /
+       *  ``SYNTH::orbitHandler``, or derive your own from
+       *  ``SYNTH::positionHandler``.
+       *
+       *  @warning ``prototype`` must outlive setup — the engine reads it to
+       *           clone but neither copies nor owns it. Call before the synth is
+       *           attached and played (rejected after setup, like ``addVoices``). */
+      interfaceObject& positionHandler(YSE::SYNTH::positionHandler& prototype);
+
+      /** @brief Set a shared handler parameter by index (e.g. the swarm centre
+       *  at indices 0..2). All of the synth's live handlers read it next block.
+       *  A bounded, allocation-free message — safe to call every control tick. */
+      interfaceObject& handlerParam(int index, float value);
+
+      /** @brief Imperatively place the voice(s) sounding ``noteNumber`` on
+       *  ``channel`` at ``pos`` (app-driven trajectories). A bounded,
+       *  allocation-free message. When a handler is attached it re-steers the
+       *  voice next block, so this is primarily for the no-handler case. */
+      interfaceObject& notePosition(int channel, int noteNumber, const Pos& pos);
+
+      /** @brief Current position of a voice sounding (``channel``, ``noteNumber``),
+       *  or the origin if none is. Best-effort audio-thread snapshot for
+       *  tests / metering. */
+      Pos getVoicePosition(int channel, int noteNumber) const;
 
       /** @brief Install an audio-thread note-rewrite hook, or clear it with
        *  ``nullptr``.

--- a/YseEngine/synth/synthMessage.h
+++ b/YseEngine/synth/synthMessage.h
@@ -61,6 +61,17 @@ namespace YSE {
       Int channel;
       Bool down; // SUSTAIN / SOSTENUTO / SOFTPEDAL  (handled by #154)
     };
+    // Per-note positioning ops (#170). Pos is stored as three loose Flt (not a
+    // Pos member) so the union stays trivial — no positional aliasing.
+    struct HandlerParamData {
+      Int index;
+      Flt value;
+    };
+    struct NotePositionData {
+      Int channel;
+      Int note;
+      Flt x, y, z; // the target position, unpacked
+    };
 
     class messageObject {
     public:
@@ -75,6 +86,8 @@ namespace YSE {
         ControllerData cc; // CONTROLLER
         AftertouchData touch; // AFTERTOUCH
         PedalData pedal; // SUSTAIN / SOSTENUTO / SOFTPEDAL
+        HandlerParamData handlerParam; // HANDLER_PARAM
+        NotePositionData notePosition; // NOTE_POSITION
       };
     };
 

--- a/YseEngine/yse.hpp
+++ b/YseEngine/yse.hpp
@@ -114,6 +114,8 @@
 
 #include "synth/dspVoice.hpp"
 #include "synth/sineVoice.hpp"
+#include "synth/positionHandler.hpp"
+#include "synth/positionHandlers.hpp"
 #include "synth/synthInterface.hpp"
 
 #include "midi/midifile.hpp"


### PR DESCRIPTION
## Summary

Adds the `positionHandler` interface and the three built-in handlers on top of
the #169 per-note positioning infrastructure (Route 2 of
`docs/design/per_note_positioning.md`). A `positionHandler` is the positional
analogue of `dspVoice`: user-derived, engine-owned, cloned once per voice slot
on the setup pool, with `noteOn` / `update(delta)` / `onRelease` hooks that run
on the audio thread with no allocation, lock or blocking (§8-§11 of the design).

## Linked issue

Closes #170

## Changes

- **`positionHandler` base + `voiceContext`** (`synth/positionHandler.hpp`) —
  read-only view of live note state: frequency, velocity, aftertouch, pitch
  wheel, plus `controller(n)` and shared `handlerParam(i)` accessors.
- **Synth wiring** (`synthImplementation.*`) — per-slot handler clone in
  `setup()`; `noteOn` on free-slot allocate and on steal re-arm; `update()`
  every block through the release tail; `onRelease` on the note-off edge
  (once); aggregate-position fallback when no handler is attached (strictly
  additive). Per-block `delta = blockLen / samplerate` so trajectories are
  deterministic and frame-rate independent.
- **Controller / aftertouch forwarding** to handlers via `voiceContext`.
- **Message ops** `HANDLER_PARAM` / `NOTE_POSITION` (bounded, allocation-free
  inbox pushes) and the public surface `synth::positionHandler` /
  `handlerParam` / `notePosition` / `getVoicePosition`.
- **Built-ins** (`positionHandlers.*`): `staticHandler`, `randomSpreadHandler`
  (deterministic seeded xorshift, re-drawn per note-on so steals re-randomise),
  `orbitHandler` (swarm workhorse — steerable centre, velocity radius,
  aftertouch widening, orbit slows through the release tail; the reference for
  user handlers).

C API surface is #171 (non-goal here). No opportunistic refactors; the #169
sound/panner path is untouched.

## Test plan

New isolated `synthhandlers` ctest process (ASan/TSan target, like
`synthpositioning`), covering the cases the issue names:

- [x] Swarm: N notes trace distinct, moving orbits (acceptance).
- [x] Position trajectories deterministic under a seed (same seed → identical
      scatter, different seed differs).
- [x] Controller / aftertouch / handler-param forwarding through `voiceContext`.
- [x] Steerable centre recentres the spread; aftertouch widens the orbit.
- [x] Handler steers through the release tail, then the slot frees.
- [x] Voice stealing re-inits handlers under heavy overcommit; pool stable,
      positions finite.
- [x] No-handler baseline: voices stay at the aggregate origin; `notePosition`
      still works.
- [x] `python yse.py test` — full suite **27/27 ctest processes pass** (incl.
      new `synthhandlers`).
- [x] `python yse.py analyze YseEngine/synth/` — no new findings in modified
      code.
- [x] `python yse.py format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
