### PR TITLE
DSP: SFZ sampler voice (#174)

### DIFF
--- a/Bench/CMakeLists.txt
+++ b/Bench/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(yse_benchmarks
   dsp/bench_reverb.cpp
   dsp/bench_plate_reverb.cpp
   dsp/bench_va_voice.cpp
+  dsp/bench_sampler_voice.cpp
   internal/bench_mpmcqueue.cpp
   patcher/bench_patcher.cpp
   integration/bench_mixing.cpp

--- a/Bench/dsp/bench_sampler_voice.cpp
+++ b/Bench/dsp/bench_sampler_voice.cpp
@@ -1,0 +1,100 @@
+// Microbenchmarks for the SFZ sampler voice (issue #174):
+//   - a single-layer sampler render block (looping, pitch-shifted), and
+//   - a 4-layer render block (worst-case per-voice cost),
+// each next to the reference sineVoice so the sampler's per-voice cost is
+// tracked relative to the cheapest voice (acceptance: "sampler voice vs sine
+// voice cost"). A regression in the cubic read / loop / envelope inner loop is
+// then visible against a stable baseline.
+
+#include "dsp/buffer.hpp"
+#include "headers/constants.hpp"
+#include "headers/enums.hpp"
+#include "synth/samplerVoice.hpp"
+#include "synth/sineVoice.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <cmath>
+#include <memory>
+
+namespace {
+
+  // Build an N-layer sampler instrument: N overlapping full-range regions each
+  // playing a resident, looping sine so the render path exercises the cubic
+  // read + loop wrap + amp EG for every layer.
+  std::shared_ptr<YSE::SYNTH::samplerInstrument> makeInst(int layers) {
+    auto inst = std::make_shared<YSE::SYNTH::samplerInstrument>();
+    const long frames = 4096;
+    const float sr = static_cast<float>(YSE::SAMPLERATE);
+    for (int k = 0; k < layers; ++k) {
+      YSE::SYNTH::residentSample rs;
+      YSE::DSP::fileBuffer buf;
+      buf.resize(static_cast<UInt>(frames));
+      float* p = buf.getPtr();
+      for (long i = 0; i < frames; ++i)
+        p[i] = std::sin(2.0f * 3.14159265358979f * 220.0f * static_cast<float>(i) / sr);
+      rs.frames = frames;
+      rs.loaded = true;
+      rs.channels.push_back(buf);
+      inst->samples.push_back(std::move(rs));
+
+      YSE::DSP::sfzRegion r;
+      r.sampleIndex = k;
+      r.pitchKeycenter = 60;
+      r.egSustain = 1.0f;
+      r.ampVeltrack = 0.0f;
+      r.loopMode = YSE::DSP::SFZ_LOOP_CONTINUOUS;
+      r.loopStart = 0;
+      r.loopEnd = frames - 1;
+      inst->model.regions.push_back(r);
+    }
+    inst->model.valid = true;
+    return inst;
+  }
+
+  void runSampler(benchmark::State& state, int layers) {
+    YSE::SYNTH::samplerVoice v;
+    v.setInstrument(makeInst(layers));
+    v.frequency(64.0f); // pitch-shifted a few semitones off the keycenter
+    v.velocity(0.9f);
+
+    YSE::SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 8; ++i)
+      v.process(intent);
+
+    for (auto _ : state) {
+      v.process(intent); // one STANDARD_BUFFERSIZE block, PLAYING
+      benchmark::DoNotOptimize(v.samples[0].getPtr());
+    }
+    state.SetItemsProcessed(state.iterations() * YSE::STANDARD_BUFFERSIZE);
+  }
+
+  void BM_SamplerVoice_1Layer(benchmark::State& s) {
+    runSampler(s, 1);
+  }
+  BENCHMARK(BM_SamplerVoice_1Layer);
+
+  void BM_SamplerVoice_4Layer(benchmark::State& s) {
+    runSampler(s, 4);
+  }
+  BENCHMARK(BM_SamplerVoice_4Layer);
+
+  // Reference baseline: the cheapest voice, same block, same warm-up.
+  void BM_SineVoice_Reference(benchmark::State& state) {
+    YSE::SYNTH::sineVoice v;
+    v.frequency(64.0f);
+    v.velocity(0.9f);
+    YSE::SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 8; ++i)
+      v.process(intent);
+    for (auto _ : state) {
+      v.process(intent);
+      benchmark::DoNotOptimize(v.samples[0].getPtr());
+    }
+    state.SetItemsProcessed(state.iterations() * YSE::STANDARD_BUFFERSIZE);
+  }
+  BENCHMARK(BM_SineVoice_Reference);
+
+} // namespace

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(YSE_TEST_SOURCES
   dsp/test_module_multichannel.cpp
   dsp/test_synth_voice.cpp
   dsp/test_sfz_parser.cpp
+  dsp/test_sampler_voice.cpp
   dsp/test_ladder_filter.cpp
   dsp/test_va_voice.cpp
   dsp/test_fm_voice.cpp

--- a/Tests/dsp/test_sampler_voice.cpp
+++ b/Tests/dsp/test_sampler_voice.cpp
@@ -1,0 +1,650 @@
+// Tests for YSE::SYNTH::samplerVoice (issue #174) — the SFZ sampler voice that
+// renders the #173 region table.
+//
+// Coverage (acceptance + amended fixtures):
+//   - pitch accuracy across the key range (±1 cent on the interpolated FFT peak),
+//   - seamless looping (no click at the loop point),
+//   - velocity-layer switching,
+//   - ampeg envelope shape (attack rise / sustain / release decay),
+//   - layered-region sum (all matching regions sound),
+//   - crossfade gain law (power vs gain curve),
+//   - round-robin 3-sample cycle order,
+//   - hi-hat choke pair (fast + normal off_mode),
+//   - multi-layer end-of-life (longest layer governs SS_STOPPED),
+//   - clone() shares the immutable instrument (no PCM duplication),
+//   - 16-voice polyphony renders with no audio-thread allocation,
+//   - real file load through DSP::fileBuffer (resident preload).
+//
+// Most fixtures are built programmatically with synthetic in-memory samples, so
+// the pitch/loop/envelope maths is exercised without any audio device or wav
+// asset. One case loads the real test_mono_44100.wav through an .sfz.
+
+#include <doctest/doctest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "synth/samplerVoice.hpp"
+#include "dsp/fourier/fft.hpp"
+#include "dsp/math.hpp"
+#include "headers/constants.hpp"
+#include "support/alloc_probe.hpp"
+#include "support/audio_helpers.hpp"
+
+#ifndef YSE_TEST_FIXTURES_DIR
+#define YSE_TEST_FIXTURES_DIR "../../Tests/support/fixtures"
+#endif
+
+using YSE::SOUND_STATUS;
+using YSE::SYNTH::dspVoice;
+using YSE::SYNTH::residentSample;
+using YSE::SYNTH::samplerConfig;
+using YSE::SYNTH::samplerInstrument;
+using YSE::SYNTH::samplerVoice;
+namespace DSP = YSE::DSP;
+
+namespace {
+
+  std::string fixturesDir() {
+    return std::string(YSE_TEST_FIXTURES_DIR);
+  }
+
+  // Append a synthetic single-channel sample to an instrument and return its
+  // index. `gen(frame)` produces the sample value at each frame.
+  template <typename Fn>
+  int addSample(samplerInstrument& inst, long frames, Fn gen, float srAdjust = 1.0f) {
+    residentSample rs;
+    DSP::fileBuffer buf;
+    buf.resize(static_cast<UInt>(frames));
+    float* p = buf.getPtr();
+    for (long i = 0; i < frames; ++i)
+      p[i] = gen(i);
+    rs.frames = frames;
+    rs.sampleRateAdjustment = srAdjust;
+    rs.loaded = true;
+    rs.channels.push_back(buf);
+    inst.samples.push_back(std::move(rs));
+    return static_cast<int>(inst.samples.size()) - 1;
+  }
+
+  int addSine(samplerInstrument& inst, float hz, long frames) {
+    const float sr = static_cast<float>(YSE::SAMPLERATE);
+    return addSample(inst, frames, [=](long i) {
+      return std::sin(2.0f * 3.14159265358979f * hz * static_cast<float>(i) / sr);
+    });
+  }
+
+  int addConst(samplerInstrument& inst, float value, long frames) {
+    return addSample(inst, frames, [=](long) { return value; });
+  }
+
+  // A one-region instrument playing sample `sampleIdx`.
+  DSP::sfzRegion baseRegion(int sampleIdx, int keycenter = 60) {
+    DSP::sfzRegion r;
+    r.sampleIndex = sampleIdx;
+    r.pitchKeycenter = keycenter;
+    r.lokey = 0;
+    r.hikey = 127;
+    r.egAttack = 0.0f;
+    r.egRelease = 0.005f;
+    r.egSustain = 1.0f;
+    r.ampVeltrack = 0.0f; // velocity does not attenuate unless a test asks for it
+    return r;
+  }
+
+  // Render one WANTSTOPLAY note into `out` (N samples), warming `warm` blocks.
+  unsigned captureNote(samplerVoice& v, DSP::buffer& out, unsigned N, int warm = 2) {
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < warm; ++i)
+      v.process(intent);
+    const unsigned block = YSE::STANDARD_BUFFERSIZE;
+    unsigned filled = 0;
+    while (filled + block <= N) {
+      v.process(intent);
+      out.copyFrom(v.samples[0], 0, filled, block);
+      filled += block;
+    }
+    return filled;
+  }
+
+  // Interpolated fundamental frequency of a captured tone: Hann-window, FFT,
+  // parabolic peak interpolation. Well under a cent for a clean tone.
+  float estimateHz(DSP::buffer& sig, unsigned N) {
+    DSP::buffer re(N), im(N);
+    re = 0.f;
+    im = 0.f;
+    float* s = sig.getPtr();
+    float* r = re.getPtr();
+    for (unsigned i = 0; i < N; ++i) {
+      float w = 0.5f * (1.0f - std::cos(2.0f * 3.14159265358979f * i / (N - 1)));
+      r[i] = s[i] * w;
+    }
+    DSP::fft f;
+    f(re, im);
+    float* fr = f.getReal().getPtr();
+    float* fi = f.getImaginary().getPtr();
+    unsigned peak = TestHelpers::peakBinIndex(fr, fi, N);
+    auto mag = [&](unsigned k) { return std::sqrt(fr[k] * fr[k] + fi[k] * fi[k]); };
+    float m0 = mag(peak - 1), m1 = mag(peak), m2 = mag(peak + 1);
+    float denom = (m0 - 2.0f * m1 + m2);
+    float delta = denom != 0.0f ? 0.5f * (m0 - m2) / denom : 0.0f;
+    float binHz = static_cast<float>(YSE::SAMPLERATE) / static_cast<float>(N);
+    return (static_cast<float>(peak) + delta) * binHz;
+  }
+
+  float cents(float a, float b) {
+    return 1200.0f * std::log2(a / b);
+  }
+
+  void releaseToStop(samplerVoice& v, int maxBlocks = 4000) {
+    SOUND_STATUS intent = YSE::SS_WANTSTOSTOP;
+    int b = 0;
+    while (intent != YSE::SS_STOPPED && b < maxBlocks) {
+      v.process(intent);
+      ++b;
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("dsp") {
+
+  // ─── pitch accuracy across the key range ─────────────────────────────────
+
+  TEST_CASE("samplerVoice: rendered pitch tracks the note within 1 cent") {
+    const int kc = 60;
+    const float f0 = DSP::MidiToFreq(static_cast<float>(kc));
+    auto inst = std::make_shared<samplerInstrument>();
+    int idx = addSine(*inst, f0, 4 * static_cast<long>(YSE::SAMPLERATE)); // 4 s
+    DSP::sfzRegion r = baseRegion(idx, kc);
+    r.loopMode = DSP::SFZ_NO_LOOP;
+    inst->model.regions.push_back(r);
+    inst->model.valid = true;
+
+    for (int note : {40, 48, 60, 67, 72}) {
+      samplerVoice v;
+      v.setInstrument(inst);
+      v.frequency(static_cast<float>(note));
+      v.velocity(1.0f);
+      // A long FFT + Hann-windowed parabolic peak resolves the tone to well
+      // under a cent (bin width ~0.67 Hz at 44.1 kHz).
+      const unsigned N = 65536;
+      DSP::buffer cap(N);
+      cap = 0.f;
+      REQUIRE(captureNote(v, cap, N) == N);
+      float hz = estimateHz(cap, N);
+      float want = DSP::MidiToFreq(static_cast<float>(note));
+      CHECK(std::abs(cents(hz, want)) < 1.0f);
+    }
+  }
+
+  // ─── seamless looping ────────────────────────────────────────────────────
+
+  TEST_CASE("samplerVoice: loop_continuous sustains without a click at the seam") {
+    // One exact period of a sine — the whole sample is the loop region, so a
+    // seamless wrap reproduces a continuous sine.
+    const long period = 100; // 441 Hz at 44100
+    auto inst = std::make_shared<samplerInstrument>();
+    int idx = addSample(*inst, period, [=](long i) {
+      return std::sin(2.0f * 3.14159265358979f * static_cast<float>(i) /
+                      static_cast<float>(period));
+    });
+    DSP::sfzRegion r = baseRegion(idx, 60);
+    r.loopMode = DSP::SFZ_LOOP_CONTINUOUS;
+    r.loopStart = 0;
+    r.loopEnd = period - 1;
+    inst->model.regions.push_back(r);
+    inst->model.valid = true;
+
+    samplerVoice v;
+    v.setInstrument(inst);
+    v.frequency(60.0f); // speed 1 → reads the sample verbatim, wrapping the loop
+    v.velocity(1.0f);
+
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 4; ++i)
+      v.process(intent); // settle the (instant) attack
+
+    float prev = 0.f;
+    bool havePrev = false;
+    float maxStep = 0.f;
+    float peak = 0.f;
+    for (int b = 0; b < 200; ++b) { // ~580 loop wraps
+      v.process(intent);
+      float* out = v.samples[0].getPtr();
+      for (unsigned i = 0; i < v.samples[0].getLength(); ++i) {
+        if (havePrev) maxStep = std::max(maxStep, std::abs(out[i] - prev));
+        peak = std::max(peak, std::abs(out[i]));
+        prev = out[i];
+        havePrev = true;
+      }
+    }
+    CHECK(peak > 0.5f); // actually sounding
+    // A continuous 441 Hz sine steps by at most ~2π·441/44100 ≈ 0.063 per sample.
+    // A discontinuity at the loop seam would be a near-full-scale jump.
+    CHECK(maxStep < 0.15f);
+  }
+
+  // ─── amplitude envelope shape ────────────────────────────────────────────
+
+  TEST_CASE("samplerVoice: ampeg envelope shapes attack / sustain / release") {
+    auto inst = std::make_shared<samplerInstrument>();
+    int idx = addConst(*inst, 1.0f, static_cast<long>(YSE::SAMPLERATE)); // 1 s of DC
+    DSP::sfzRegion r = baseRegion(idx, 60);
+    r.egAttack = 0.05f;
+    r.egDecay = 0.0f;
+    r.egSustain = 0.5f;
+    r.egRelease = 0.05f;
+    inst->model.regions.push_back(r);
+    inst->model.valid = true;
+
+    samplerVoice v;
+    v.setInstrument(inst);
+    v.frequency(60.0f);
+    v.velocity(1.0f);
+
+    // With a DC=1 sample and no velocity tracking, output == the envelope.
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    float firstBlock = TestHelpers::measureRms(v.samples[0]); // mid-attack, small
+    for (int i = 0; i < 60; ++i)
+      v.process(intent); // reach sustain
+    float sustainLvl = TestHelpers::measureRms(v.samples[0]);
+
+    CHECK(firstBlock < sustainLvl); // attack ramps up
+    CHECK(sustainLvl == doctest::Approx(0.5f).epsilon(0.05)); // holds sustain
+
+    releaseToStop(v);
+    v.process(intent = YSE::SS_STOPPED);
+    CHECK(TestHelpers::decaysToSilence(v.samples[0], 1e-4f)); // release reached 0
+  }
+
+  // ─── velocity-layer switching ────────────────────────────────────────────
+
+  TEST_CASE("samplerVoice: velocity selects the matching layer") {
+    auto inst = std::make_shared<samplerInstrument>();
+    int soft = addConst(*inst, 0.3f, 2000);
+    int hard = addConst(*inst, 0.9f, 2000);
+    DSP::sfzRegion rs = baseRegion(soft, 60);
+    rs.lovel = 1;
+    rs.hivel = 63;
+    DSP::sfzRegion rh = baseRegion(hard, 60);
+    rh.lovel = 64;
+    rh.hivel = 127;
+    inst->model.regions.push_back(rs); // index 0 = soft
+    inst->model.regions.push_back(rh); // index 1 = hard
+    inst->model.valid = true;
+
+    samplerVoice v;
+    v.setInstrument(inst);
+
+    v.frequency(60.0f);
+    v.velocity(30.0f / 127.0f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    CHECK(v.activeLayers() == 1);
+    CHECK(v.layerRegion(0) == 0); // soft
+    releaseToStop(v);
+
+    v.frequency(60.0f);
+    v.velocity(100.0f / 127.0f);
+    intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    CHECK(v.activeLayers() == 1);
+    CHECK(v.layerRegion(0) == 1); // hard
+  }
+
+  // ─── layered-region sum ──────────────────────────────────────────────────
+
+  TEST_CASE("samplerVoice: overlapping regions all sound and sum") {
+    auto inst = std::make_shared<samplerInstrument>();
+    int a = addConst(*inst, 0.5f, 4000);
+    int b = addConst(*inst, 0.5f, 4000);
+    inst->model.regions.push_back(baseRegion(a, 60)); // both full-range
+    inst->model.regions.push_back(baseRegion(b, 60));
+    inst->model.valid = true;
+
+    samplerVoice v;
+    v.setInstrument(inst);
+    v.frequency(60.0f);
+    v.velocity(1.0f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 4; ++i)
+      v.process(intent);
+    CHECK(v.activeLayers() == 2);
+    // 0.5 + 0.5 = 1.0 at full envelope.
+    CHECK(TestHelpers::measureRms(v.samples[0]) == doctest::Approx(1.0f).epsilon(0.02));
+  }
+
+  // ─── crossfade gain law ──────────────────────────────────────────────────
+
+  TEST_CASE("samplerVoice: velocity crossfade follows the power / gain curve") {
+    auto build = [](int curve) {
+      auto inst = std::make_shared<samplerInstrument>();
+      int a = addConst(*inst, 1.0f, 2000);
+      int b = addConst(*inst, 1.0f, 2000);
+      DSP::sfzRegion r0 = baseRegion(a, 60); // fades OUT over vel 60..80
+      r0.lovel = 1;
+      r0.hivel = 127;
+      r0.xfoutLovel = 60;
+      r0.xfoutHivel = 80;
+      r0.xfVelcurve = curve;
+      DSP::sfzRegion r1 = baseRegion(b, 60); // fades IN over vel 60..80
+      r1.lovel = 1;
+      r1.hivel = 127;
+      r1.xfinLovel = 60;
+      r1.xfinHivel = 80;
+      r1.xfVelcurve = curve;
+      inst->model.regions.push_back(r0);
+      inst->model.regions.push_back(r1);
+      inst->model.valid = true;
+      return inst;
+    };
+
+    // At velocity 70 the fade fraction is 0.5 on both layers.
+    {
+      samplerVoice v;
+      v.setInstrument(build(DSP::SFZ_CURVE_POWER));
+      v.frequency(60.0f);
+      v.velocity(70.0f / 127.0f);
+      SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+      v.process(intent);
+      REQUIRE(v.activeLayers() == 2);
+      const float eq = std::sqrt(0.5f); // equal power
+      CHECK(v.layerGain(0) == doctest::Approx(eq).epsilon(0.001));
+      CHECK(v.layerGain(1) == doctest::Approx(eq).epsilon(0.001));
+    }
+    {
+      samplerVoice v;
+      v.setInstrument(build(DSP::SFZ_CURVE_GAIN));
+      v.frequency(60.0f);
+      v.velocity(70.0f / 127.0f);
+      SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+      v.process(intent);
+      REQUIRE(v.activeLayers() == 2);
+      CHECK(v.layerGain(0) == doctest::Approx(0.5f).epsilon(0.001)); // linear
+      CHECK(v.layerGain(1) == doctest::Approx(0.5f).epsilon(0.001));
+    }
+  }
+
+  // ─── round-robin cycle order ─────────────────────────────────────────────
+
+  TEST_CASE("samplerVoice: round-robin cycles 3 samples in seq order") {
+    auto inst = std::make_shared<samplerInstrument>();
+    for (int k = 0; k < 3; ++k) {
+      int s = addConst(*inst, 0.5f, 1000);
+      DSP::sfzRegion r = baseRegion(s, 42);
+      r.lokey = r.hikey = 42;
+      r.seqLength = 3;
+      r.seqPosition = k + 1;
+      inst->model.regions.push_back(r);
+    }
+    inst->model.valid = true;
+
+    samplerVoice v;
+    v.setInstrument(inst);
+
+    // Successive hits of key 42 must select regions 0,1,2,0,1,2 in order.
+    for (int hit = 0; hit < 6; ++hit) {
+      v.frequency(42.0f);
+      v.velocity(1.0f);
+      SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+      v.process(intent);
+      CHECK(v.activeLayers() == 1);
+      CHECK(v.layerRegion(0) == hit % 3);
+      releaseToStop(v);
+    }
+  }
+
+  // ─── hi-hat choke pair (fast + normal) ───────────────────────────────────
+
+  TEST_CASE("samplerVoice: choke group silences off_by voices (fast + normal)") {
+    auto buildKit = [](int openOffMode) {
+      auto inst = std::make_shared<samplerInstrument>();
+      int closed = addConst(*inst, 0.5f, 4000);
+      int open = addConst(*inst, 0.5f, static_cast<long>(YSE::SAMPLERATE)); // long one-shot
+      DSP::sfzRegion rc = baseRegion(closed, 42); // closed hat, group 1
+      rc.lokey = rc.hikey = 42;
+      rc.chokeGroup = 1;
+      rc.offBy = 2;
+      DSP::sfzRegion ro = baseRegion(open, 46); // open hat, group 2, choked by 1
+      ro.lokey = ro.hikey = 46;
+      ro.chokeGroup = 2;
+      ro.offBy = 1;
+      ro.offMode = openOffMode;
+      ro.loopMode = DSP::SFZ_ONE_SHOT; // rings until choked
+      inst->model.regions.push_back(rc);
+      inst->model.regions.push_back(ro);
+      inst->model.valid = true;
+      return inst;
+    };
+
+    for (int mode : {DSP::SFZ_OFF_FAST, DSP::SFZ_OFF_NORMAL}) {
+      auto inst = buildKit(mode);
+      samplerVoice proto;
+      proto.setInstrument(inst);
+      std::unique_ptr<dspVoice> openV(proto.clone());
+      std::unique_ptr<dspVoice> closedV(proto.clone());
+      auto* vOpen = static_cast<samplerVoice*>(openV.get());
+      auto* vClosed = static_cast<samplerVoice*>(closedV.get());
+
+      // Open hat starts and rings.
+      vOpen->frequency(46.0f);
+      vOpen->velocity(1.0f);
+      SOUND_STATUS iOpen = YSE::SS_WANTSTOPLAY;
+      vOpen->process(iOpen);
+      for (int i = 0; i < 10; ++i)
+        vOpen->process(iOpen);
+      REQUIRE(iOpen == YSE::SS_PLAYING);
+      REQUIRE(TestHelpers::measureRms(vOpen->samples[0]) > 0.1f);
+
+      // Closed hat fires group 1 → chokes the open hat (off_by = 1).
+      vClosed->frequency(42.0f);
+      vClosed->velocity(1.0f);
+      SOUND_STATUS iClosed = YSE::SS_WANTSTOPLAY;
+      vClosed->process(iClosed);
+
+      // The open hat must die: fast within a few blocks, normal after its release.
+      int blocks = 0;
+      const int kMax = 5000;
+      while (iOpen != YSE::SS_STOPPED && blocks < kMax) {
+        vOpen->process(iOpen);
+        ++blocks;
+      }
+      CHECK(iOpen == YSE::SS_STOPPED);
+      if (mode == DSP::SFZ_OFF_FAST) CHECK(blocks < 8); // ~5 ms declick
+    }
+  }
+
+  // ─── multi-layer end-of-life ─────────────────────────────────────────────
+
+  TEST_CASE("samplerVoice: voice ends only when the longest layer release finishes") {
+    auto inst = std::make_shared<samplerInstrument>();
+    int a = addConst(*inst, 0.5f, 8000);
+    int b = addConst(*inst, 0.5f, 8000);
+    DSP::sfzRegion rShort = baseRegion(a, 60);
+    rShort.egRelease = 0.005f; // very short tail
+    DSP::sfzRegion rLong = baseRegion(b, 60);
+    rLong.egRelease = 0.20f; // long tail
+    inst->model.regions.push_back(rShort);
+    inst->model.regions.push_back(rLong);
+    inst->model.valid = true;
+
+    samplerVoice v;
+    v.setInstrument(inst);
+    v.frequency(60.0f);
+    v.velocity(1.0f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 4; ++i)
+      v.process(intent);
+    REQUIRE(v.activeLayers() == 2);
+
+    // Release: the short layer finishes early but the voice keeps sounding until
+    // the long layer's 200 ms release completes.
+    intent = YSE::SS_WANTSTOSTOP;
+    int shortGoneAt = -1, stoppedAt = -1;
+    for (int b2 = 0; b2 < 4000 && intent != YSE::SS_STOPPED; ++b2) {
+      v.process(intent);
+      if (shortGoneAt < 0 && v.activeLayers() == 1) shortGoneAt = b2;
+      if (intent == YSE::SS_STOPPED) stoppedAt = b2;
+    }
+    CHECK(intent == YSE::SS_STOPPED);
+    CHECK(shortGoneAt >= 0);
+    CHECK(stoppedAt > shortGoneAt); // longer layer outlived the shorter one
+  }
+
+  // ─── clone shares the immutable instrument ───────────────────────────────
+
+  TEST_CASE("samplerVoice: clone shares the instrument and PCM, keeps own state") {
+    auto inst = std::make_shared<samplerInstrument>();
+    int idx = addConst(*inst, 0.5f, 2000);
+    inst->model.regions.push_back(baseRegion(idx, 60));
+    inst->model.valid = true;
+
+    samplerVoice proto;
+    proto.setInstrument(inst);
+    std::unique_ptr<dspVoice> a(proto.clone());
+    std::unique_ptr<dspVoice> b(proto.clone());
+    auto* va = static_cast<samplerVoice*>(a.get());
+    auto* vb = static_cast<samplerVoice*>(b.get());
+
+    // Same shared instrument and same resident PCM pointer (no duplication).
+    CHECK(va->instrument().get() == inst.get());
+    CHECK(vb->instrument().get() == inst.get());
+    CHECK(va->instrument()->samples[0].channels[0].getPtr() ==
+          vb->instrument()->samples[0].channels[0].getPtr());
+
+    // Independent render state: driving one leaves the other silent.
+    va->frequency(60.0f);
+    va->velocity(1.0f);
+    SOUND_STATUS ia = YSE::SS_WANTSTOPLAY;
+    for (int i = 0; i < 4; ++i)
+      va->process(ia);
+    CHECK(vb->samples[0].isSilent());
+  }
+
+  // ─── no region matched → clean drop ──────────────────────────────────────
+
+  TEST_CASE("samplerVoice: a note with no matching region drops to STOPPED") {
+    auto inst = std::make_shared<samplerInstrument>();
+    int idx = addConst(*inst, 0.5f, 1000);
+    DSP::sfzRegion r = baseRegion(idx, 60);
+    r.lokey = r.hikey = 60; // only key 60
+    inst->model.regions.push_back(r);
+    inst->model.valid = true;
+
+    samplerVoice v;
+    v.setInstrument(inst);
+    v.frequency(48.0f); // no region covers key 48
+    v.velocity(1.0f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    CHECK(intent == YSE::SS_STOPPED);
+    CHECK(v.samples[0].isSilent());
+  }
+
+  // ─── 16-voice polyphony: no audio-thread allocation ──────────────────────
+
+  TEST_CASE("samplerVoice: 16-voice polyphony renders without audio-thread alloc") {
+    auto inst = std::make_shared<samplerInstrument>();
+    int lo = addConst(*inst, 0.5f, 8000);
+    int hi = addSine(*inst, 440.0f, 8000);
+    DSP::sfzRegion r0 = baseRegion(lo, 60);
+    r0.lovel = 1;
+    r0.hivel = 100;
+    r0.loopMode = DSP::SFZ_LOOP_CONTINUOUS;
+    r0.loopStart = 0;
+    r0.loopEnd = 7999;
+    DSP::sfzRegion r1 = baseRegion(hi, 60); // overlaps → layered voice
+    r1.lovel = 1;
+    r1.hivel = 127;
+    inst->model.regions.push_back(r0);
+    inst->model.regions.push_back(r1);
+    inst->model.valid = true;
+
+    samplerVoice proto;
+    proto.setInstrument(inst);
+    std::vector<std::unique_ptr<dspVoice>> voices;
+    for (int i = 0; i < 16; ++i)
+      voices.emplace_back(proto.clone());
+
+    auto drive = [&](bool underProbe) {
+      for (int i = 0; i < 16; ++i) {
+        auto* v = static_cast<samplerVoice*>(voices[i].get());
+        v->frequency(static_cast<float>(48 + i));
+        v->velocity(0.8f);
+        SOUND_STATUS in = YSE::SS_WANTSTOPLAY;
+        v->process(in);
+        for (int b = 0; b < 6; ++b)
+          v->process(in);
+        in = YSE::SS_WANTSTOSTOP;
+        for (int b = 0; b < 200 && in != YSE::SS_STOPPED; ++b)
+          v->process(in);
+        (void)underProbe;
+      }
+    };
+
+    drive(false); // warm every path (attack / loop / release / retrigger)
+
+    {
+      TestHelpers::ProbeScope probe;
+      drive(true);
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+  }
+
+  // ─── real file load through the resident preload path ────────────────────
+
+  TEST_CASE("samplerVoice: loads a real .sfz and renders its PCM (resident preload)") {
+    // sfz_dedup.sfz names the real test_mono_44100.wav twice (de-duped by #173).
+    samplerVoice v;
+    bool ok = v.loadSFZ(fixturesDir() + "/sfz_dedup.sfz");
+    REQUIRE(ok);
+    REQUIRE(v.instrument()->valid());
+    // One de-duplicated, resident sample with actual PCM frames.
+    REQUIRE(v.instrument()->samples.size() == 1);
+    CHECK(v.instrument()->samples[0].loaded);
+    CHECK(v.instrument()->samples[0].frames > 0);
+
+    v.frequency(60.0f); // key 60 is covered by the c4 region
+    v.velocity(1.0f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    CHECK(intent == YSE::SS_PLAYING);
+    for (int i = 0; i < 4; ++i)
+      v.process(intent);
+    // The voice resolved a layer and is rendering (PCM decoded, not silent stub).
+    CHECK(v.activeLayers() >= 1);
+  }
+
+  // ─── samplerConfig facade ────────────────────────────────────────────────
+
+  TEST_CASE("samplerVoice: samplerConfig builds a one-region instrument from a file") {
+    std::string wav = fixturesDir() + "/test_mono_44100.wav";
+    samplerConfig cfg;
+    cfg.name("test").file(wav.c_str()).root(60).range(48, 72).envelope(0.0f, 0.1f, 5.0f);
+
+    samplerVoice v;
+    REQUIRE(v.configure(cfg));
+    REQUIRE(v.instrument()->valid());
+    REQUIRE(v.instrument()->model.regions.size() == 1);
+    CHECK(v.instrument()->model.regions[0].pitchKeycenter == 60);
+    CHECK(v.instrument()->model.regions[0].lokey == 48);
+    CHECK(v.instrument()->model.regions[0].hikey == 72);
+
+    v.frequency(60.0f);
+    v.velocity(1.0f);
+    SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 4; ++i)
+      v.process(intent);
+    CHECK(v.activeLayers() == 1);
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -151,6 +151,7 @@ set(YSE_SRCS
   sound/soundManager.cpp
   synth/sineVoice.cpp
   synth/vaVoice.cpp
+  synth/samplerVoice.cpp
   synth/positionHandlers.cpp
   synth/synthImplementation.cpp
   synth/synthInterface.cpp

--- a/YseEngine/dsp/fileBuffer.cpp
+++ b/YseEngine/dsp/fileBuffer.cpp
@@ -10,34 +10,65 @@
 
 #include "fileBuffer.hpp"
 #include "../internalHeaders.h"
+#include "../internal/customFileReader.h"
 #include "../io.hpp"
 
-/*namespace YSE {
-  namespace DSP {
+#include <algorithm>
+#include <sndfile.hh>
+#include <vector>
 
-    // exists in sampleFunctions.cpp
-    juce::AudioFormatReader * getReader(const char * fileName);
+// Resident full-preload of one channel of an audio file into this buffer
+// (issue #174). #173 deferred PCM decode to the sampler as the first consumer,
+// because this was a non-functional stub. It is now a real libsndfile-backed
+// load: the whole file is decoded into RAM on the calling (setup / slow-pool)
+// thread — never the audio thread — so the sampler voice's process() is a pure
+// in-RAM interpolated read (spec §9/§10). Honours the custom-IO backend
+// (BufferIO / IO()) exactly as INTERNAL::soundFile::loadNonStreaming does.
+bool YSE::DSP::fileBuffer::load(const char* fileName, UInt channel) {
+  if (fileName == nullptr) return false;
+
+  void* ioHandle = nullptr;
+  SndfileHandle handle;
+  if (IO().getActive()) {
+    long long size = 0;
+    if (!INTERNAL::customFileReader::Open(fileName, &size, &ioHandle)) return false;
+    handle = SndfileHandle(INTERNAL::customFileReader::GetVIO(), ioHandle);
+  } else {
+    handle = SndfileHandle(fileName);
   }
-}*/
 
-bool YSE::DSP::fileBuffer::load(const char* /*fileName*/, UInt /*channel*/) {
-  /*ScopedPointer<AudioFormatReader> reader = getReader(fileName);
-  if (reader == nullptr) return false;
-  if (channel >= reader->numChannels) return false;
+  if (!handle) {
+    if (ioHandle != nullptr) INTERNAL::customFileReader::Close(ioHandle);
+    return false;
+  }
 
-  juce::AudioSampleBuffer tBuf;
-  tBuf.setSize(reader->numChannels, (Int)reader->lengthInSamples);
-  reader->read(&tBuf, 0, (Int)reader->lengthInSamples, 0, true, true);
+  const int fileChannels = handle.channels();
+  const long frames = static_cast<long>(handle.frames());
+  if (static_cast<int>(channel) >= fileChannels || frames <= 0) {
+    if (ioHandle != nullptr) INTERNAL::customFileReader::Close(ioHandle);
+    return false;
+  }
 
-  setSampleRateAdjustment(static_cast<Flt>(reader->sampleRate) / static_cast<Flt>(SAMPLERATE));
+  setSampleRateAdjustment(static_cast<Flt>(handle.samplerate()) / static_cast<Flt>(SAMPLERATE));
+  resize(static_cast<UInt>(frames));
+  Flt* out = getPtr();
 
-  resize(tBuf.getNumSamples());
-  const float * in = tBuf.getReadPointer(channel);
-  Flt * out = getPtr();
-  for (int i = 0; i < tBuf.getNumSamples(); i++) {
-    *out++ = *in++;
-  }*/
+  // Read interleaved in bounded chunks and pull out the requested channel. A
+  // fixed scratch keeps peak memory low for many-channel files.
+  const long kChunkFrames = 8192;
+  std::vector<float> scratch(static_cast<size_t>(kChunkFrames) * fileChannels);
+  long done = 0;
+  while (done < frames) {
+    sf_count_t want = std::min<long>(kChunkFrames, frames - done);
+    sf_count_t got = handle.readf(scratch.data(), want);
+    if (got <= 0) break;
+    for (sf_count_t i = 0; i < got; ++i) {
+      out[done + i] = scratch[static_cast<size_t>(i) * fileChannels + channel];
+    }
+    done += got;
+  }
 
+  if (ioHandle != nullptr) INTERNAL::customFileReader::Close(ioHandle);
   copyOverflow();
   return true;
 }

--- a/YseEngine/synth/samplerVoice.cpp
+++ b/YseEngine/synth/samplerVoice.cpp
@@ -1,0 +1,573 @@
+/*
+  ==============================================================================
+
+    samplerVoice.cpp
+    SFZ sampler voice — see samplerVoice.hpp and
+    docs/design/sfz_opcode_subset.md.
+
+  ==============================================================================
+*/
+
+#include "samplerVoice.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "../headers/constants.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    // Pitch-wheel bend range, semitones per unit deflection (§6 recommends ±2).
+    static const double kBendRangeSemitones = 2.0;
+    // Amp-EG release floor (~5 ms) so a released note never hard-cuts (§8).
+    static const Flt kReleaseFloor = 0.005f;
+    // Fast-choke declick, seconds — the voice-side equivalent of the engine
+    // steal-fade for off_mode=fast (§4).
+    static const Flt kChokeFadeSec = 0.005f;
+    // Smallest legal envelope segment, seconds (avoids divide-by-zero slopes).
+    static const Flt kMinSegment = 1e-5f;
+
+    static inline Flt clampf(Flt v, Flt lo, Flt hi) {
+      return v < lo ? lo : (v > hi ? hi : v);
+    }
+    static inline long clampl(long v, long lo, long hi) {
+      return v < lo ? lo : (v > hi ? hi : v);
+    }
+
+    // ---- sfzADSR (allocation-free DAHDSR) ---------------------------------
+
+    void sfzADSR::configure(Flt delay, Flt attack, Flt hold, Flt decay, Flt sustain, Flt release,
+                            Flt sr_) {
+      sr = sr_ > 0.0f ? sr_ : 44100.0f;
+      sus = clampf(sustain, 0.0f, 1.0f);
+      delaySamps = static_cast<long>(std::max(0.0f, delay) * sr);
+      holdSamps = static_cast<long>(std::max(0.0f, hold) * sr);
+      const Flt aT = std::max(attack, kMinSegment);
+      const Flt dT = std::max(decay, kMinSegment);
+      rSecs = std::max(release, kMinSegment);
+      aInc = 1.0f / (aT * sr);
+      dInc = (1.0f - sus) / (dT * sr);
+      rInc = 1.0f / (rSecs * sr);
+    }
+
+    void sfzADSR::gateOn() {
+      lvl = 0.0f;
+      delayCnt = delaySamps;
+      holdCnt = holdSamps;
+      stage = delaySamps > 0 ? DELAY : ATTACK;
+    }
+
+    void sfzADSR::gateOff() {
+      if (stage == IDLE || stage == DONE) return;
+      rInc = (rSecs > 0.0f) ? (lvl / (rSecs * sr)) : lvl;
+      if (rInc <= 0.0f) rInc = 1.0f; // already silent -> finish next tick
+      stage = RELEASE;
+    }
+
+    Flt sfzADSR::tick() {
+      switch (stage) {
+      case IDLE:
+        return 0.0f;
+      case DELAY:
+        if (delayCnt-- > 0) return 0.0f;
+        stage = ATTACK;
+        [[fallthrough]];
+      case ATTACK:
+        lvl += aInc;
+        if (lvl >= 1.0f) {
+          lvl = 1.0f;
+          holdCnt = holdSamps;
+          stage = holdSamps > 0 ? HOLD : DECAY;
+        }
+        return lvl;
+      case HOLD:
+        if (holdCnt-- > 0) return lvl;
+        stage = DECAY;
+        return lvl;
+      case DECAY:
+        lvl -= dInc;
+        if (lvl <= sus) {
+          lvl = sus;
+          stage = SUSTAIN;
+        }
+        return lvl;
+      case SUSTAIN:
+        return lvl;
+      case RELEASE:
+        lvl -= rInc;
+        if (lvl <= 0.0f) {
+          lvl = 0.0f;
+          stage = DONE;
+        }
+        return lvl;
+      case DONE:
+      default:
+        return 0.0f;
+      }
+    }
+
+    // ---- samplerInstrument ------------------------------------------------
+
+    bool samplerInstrument::load() {
+      if (!model.valid) return false;
+
+      samples.clear();
+      samples.resize(model.samples.size());
+      bool anyLoaded = false;
+      for (size_t i = 0; i < model.samples.size(); ++i) {
+        residentSample& rs = samples[i];
+        const DSP::sfzSample& src = model.samples[i];
+        if (src.silence) {
+          rs.silence = true;
+          rs.loaded = true;
+          rs.frames = 0;
+          anyLoaded = true;
+          continue;
+        }
+        DSP::fileBuffer ch0;
+        if (!ch0.load(src.path.c_str(), 0)) {
+          rs.loaded = false; // regions naming it will render silence
+          continue;
+        }
+        rs.frames = static_cast<long>(ch0.getLength());
+        rs.sampleRateAdjustment = ch0.getSampleRateAdjustment();
+        rs.channels.push_back(ch0);
+        DSP::fileBuffer ch1;
+        if (ch1.load(src.path.c_str(), 1)) rs.channels.push_back(ch1);
+        rs.loaded = true;
+        anyLoaded = true;
+      }
+      (void)anyLoaded;
+      return valid();
+    }
+
+    uint32_t samplerInstrument::bumpChoke(int g) {
+      if (g <= 0) return 0;
+      int idx = g >= kMaxChokeGroups ? kMaxChokeGroups - 1 : g;
+      return ++chokeGenerations[static_cast<size_t>(idx)];
+    }
+
+    uint32_t samplerInstrument::chokeGen(int g) const {
+      if (g <= 0) return 0;
+      int idx = g >= kMaxChokeGroups ? kMaxChokeGroups - 1 : g;
+      return chokeGenerations[static_cast<size_t>(idx)];
+    }
+
+    // ---- samplerConfig facade ---------------------------------------------
+
+    bool samplerConfig::build(samplerInstrument& inst) const {
+      inst.model = DSP::sfzInstrument{};
+      if (file_.empty()) return false;
+
+      DSP::sfzSample s;
+      s.path = file_;
+      s.silence = false;
+      inst.model.samples.push_back(s);
+
+      DSP::sfzRegion r; // defaults from the model
+      r.sampleIndex = 0;
+      r.pitchKeycenter = root_;
+      r.lokey = low_;
+      r.hikey = high_;
+      r.egAttack = attack_;
+      r.egRelease = release_;
+      r.ampVeltrack = 100.0f;
+      r.loopMode = DSP::SFZ_NO_LOOP; // the facade never exposed looping (§11)
+      inst.model.regions.push_back(r);
+      inst.model.valid = true;
+      inst.model.sourceFile = name_;
+
+      if (!inst.load()) return false;
+
+      // maxLength caps the one-shot length (§11): clamp `end` to maxLength
+      // seconds of source audio. Not a native SFZ opcode.
+      if (!inst.samples.empty() && inst.samples[0].loaded && inst.samples[0].frames > 0) {
+        const long frames = inst.samples[0].frames;
+        const Flt sra = inst.samples[0].sampleRateAdjustment;
+        long end = frames - 1;
+        long cap = static_cast<long>(maxLength_ * static_cast<Flt>(SAMPLERATE) * sra);
+        if (cap > 0 && cap < end) end = cap;
+        inst.model.regions[0].endFrame = end;
+      }
+      return true;
+    }
+
+    // ---- samplerVoice -----------------------------------------------------
+
+    samplerVoice::samplerVoice(int outputChannels) : dspVoice(outputChannels) {
+      chokeFadeSamps = std::max(1, static_cast<int>(static_cast<Flt>(SAMPLERATE) * kChokeFadeSec));
+    }
+
+    samplerVoice::samplerVoice(const samplerVoice& other)
+      : dspVoice(other), inst(other.inst) { // share the immutable instrument (spec §10)
+      note_.store(other.note_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+      chokeFadeSamps = other.chokeFadeSamps;
+      // per-voice playback state stays at rest (fresh, independent of the prototype)
+    }
+
+    dspVoice* samplerVoice::clone() {
+      return new samplerVoice(*this);
+    }
+
+    void samplerVoice::frequency(Flt midiNote) {
+      dspVoice::frequency(midiNote); // base stores Hz for the position/pan path
+      note_.store(static_cast<int>(std::lround(midiNote)), std::memory_order_relaxed);
+    }
+
+    bool samplerVoice::loadSFZ(const std::string& path) {
+      inst = std::make_shared<samplerInstrument>();
+      inst->model = DSP::loadSFZ(path);
+      return inst->load();
+    }
+
+    bool samplerVoice::configure(const samplerConfig& cfg) {
+      inst = std::make_shared<samplerInstrument>();
+      return cfg.build(*inst);
+    }
+
+    // Same cubic kernel as DSP::interpolate4, with loop-region-aware tap fetch so
+    // the 4 taps stay valid across a seamless loop seam (spec §7).
+    Flt samplerVoice::cubic(const Flt* d, long n, double pos, long loopStart, long loopEnd,
+                            bool looping) {
+      const long loopLen = loopEnd - loopStart + 1;
+      auto tap = [&](long t) -> Flt {
+        if (looping && loopLen > 0) {
+          if (t > loopEnd)
+            t = loopStart + ((t - loopStart) % loopLen);
+          else if (t < loopStart)
+            t = loopStart; // pre-loop guard; positions only wrap forward
+        }
+        if (t < 0) t = 0;
+        if (t >= n) t = n - 1;
+        return d[t];
+      };
+      long i = static_cast<long>(std::floor(pos));
+      Flt frac = static_cast<Flt>(pos - static_cast<double>(i));
+      Flt a = tap(i - 1), b = tap(i), c = tap(i + 1), dd = tap(i + 2);
+      Flt cmb = c - b;
+      return b + frac * (cmb - 0.1666667f * (1.0f - frac) *
+                                   ((dd - a - 3.0f * cmb) * frac + (dd + 2.0f * a - 3.0f * b)));
+    }
+
+    void samplerVoice::armLayer(Layer& L, int regionIndex, int note, int velocity) {
+      const DSP::sfzRegion& r = inst->model.regions[static_cast<size_t>(regionIndex)];
+      // Non-const to take a raw Flt* for reading; the PCM itself is never written.
+      residentSample& rs = inst->samples[static_cast<size_t>(r.sampleIndex)];
+
+      L.active = true;
+      L.finished = false;
+      L.releasing = false;
+      L.sampleDone = false;
+      L.regionIndex = regionIndex;
+
+      const long frames = rs.frames;
+      if (rs.silence || !rs.loaded || frames <= 0) {
+        L.numCh = 0;
+        L.frames = 0;
+        L.ch[0] = L.ch[1] = nullptr;
+      } else {
+        L.numCh = std::min<int>(2, static_cast<int>(rs.channels.size()));
+        L.ch[0] = rs.channels[0].getPtr();
+        L.ch[1] = L.numCh > 1 ? rs.channels[1].getPtr() : nullptr;
+        L.frames = frames;
+      }
+
+      // pitch / tuning (spec §6)
+      const double semis =
+          (note - r.pitchKeycenter) * (static_cast<double>(r.pitchKeytrack) / 100.0) +
+          r.transposeSemis;
+      const double cents = r.tuneCents;
+      const double ratio = std::pow(2.0, (semis + cents / 100.0) / 12.0);
+      L.baseSpeed = ratio * static_cast<double>(rs.sampleRateAdjustment);
+
+      // playback bounds (spec §7)
+      const long lastFrame = frames > 0 ? frames - 1 : 0;
+      L.offset = clampl(r.offset, 0, lastFrame);
+      L.endFrame = (r.endFrame == DSP::SFZ_UNSET) ? lastFrame : clampl(r.endFrame, 0, lastFrame);
+      L.pos = static_cast<double>(L.offset);
+      L.loopMode = r.loopMode;
+      long ls = (r.loopStart == DSP::SFZ_UNSET) ? 0 : r.loopStart;
+      long le = (r.loopEnd == DSP::SFZ_UNSET) ? L.endFrame : r.loopEnd;
+      ls = clampl(ls, 0, lastFrame);
+      le = clampl(le, 0, lastFrame);
+      L.loopStart = ls;
+      L.loopEnd = le;
+      L.looping = (r.loopMode == DSP::SFZ_LOOP_CONTINUOUS || r.loopMode == DSP::SFZ_LOOP_SUSTAIN) &&
+                  ls < le && frames > 0;
+
+      // amplitude: volume * velocity-track * crossfade (constant NOTE_ON gain, §8)
+      const Flt volGain = std::pow(10.0f, r.volumeDb / 20.0f);
+      const Flt v = static_cast<Flt>(velocity) / 127.0f;
+      const Flt track = r.ampVeltrack / 100.0f;
+      Flt velGain = 1.0f - track * (1.0f - v * v);
+      if (velGain < 0.0f) velGain = 0.0f;
+
+      auto curve = [](Flt p, int c) -> Flt {
+        if (p < 0.0f) p = 0.0f;
+        if (p > 1.0f) p = 1.0f;
+        return c == DSP::SFZ_CURVE_POWER ? std::sqrt(p) : p;
+      };
+      auto xfadeAxis = [&](int x, int inLo, int inHi, int outLo, int outHi, int c) -> Flt {
+        Flt gin = 1.0f, gout = 1.0f;
+        if (inLo > 0 || inHi > 0) {
+          if (x <= inLo)
+            gin = 0.0f;
+          else if (x >= inHi)
+            gin = 1.0f;
+          else
+            gin = static_cast<Flt>(x - inLo) / static_cast<Flt>(inHi - inLo);
+        }
+        if (outLo > 0 || outHi > 0) {
+          if (x <= outLo)
+            gout = 1.0f;
+          else if (x >= outHi)
+            gout = 0.0f;
+          else
+            gout = 1.0f - static_cast<Flt>(x - outLo) / static_cast<Flt>(outHi - outLo);
+        }
+        return curve(gin, c) * curve(gout, c);
+      };
+      const Flt xfVel =
+          xfadeAxis(velocity, r.xfinLovel, r.xfinHivel, r.xfoutLovel, r.xfoutHivel, r.xfVelcurve);
+      const Flt xfKey =
+          xfadeAxis(note, r.xfinLokey, r.xfinHikey, r.xfoutLokey, r.xfoutHikey, r.xfKeycurve);
+      L.gain = volGain * velGain * xfVel * xfKey;
+
+      // amp EG (§8) — DAHDSR with a ~5 ms release floor.
+      const Flt rel = std::max(r.egRelease, kReleaseFloor);
+      L.env.configure(r.egDelay, r.egAttack, r.egHold, r.egDecay, r.egSustain, rel,
+                      static_cast<Flt>(SAMPLERATE));
+      L.env.gateOn();
+
+      // choke bookkeeping (§4): record the baseline generation this layer will
+      // watch, so a later fire of its off_by group is detected.
+      L.chokeGroup = r.chokeGroup;
+      L.offBy = r.offBy;
+      L.offMode = r.offMode;
+      L.offByBaseline = inst->chokeGen(r.offBy);
+    }
+
+    void samplerVoice::startNote() {
+      // Reset every layer to rest first, so a dropped note leaves no stale state.
+      for (auto& L : layers) {
+        L.active = false;
+        L.finished = false;
+        L.regionIndex = -1;
+        L.env.reset();
+      }
+      chokeFading = false;
+      chokeFadePos = 0;
+      phase = IDLE;
+
+      if (!inst || !inst->valid()) return;
+
+      const int n = note_.load(std::memory_order_relaxed) & 127;
+      int vel = static_cast<int>(std::lround(getVelocity() * 127.0f));
+      vel = std::min(127, std::max(1, vel));
+
+      // Round-robin: read + increment the per-key counter in this single-threaded
+      // audio pass; the region table stays immutable (spec §4).
+      const int hit = inst->seqCounter[static_cast<size_t>(n)]++;
+      lastHit_ = hit;
+
+      int idx[DSP::YSE_MAX_REGION_LAYERS];
+      const int count = DSP::resolveLayers(inst->model, n, vel, hit, idx);
+      if (count == 0) return; // no region matched -> voice drops cleanly (§5)
+
+      for (int k = 0; k < count; ++k) {
+        armLayer(layers[static_cast<size_t>(k)], idx[k], n, vel);
+      }
+      phase = PLAYING;
+
+      // Fire choke groups after arming all layers (baselines already recorded),
+      // so this voice never chokes itself off its own fire (§4).
+      for (int k = 0; k < count; ++k) {
+        const int g = layers[static_cast<size_t>(k)].chokeGroup;
+        if (g != 0) inst->bumpChoke(g);
+      }
+    }
+
+    void samplerVoice::releaseNote() {
+      phase = RELEASING;
+      for (auto& L : layers) {
+        if (!L.active || L.finished) continue;
+        if (L.loopMode == DSP::SFZ_ONE_SHOT) continue; // one-shot ignores note-off (§7)
+        if (!L.releasing) {
+          L.releasing = true;
+          L.env.gateOff();
+          if (L.loopMode == DSP::SFZ_LOOP_SUSTAIN) L.looping = false; // play out on release
+        }
+      }
+    }
+
+    void samplerVoice::applyChoke() {
+      if (phase == IDLE || chokeFading) return;
+      bool fast = false, normal = false;
+      for (auto& L : layers) {
+        if (!L.active || L.finished || L.offBy == 0) continue;
+        if (inst->chokeGen(L.offBy) != L.offByBaseline) {
+          if (L.offMode == DSP::SFZ_OFF_FAST)
+            fast = true;
+          else
+            normal = true;
+        }
+      }
+      if (fast) {
+        chokeFading = true;
+        chokeFadePos = 0;
+      } else if (normal) {
+        releaseNote();
+      }
+    }
+
+    bool samplerVoice::renderLayers(int blockLen) {
+      Flt* out = samples[0].getPtr();
+      for (int i = 0; i < blockLen; ++i)
+        out[i] = 0.0f;
+
+      const Flt wheel = getPitchWheel();
+      const double wheelRatio =
+          wheel != 0.0f ? std::pow(2.0, static_cast<double>(wheel) * kBendRangeSemitones / 12.0)
+                        : 1.0;
+
+      bool anySound = false;
+      for (auto& L : layers) {
+        if (!L.active || L.finished) continue;
+        const double speed = L.baseSpeed * wheelRatio;
+        const double loopLen = static_cast<double>(L.loopEnd - L.loopStart + 1);
+
+        for (int s = 0; s < blockLen; ++s) {
+          const Flt env = L.env.tick();
+          Flt sampleVal = 0.0f;
+          if (L.numCh > 0 && !L.sampleDone) {
+            Flt v0 = cubic(L.ch[0], L.frames, L.pos, L.loopStart, L.loopEnd, L.looping);
+            if (L.numCh > 1) {
+              Flt v1 = cubic(L.ch[1], L.frames, L.pos, L.loopStart, L.loopEnd, L.looping);
+              sampleVal = 0.5f * (v0 + v1);
+            } else {
+              sampleVal = v0;
+            }
+            L.pos += speed;
+            if (L.looping) {
+              while (L.pos >= static_cast<double>(L.loopStart) + loopLen)
+                L.pos -= loopLen;
+            } else if (L.pos > static_cast<double>(L.endFrame)) {
+              L.sampleDone = true;
+            }
+          }
+          out[s] += sampleVal * L.gain * env;
+        }
+
+        // Retire the layer once it can produce no more sound (spec §8): a
+        // one-shot ends at its sample end; every other mode ends when its own
+        // release EG has finished (so a short layer never cuts a longer one).
+        if (L.loopMode == DSP::SFZ_ONE_SHOT) {
+          if (L.sampleDone) L.finished = true;
+        } else if (L.env.atEnd()) {
+          L.finished = true;
+        }
+        if (!L.finished) anySound = true;
+      }
+      return anySound;
+    }
+
+    void samplerVoice::process(SOUND_STATUS& intent) {
+      const int blockLen = static_cast<int>(samples[0].getLength());
+      Flt* out = samples[0].getPtr();
+
+      if (intent == SS_WANTSTOPLAY || intent == SS_WANTSTORESTART) {
+        startNote();
+        intent = SS_PLAYING;
+        if (phase == IDLE) {
+          // No region matched (or no instrument) — drop the note cleanly (§5).
+          for (int i = 0; i < blockLen; ++i)
+            out[i] = 0.0f;
+          intent = SS_STOPPED;
+          return;
+        }
+      } else if (intent == SS_WANTSTOSTOP || intent == SS_WANTSTOPAUSE) {
+        if (phase == IDLE) {
+          intent = SS_STOPPED;
+          for (int i = 0; i < blockLen; ++i)
+            out[i] = 0.0f;
+          return;
+        }
+        if (phase != RELEASING) releaseNote(); // take the release edge once
+      } else if (intent == SS_PLAYING || intent == SS_PLAYING_FULL_VOLUME) {
+        // sustaining — fall through to render
+      } else {
+        // SS_STOPPED / SS_PAUSED — emit silence, keep state.
+        for (int i = 0; i < blockLen; ++i)
+          out[i] = 0.0f;
+        return;
+      }
+
+      // Choke scan (§4): a fired choke group targeting one of our layers' off_by
+      // either fast-fades us or triggers our release.
+      applyChoke();
+
+      renderLayers(blockLen);
+
+      // Fast-choke declick overlay.
+      if (chokeFading) {
+        const Flt fade = static_cast<Flt>(chokeFadeSamps);
+        for (int s = 0; s < blockLen; ++s) {
+          Flt g = 1.0f - static_cast<Flt>(chokeFadePos + s) / fade;
+          if (g < 0.0f) g = 0.0f;
+          out[s] *= g;
+        }
+        chokeFadePos += blockLen;
+        if (chokeFadePos >= chokeFadeSamps) {
+          for (auto& L : layers)
+            if (L.active) L.finished = true;
+        }
+      }
+
+      // Settle STOPPED only when every sounding layer has finished — i.e. the
+      // longest layer release governs the voice's end of life (spec §8).
+      bool anyActive = false, allDone = true;
+      for (auto& L : layers) {
+        if (!L.active) continue;
+        anyActive = true;
+        if (!L.finished) allDone = false;
+      }
+      if (!anyActive || allDone) {
+        intent = SS_STOPPED;
+        phase = IDLE;
+      }
+    }
+
+    // ---- introspection ----------------------------------------------------
+
+    int samplerVoice::activeLayers() const {
+      int n = 0;
+      for (const auto& L : layers)
+        if (L.active && !L.finished) ++n;
+      return n;
+    }
+
+    int samplerVoice::layerRegion(int i) const {
+      int n = 0;
+      for (const auto& L : layers) {
+        if (L.active && !L.finished) {
+          if (n == i) return L.regionIndex;
+          ++n;
+        }
+      }
+      return -1;
+    }
+
+    Flt samplerVoice::layerGain(int i) const {
+      int n = 0;
+      for (const auto& L : layers) {
+        if (L.active && !L.finished) {
+          if (n == i) return L.gain;
+          ++n;
+        }
+      }
+      return 0.0f;
+    }
+
+  } // namespace SYNTH
+} // namespace YSE

--- a/YseEngine/synth/samplerVoice.hpp
+++ b/YseEngine/synth/samplerVoice.hpp
@@ -1,0 +1,356 @@
+/*
+  ==============================================================================
+
+    samplerVoice.hpp
+    SFZ sampler synthesiser voice for YSE::synth (issue #174).
+
+    A SYNTH::dspVoice subclass that renders the #173 RT-ready region table: it
+    resolves the layer set for a note at NOTE_ON (allocation-free), pitch-tracks
+    each layer through the engine's 4-point cubic kernel, loops seamlessly,
+    shapes each layer with its own amplitude EG, and sums up to
+    YSE_MAX_REGION_LAYERS layers into one voice. Round-robin and choke groups
+    are coordinated through a shared, audio-thread-only state block carried
+    across clone() by shared pointer — so the generic synth allocator stays
+    untouched and the sample data is shared, never duplicated.
+
+    Contract: docs/design/sfz_opcode_subset.md (§5 selection, §6 pitch, §7 loop,
+    §8 amp EG, §10 buffer sharing, §11 samplerConfig facade).
+
+    Real-time discipline: every per-voice buffer and every per-layer state field
+    is sized in the constructor / clone() on the setup pool. process() and the
+    render loop allocate nothing, take no lock, and never touch the disk — the
+    whole PCM set is resident (spec §9), loaded off the audio thread before the
+    prototype is handed to addVoices().
+
+  ==============================================================================
+*/
+
+#ifndef YSE_SYNTH_SAMPLERVOICE_HPP
+#define YSE_SYNTH_SAMPLERVOICE_HPP
+
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dspVoice.hpp"
+#include "../dsp/fileBuffer.hpp"
+#include "../dsp/sfzModel.hpp"
+#include "../headers/types.hpp"
+
+namespace YSE {
+  namespace SYNTH {
+
+    /**
+     *  @brief One fully-resident, de-duplicated sample (all channels in RAM).
+     *
+     *  Built once on the setup / slow-pool thread by ``samplerInstrument::load``
+     *  and immutable thereafter, so any number of voices read it concurrently on
+     *  the audio thread without synchronisation (spec §10). Parallel to
+     *  ``sfzInstrument::samples`` (index == sampleIndex).
+     */
+    struct residentSample {
+      std::vector<DSP::fileBuffer> channels; ///< One buffer per source channel.
+      long frames = 0; ///< Frame count (per channel).
+      Flt sampleRateAdjustment = 1.0f; ///< fileRate / deviceRate (spec §6).
+      bool silence = false; ///< sample=*silence — produces silence, no PCM.
+      bool loaded = false; ///< PCM decoded (or silence), ready to render.
+    };
+
+    /**
+     *  @brief The shared, playable SFZ instrument: region table + resident PCM.
+     *
+     *  All voices cloned from one prototype share **one** ``samplerInstrument``
+     *  (like ``vaParams`` for ``vaVoice``): the immutable region table and PCM
+     *  are read-only on the audio thread, while the small cross-note round-robin
+     *  and choke coordination state is touched only inside the audio-thread
+     *  render pass (single-threaded — plain ints, no atomics, no locks).
+     */
+    class API samplerInstrument {
+    public:
+      DSP::sfzInstrument model; ///< Flattened region table (immutable after load).
+      std::vector<residentSample> samples; ///< Resident PCM, parallel to model.samples.
+
+      /** @brief Decode every unique sample into RAM. Setup / slow-pool thread
+       *  only — never the audio thread. Returns true if the instrument is
+       *  playable (valid region table + at least one loaded sample). */
+      bool load();
+
+      /** @brief Whether this instrument is playable (valid region table + at
+       *  least one resident sample). Computed, so a caller may also build the
+       *  model + samples in place without going through ``load``. */
+      bool valid() const {
+        return model.valid && !samples.empty();
+      }
+
+      // ---- audio-thread-only cross-note state (spec §4) --------------------
+
+      /** @brief Per-key round-robin hit counter (spec §4). Read+incremented at
+       *  the NOTE_ON edge inside process(); the region table stays immutable. */
+      std::array<int, 128> seqCounter{};
+
+      /** @brief Bump the choke generation for group ``g`` (a region fired it).
+       *  Returns the new generation. Groups outside [1,127] clamp into range. */
+      uint32_t bumpChoke(int g);
+
+      /** @brief Current choke generation for group ``g`` (0 if never fired). */
+      uint32_t chokeGen(int g) const;
+
+    private:
+      // group id -> generation, direct-indexed and clamped. 128 covers a full
+      // drum kit's worth of choke groups; ids beyond clamp to the last slot.
+      static constexpr int kMaxChokeGroups = 128;
+      std::array<uint32_t, kMaxChokeGroups> chokeGenerations{};
+    };
+
+    /**
+     *  @brief Chainable single-sample convenience facade (spec §11).
+     *
+     *  Sugar that builds a one-region instrument without an ``.sfz`` file. It
+     *  emits the same flattened region model the parser produces, so a
+     *  ``samplerConfig`` sampler behaves identically to the equivalent
+     *  hand-written one-region file.
+     */
+    class API samplerConfig {
+    public:
+      /** @brief Instrument label (identification only; not an SFZ opcode). */
+      samplerConfig& name(const char* n) {
+        name_ = n;
+        return *this;
+      }
+      /** @brief Absolute path to the sample file (``sample=``). */
+      samplerConfig& file(const char* f) {
+        file_ = f;
+        return *this;
+      }
+      /** @brief MIDI channel for addVoices (0 = omni). Not an SFZ opcode. */
+      samplerConfig& channel(U8 c) {
+        channel_ = c;
+        return *this;
+      }
+      /** @brief Root note — the key that plays the sample untransposed. */
+      samplerConfig& root(U8 rootNote) {
+        root_ = rootNote;
+        return *this;
+      }
+      /** @brief Playable key range (also the addVoices window). */
+      samplerConfig& range(U8 low, U8 high) {
+        low_ = low;
+        high_ = high;
+        return *this;
+      }
+      /** @brief Amplitude envelope: attack / release (seconds) and a one-shot
+       *  length cap (seconds; clamps ``end`` when the region does not loop). */
+      samplerConfig& envelope(Flt attack, Flt release, Flt maxLength) {
+        attack_ = attack;
+        release_ = release;
+        maxLength_ = maxLength;
+        return *this;
+      }
+
+      const std::string& name() const {
+        return name_;
+      }
+      U8 channel() const {
+        return channel_;
+      }
+      U8 low() const {
+        return low_;
+      }
+      U8 high() const {
+        return high_;
+      }
+
+      /** @brief Build the one-region model this facade describes into ``inst``
+       *  and decode its sample. Setup thread only. Returns true on success. */
+      bool build(samplerInstrument& inst) const;
+
+    private:
+      std::string name_;
+      std::string file_;
+      U8 channel_ = 0;
+      U8 root_ = 60;
+      U8 low_ = 0;
+      U8 high_ = 127;
+      Flt attack_ = 0.0f;
+      Flt release_ = 0.1f;
+      Flt maxLength_ = 10.0f;
+    };
+
+    /**
+     *  @brief Amplitude EG for one layer — allocation-free DAHDSR.
+     *
+     *  The spec (§8) maps ``ampeg_*`` onto the engine's ``DSP::ADSRenvelope``,
+     *  but that envelope's ``generate()`` allocates, and a sampler voice is
+     *  reused across notes that resolve to *different* regions with different
+     *  ``ampeg_*`` values — so rebuilding it at NOTE_ON would allocate on the
+     *  audio path. This lightweight envelope reconfigures its per-sample slopes
+     *  with no allocation, exactly the reason ``vaVoice`` introduced ``vaADSR``.
+     *  It adds the delay + hold stages the full DAHDSR set needs.
+     */
+    class sfzADSR {
+    public:
+      /** @brief (Re)configure from ``ampeg_*`` times (seconds), sustain [0,1]. */
+      void configure(Flt delay, Flt attack, Flt hold, Flt decay, Flt sustain, Flt release, Flt sr);
+      /** @brief Begin at the delay/attack stage from silence. */
+      void gateOn();
+      /** @brief Enter the release stage from the current level. */
+      void gateOff();
+      /** @brief Advance one sample; return the new level. */
+      Flt tick();
+      /** @brief Whether the release has finished (envelope at rest after gateOff). */
+      bool atEnd() const {
+        return stage == DONE;
+      }
+      /** @brief Whether the envelope is producing sound (past IDLE, before DONE). */
+      bool active() const {
+        return stage != IDLE && stage != DONE;
+      }
+      /** @brief Reset to rest. */
+      void reset() {
+        stage = IDLE;
+        lvl = 0.0f;
+      }
+
+    private:
+      enum Stage { IDLE, DELAY, ATTACK, HOLD, DECAY, SUSTAIN, RELEASE, DONE };
+      Stage stage = IDLE;
+      Flt lvl = 0.0f;
+      Flt sus = 1.0f;
+      Flt sr = 44100.0f;
+      long delaySamps = 0, holdSamps = 0;
+      long delayCnt = 0, holdCnt = 0;
+      Flt aInc = 1.0f, dInc = 1.0f, rInc = 1.0f;
+      Flt rSecs = 0.1f; // release time (seconds); slope resolved at gateOff
+    };
+
+    /**
+     *  @brief SFZ sampler voice — renders the shared region table for one note.
+     *
+     *  Load an instrument (``loadSFZ`` / ``configure``) into the prototype, then
+     *  hand it to ``synth::addVoices``; every clone shares the same immutable
+     *  region table and resident PCM (``instrument()``) while keeping its own
+     *  independent per-layer playback state.
+     */
+    class API samplerVoice : public dspVoice {
+    public:
+      /** @brief Construct an empty mono (or wider) sampler voice. */
+      samplerVoice(int outputChannels = 1);
+
+      /** @brief Load and preload an ``.sfz`` file into this prototype. Setup
+       *  thread only (parses + decodes off the audio thread). Returns true when
+       *  the instrument is playable. */
+      bool loadSFZ(const std::string& path);
+
+      /** @brief Build this prototype from a ``samplerConfig`` facade. Setup
+       *  thread only. Returns true when the instrument is playable. */
+      bool configure(const samplerConfig& cfg);
+
+      /** @brief The shared instrument (region table + resident PCM). Retain to
+       *  keep it alive alongside the prototype and its clones. */
+      std::shared_ptr<samplerInstrument> instrument() const {
+        return inst;
+      }
+
+      /** @brief Attach an already-built instrument. Clones made afterwards share
+       *  it (the region table + PCM are never duplicated, spec §10). Setup
+       *  thread only. */
+      samplerVoice& setInstrument(std::shared_ptr<samplerInstrument> i) {
+        inst = std::move(i);
+        return *this;
+      }
+
+      // ---- dspVoice contract -------------------------------------------------
+
+      /** @brief Render one block, honouring and settling ``intent``. Audio-thread only. */
+      void process(SOUND_STATUS& intent) override;
+
+      /** @brief Return a new voice sharing this voice's instrument, fresh state. Setup-thread only.
+       */
+      dspVoice* clone() override;
+
+      /** @brief Store the note frequency (Hz, base) and the raw MIDI note the
+       *  region matcher needs. Called by the allocator on NOTE_ON. */
+      void frequency(Flt midiNote) override;
+
+      /** @brief Current raw MIDI note number for region selection. */
+      int getNote() const {
+        return note_.load(std::memory_order_relaxed);
+      }
+
+      // ---- test / introspection hooks (audio-thread snapshot) ----------------
+
+      /** @brief Number of layers currently sounding. */
+      int activeLayers() const;
+      /** @brief Region-table index of sounding layer ``i`` (-1 if none). */
+      int layerRegion(int i) const;
+      /** @brief Constant NOTE_ON amplitude gain of sounding layer ``i``. */
+      Flt layerGain(int i) const;
+      /** @brief The round-robin hit number chosen at the last NOTE_ON. */
+      int lastHit() const {
+        return lastHit_;
+      }
+
+    protected:
+      /** @brief Copy-construct: share the instrument, reset per-voice state. */
+      samplerVoice(const samplerVoice& other);
+
+    private:
+      // Per-layer playback state. All fields are plain values sized once (the
+      // layer array is fixed at YSE_MAX_REGION_LAYERS), so arming a layer at
+      // NOTE_ON allocates nothing.
+      struct Layer {
+        bool active = false;
+        bool finished = false;
+        int regionIndex = -1;
+        // cached pointers into the shared resident sample (read-only)
+        const Flt* ch[2] = {nullptr, nullptr};
+        int numCh = 0;
+        long frames = 0;
+        // playback
+        double pos = 0.0; // fractional read position, frames
+        double baseSpeed = 1.0; // resample ratio at unity pitch-wheel
+        long offset = 0;
+        long endFrame = 0;
+        int loopMode = DSP::SFZ_NO_LOOP;
+        bool looping = false; // currently wrapping the loop region
+        long loopStart = 0, loopEnd = 0;
+        bool sampleDone = false; // reached endFrame (non-loop / one_shot)
+        // amplitude
+        Flt gain = 1.0f; // volume * veltrack * xfade (constant, NOTE_ON-time)
+        sfzADSR env;
+        bool releasing = false;
+        // choke
+        int chokeGroup = 0, offBy = 0, offMode = DSP::SFZ_OFF_FAST;
+        uint32_t offByBaseline = 0;
+      };
+
+      // Where the voice is in its own note arc (separate from the intent gate).
+      enum Phase { IDLE, PLAYING, RELEASING };
+
+      void startNote(); // resolve layers + arm state at the NOTE_ON edge
+      void releaseNote(); // enter release on the held layers (note-off)
+      void armLayer(Layer& L, int regionIndex, int note, int velocity);
+      bool
+      renderLayers(int blockLen); // sum active layers into samples[0]; returns true if any sound
+      void applyChoke(); // scan layers for a fired choke group
+      static Flt cubic(const Flt* d, long n, double pos, long loopStart, long loopEnd,
+                       bool looping);
+
+      std::shared_ptr<samplerInstrument> inst;
+      std::array<Layer, DSP::YSE_MAX_REGION_LAYERS> layers;
+      Phase phase = IDLE;
+      aInt note_{60};
+      int lastHit_ = 0;
+
+      // Fast-choke declick: a short linear fade to silence then settle STOPPED,
+      // the voice-side equivalent of the engine steal-fade for off_mode=fast.
+      bool chokeFading = false;
+      int chokeFadePos = 0;
+      int chokeFadeSamps = 1;
+    };
+
+  } // namespace SYNTH
+} // namespace YSE
+
+#endif // YSE_SYNTH_SAMPLERVOICE_HPP

--- a/docs/design/sfz_opcode_subset.md
+++ b/docs/design/sfz_opcode_subset.md
@@ -350,6 +350,22 @@ voice holding a layer with `off_by = N` — via the steal fade
 scan is field compares only. This is a small, bounded extension of the
 allocator's existing steal pass, not a new lifecycle.
 
+> **Implementation note (#174).** The round-robin counters and the choke
+> coordination live in a shared, audio-thread-only state block owned by the
+> `samplerVoice` prototype and carried across `clone()` by shared pointer
+> (`SYNTH::samplerInstrument`), rather than baked into the generic synth
+> allocator. Every voice of one instrument shares that block, so the per-key
+> `seqCounter[128]` and the per-group choke generations are visible across
+> voices, yet the allocator ([synth_core.md][doc-synth]) stays instrument-
+> agnostic. NOTE_ON reads/increments `seqCounter[note]` and fires its layers'
+> choke groups on the voice's own audio-thread `process()` edge; a sounding
+> voice whose `off_by` group's generation has advanced choking itself —
+> `off_mode=fast` via a ~5 ms voice-side declick fade (the steal-fade
+> equivalent), `off_mode=normal` via its own `ampeg_release`. The observable
+> behaviour — round-robin cycle order, choke pairs — matches this section; only
+> the home of the mutable state differs (voice-shared block vs allocator), which
+> keeps the change self-contained and the region table strictly immutable.
+
 ---
 
 ## Region selection


### PR DESCRIPTION
## Summary

Implements `SYNTH::samplerVoice` — the SFZ sampler voice (epic #148) — on top of the #173 region model and the #153 synth core. It renders the immutable region table with per-layer pitch-tracking, seamless looping, amplitude envelopes, velocity/key crossfades, round-robin and choke groups, and adds the `samplerConfig` single-file facade. It also makes sample loading actually work (the deferred resident-preload from #173).

## Linked issue
Closes #174

## Changes

- **`YseEngine/synth/samplerVoice.{hpp,cpp}`** — new voice:
  - Layer-set rendering up to `YSE_MAX_REGION_LAYERS=4` regions per note (own read position / cubic interpolation / speed / amp EG / NOTE_ON gains), summed in one voice; settles `SS_STOPPED` only when the *longest* layer release finishes (spec §5/§8).
  - Pitch tracking from `pitch_keycenter`/`tune`/`transpose`/`pitch_keytrack` through the engine's 4-point cubic kernel; ±2-semitone pitch wheel (§6).
  - `loop_mode` handling — `no_loop`/`one_shot`/`loop_continuous`/`loop_sustain` — with an interpolation-safe loop-region tap wrap for a click-free seam (§7).
  - `ampeg_*` DAHDSR via an allocation-free per-layer envelope with a ~5 ms release floor (§8). *Rationale:* regions vary per note, so `DSP::ADSRenvelope::generate()` at NOTE_ON would allocate on the audio path — the same reason `vaVoice` introduced `vaADSR`.
  - `amp_veltrack` + `xfin/xfout` velocity/key crossfades as NOTE_ON-time constant gains (power/gain curves, §8).
  - **Round-robin** (per-key `seqCounter`) and **choke groups** (`group`/`off_by`/`off_mode`, fast declick vs normal release) coordinated through a shared, audio-thread-only `samplerInstrument` carried across `clone()` by shared pointer — the generic allocator stays instrument-agnostic and PCM is shared, never duplicated. Design doc §4 gained a short note on this voice-side realization.
  - `samplerConfig` single-region facade (§11).
- **`YseEngine/dsp/fileBuffer.cpp`** — implement the previously non-functional `load()` with libsndfile: resident full-preload of one channel into RAM off the audio thread (spec §9/§10). This unblocks the sampler (#173 deferred PCM decode to this issue).
- **Tests / Bench / CMake** wiring.

## Real-time discipline

Every per-voice buffer and per-layer field is sized in the constructor/`clone()`; `process()` and the render loop allocate nothing, take no lock and never touch the disk. Verified by a 16-voice `ProbeScope` audit (0 allocations) and by asserting clones share one resident PCM pointer.

## Test plan

- [x] `python yse.py format` clean (only this PR's files changed)
- [x] `python yse.py analyze YseEngine/synth/samplerVoice.cpp` / `YseEngine/dsp/fileBuffer.cpp` — no user-code findings
- [x] `python yse.py test` — **100% tests passed, 0 failed out of 27** (ctest targets). New `test_sampler_voice.cpp`: 14 cases / 71 assertions pass, covering pitch (<1 cent), loop seamlessness, velocity layers, envelope shape, layered sum, crossfade gain law, 3-sample round-robin order, hi-hat choke (fast + normal), multi-layer end-of-life, clone/PCM-sharing, 16-voice RT-alloc audit, real `.sfz` load, `samplerConfig`.
- [x] Benchmarks build and run: `BM_SamplerVoice_1Layer` 678 ns, `BM_SamplerVoice_4Layer` 2621 ns vs `BM_SineVoice_Reference` 214 ns per block.

No integration/e2e layer applies here: `samplerVoice` is an engine-internal DSP node with no user-visible UI/flow; it is driven end-to-end through the real voice contract (render blocks, FFT, RT-alloc probe) in the unit suite, and one case loads and renders a real `.sfz` off disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
