### PR TITLE
c-api: per-note positioning surface (#171)

### DIFF
--- a/Tests/synth/test_c_api_synth.cpp
+++ b/Tests/synth/test_c_api_synth.cpp
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <thread>
 
 #include "yse_c/yse_synth.h"
@@ -262,6 +263,253 @@ TEST_SUITE("synthcapi") {
     yse_sound_destroy(snd);
     yse_synth_destroy(syn);
     drainFor(sys, 300ms); // let the delete jobs free the impls before close
+    yse_system_close(sys);
+  }
+
+  // ─── per-note positioning: NULL-handle safety (no engine required) ─────────
+
+  TEST_CASE("c-api synth: position-handler NULL handles are null-safe") {
+    YseSynthPositionParams params{};
+    // Fallible entry point rejects a NULL handle explicitly.
+    CHECK(yse_synth_set_position_handler(nullptr, YSE_POSITION_HANDLER_RANDOM_SPREAD, &params) ==
+          YSE_ERR_INVALID_HANDLE);
+    // Void entry points must no-op, not crash, on a NULL handle.
+    yse_synth_handler_param(nullptr, YSE_HANDLER_PARAM_CENTER_X, 1.0f);
+    yse_synth_note_position(nullptr, 1, 60, 1.0f, 2.0f, 3.0f);
+    // get_voice_position writes the origin on a NULL handle and tolerates NULL outs.
+    float x = 9.f, y = 9.f, z = 9.f;
+    yse_synth_get_voice_position(nullptr, 1, 60, &x, &y, &z);
+    CHECK(x == 0.f);
+    CHECK(y == 0.f);
+    CHECK(z == 0.f);
+    yse_synth_get_voice_position(nullptr, 1, 60, nullptr, nullptr, nullptr);
+  }
+
+  // ─── randomSpread: distinct per-note positions + steerable centre ──────────
+  //
+  // The issue's acceptance case, driven entirely through the flat C ABI: create
+  // a synth, select the random-spread handler, play notes, and observe distinct
+  // per-note positions via engine introspection (yse_synth_get_voice_position).
+  // Then steer the shared centre with yse_synth_handler_param and confirm the
+  // whole scatter tracks it.
+
+  TEST_CASE("c-api synth: randomSpread gives distinct per-note positions") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return;
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    REQUIRE(yse_synth_add_voices_sine(syn, 8, 0, 0, 127, 0.005f, 0.05f, 0.8f, 0.05f) == YSE_OK);
+
+    // Select the random-spread handler with a generous radius and a fixed seed,
+    // BEFORE attach (the engine rejects a handler swap after the pool is built).
+    YseSynthPositionParams params{};
+    params.spread_radius = 5.0f;
+    params.spread_seed = 1234u;
+    REQUIRE(yse_synth_set_position_handler(syn, YSE_POSITION_HANDLER_RANDOM_SPREAD, &params) ==
+            YSE_OK);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    yse_sound_play(snd);
+    REQUIRE(drainUntilVoices(sys, syn, 8));
+
+    // Sound six distinct notes; each lands on its own slot with its own draw.
+    const int base = 60;
+    const int n = 6;
+    for (int i = 0; i < n; ++i)
+      yse_synth_note_on(syn, 1, base + i, 0.7f);
+    render(sys, 3);
+
+    // Collect each note's position and require distinct scatter: at least one
+    // pair differs (radius 5 across separate RNG streams -> effectively all do).
+    float px[n], py[n], pz[n];
+    for (int i = 0; i < n; ++i)
+      yse_synth_get_voice_position(syn, 1, base + i, &px[i], &py[i], &pz[i]);
+    int distinctPairs = 0;
+    for (int i = 0; i < n; ++i) {
+      // Draw sits inside the radius sphere around the origin centre.
+      CHECK(std::sqrt(px[i] * px[i] + py[i] * py[i] + pz[i] * pz[i]) <= 5.0f * 1.7321f + 1e-3f);
+      for (int j = i + 1; j < n; ++j) {
+        if (px[i] != px[j] || py[i] != py[j] || pz[i] != pz[j]) ++distinctPairs;
+      }
+    }
+    CHECK(distinctPairs > 0);
+
+    // Steer the shared centre far along +X; the held scatter tracks it next block.
+    float bx = px[0];
+    yse_synth_handler_param(syn, YSE_HANDLER_PARAM_CENTER_X, 100.0f);
+    render(sys, 3);
+    float ax = 0.f, ay = 0.f, az = 0.f;
+    yse_synth_get_voice_position(syn, 1, base, &ax, &ay, &az);
+    CHECK(ax > bx + 90.0f); // moved by ~the centre shift, radius aside
+
+    yse_synth_all_notes_off(syn, 0);
+    render(sys, 6);
+
+    yse_sound_destroy(snd);
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms);
+    yse_system_close(sys);
+  }
+
+  // ─── orbit: swarm notes trace distinct, moving orbits ──────────────────────
+
+  TEST_CASE("c-api synth: orbit handler moves voices over time") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return;
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    REQUIRE(yse_synth_add_voices_sine(syn, 8, 0, 0, 127, 0.005f, 0.05f, 0.8f, 0.1f) == YSE_OK);
+
+    // Fixed-radius orbit so phase alone separates notes; a brisk rate so a few
+    // blocks visibly advance each orbit.
+    YseSynthPositionParams params{};
+    params.orbit_radius = 2.0f;
+    params.orbit_velocity_radius = 0.0f;
+    params.orbit_aftertouch_widen = 0.0f;
+    params.orbit_rate = 4.0f;
+    params.orbit_height = 0.0f;
+    params.orbit_release_slow = 0.5f;
+    REQUIRE(yse_synth_set_position_handler(syn, YSE_POSITION_HANDLER_ORBIT, &params) == YSE_OK);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    yse_sound_play(snd);
+    REQUIRE(drainUntilVoices(sys, syn, 8));
+
+    const int base = 48;
+    const int n = 6;
+    for (int i = 0; i < n; ++i)
+      yse_synth_note_on(syn, 1, base + i, 0.8f);
+    render(sys, 2);
+
+    // Distinct per note, and each sits on the fixed-radius ring.
+    float fx[n], fy[n], fz[n];
+    for (int i = 0; i < n; ++i) {
+      yse_synth_get_voice_position(syn, 1, base + i, &fx[i], &fy[i], &fz[i]);
+      CHECK(std::sqrt(fx[i] * fx[i] + fz[i] * fz[i]) == doctest::Approx(2.0).epsilon(0.05));
+    }
+    int distinctPairs = 0;
+    for (int i = 0; i < n; ++i)
+      for (int j = i + 1; j < n; ++j)
+        if (fx[i] != fx[j] || fz[i] != fz[j]) ++distinctPairs;
+    CHECK(distinctPairs > 0);
+
+    // Advance several blocks: every note's orbit has moved.
+    render(sys, 30);
+    int moved = 0;
+    for (int i = 0; i < n; ++i) {
+      float cx = 0.f, cy = 0.f, cz = 0.f;
+      yse_synth_get_voice_position(syn, 1, base + i, &cx, &cy, &cz);
+      if (cx != fx[i] || cz != fz[i]) ++moved;
+    }
+    CHECK(moved == n);
+
+    yse_synth_all_notes_off(syn, 0);
+    render(sys, 6);
+
+    yse_sound_destroy(snd);
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms);
+    yse_system_close(sys);
+  }
+
+  // ─── static handler holds a fixed position; unknown kind is rejected ───────
+
+  TEST_CASE("c-api synth: static handler fixes every voice's position") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return;
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    REQUIRE(yse_synth_add_voices_sine(syn, 4, 0, 0, 127, 0.005f, 0.05f, 0.8f, 0.05f) == YSE_OK);
+
+    // Unknown kind is rejected before any prototype is built.
+    CHECK(yse_synth_set_position_handler(syn, (YseSynthPositionHandler)999, nullptr) ==
+          YSE_ERR_INVALID_ARGUMENT);
+
+    YseSynthPositionParams params{};
+    params.static_x = 7.0f;
+    params.static_y = -1.0f;
+    params.static_z = -3.0f;
+    REQUIRE(yse_synth_set_position_handler(syn, YSE_POSITION_HANDLER_STATIC, &params) == YSE_OK);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    yse_sound_play(snd);
+    REQUIRE(drainUntilVoices(sys, syn, 4));
+
+    yse_synth_note_on(syn, 1, 60, 0.9f);
+    render(sys, 3);
+    float x = 0.f, y = 0.f, z = 0.f;
+    yse_synth_get_voice_position(syn, 1, 60, &x, &y, &z);
+    CHECK(x == doctest::Approx(7.0f));
+    CHECK(y == doctest::Approx(-1.0f));
+    CHECK(z == doctest::Approx(-3.0f));
+
+    yse_synth_all_notes_off(syn, 0);
+    render(sys, 6);
+
+    yse_sound_destroy(snd);
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms);
+    yse_system_close(sys);
+  }
+
+  // ─── no handler: default origin, then app-driven notePosition placement ────
+  //
+  // With no handler attached, notePosition is the imperative placement path (a
+  // handler would re-steer the voice each block; see the header docs).
+
+  TEST_CASE("c-api synth: notePosition places voices with no handler") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return;
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    REQUIRE(yse_synth_add_voices_sine(syn, 4, 0, 0, 127, 0.005f, 0.05f, 0.8f, 0.05f) == YSE_OK);
+    // No set_position_handler call — voices default to the aggregate origin.
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    yse_sound_play(snd);
+    REQUIRE(drainUntilVoices(sys, syn, 4));
+
+    yse_synth_note_on(syn, 1, 60, 0.9f);
+    render(sys, 3);
+    float x = 9.f, y = 9.f, z = 9.f;
+    yse_synth_get_voice_position(syn, 1, 60, &x, &y, &z);
+    CHECK(x == doctest::Approx(0.0f));
+    CHECK(y == doctest::Approx(0.0f));
+    CHECK(z == doctest::Approx(0.0f));
+
+    // notePosition places the voice imperatively (bounded RT-safe message).
+    yse_synth_note_position(syn, 1, 60, -4.0f, 0.0f, 2.0f);
+    render(sys, 3);
+    yse_synth_get_voice_position(syn, 1, 60, &x, &y, &z);
+    CHECK(x == doctest::Approx(-4.0f));
+    CHECK(z == doctest::Approx(2.0f));
+
+    yse_synth_all_notes_off(syn, 0);
+    render(sys, 6);
+
+    yse_sound_destroy(snd);
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms);
     yse_system_close(sys);
   }
 

--- a/YseEngine/c_api/include/yse_c/yse_enums.h
+++ b/YseEngine/c_api/include/yse_c/yse_enums.h
@@ -119,6 +119,32 @@ typedef enum YseInletAccepts {
   YSE_IN_ACCEPTS_LIST = 1u << 4
 } YseInletAccepts;
 
+/* Selects which built-in per-note position handler
+   yse_synth_set_position_handler attaches. Mirrors the three shipped handler
+   classes in synth/positionHandlers.hpp (staticHandler / randomSpreadHandler /
+   orbitHandler). This is a C-API-owned dispatch selector: the engine has no
+   single enum of handler kinds (each is a distinct class), so its drift guard
+   is structural, not a value mirror — the exhaustive dispatch in yse_synth.cpp
+   plus the YSE_POSITION_HANDLER_COUNT sentinel and the is_base_of asserts in
+   yse_enums_check.cpp. Keep YSE_POSITION_HANDLER_COUNT last. */
+typedef enum YseSynthPositionHandler {
+  YSE_POSITION_HANDLER_STATIC = 0, /* staticHandler — one fixed position. */
+  YSE_POSITION_HANDLER_RANDOM_SPREAD = 1, /* randomSpreadHandler — seeded scatter. */
+  YSE_POSITION_HANDLER_ORBIT = 2, /* orbitHandler — the swarm handler. */
+  YSE_POSITION_HANDLER_COUNT = 3 /* sentinel — number of kinds; keep last. */
+} YseSynthPositionHandler;
+
+/* Shared handler-parameter indices the built-in handlers read for their
+   steerable centre; mirrors YSE::SYNTH::HandlerParamIndex in
+   synth/positionHandlers.hpp. Pass one to yse_synth_handler_param to move the
+   swarm / spread centre at runtime. Indices 0..2 are the centre X / Y / Z;
+   higher indices (up to the engine's block size) are free for custom use. */
+typedef enum YseSynthHandlerParam {
+  YSE_HANDLER_PARAM_CENTER_X = 0,
+  YSE_HANDLER_PARAM_CENTER_Y = 1,
+  YSE_HANDLER_PARAM_CENTER_Z = 2
+} YseSynthHandlerParam;
+
 /* Mirrors YSE::REVERB_PRESET in headers/enums.hpp. */
 typedef enum YseReverbPreset {
   YSE_REVERB_OFF = 0,

--- a/YseEngine/c_api/include/yse_c/yse_synth.h
+++ b/YseEngine/c_api/include/yse_c/yse_synth.h
@@ -19,6 +19,17 @@
   (see yse_dsp.h and docs/design/synth_core.md §1 non-goals). Instrument
   voices (#148) will add more yse_synth_add_voices_* variants later.
 
+  Per-note 3D positioning (issue #171, §14 of
+  docs/design/per_note_positioning.md) is exposed by the same policy: only the
+  BUILT-IN position handlers (static / random-spread / orbit) are selectable,
+  via yse_synth_set_position_handler with the YseSynthPositionHandler enum.
+  Defining a CUSTOM position handler (subclassing YSE::SYNTH::positionHandler
+  from C) is DEFERRED for the same reason a custom dspVoice is — its noteOn /
+  update / onRelease hooks run on the AUDIO THREAD, which needs the callback
+  plumbing that keeps dspSourceObject unwrapped (see yse_dsp.h). Per-note
+  position readback here is a single best-effort snapshot
+  (yse_synth_get_voice_position), not a continuous readback stream.
+
   Convention: every void-returning function in this header is a null-safe
   no-op when called with a NULL handle. Status queries return 0 / false on
   NULL. Operations that can fail (add-voices, attach) return YseStatus and
@@ -32,6 +43,7 @@
 #define YSE_C_SYNTH_H_INCLUDED
 
 #include "yse_common.h"
+#include "yse_enums.h" /* YseSynthPositionHandler, YseSynthHandlerParam */
 
 #ifdef __cplusplus
 extern "C" {
@@ -135,6 +147,75 @@ YSE_C_API void yse_synth_set_note_callback(YseSynth* h, YseSynthNoteCallback cb)
    yse_last_error() is set. */
 YSE_C_API YseStatus yse_synth_attach_to_sound(YseSynth* h, YseSound* sound, YseChannel* channel,
                                               float volume);
+
+/* ─── per-note 3D positioning (issue #171) ────────────────────────────────
+
+   Configuration for yse_synth_set_position_handler. One flat, ffigen-friendly
+   struct covering every built-in handler; only the fields belonging to the
+   selected kind are read. Pass NULL to take the engine's defaults for that
+   kind. Mirrors the chainable setters on YSE::SYNTH::staticHandler /
+   randomSpreadHandler / orbitHandler. All positions are in the same coordinate
+   frame as a sound position. */
+typedef struct YseSynthPositionParams {
+  /* YSE_POSITION_HANDLER_STATIC — the single fixed position. */
+  float static_x;
+  float static_y;
+  float static_z;
+
+  /* YSE_POSITION_HANDLER_RANDOM_SPREAD */
+  float spread_radius; /* radius of the scatter sphere around the centre */
+  unsigned int spread_seed; /* base RNG seed (a given seed reproduces the scatter) */
+
+  /* YSE_POSITION_HANDLER_ORBIT */
+  float orbit_radius; /* base orbit radius */
+  float orbit_velocity_radius; /* extra radius added at full velocity */
+  float orbit_aftertouch_widen; /* fraction of extra radius at full aftertouch */
+  float orbit_rate; /* orbit angular speed, radians per second */
+  float orbit_height; /* vertical offset of the orbit plane */
+  float orbit_release_slow; /* rate multiplier once the note is released */
+} YseSynthPositionParams;
+
+/* Attach one of the built-in per-note position handlers, giving every voice its
+   own 3D position and movement (mirrors YSE::synth::positionHandler with a
+   shipped handler prototype). `kind` selects the handler; `params` configures
+   it (NULL = engine defaults for that kind). The handle keeps the prototype
+   alive; the engine clones it once per voice slot on the setup pool.
+
+   Must be called BEFORE the synth is attached/played — like add-voices, the
+   engine rejects a handler swap after the voice pool is built (it logs a
+   warning and keeps the existing handler; the call still returns YSE_OK).
+   Returns YSE_ERR_INVALID_ARGUMENT for an unknown `kind`; yse_last_error() is
+   set on failure.
+
+   Custom C-side handlers (subclassing YSE::SYNTH::positionHandler from C) are
+   DEFERRED — the hooks run on the AUDIO THREAD, the same callback-plumbing gap
+   that keeps custom dspVoice / dspSourceObject unwrapped (see yse_dsp.h and the
+   scope note at the top of this header). Only the built-ins are reachable. */
+YSE_C_API YseStatus yse_synth_set_position_handler(YseSynth* h, YseSynthPositionHandler kind,
+                                                   const YseSynthPositionParams* params);
+
+/* Update a shared handler parameter at runtime (message-based, RT-safe). All of
+   the synth's live handlers read the block next audio block, so this steers the
+   swarm / spread centre from the control thread. `index` is a
+   YseSynthHandlerParam (0..2 = centre X / Y / Z); out-of-range indices are
+   ignored engine-side. A bounded, allocation-free message — safe to call every
+   control tick. */
+YSE_C_API void yse_synth_handler_param(YseSynth* h, int index, float value);
+
+/* Imperatively place the voice(s) sounding `note_number` on `channel` at
+   (x, y, z) — app-driven trajectories (mirrors YSE::synth::notePosition). A
+   bounded, allocation-free message. When a handler is attached it re-steers the
+   voice next block, so this is primarily for the no-handler case. */
+YSE_C_API void yse_synth_note_position(YseSynth* h, int channel, int note_number, float x, float y,
+                                       float z);
+
+/* Best-effort snapshot of the current position of a voice sounding
+   (channel, note_number); writes the origin (0, 0, 0) if none is sounding
+   (mirrors YSE::synth::getVoicePosition, intended for tests / metering). Any of
+   the out pointers may be NULL. This is a single snapshot, not a per-note
+   readback stream. On a NULL synth handle it writes the origin. */
+YSE_C_API void yse_synth_get_voice_position(YseSynth* h, int channel, int note_number, float* x,
+                                            float* y, float* z);
 
 #ifdef __cplusplus
 }

--- a/YseEngine/c_api/yse_enums_check.cpp
+++ b/YseEngine/c_api/yse_enums_check.cpp
@@ -17,6 +17,10 @@
 #include "../dsp/modules/parametricEQ.hpp"
 #include "../dsp/modules/compressor.hpp"
 #include "../patcher/pEnums.h"
+#include "../synth/positionHandler.hpp"
+#include "../synth/positionHandlers.hpp"
+
+#include <type_traits>
 
 namespace {
 
@@ -101,6 +105,27 @@ namespace {
   YSE_ASSERT_ENUM(YSE_IN_ACCEPTS_INT, YSE::PATCHER::IT_INT);
   YSE_ASSERT_ENUM(YSE_IN_ACCEPTS_BANG, YSE::PATCHER::IT_BANG);
   YSE_ASSERT_ENUM(YSE_IN_ACCEPTS_LIST, YSE::PATCHER::IT_LIST);
+
+  // YseSynthHandlerParam ↔ YSE::SYNTH::HandlerParamIndex
+  YSE_ASSERT_ENUM(YSE_HANDLER_PARAM_CENTER_X, YSE::SYNTH::HP_CENTER_X);
+  YSE_ASSERT_ENUM(YSE_HANDLER_PARAM_CENTER_Y, YSE::SYNTH::HP_CENTER_Y);
+  YSE_ASSERT_ENUM(YSE_HANDLER_PARAM_CENTER_Z, YSE::SYNTH::HP_CENTER_Z);
+
+  // YseSynthPositionHandler has no single engine kind-enum to value-mirror (each
+  // built-in is a distinct class in positionHandlers.hpp), so guard it
+  // structurally: the shipped handler classes must exist and derive from
+  // positionHandler, and the count sentinel must match the number of kinds the
+  // dispatch in yse_synth.cpp maps. Adding a built-in must update both sides.
+  static_assert(std::is_base_of<YSE::SYNTH::positionHandler, YSE::SYNTH::staticHandler>::value,
+                "C ABI drift: YSE::SYNTH::staticHandler must derive from positionHandler");
+  static_assert(
+      std::is_base_of<YSE::SYNTH::positionHandler, YSE::SYNTH::randomSpreadHandler>::value,
+      "C ABI drift: YSE::SYNTH::randomSpreadHandler must derive from positionHandler");
+  static_assert(std::is_base_of<YSE::SYNTH::positionHandler, YSE::SYNTH::orbitHandler>::value,
+                "C ABI drift: YSE::SYNTH::orbitHandler must derive from positionHandler");
+  static_assert(YSE_POSITION_HANDLER_COUNT == 3,
+                "C ABI drift: YseSynthPositionHandler no longer matches the built-in handler set "
+                "— update yse_enums.h and the dispatch in yse_synth.cpp");
 
   // YseReverbPreset ↔ YSE::REVERB_PRESET
   YSE_ASSERT_ENUM(YSE_REVERB_OFF, YSE::REVERB_OFF);

--- a/YseEngine/c_api/yse_synth.cpp
+++ b/YseEngine/c_api/yse_synth.cpp
@@ -4,8 +4,11 @@
 #include "../synth/synthInterface.hpp"
 #include "../synth/sineVoice.hpp"
 #include "../synth/dspVoice.hpp"
+#include "../synth/positionHandler.hpp"
+#include "../synth/positionHandlers.hpp"
 #include "../sound/soundInterface.hpp"
 #include "../channel/channelInterface.hpp"
+#include "../utils/vector.hpp"
 
 #include <exception>
 #include <memory>
@@ -24,6 +27,12 @@ namespace {
   struct YseSynthImpl {
     YSE::synth synth;
     std::vector<std::unique_ptr<YSE::SYNTH::dspVoice>> prototypes;
+    // The position-handler prototype (issue #171). Like a voice prototype, the
+    // engine records a raw pointer at set-position-handler time and clones from
+    // it LATER on the setup pool; it never copies or owns it. So the handle owns
+    // the single attached prototype and frees it on destroy. Allocated on the
+    // control thread only.
+    std::unique_ptr<YSE::SYNTH::positionHandler> positionHandler;
   };
 
   inline YseSynthImpl* to_impl(YseSynth* h) {
@@ -177,6 +186,84 @@ YSE_C_API YseStatus yse_synth_attach_to_sound(YseSynth* h, YseSound* sound, YseC
     yse_c::set_last_error("yse_synth_attach_to_sound: unknown C++ exception");
     return YSE_ERR_EXCEPTION;
   }
+}
+
+// ─── per-note 3D positioning (issue #171) ──────────────────────────────
+
+YSE_C_API YseStatus yse_synth_set_position_handler(YseSynth* h, YseSynthPositionHandler kind,
+                                                   const YseSynthPositionParams* params) {
+  if (!h) return YSE_ERR_INVALID_HANDLE;
+  // Drift tripwire: if a built-in handler kind is added to yse_enums.h, this
+  // dispatch (and the count) must grow to match. See yse_enums_check.cpp.
+  static_assert(YSE_POSITION_HANDLER_COUNT == 3,
+                "add a case below when a built-in position-handler kind is added");
+  try {
+    auto* impl = to_impl(h);
+    std::unique_ptr<YSE::SYNTH::positionHandler> proto;
+    switch (kind) {
+    case YSE_POSITION_HANDLER_STATIC: {
+      auto p = std::make_unique<YSE::SYNTH::staticHandler>();
+      if (params) p->position(YSE::Pos(params->static_x, params->static_y, params->static_z));
+      proto = std::move(p);
+      break;
+    }
+    case YSE_POSITION_HANDLER_RANDOM_SPREAD: {
+      auto p = std::make_unique<YSE::SYNTH::randomSpreadHandler>();
+      if (params) p->radius(params->spread_radius).seed(params->spread_seed);
+      proto = std::move(p);
+      break;
+    }
+    case YSE_POSITION_HANDLER_ORBIT: {
+      auto p = std::make_unique<YSE::SYNTH::orbitHandler>();
+      if (params)
+        p->radius(params->orbit_radius)
+            .velocityRadius(params->orbit_velocity_radius)
+            .aftertouchWiden(params->orbit_aftertouch_widen)
+            .rate(params->orbit_rate)
+            .height(params->orbit_height)
+            .releaseSlow(params->orbit_release_slow);
+      proto = std::move(p);
+      break;
+    }
+    case YSE_POSITION_HANDLER_COUNT:
+    default:
+      yse_c::set_last_error("yse_synth_set_position_handler: unknown handler kind");
+      return YSE_ERR_INVALID_ARGUMENT;
+    }
+    // Keep the prototype alive past the setup pool's clone() (the engine records
+    // a raw pointer and clones LATER). The handle owns it; swapping in a new
+    // prototype frees any earlier one — safe before setup (the engine has not
+    // read it yet) and harmless after (the engine's per-slot clones are already
+    // independent and the swap is engine-rejected). The pointed-to object never
+    // moves (only the unique_ptr does), so the recorded pointer stays valid.
+    YSE::SYNTH::positionHandler* raw = proto.get();
+    impl->positionHandler = std::move(proto);
+    impl->synth.positionHandler(*raw);
+    return YSE_OK;
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return YSE_ERR_EXCEPTION;
+  } catch (...) {
+    yse_c::set_last_error("yse_synth_set_position_handler: unknown C++ exception");
+    return YSE_ERR_EXCEPTION;
+  }
+}
+
+YSE_C_API void yse_synth_handler_param(YseSynth* h, int index, float value) {
+  if (h) to_impl(h)->synth.handlerParam(index, value);
+}
+
+YSE_C_API void yse_synth_note_position(YseSynth* h, int channel, int note_number, float x, float y,
+                                       float z) {
+  if (h) to_impl(h)->synth.notePosition(channel, note_number, YSE::Pos(x, y, z));
+}
+
+YSE_C_API void yse_synth_get_voice_position(YseSynth* h, int channel, int note_number, float* x,
+                                            float* y, float* z) {
+  YSE::Pos p = h ? to_impl(h)->synth.getVoicePosition(channel, note_number) : YSE::Pos(0.f);
+  if (x) *x = p.x;
+  if (y) *y = p.y;
+  if (z) *z = p.z;
 }
 
 } // extern "C"


### PR DESCRIPTION
## Summary

Extends the flat C ABI (`YseEngine/c_api/`) with the per-note 3D positioning surface for synths — selecting and parameterising the built-in position handlers from FFI consumers (dart-yse). Mirrors `YSE::synth`'s §14 positioning surface (`synthInterface.hpp`) and the shipped handlers from #170 (`positionHandlers.hpp`). Follows the `c-api-extend` conventions (opaque-handle ownership, null-safe no-ops, exception→`YseStatus`, enum drift guard, ffigen-friendly headers).

## Linked issue

Closes #171 (part of epic #147).

## Changes

New surface in `yse_synth.{h,cpp}`:
- `yse_synth_set_position_handler(synth, kind, params)` — attach a built-in handler (`static` / `randomSpread` / `orbit`) via the `YseSynthPositionHandler` enum and a flat, ffigen-friendly `YseSynthPositionParams` struct (radius, rate, centre/height offsets, seed, …). `NULL` params = engine defaults. The handle owns the prototype past the setup pool's `clone()`, exactly like a voice prototype.
- `yse_synth_handler_param(synth, index, value)` — runtime, message-based, RT-safe steer of the shared handler-param block (swarm / spread centre).
- `yse_synth_note_position(...)` / `yse_synth_get_voice_position(...)` — imperative placement and a single best-effort position snapshot (**not** a readback stream — that non-goal is deferred).

Enums + drift guard:
- `YseSynthPositionHandler` (kind selector) in `yse_enums.h`, guarded structurally in `yse_enums_check.cpp` (`is_base_of` on each shipped handler class + a `COUNT` sentinel + the exhaustive dispatch switch), since the engine has no single kind-enum to value-mirror.
- `YseSynthHandlerParam`, a true value mirror of `YSE::SYNTH::HandlerParamIndex` with `YSE_ASSERT_ENUM` lines.

Deferral documented in the header: **custom C-side handlers are deferred** — the `noteOn`/`update`/`onRelease` hooks run on the audio thread, the same callback-plumbing gap that keeps custom `dspVoice` / `dspSourceObject` unwrapped (cites the `yse_dsp.h` precedent).

## Non-goals (not built)

- Custom position handlers from C (audio-thread callback plumbing — deferred, documented).
- Per-note position *readback streams* (bus territory, later). A single-snapshot getter is provided instead.

No opportunistic refactors; only the five files below changed.

## Test plan

C-only parity + integration cases added to the `synthcapi` suite (`Tests/synth/test_c_api_synth.cpp`), driven entirely through the flat C ABI under an offline engine (no audio hardware, runs in CI):
- NULL-handle safety for every new entry point.
- **randomSpread**: create synth → select `randomSpread` → play notes → observe distinct per-note positions via `yse_synth_get_voice_position` (engine introspection), then steer the centre with `yse_synth_handler_param` and confirm the scatter tracks it.
- **orbit**: distinct notes on a fixed-radius ring, each orbit advancing over blocks.
- **static**: fixed position held every block; unknown-kind rejected with `YSE_ERR_INVALID_ARGUMENT`.
- **no handler**: default origin, then `yse_synth_note_position` app-driven placement.

- [x] `clang-format --dry-run --Werror` clean on all changed files
- [x] `python yse.py analyze` clean on changed `.cpp` (no findings in user code)
- [x] `python yse.py test` — **27/27 ctest entries pass**; `synthcapi` suite = 9 cases / 90 assertions, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)