### PR TITLE
DSP: SFZ parser + region model (#173)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(YSE_TEST_SOURCES
   dsp/test_module_compressor.cpp
   dsp/test_module_multichannel.cpp
   dsp/test_synth_voice.cpp
+  dsp/test_sfz_parser.cpp
   dsp/test_ladder_filter.cpp
   dsp/test_va_voice.cpp
   dsp/test_fm_voice.cpp

--- a/Tests/dsp/test_sfz_parser.cpp
+++ b/Tests/dsp/test_sfz_parser.cpp
@@ -1,0 +1,272 @@
+// Golden-file tests for the SFZ parser + region model (issue #173).
+//
+// The region-resolution golden tables are the PRIMARY contract (spec §5/§14):
+// "for note N, velocity V, hit#, which region SET sounds?". Expected sets are
+// keyed by (note, velocity, hit#) and validated against sfizz's documented
+// layering behaviour. The fixtures use sample=*silence for the mapping cases
+// so the tables are exact and need no audio device; the de-dup fixture uses
+// the real test_mono_44100.wav.
+//
+// No engine init and no audio device: parsing and resolution are pure offline
+// functions over an immutable table.
+
+#include <doctest/doctest.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "dsp/sfzModel.hpp"
+
+#ifndef YSE_TEST_FIXTURES_DIR
+#define YSE_TEST_FIXTURES_DIR "../../Tests/support/fixtures"
+#endif
+
+using namespace YSE::DSP;
+
+namespace {
+
+  std::string fixturesDir() {
+    return std::string(YSE_TEST_FIXTURES_DIR);
+  }
+
+  sfzInstrument loadFixture(const char* name) {
+    return loadSFZ(fixturesDir() + "/" + name);
+  }
+
+  // Resolve a layer set and return it as a sorted vector of region indices.
+  std::vector<int> layers(const sfzInstrument& inst, int note, int vel, int hit = 0) {
+    int out[YSE_MAX_REGION_LAYERS];
+    int n = resolveLayers(inst, note, vel, hit, out);
+    return std::vector<int>(out, out + n);
+  }
+
+} // namespace
+
+TEST_SUITE("dsp") {
+
+  // ─── one region ──────────────────────────────────────────────────────────
+
+  TEST_CASE("sfz: minimal one-region instrument maps every key/velocity") {
+    sfzInstrument inst = loadFixture("sfz_one_region.sfz");
+    REQUIRE(inst.valid);
+    REQUIRE(inst.regions.size() == 1);
+    CHECK(inst.regions[0].pitchKeycenter == 60);
+    CHECK(inst.regions[0].lokey == 0);
+    CHECK(inst.regions[0].hikey == 127);
+
+    CHECK(layers(inst, 0, 1) == std::vector<int>{0});
+    CHECK(layers(inst, 60, 64) == std::vector<int>{0});
+    CHECK(layers(inst, 127, 127) == std::vector<int>{0});
+  }
+
+  // ─── key split + group inheritance ────────────────────────────────────────
+
+  TEST_CASE("sfz: key split inherits group opcodes and maps by key") {
+    sfzInstrument inst = loadFixture("sfz_key_split.sfz");
+    REQUIRE(inst.valid);
+    REQUIRE(inst.regions.size() == 2);
+
+    // group defaults inherited by both regions
+    CHECK(inst.regions[0].loopMode == SFZ_LOOP_CONTINUOUS);
+    CHECK(inst.regions[1].loopMode == SFZ_LOOP_CONTINUOUS);
+    CHECK(inst.regions[0].egRelease == doctest::Approx(0.3f));
+    CHECK(inst.defaultPath == "samples/");
+
+    CHECK(inst.regions[0].lokey == 0);
+    CHECK(inst.regions[0].hikey == 47);
+    CHECK(inst.regions[1].lokey == 48);
+
+    CHECK(layers(inst, 40, 64) == std::vector<int>{0}); // bass
+    CHECK(layers(inst, 60, 64) == std::vector<int>{1}); // lead
+    CHECK(layers(inst, 47, 1) == std::vector<int>{0}); // boundary inclusive
+    CHECK(layers(inst, 48, 1) == std::vector<int>{1});
+  }
+
+  // ─── velocity split + global inheritance ──────────────────────────────────
+
+  TEST_CASE("sfz: velocity layers select by velocity and inherit global") {
+    sfzInstrument inst = loadFixture("sfz_velocity_split.sfz");
+    REQUIRE(inst.regions.size() == 2);
+    CHECK(inst.regions[0].pitchKeycenter == 60); // from <global>
+    CHECK(inst.regions[1].pitchKeycenter == 60);
+
+    CHECK(layers(inst, 60, 30) == std::vector<int>{0}); // soft
+    CHECK(layers(inst, 60, 63) == std::vector<int>{0}); // boundary
+    CHECK(layers(inst, 60, 64) == std::vector<int>{1}); // hard
+    CHECK(layers(inst, 60, 127) == std::vector<int>{1});
+  }
+
+  // ─── four-level inheritance (global/master/group/region) ──────────────────
+
+  TEST_CASE("sfz: <master> gives four-level inheritance, innermost wins") {
+    sfzInstrument inst = loadFixture("sfz_master.sfz");
+    REQUIRE(inst.regions.size() == 2);
+
+    // region 0 inherits every level
+    CHECK(inst.regions[0].egRelease == doctest::Approx(0.5f)); // <global>
+    CHECK(inst.regions[0].volumeDb == doctest::Approx(-3.0f)); // <master>
+    CHECK(inst.regions[0].pitchKeycenter == 48); // <master>
+    CHECK(inst.regions[0].loopMode == SFZ_ONE_SHOT); // <group>
+
+    // region 1 overrides the master volume with its own
+    CHECK(inst.regions[1].volumeDb == doctest::Approx(-6.0f)); // <region> wins
+    CHECK(inst.regions[1].pitchKeycenter == 48); // still inherited
+    CHECK(inst.regions[1].egRelease == doctest::Approx(0.5f));
+    CHECK(inst.regions[1].loopMode == SFZ_ONE_SHOT);
+  }
+
+  // ─── round-robin + choke ──────────────────────────────────────────────────
+
+  TEST_CASE("sfz: round-robin cycles samples on successive hits (keyed by hit#)") {
+    sfzInstrument inst = loadFixture("sfz_hihat.sfz");
+    REQUIRE(inst.regions.size() == 3);
+
+    CHECK(inst.regions[0].seqLength == 2);
+    CHECK(inst.regions[0].seqPosition == 1);
+    CHECK(inst.regions[1].seqPosition == 2);
+
+    // key 42 alternates the two closed-hat regions across hits
+    CHECK(layers(inst, 42, 100, 0) == std::vector<int>{0});
+    CHECK(layers(inst, 42, 100, 1) == std::vector<int>{1});
+    CHECK(layers(inst, 42, 100, 2) == std::vector<int>{0});
+    CHECK(layers(inst, 42, 100, 3) == std::vector<int>{1});
+
+    // open hat is a separate region on key 46
+    CHECK(layers(inst, 46, 100, 0) == std::vector<int>{2});
+  }
+
+  TEST_CASE("sfz: choke opcodes parse onto the region model") {
+    sfzInstrument inst = loadFixture("sfz_hihat.sfz");
+    REQUIRE(inst.regions.size() == 3);
+
+    CHECK(inst.regions[0].chokeGroup == 1);
+    CHECK(inst.regions[0].offBy == 2);
+    CHECK(inst.regions[0].offMode == SFZ_OFF_FAST); // default
+
+    CHECK(inst.regions[2].chokeGroup == 2);
+    CHECK(inst.regions[2].offBy == 1);
+    CHECK(inst.regions[2].loopMode == SFZ_ONE_SHOT);
+  }
+
+  // ─── velocity crossfades ──────────────────────────────────────────────────
+
+  TEST_CASE("sfz: crossfaded layers overlap and parse xf opcodes") {
+    sfzInstrument inst = loadFixture("sfz_crossfade.sfz");
+    REQUIRE(inst.regions.size() == 2);
+
+    CHECK(inst.regions[0].xfinLovel == 1);
+    CHECK(inst.regions[0].xfinHivel == 20);
+    CHECK(inst.regions[0].xfoutLovel == 60);
+    CHECK(inst.regions[0].xfoutHivel == 80);
+    CHECK(inst.regions[0].xfVelcurve == SFZ_CURVE_POWER); // default
+    CHECK(inst.regions[1].xfVelcurve == SFZ_CURVE_GAIN);
+
+    // overlap region: both layer
+    CHECK(layers(inst, 60, 70) == std::vector<int>{0, 1});
+    CHECK(layers(inst, 60, 30) == std::vector<int>{0});
+    CHECK(layers(inst, 60, 120) == std::vector<int>{1});
+  }
+
+  // ─── overlapping layers below the bound ───────────────────────────────────
+
+  TEST_CASE("sfz: all matching regions sound as layers (below the 4-layer bound)") {
+    sfzInstrument inst = loadFixture("sfz_overlap.sfz");
+    REQUIRE(inst.regions.size() == 3);
+    CHECK_FALSE(inst.layerOverflowWarning);
+
+    CHECK(layers(inst, 65, 64) == std::vector<int>{0, 1, 2}); // inside all three
+    CHECK(layers(inst, 61, 64) == std::vector<int>{0, 1}); // outside region 2
+  }
+
+  // ─── >4-layer cell: truncation + parse warning ────────────────────────────
+
+  TEST_CASE("sfz: over-bound cell truncates by priority and warns at parse time") {
+    sfzInstrument inst = loadFixture("sfz_overflow.sfz");
+    REQUIRE(inst.regions.size() == 5);
+    CHECK(inst.layerOverflowWarning);
+
+    // At (60,64) all five match. Priority: narrowest velocity range (region 2,
+    // vel 64..64), then narrowest key range among the rest (region 1 key 60,
+    // region 3 key 59..61, region 4 key 60..72), dropping the widest (region 0).
+    std::vector<int> got = layers(inst, 60, 64);
+    REQUIRE(got.size() == static_cast<size_t>(YSE_MAX_REGION_LAYERS));
+    CHECK(got == std::vector<int>{1, 2, 3, 4});
+    CHECK(std::find(got.begin(), got.end(), 0) == got.end()); // widest dropped
+
+    // A non-overflowing cell resolves normally.
+    CHECK(layers(inst, 65, 64) == std::vector<int>{0, 4});
+  }
+
+  // ─── lenient error policy ─────────────────────────────────────────────────
+
+  TEST_CASE("sfz: lenient parse keeps valid regions, drops/skips the rest") {
+    sfzInstrument inst = loadFixture("sfz_lenient.sfz");
+    REQUIRE(inst.valid);
+    CHECK(inst.regions.size() == 1); // one valid *silence region
+    CHECK(inst.droppedRegions == 2); // missing-sample + no-sample regions
+
+    // OUT opcodes ignored, malformed known value falls back to the default.
+    CHECK(inst.regions[0].pitchKeycenter == 48);
+    CHECK(inst.regions[0].lovel == 1); // "notanumber" rejected -> default kept
+  }
+
+  // ─── buffer de-dup + note names + real file ───────────────────────────────
+
+  TEST_CASE("sfz: identical sample paths share one buffer; note names parse") {
+    sfzInstrument inst = loadFixture("sfz_dedup.sfz");
+    REQUIRE(inst.valid);
+    REQUIRE(inst.regions.size() == 2);
+
+    // both regions name the same real file -> one de-duplicated sample entry
+    REQUIRE(inst.samples.size() == 1);
+    CHECK_FALSE(inst.samples[0].silence);
+    CHECK(inst.regions[0].sampleIndex == inst.regions[1].sampleIndex);
+
+    // key=c4 shorthand -> lokey = hikey = pitch_keycenter = 60
+    CHECK(inst.regions[0].lokey == 60);
+    CHECK(inst.regions[0].hikey == 60);
+    CHECK(inst.regions[0].pitchKeycenter == 60);
+
+    // c5 = 72, c6 = 84
+    CHECK(inst.regions[1].lokey == 72);
+    CHECK(inst.regions[1].hikey == 84);
+    CHECK(inst.regions[1].pitchKeycenter == 72);
+
+    CHECK(inst.regions[0].loopMode == SFZ_LOOP_CONTINUOUS); // from <group>
+  }
+
+  // ─── hard failures / empty input ──────────────────────────────────────────
+
+  TEST_CASE("sfz: unreadable file and empty text are invalid, never crash") {
+    sfzInstrument missing = loadSFZ(fixturesDir() + "/does_not_exist_at_all.sfz");
+    CHECK_FALSE(missing.valid);
+    CHECK(missing.regions.empty());
+
+    sfzInstrument empty = parseSFZ("", fixturesDir(), "empty");
+    CHECK_FALSE(empty.valid);
+    CHECK(empty.regions.empty());
+
+    // No matching region -> empty layer set, no stuck voice.
+    sfzInstrument inst = loadFixture("sfz_velocity_split.sfz");
+    CHECK(layers(inst, 60, 64, 0).size() >= 1);
+    int out[YSE_MAX_REGION_LAYERS];
+    // velocity 0 is below every region's lovel (1) -> no match
+    CHECK(resolveLayers(inst, 60, 0, 0, out) == 0);
+  }
+
+  // ─── note-name parsing edge cases via a synthetic instrument ──────────────
+
+  TEST_CASE("sfz: note names, sharps/flats, and octave -1 parse to MIDI numbers") {
+    // c-1 = 0, a-1 = 9, f#3 = 54, bb2 = 46, c4 = 60
+    const char* text = "<region> sample=*silence key=c-1\n"
+                       "<region> sample=*silence lokey=f#3 hikey=bb2 pitch_keycenter=c4\n";
+    sfzInstrument inst = parseSFZ(text, fixturesDir(), "notenames");
+    REQUIRE(inst.regions.size() == 2);
+    CHECK(inst.regions[0].lokey == 0); // c-1
+    CHECK(inst.regions[1].lokey == 54); // f#3
+    CHECK(inst.regions[1].hikey == 46); // bb2
+    CHECK(inst.regions[1].pitchKeycenter == 60); // c4
+  }
+
+} // TEST_SUITE

--- a/Tests/support/fixtures/sfz_crossfade.sfz
+++ b/Tests/support/fixtures/sfz_crossfade.sfz
@@ -1,0 +1,6 @@
+// Velocity crossfade layers. The two regions overlap over velocity 60..80,
+// where both sound as layers (spec §2). xf_velcurve defaults to power;
+// region 2 selects the gain curve.
+<global> pitch_keycenter=60
+<region> sample=*silence lovel=1  hivel=80  xfin_lovel=1  xfin_hivel=20 xfout_lovel=60 xfout_hivel=80
+<region> sample=*silence lovel=60 hivel=127 xfin_lovel=60 xfin_hivel=80 xf_velcurve=gain

--- a/Tests/support/fixtures/sfz_dedup.sfz
+++ b/Tests/support/fixtures/sfz_dedup.sfz
@@ -1,0 +1,6 @@
+// Buffer de-duplication + note-name parsing. Two regions naming the same
+// real file share one sample-table entry. Keys are given as note names
+// (c4 = 60, sfizz/SFZ middle-C convention).
+<group> loop_mode=loop_continuous
+<region> sample=test_mono_44100.wav key=c4
+<region> sample=test_mono_44100.wav lokey=c5 hikey=c6 pitch_keycenter=c5

--- a/Tests/support/fixtures/sfz_hihat.sfz
+++ b/Tests/support/fixtures/sfz_hihat.sfz
@@ -1,0 +1,8 @@
+// Round-robin + choke, a hi-hat pair (spec Example 6). Two closed-hat
+// samples alternate on key 42 (seq_position/seq_length); the open hat on
+// key 46 is choked by the closed group and vice versa (group/off_by).
+<group> lokey=42 hikey=42 pitch_keycenter=42 group=1 off_by=2
+<region> sample=*silence seq_length=2 seq_position=1
+<region> sample=*silence seq_length=2 seq_position=2
+
+<region> sample=*silence lokey=46 hikey=46 pitch_keycenter=46 group=2 off_by=1 loop_mode=one_shot

--- a/Tests/support/fixtures/sfz_key_split.sfz
+++ b/Tests/support/fixtures/sfz_key_split.sfz
@@ -1,0 +1,11 @@
+// Key split inheriting group defaults (spec Example 2). *silence stands in
+// for the real bass/lead samples so the mapping is testable without audio.
+<control>
+default_path=samples/
+
+<group>
+loop_mode=loop_continuous
+ampeg_release=0.3
+
+<region> sample=*silence lokey=0   hikey=47  pitch_keycenter=36
+<region> sample=*silence lokey=48  hikey=127 pitch_keycenter=72

--- a/Tests/support/fixtures/sfz_lenient.sfz
+++ b/Tests/support/fixtures/sfz_lenient.sfz
@@ -1,0 +1,22 @@
+// Lenient parse (spec Example 5 + §14.6): an unknown header, OUT opcodes, a
+// malformed known value, a missing-sample region, and a region with no
+// sample. Exactly one valid region survives; the rest are skipped/dropped
+// and logged, never a parse failure.
+<weird>
+depth=5
+
+<region>
+sample=*silence
+pitch_keycenter=48
+cutoff=800          // OUT: filter
+lfo01_freq=5        // OUT: LFO
+fileg_attack=0.2    // OUT: filter EG
+sw_last=24          // OUT: key switching
+lovel=notanumber    // malformed known value -> default (1) kept
+
+<region>
+sample=does_not_exist_12345.wav   // missing file -> region dropped
+pitch_keycenter=50
+
+<region>
+pitch_keycenter=52   // no sample opcode -> region dropped

--- a/Tests/support/fixtures/sfz_master.sfz
+++ b/Tests/support/fixtures/sfz_master.sfz
@@ -1,0 +1,15 @@
+// Four-level inheritance: <global> <master> <group> <region> (spec §3).
+// Region 1 overrides the master volume, proving innermost-wins.
+<global>
+ampeg_release=0.5
+pitch_keytrack=100
+
+<master>
+volume=-3
+pitch_keycenter=48
+
+<group>
+loop_mode=one_shot
+
+<region> sample=*silence lokey=36 hikey=47
+<region> sample=*silence lokey=48 hikey=59 volume=-6

--- a/Tests/support/fixtures/sfz_one_region.sfz
+++ b/Tests/support/fixtures/sfz_one_region.sfz
@@ -1,0 +1,5 @@
+// Minimal one-region instrument (spec Example 1).
+// Plays across all keys, pitch-tracked from note 60, every velocity.
+<region>
+sample=*silence
+pitch_keycenter=60

--- a/Tests/support/fixtures/sfz_overflow.sfz
+++ b/Tests/support/fixtures/sfz_overflow.sfz
@@ -1,0 +1,10 @@
+// A cell with more than YSE_MAX_REGION_LAYERS (4) matching regions. At
+// note 60 / velocity 64 all five match; the widest (region 0) is truncated
+// by the priority rule (narrowest velocity range, then narrowest key range,
+// then last-in-file). The parser also flags a parse-time overflow warning.
+<global> pitch_keycenter=60
+<region> sample=*silence lokey=0  hikey=127 lovel=1  hivel=127
+<region> sample=*silence lokey=60 hikey=60  lovel=1  hivel=127
+<region> sample=*silence lokey=60 hikey=60  lovel=64 hivel=64
+<region> sample=*silence lokey=59 hikey=61  lovel=1  hivel=127
+<region> sample=*silence lokey=60 hikey=72  lovel=1  hivel=127

--- a/Tests/support/fixtures/sfz_overlap.sfz
+++ b/Tests/support/fixtures/sfz_overlap.sfz
@@ -1,0 +1,6 @@
+// Overlapping layered zones (below the 4-layer bound). Notes in the shared
+// range sound all matching regions simultaneously.
+<global> pitch_keycenter=60
+<region> sample=*silence lokey=60 hikey=72
+<region> sample=*silence lokey=60 hikey=72
+<region> sample=*silence lokey=64 hikey=67

--- a/Tests/support/fixtures/sfz_velocity_split.sfz
+++ b/Tests/support/fixtures/sfz_velocity_split.sfz
@@ -1,0 +1,5 @@
+// Velocity layers (spec Example 3). Non-overlapping, so the choice is
+// unambiguous. pitch_keycenter inherited from <global>.
+<global> pitch_keycenter=60
+<region> sample=*silence lovel=1   hivel=63
+<region> sample=*silence lovel=64  hivel=127

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -65,6 +65,7 @@ set(YSE_SRCS
   dsp/ramp.cpp
   dsp/rawFilters.cpp
   dsp/sample_functions.cpp
+  dsp/sfzModel.cpp
   dsp/wavetable.cpp
   implementations/listenerImplementation.cpp
   implementations/logImplementation.cpp

--- a/YseEngine/dsp/sfzModel.cpp
+++ b/YseEngine/dsp/sfzModel.cpp
@@ -1,0 +1,870 @@
+/*
+  ==============================================================================
+
+    sfzModel.cpp
+    SFZ v1 opcode-subset parser + region model (issue #173).
+    Contract: docs/design/sfz_opcode_subset.md.
+
+  ==============================================================================
+*/
+
+#include "sfzModel.hpp"
+
+#include "../implementations/logImplementation.h"
+#include "../utils/fileFunctions.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <fstream>
+#include <map>
+#include <numeric>
+#include <sstream>
+
+namespace YSE {
+  namespace DSP {
+
+    namespace {
+
+      // ---- small string helpers -------------------------------------------
+
+      std::string toLower(std::string s) {
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return s;
+      }
+
+      // Log an SFZ parse note through the engine log facility. All parsing is
+      // offline (slow pool), so this never runs on the audio thread.
+      void logSFZ(ERROR_CODE code, const std::string& source, const std::string& detail) {
+        std::string msg = "[sfz";
+        if (!source.empty()) msg += " " + source;
+        msg += "] " + detail;
+        INTERNAL::LogImpl().emit(code, msg);
+      }
+
+      // Normalise backslashes to forward slashes (SFZ files from Windows tools
+      // use '\'). Forward slashes work on every platform we target.
+      std::string normaliseSeparators(std::string p) {
+        std::replace(p.begin(), p.end(), '\\', '/');
+        return p;
+      }
+
+      // Strip SFZ comments: line comments ("// ... EOL") and C-style block
+      // comments ("/* ... */", possibly multi-line). Done before tokenising.
+      std::string stripComments(const std::string& in) {
+        std::string out;
+        out.reserve(in.size());
+        bool inBlock = false;
+        for (size_t i = 0; i < in.size(); ++i) {
+          if (inBlock) {
+            if (in[i] == '*' && i + 1 < in.size() && in[i + 1] == '/') {
+              inBlock = false;
+              ++i;
+            }
+            continue;
+          }
+          if (in[i] == '/' && i + 1 < in.size() && in[i + 1] == '*') {
+            inBlock = true;
+            ++i;
+            continue;
+          }
+          if (in[i] == '/' && i + 1 < in.size() && in[i + 1] == '/') {
+            // line comment: skip to end of line (keep the newline)
+            while (i < in.size() && in[i] != '\n')
+              ++i;
+            if (i < in.size()) out += '\n';
+            continue;
+          }
+          out += in[i];
+        }
+        return out;
+      }
+
+      // ---- value parsing --------------------------------------------------
+
+      // Parse an integer, tolerating a leading/trailing sign and stray space.
+      bool parseIntValue(const std::string& v, int& out) {
+        if (v.empty()) return false;
+        char* end = nullptr;
+        long n = std::strtol(v.c_str(), &end, 10);
+        if (end == v.c_str()) return false;
+        while (*end == ' ' || *end == '\t')
+          ++end;
+        if (*end != '\0') return false;
+        out = static_cast<int>(n);
+        return true;
+      }
+
+      bool parseLongValue(const std::string& v, long& out) {
+        if (v.empty()) return false;
+        char* end = nullptr;
+        long n = std::strtol(v.c_str(), &end, 10);
+        if (end == v.c_str()) return false;
+        while (*end == ' ' || *end == '\t')
+          ++end;
+        if (*end != '\0') return false;
+        out = n;
+        return true;
+      }
+
+      bool parseFloatValue(const std::string& v, float& out) {
+        if (v.empty()) return false;
+        char* end = nullptr;
+        double n = std::strtod(v.c_str(), &end);
+        if (end == v.c_str()) return false;
+        while (*end == ' ' || *end == '\t')
+          ++end;
+        if (*end != '\0') return false;
+        out = static_cast<float>(n);
+        return true;
+      }
+
+      // Note name -> MIDI number, middle-C convention c4 = 60 (SFZ/sfizz
+      // default). Accepts plain integers, or note names like c4, f#3, bb2,
+      // c-1. Returns false on anything unrecognised.
+      bool parseKeyValue(const std::string& raw, int& out) {
+        std::string v = raw;
+        // trim
+        while (!v.empty() && (v.front() == ' ' || v.front() == '\t'))
+          v.erase(v.begin());
+        while (!v.empty() && (v.back() == ' ' || v.back() == '\t'))
+          v.pop_back();
+        if (v.empty()) return false;
+
+        // plain integer?
+        int asInt = 0;
+        if (parseIntValue(v, asInt)) {
+          out = asInt;
+          return true;
+        }
+
+        std::string low = toLower(v);
+        size_t idx = 0;
+        int semitone;
+        switch (low[idx]) {
+        case 'c':
+          semitone = 0;
+          break;
+        case 'd':
+          semitone = 2;
+          break;
+        case 'e':
+          semitone = 4;
+          break;
+        case 'f':
+          semitone = 5;
+          break;
+        case 'g':
+          semitone = 7;
+          break;
+        case 'a':
+          semitone = 9;
+          break;
+        case 'b':
+          semitone = 11;
+          break;
+        default:
+          return false;
+        }
+        ++idx;
+        // accidental
+        if (idx < low.size() && (low[idx] == '#' || low[idx] == 's')) {
+          semitone += 1;
+          ++idx;
+        } else if (idx < low.size() && low[idx] == 'b') {
+          semitone -= 1;
+          ++idx;
+        }
+        if (idx >= low.size()) return false; // needs an octave
+        int octave = 0;
+        if (!parseIntValue(low.substr(idx), octave)) return false;
+        int note = (octave + 1) * 12 + semitone;
+        if (note < 0 || note > 127) return false;
+        out = note;
+        return true;
+      }
+
+      bool parseLoopMode(const std::string& v, int& out) {
+        std::string low = toLower(v);
+        if (low == "no_loop") {
+          out = SFZ_NO_LOOP;
+          return true;
+        }
+        if (low == "one_shot") {
+          out = SFZ_ONE_SHOT;
+          return true;
+        }
+        if (low == "loop_continuous") {
+          out = SFZ_LOOP_CONTINUOUS;
+          return true;
+        }
+        if (low == "loop_sustain") {
+          out = SFZ_LOOP_SUSTAIN;
+          return true;
+        }
+        return false;
+      }
+
+      bool parseOffMode(const std::string& v, int& out) {
+        std::string low = toLower(v);
+        if (low == "fast") {
+          out = SFZ_OFF_FAST;
+          return true;
+        }
+        if (low == "normal") {
+          out = SFZ_OFF_NORMAL;
+          return true;
+        }
+        return false;
+      }
+
+      bool parseCurve(const std::string& v, int& out) {
+        std::string low = toLower(v);
+        if (low == "gain") {
+          out = SFZ_CURVE_GAIN;
+          return true;
+        }
+        if (low == "power") {
+          out = SFZ_CURVE_POWER;
+          return true;
+        }
+        return false;
+      }
+
+      // The set of opcodes we recognise (IN, per spec §4). Anything outside
+      // this set is skipped-and-logged rather than failing the parse.
+      bool isKnownOpcode(const std::string& op) {
+        static const char* const known[] = {
+            "sample",       "default_path",    "lokey",         "hikey",
+            "key",          "pitch_keycenter", "lovel",         "hivel",
+            "tune",         "pitch",           "transpose",     "pitch_keytrack",
+            "loop_mode",    "loop_start",      "loop_end",      "offset",
+            "end",          "volume",          "pan",           "amp_veltrack",
+            "xfin_lovel",   "xfin_hivel",      "xfout_lovel",   "xfout_hivel",
+            "xfin_lokey",   "xfin_hikey",      "xfout_lokey",   "xfout_hikey",
+            "xf_velcurve",  "xf_keycurve",     "ampeg_delay",   "ampeg_attack",
+            "ampeg_hold",   "ampeg_decay",     "ampeg_sustain", "ampeg_release",
+            "group",        "polyphony_group", "off_by",        "off_mode",
+            "seq_position", "seq_length",
+        };
+        for (const char* k : known) {
+          if (op == k) return true;
+        }
+        return false;
+      }
+
+      // ---- opcode dictionaries + merge ------------------------------------
+
+      using OpcodeMap = std::map<std::string, std::string>;
+
+      // Innermost wins: global <- master <- group <- region-own.
+      void mergeInto(OpcodeMap& dst, const OpcodeMap& src) {
+        for (const auto& kv : src)
+          dst[kv.first] = kv.second;
+      }
+
+    } // namespace
+
+    // -----------------------------------------------------------------------
+    // Parser
+    // -----------------------------------------------------------------------
+
+    // A running builder that flattens the four-level header hierarchy into a
+    // region table as regions are encountered.
+    namespace {
+
+      struct Parser {
+        sfzInstrument inst;
+        std::string source;
+        std::string sfzDir;
+
+        OpcodeMap globalOps;
+        OpcodeMap masterOps;
+        OpcodeMap groupOps;
+        std::string defaultPath; // running, updated wherever default_path appears
+
+        // De-dup sample table. Keyed by the resolved lookup string.
+        std::map<std::string, int> sampleIndexByKey;
+
+        // Resolve a sample= value to a table index, or -1 to drop the region.
+        int resolveSample(const std::string& rawValue) {
+          std::string value = rawValue;
+          // trim
+          while (!value.empty() && (value.front() == ' ' || value.front() == '\t'))
+            value.erase(value.begin());
+          while (!value.empty() && (value.back() == ' ' || value.back() == '\t'))
+            value.pop_back();
+
+          if (value.empty()) return -1;
+
+          if (toLower(value) == "*silence") {
+            auto it = sampleIndexByKey.find("*silence");
+            if (it != sampleIndexByKey.end()) return it->second;
+            sfzSample s;
+            s.silence = true;
+            int idx = static_cast<int>(inst.samples.size());
+            inst.samples.push_back(s);
+            sampleIndexByKey["*silence"] = idx;
+            return idx;
+          }
+
+          std::string rel = normaliseSeparators(value);
+          std::string resolved;
+          if (IsPathAbsolute(rel)) {
+            resolved = rel;
+          } else {
+            std::string prefix = normaliseSeparators(defaultPath);
+            std::string base = sfzDir;
+            if (!base.empty() && base.back() != '/' && base.back() != '\\') base += '/';
+            if (!prefix.empty() && prefix.back() != '/') prefix += '/';
+            resolved = base + prefix + rel;
+          }
+
+          if (!FileExists(resolved)) {
+            logSFZ(E_FILE_NOT_FOUND, source, "sample not found, region dropped: " + resolved);
+            return -1;
+          }
+
+          auto it = sampleIndexByKey.find(resolved);
+          if (it != sampleIndexByKey.end()) return it->second;
+          sfzSample s;
+          s.path = resolved;
+          int idx = static_cast<int>(inst.samples.size());
+          inst.samples.push_back(s);
+          sampleIndexByKey[resolved] = idx;
+          return idx;
+        }
+
+        // Apply one opcode to a region under construction. Malformed known
+        // values are logged as warnings and the default is kept.
+        void applyOpcode(sfzRegion& r, const std::string& op, const std::string& value) {
+          int i = 0;
+          long l = 0;
+          float f = 0.0f;
+
+          auto warnBad = [&]() {
+            logSFZ(E_WARNING, source, "malformed value for '" + op + "': '" + value + "'");
+          };
+
+          if (op == "lokey") {
+            if (parseKeyValue(value, i))
+              r.lokey = i;
+            else
+              warnBad();
+          } else if (op == "hikey") {
+            if (parseKeyValue(value, i))
+              r.hikey = i;
+            else
+              warnBad();
+          } else if (op == "key") {
+            if (parseKeyValue(value, i)) {
+              r.lokey = r.hikey = r.pitchKeycenter = i;
+            } else
+              warnBad();
+          } else if (op == "pitch_keycenter") {
+            if (parseKeyValue(value, i))
+              r.pitchKeycenter = i;
+            else
+              warnBad();
+          } else if (op == "lovel") {
+            if (parseIntValue(value, i))
+              r.lovel = i;
+            else
+              warnBad();
+          } else if (op == "hivel") {
+            if (parseIntValue(value, i))
+              r.hivel = i;
+            else
+              warnBad();
+          } else if (op == "tune" || op == "pitch") {
+            if (parseFloatValue(value, f))
+              r.tuneCents = f;
+            else
+              warnBad();
+          } else if (op == "transpose") {
+            if (parseIntValue(value, i))
+              r.transposeSemis = i;
+            else
+              warnBad();
+          } else if (op == "pitch_keytrack") {
+            if (parseFloatValue(value, f))
+              r.pitchKeytrack = f;
+            else
+              warnBad();
+          } else if (op == "loop_mode") {
+            if (parseLoopMode(value, i))
+              r.loopMode = i;
+            else
+              warnBad();
+          } else if (op == "loop_start") {
+            if (parseLongValue(value, l))
+              r.loopStart = l;
+            else
+              warnBad();
+          } else if (op == "loop_end") {
+            if (parseLongValue(value, l))
+              r.loopEnd = l;
+            else
+              warnBad();
+          } else if (op == "offset") {
+            if (parseLongValue(value, l))
+              r.offset = l;
+            else
+              warnBad();
+          } else if (op == "end") {
+            if (parseLongValue(value, l))
+              r.endFrame = l;
+            else
+              warnBad();
+          } else if (op == "volume") {
+            if (parseFloatValue(value, f))
+              r.volumeDb = f;
+            else
+              warnBad();
+          } else if (op == "pan") {
+            if (parseFloatValue(value, f))
+              r.pan = f;
+            else
+              warnBad();
+          } else if (op == "amp_veltrack") {
+            if (parseFloatValue(value, f))
+              r.ampVeltrack = f;
+            else
+              warnBad();
+          } else if (op == "xfin_lovel") {
+            if (parseIntValue(value, i))
+              r.xfinLovel = i;
+            else
+              warnBad();
+          } else if (op == "xfin_hivel") {
+            if (parseIntValue(value, i))
+              r.xfinHivel = i;
+            else
+              warnBad();
+          } else if (op == "xfout_lovel") {
+            if (parseIntValue(value, i))
+              r.xfoutLovel = i;
+            else
+              warnBad();
+          } else if (op == "xfout_hivel") {
+            if (parseIntValue(value, i))
+              r.xfoutHivel = i;
+            else
+              warnBad();
+          } else if (op == "xfin_lokey") {
+            if (parseKeyValue(value, i))
+              r.xfinLokey = i;
+            else
+              warnBad();
+          } else if (op == "xfin_hikey") {
+            if (parseKeyValue(value, i))
+              r.xfinHikey = i;
+            else
+              warnBad();
+          } else if (op == "xfout_lokey") {
+            if (parseKeyValue(value, i))
+              r.xfoutLokey = i;
+            else
+              warnBad();
+          } else if (op == "xfout_hikey") {
+            if (parseKeyValue(value, i))
+              r.xfoutHikey = i;
+            else
+              warnBad();
+          } else if (op == "xf_velcurve") {
+            if (parseCurve(value, i))
+              r.xfVelcurve = i;
+            else
+              warnBad();
+          } else if (op == "xf_keycurve") {
+            if (parseCurve(value, i))
+              r.xfKeycurve = i;
+            else
+              warnBad();
+          } else if (op == "ampeg_delay") {
+            if (parseFloatValue(value, f))
+              r.egDelay = f;
+            else
+              warnBad();
+          } else if (op == "ampeg_attack") {
+            if (parseFloatValue(value, f))
+              r.egAttack = f;
+            else
+              warnBad();
+          } else if (op == "ampeg_hold") {
+            if (parseFloatValue(value, f))
+              r.egHold = f;
+            else
+              warnBad();
+          } else if (op == "ampeg_decay") {
+            if (parseFloatValue(value, f))
+              r.egDecay = f;
+            else
+              warnBad();
+          } else if (op == "ampeg_sustain") {
+            if (parseFloatValue(value, f))
+              r.egSustain = f / 100.0f;
+            else
+              warnBad();
+          } else if (op == "ampeg_release") {
+            if (parseFloatValue(value, f))
+              r.egRelease = f;
+            else
+              warnBad();
+          } else if (op == "group" || op == "polyphony_group") {
+            if (parseIntValue(value, i))
+              r.chokeGroup = i;
+            else
+              warnBad();
+          } else if (op == "off_by") {
+            if (parseIntValue(value, i))
+              r.offBy = i;
+            else
+              warnBad();
+          } else if (op == "off_mode") {
+            if (parseOffMode(value, i))
+              r.offMode = i;
+            else
+              warnBad();
+          } else if (op == "seq_position") {
+            if (parseIntValue(value, i))
+              r.seqPosition = i;
+            else
+              warnBad();
+          } else if (op == "seq_length") {
+            if (parseIntValue(value, i))
+              r.seqLength = i;
+            else
+              warnBad();
+          }
+          // sample / default_path handled by the caller; unknown handled at
+          // tokenise time.
+        }
+
+        // Finalise a <region>: merge the hierarchy, resolve the sample, apply
+        // opcodes, and append to the table (or drop it).
+        void finaliseRegion(const OpcodeMap& regionOps) {
+          OpcodeMap eff = globalOps;
+          mergeInto(eff, masterOps);
+          mergeInto(eff, groupOps);
+          mergeInto(eff, regionOps);
+
+          // sample is mandatory for a playable region.
+          auto sampleIt = eff.find("sample");
+          if (sampleIt == eff.end()) {
+            logSFZ(E_WARNING, source, "region with no sample opcode dropped");
+            ++inst.droppedRegions;
+            return;
+          }
+
+          // end = -1 explicitly disables the region (SFZ convention) -> drop
+          // it. This is distinct from the endFrame default (SFZ_UNSET = "play
+          // to the file end"), which must NOT drop the region.
+          auto endIt = eff.find("end");
+          if (endIt != eff.end()) {
+            long ev = 0;
+            if (parseLongValue(endIt->second, ev) && ev == -1) {
+              ++inst.droppedRegions;
+              return;
+            }
+          }
+
+          int sampleIdx = resolveSample(sampleIt->second);
+          if (sampleIdx < 0) {
+            ++inst.droppedRegions;
+            return;
+          }
+
+          sfzRegion r;
+          r.sampleIndex = sampleIdx;
+          for (const auto& kv : eff) {
+            if (kv.first == "sample" || kv.first == "default_path") continue;
+            applyOpcode(r, kv.first, kv.second);
+          }
+
+          // Defensive clamps so an inverted/absurd range never breaks the
+          // audio-thread matcher; log but keep the region.
+          if (r.seqLength < 1) r.seqLength = 1;
+          if (r.seqPosition < 1) r.seqPosition = 1;
+
+          inst.regions.push_back(r);
+        }
+      };
+
+      // Tokenise comment-stripped SFZ into a header/opcode stream and drive the
+      // Parser. Handles values containing spaces (sample paths) by consuming
+      // continuation tokens up to the next opcode/header.
+      void run(Parser& P, const std::string& text) {
+        std::string clean = stripComments(text);
+
+        // Split into whitespace-separated tokens (newlines are not significant
+        // once comments are gone).
+        std::vector<std::string> tokens;
+        {
+          std::string cur;
+          for (char c : clean) {
+            if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+              if (!cur.empty()) {
+                tokens.push_back(cur);
+                cur.clear();
+              }
+            } else {
+              cur += c;
+            }
+          }
+          if (!cur.empty()) tokens.push_back(cur);
+        }
+
+        auto isHeader = [](const std::string& t) {
+          return t.size() >= 2 && t.front() == '<' && t.back() == '>';
+        };
+
+        enum Scope { S_NONE, S_GLOBAL, S_MASTER, S_GROUP, S_REGION, S_CONTROL, S_SKIP };
+        Scope scope = S_NONE;
+        OpcodeMap regionOps;
+        bool regionOpen = false;
+
+        auto closeRegion = [&]() {
+          if (regionOpen) {
+            P.finaliseRegion(regionOps);
+            regionOps.clear();
+            regionOpen = false;
+          }
+        };
+
+        for (size_t t = 0; t < tokens.size(); ++t) {
+          const std::string& tok = tokens[t];
+
+          if (isHeader(tok)) {
+            closeRegion();
+            std::string name = toLower(tok.substr(1, tok.size() - 2));
+            if (name == "global") {
+              scope = S_GLOBAL;
+              P.globalOps.clear();
+              P.masterOps.clear();
+              P.groupOps.clear();
+            } else if (name == "master") {
+              scope = S_MASTER;
+              P.masterOps.clear();
+              P.groupOps.clear();
+            } else if (name == "group") {
+              scope = S_GROUP;
+              P.groupOps.clear();
+            } else if (name == "region") {
+              scope = S_REGION;
+              regionOpen = true;
+            } else if (name == "control") {
+              scope = S_CONTROL;
+            } else {
+              logSFZ(E_DEBUG, P.source, "unsupported header <" + name + "> skipped");
+              scope = S_SKIP;
+            }
+            continue;
+          }
+
+          // opcode=value (value may continue across following tokens)
+          size_t eq = tok.find('=');
+          if (eq == std::string::npos) {
+            logSFZ(E_DEBUG, P.source, "stray token skipped: " + tok);
+            continue;
+          }
+          std::string op = toLower(tok.substr(0, eq));
+          std::string value = tok.substr(eq + 1);
+          // consume continuation tokens (spaces in a value, e.g. sample paths)
+          while (t + 1 < tokens.size() && !isHeader(tokens[t + 1]) &&
+                 tokens[t + 1].find('=') == std::string::npos) {
+            value += " " + tokens[t + 1];
+            ++t;
+          }
+
+          // default_path is tolerated in any header and updates the running value.
+          if (op == "default_path") {
+            P.defaultPath = value;
+            P.inst.defaultPath = value;
+            continue;
+          }
+
+          if (scope == S_SKIP) continue;
+
+          if (!isKnownOpcode(op)) {
+            logSFZ(E_DEBUG, P.source, "unknown/unsupported opcode skipped: " + op);
+            continue;
+          }
+
+          switch (scope) {
+          case S_GLOBAL:
+            P.globalOps[op] = value;
+            break;
+          case S_MASTER:
+            P.masterOps[op] = value;
+            break;
+          case S_GROUP:
+            P.groupOps[op] = value;
+            break;
+          case S_REGION:
+            regionOps[op] = value;
+            break;
+          case S_CONTROL: // only default_path (handled above) is read here
+          case S_NONE:
+          default:
+            logSFZ(E_DEBUG, P.source, "opcode outside a region context skipped: " + op);
+            break;
+          }
+        }
+        closeRegion();
+      }
+
+      // Parse-time overflow warning (spec §5): flag when any (note, velocity)
+      // cell can exceed the layer bound on some round-robin hit. Offline scan;
+      // allocation is fine here (never the audio thread).
+      void computeLayerOverflow(sfzInstrument& inst) {
+        if (inst.regions.size() <= static_cast<size_t>(YSE_MAX_REGION_LAYERS)) return;
+
+        for (int note = 0; note <= 127 && !inst.layerOverflowWarning; ++note) {
+          for (int vel = 1; vel <= 127 && !inst.layerOverflowWarning; ++vel) {
+            // Collect matching regions for this cell.
+            std::vector<const sfzRegion*> matched;
+            for (const auto& r : inst.regions) {
+              if (regionMatches(r, note, vel)) matched.push_back(&r);
+            }
+            if (matched.size() <= static_cast<size_t>(YSE_MAX_REGION_LAYERS)) continue;
+
+            // Round-robin variants are alternatives, not simultaneous. Walk one
+            // full counter cycle (lcm of seq lengths, capped) and take the max
+            // simultaneous count.
+            long cycle = 1;
+            for (const sfzRegion* r : matched) {
+              long L = r->seqLength > 0 ? r->seqLength : 1;
+              cycle = std::lcm(cycle, L);
+              if (cycle > 512) {
+                cycle = 512;
+                break;
+              }
+            }
+            for (long hit = 0; hit < cycle && !inst.layerOverflowWarning; ++hit) {
+              int simultaneous = 0;
+              for (const sfzRegion* r : matched) {
+                long L = r->seqLength > 0 ? r->seqLength : 1;
+                if ((hit % L) == (r->seqPosition - 1)) ++simultaneous;
+              }
+              if (simultaneous > YSE_MAX_REGION_LAYERS) inst.layerOverflowWarning = true;
+            }
+          }
+        }
+
+        if (inst.layerOverflowWarning) {
+          logSFZ(E_WARNING, inst.sourceFile,
+                 "a (note,velocity) cell can exceed " + std::to_string(YSE_MAX_REGION_LAYERS) +
+                     " simultaneous layers; extra layers will be truncated by priority");
+        }
+      }
+
+    } // namespace
+
+    sfzInstrument parseSFZ(const std::string& text, const std::string& sfzDir,
+                           const std::string& sourceName) {
+      Parser P;
+      P.source = sourceName;
+      P.sfzDir = sfzDir;
+      P.inst.sourceFile = sourceName;
+
+      run(P, text);
+
+      P.inst.valid = !P.inst.regions.empty();
+      if (!P.inst.valid) {
+        logSFZ(E_FILE_ERROR, sourceName, "no valid regions; instrument failed to load");
+      }
+      computeLayerOverflow(P.inst);
+      return P.inst;
+    }
+
+    sfzInstrument loadSFZ(const std::string& filePath) {
+      std::ifstream file(filePath, std::ios::in | std::ios::binary);
+      if (!file.good()) {
+        sfzInstrument inst;
+        inst.sourceFile = filePath;
+        inst.valid = false;
+        logSFZ(E_FILE_ERROR, filePath, "cannot open .sfz file");
+        return inst;
+      }
+      std::stringstream ss;
+      ss << file.rdbuf();
+
+      // Derive the .sfz directory for relative sample resolution.
+      std::string dir;
+      std::string norm = normaliseSeparators(filePath);
+      size_t slash = norm.find_last_of('/');
+      if (slash != std::string::npos) dir = norm.substr(0, slash);
+
+      return parseSFZ(ss.str(), dir, filePath);
+    }
+
+    // -----------------------------------------------------------------------
+    // Region resolution (audio-thread callable, allocation-free)
+    // -----------------------------------------------------------------------
+
+    bool regionMatches(const sfzRegion& r, int note, int velocity) {
+      return note >= r.lokey && note <= r.hikey && velocity >= r.lovel && velocity <= r.hivel;
+    }
+
+    namespace {
+      // Priority comparator for layer-limit truncation (spec §5): higher
+      // priority = narrowest velocity range, then narrowest key range, then
+      // last-in-file (higher index). Returns true if region `a` outranks `b`.
+      bool higherPriority(const sfzInstrument& inst, int a, int b) {
+        const sfzRegion& ra = inst.regions[a];
+        const sfzRegion& rb = inst.regions[b];
+        int velA = ra.hivel - ra.lovel;
+        int velB = rb.hivel - rb.lovel;
+        if (velA != velB) return velA < velB;
+        int keyA = ra.hikey - ra.lokey;
+        int keyB = rb.hikey - rb.lokey;
+        if (keyA != keyB) return keyA < keyB;
+        return a > b; // later in file wins
+      }
+    } // namespace
+
+    int resolveLayers(const sfzInstrument& inst, int note, int velocity, int hit,
+                      int outIndices[YSE_MAX_REGION_LAYERS]) {
+      // Fixed-size priority buffer kept sorted best-first; no allocation.
+      int best[YSE_MAX_REGION_LAYERS];
+      int count = 0;
+
+      const int n = static_cast<int>(inst.regions.size());
+      for (int i = 0; i < n; ++i) {
+        const sfzRegion& r = inst.regions[i];
+        if (!regionMatches(r, note, velocity)) continue;
+        // Round-robin filter: region sounds only on its slot of the cycle.
+        int L = r.seqLength > 0 ? r.seqLength : 1;
+        if ((hit % L) != (r.seqPosition - 1)) continue;
+
+        if (count < YSE_MAX_REGION_LAYERS) {
+          // insert keeping best[] sorted by descending priority
+          int pos = count;
+          while (pos > 0 && higherPriority(inst, i, best[pos - 1])) {
+            best[pos] = best[pos - 1];
+            --pos;
+          }
+          best[pos] = i;
+          ++count;
+        } else if (higherPriority(inst, i, best[count - 1])) {
+          // replace the weakest, then bubble into place
+          int pos = count - 1;
+          while (pos > 0 && higherPriority(inst, i, best[pos - 1])) {
+            best[pos] = best[pos - 1];
+            --pos;
+          }
+          best[pos] = i;
+        }
+      }
+
+      // Return in ascending file order for a stable, set-comparable result.
+      for (int a = 0; a < count; ++a)
+        outIndices[a] = best[a];
+      std::sort(outIndices, outIndices + count);
+      return count;
+    }
+
+  } // namespace DSP
+} // namespace YSE

--- a/YseEngine/dsp/sfzModel.hpp
+++ b/YseEngine/dsp/sfzModel.hpp
@@ -1,0 +1,164 @@
+/*
+  ==============================================================================
+
+    sfzModel.hpp
+    SFZ v1 opcode-subset parser + RT-ready region model (issue #173).
+
+    Implements the contract in docs/design/sfz_opcode_subset.md: an offline
+    text parser (slow-pool / setup thread only) that flattens an .sfz file
+    into an immutable region table, plus allocation-free region-resolution
+    free functions the sampler voice (#174) calls on the audio thread.
+
+    Nothing in this file runs on the audio thread except resolveLayers(),
+    which is allocation-free and takes only integer field compares over the
+    immutable table.
+
+  ==============================================================================
+*/
+
+#ifndef SFZMODEL_HPP_INCLUDED
+#define SFZMODEL_HPP_INCLUDED
+
+#include <string>
+#include <vector>
+
+namespace YSE {
+  namespace DSP {
+
+    /// Maximum simultaneous region layers rendered per note (spec §2/§5).
+    /// A (note, velocity) cell whose match set exceeds this is truncated by
+    /// the deterministic priority rule in resolveLayers(); the parser warns
+    /// at parse time when any cell can overflow.
+    constexpr int YSE_MAX_REGION_LAYERS = 4;
+
+    /// Sentinel for "unset / resolve from the sample file at load time"
+    /// (e.g. loop points that default to the file's embedded markers, or an
+    /// end frame that defaults to the last frame). The parser records intent;
+    /// the sample loader (#174) resolves sentinels against the decoded file.
+    constexpr long SFZ_UNSET = -1;
+
+    /// Sample-table index meaning "this region produces silence" (sample=*silence).
+    /// Distinct from a real de-duplicated sample entry.
+    constexpr int SFZ_SILENCE_SAMPLE = -2;
+
+    enum sfzLoopMode {
+      SFZ_NO_LOOP, ///< Play once from offset to end, then EG release.
+      SFZ_ONE_SHOT, ///< Play to completion ignoring note-off (drums).
+      SFZ_LOOP_CONTINUOUS, ///< Loop while held and through the release tail.
+      SFZ_LOOP_SUSTAIN, ///< Loop only while held; play out on release.
+    };
+
+    enum sfzOffMode {
+      SFZ_OFF_FAST, ///< Choke via the engine steal-fade (~5 ms declick).
+      SFZ_OFF_NORMAL, ///< Choke by triggering the region's own ampeg_release.
+    };
+
+    enum sfzCurve {
+      SFZ_CURVE_GAIN, ///< Linear-amplitude crossfade curve.
+      SFZ_CURVE_POWER, ///< Equal-power crossfade curve (SFZ default).
+    };
+
+    /// One de-duplicated sample referenced by the instrument. Regions that
+    /// resolve to the same path share one entry (the memory budget counts
+    /// unique files). #173 owns path resolution + de-dup; the actual PCM
+    /// residency is populated by the consumer's slow-pool load (#174).
+    struct sfzSample {
+      std::string path; ///< Resolved absolute-or-relative path; empty for silence.
+      bool silence = false; ///< True for sample=*silence (no file).
+    };
+
+    /// Fully flattened, immutable region. All hierarchy (global/master/group)
+    /// has been merged at parse time; the voice never walks a chain. Fields
+    /// are the RT-ready shape from spec §13 — integer compares on the audio
+    /// thread, no strings, no allocation on read.
+    struct sfzRegion {
+      // --- selection (integer compares on the audio thread) ---
+      int lokey = 0, hikey = 127; ///< Key range, 0..127.
+      int lovel = 1, hivel = 127; ///< Velocity range, 1..127.
+      int pitchKeycenter = 60; ///< Note that plays the sample at recorded pitch.
+      int seqPosition = 1, seqLength = 1; ///< Round-robin (1/1 = always).
+
+      // --- crossfades (NOTE_ON-time constant gains; 0 = unset) ---
+      int xfinLokey = 0, xfinHikey = 0, xfoutLokey = 0, xfoutHikey = 0;
+      int xfinLovel = 0, xfinHivel = 0, xfoutLovel = 0, xfoutHivel = 0;
+      int xfKeycurve = SFZ_CURVE_POWER, xfVelcurve = SFZ_CURVE_POWER;
+
+      // --- choke ---
+      int chokeGroup = 0, offBy = 0; ///< 0 = none.
+      int offMode = SFZ_OFF_FAST;
+
+      // --- pitch / tuning ---
+      float tuneCents = 0.0f; ///< tune / pitch, cents.
+      int transposeSemis = 0; ///< transpose, semitones.
+      float pitchKeytrack = 100.0f; ///< cents per key (100 = chromatic).
+
+      // --- playback ---
+      int sampleIndex =
+          SFZ_SILENCE_SAMPLE; ///< Index into sfzInstrument::samples, or SFZ_SILENCE_SAMPLE.
+      long offset = 0; ///< Start this many frames in.
+      long endFrame = SFZ_UNSET; ///< Last playable frame; SFZ_UNSET = file end.
+      int loopMode = SFZ_NO_LOOP;
+      long loopStart = SFZ_UNSET; ///< SFZ_UNSET = file marker / 0.
+      long loopEnd = SFZ_UNSET; ///< SFZ_UNSET = file marker / last frame.
+
+      // --- amplitude ---
+      float volumeDb = 0.0f;
+      float pan = 0.0f; ///< -100..100.
+      float ampVeltrack = 100.0f; ///< percent.
+
+      // --- amp EG (seconds; sustain 0..1) ---
+      float egDelay = 0.0f, egAttack = 0.0f, egHold = 0.0f, egDecay = 0.0f;
+      float egSustain = 1.0f, egRelease = 0.0f;
+    };
+
+    /// The parser's output: an immutable flattened region table plus the
+    /// de-duplicated sample list. Owned (shared) by the voice-group prototype;
+    /// this is an engine asset, not sampler-private (spec §10).
+    struct sfzInstrument {
+      std::vector<sfzRegion> regions; ///< Flattened; index == file order.
+      std::vector<sfzSample> samples; ///< De-duped by resolved path.
+      std::string defaultPath; ///< Effective default_path at end of parse.
+      std::string sourceFile; ///< Source .sfz path (for logging), if any.
+
+      bool valid = false; ///< True when at least one region loaded.
+      int droppedRegions = 0; ///< Regions dropped (missing/disabled sample).
+      bool layerOverflowWarning = false; ///< A (note,vel) cell can exceed the layer bound.
+    };
+
+    // ---- Parsing (offline; slow-pool / setup thread only) -------------------
+
+    /// Parse SFZ text into an immutable instrument. `sfzDir` is the directory
+    /// of the source .sfz file (relative sample paths resolve against
+    /// default_path, itself relative to sfzDir). `sourceName` is used only in
+    /// log messages. Lenient: unknown/OUT opcodes are skipped-and-logged,
+    /// malformed values fall back to defaults, regions with an unresolvable
+    /// sample are dropped. Never throws.
+    sfzInstrument parseSFZ(const std::string& text, const std::string& sfzDir,
+                           const std::string& sourceName = std::string());
+
+    /// Read an .sfz file from disk and parse it. Derives `sfzDir` from the
+    /// path. If the file is unreadable/empty, returns an instrument with
+    /// valid == false (the one hard failure, spec §12).
+    sfzInstrument loadSFZ(const std::string& filePath);
+
+    // ---- Region resolution (audio-thread callable; allocation-free) ---------
+
+    /// Whether a region matches a raw (note 0..127, velocity 1..127), ignoring
+    /// round-robin. Pure integer compares.
+    bool regionMatches(const sfzRegion& r, int note, int velocity);
+
+    /// Resolve the layer set that sounds for (note, velocity) on hit number
+    /// `hit` (the note's round-robin counter, 0-based). Writes up to
+    /// YSE_MAX_REGION_LAYERS region indices into `outIndices` (ascending file
+    /// order) and returns the count (0..YSE_MAX_REGION_LAYERS). If more than
+    /// the bound match, the set is truncated by the deterministic priority
+    /// rule (spec §5): narrowest velocity range, then narrowest key range,
+    /// then last-in-file. Allocation-free and O(regions) — safe on the audio
+    /// thread over the immutable table.
+    int resolveLayers(const sfzInstrument& inst, int note, int velocity, int hit,
+                      int outIndices[YSE_MAX_REGION_LAYERS]);
+
+  } // namespace DSP
+} // namespace YSE
+
+#endif // SFZMODEL_HPP_INCLUDED


### PR DESCRIPTION
## Summary

Implements the offline **SFZ v1 opcode-subset parser** and the immutable,
RT-ready **region model** specified in `docs/design/sfz_opcode_subset.md`
(design gate #172, amended in PR #320). This is the parser half of the SFZ
sampler track of epic #148; the sampler voice that renders these regions is
#174.

Everything here runs on the setup/slow-pool thread except `resolveLayers()`,
which is allocation-free and does only integer field compares over the
immutable table — safe on the audio thread.

## Linked issue

Closes #173

## Changes

- **`YseEngine/dsp/sfzModel.{hpp,cpp}`** — `parseSFZ` / `loadSFZ` turn `.sfz`
  text into an immutable `sfzInstrument` (a flattened `sfzRegion` table plus a
  de-duplicated sample list).
  - Four-level inheritance `<global> ⊕ <master> ⊕ <group> ⊕ <region>`
    (innermost wins), computed once at parse time.
  - Note-name parsing (`c4 = 60` sfizz convention, sharps/flats, octave −1),
    `key=` shorthand, `default_path` resolution with backslash normalisation,
    `sample=*silence`.
  - Full IN opcode set from spec §4: key/velocity mapping, pitch/tuning
    (`tune`/`transpose`/`pitch_keytrack`), loop, amp EG (`ampeg_*`),
    round-robin (`seq_position`/`seq_length`), choke (`group`/`off_by`/
    `off_mode`), and velocity/key crossfades (`xf*`).
  - **Lenient** (spec §12): unknown/OUT opcodes and malformed values are
    skipped/defaulted and logged; regions with an unresolvable sample are
    dropped; a valid partial instrument still loads. The only hard failure is
    zero valid regions.
  - **`resolveLayers()`** — free function over the immutable table: match →
    round-robin filter → truncate to `YSE_MAX_REGION_LAYERS = 4` by the
    deterministic priority rule (narrowest velocity range, then narrowest key
    range, then last-in-file). Allocation-free, O(regions), fixed 4-slot
    buffer. The parser also sets a **parse-time overflow warning** when any
    `(note, velocity)` cell can exceed the bound.
- **`Tests/dsp/test_sfz_parser.cpp` + `Tests/support/fixtures/sfz_*.sfz`** —
  golden-file tests keyed by `(note, velocity, hit#)` over hand-written
  fixtures, validated against sfizz's documented layering behaviour: `<master>`
  inheritance, key/velocity splits, round-robin + choke (hi-hat pair),
  crossfaded velocity layers, a >4-layer cell (truncation + warning), buffer
  de-dup on a real file, note names, and the lenient error cases. Mapping
  fixtures use `sample=*silence` so the tables are exact with no audio device.
- CMake registration for the new engine source and test TU.

## Scope note (the #173 / #174 seam)

`#173` owns sample **path resolution, de-duplication, and existence-based
region dropping**. Decoding PCM into resident buffers is left to the consumer
(**#174**, the rendering voice): `DSP::fileBuffer::load` is currently a
non-functional JUCE-era stub, and the functional loader is the slow-pool
`abstractSoundFile` read path the voice already needs. Spec §10 explicitly
frames that resident-load helper as additive and consumer-driven, so no
`abstractSoundFile`/`fileBuffer` change is made here. The region-resolution
golden tests — the primary contract per spec §14 — validate parsing and
resolution without decoded audio.

## Test plan

- [x] `clang-format 22.1.4 --dry-run --Werror` clean on all changed files
- [x] `python yse.py analyze` clean on `sfzModel.cpp` and the test TU (no
      new findings in modified code)
- [x] New SFZ suite: **13 test cases / 101 assertions pass**
      (`yse_tests --test-suite=dsp --test-case="sfz*"`)
- [x] Full `dsp` suite green: **361 cases / 60,793 assertions**
- [x] Catch-all unit run green: **1,258 cases / 347,743 assertions**
      (`python yse.py test` — all non-lifecycle suites pass; failures seen
      mid-work were the `end=-1`-vs-`SFZ_UNSET` sentinel collision, fixed)
- [x] No integration/e2e test warranted: the change is offline parser + pure
      resolution logic with no audio-thread runtime surface to drive; region
      resolution is exercised end-to-end by the deterministic golden tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
