### PR TITLE
c-api: instrument surface — sampler / VA / FM (#178)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -82,6 +82,7 @@ set(YSE_TEST_SOURCES
   synth/test_synth_positioning.cpp
   synth/test_synth_handlers.cpp
   synth/test_c_api_synth.cpp
+  synth/test_c_api_instrument.cpp
   dsp/test_panner.cpp
   reverb/test_reverb_dsp.cpp
   reverb/test_reverb_concurrency.cpp
@@ -212,7 +213,7 @@ add_test(
   # `channelcapi` (issue #166 C-API channel-DSP/send surface) is excluded for
   # the same reason — it drives yse_system_init_offline() and runs in its own
   # process (yse_tests_channelcapi).
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,midisynth,playersynth,playercapi,sendstress,channelcapi "--test-case-exclude=* concurrency: *" --duration=true
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi "--test-case-exclude=* concurrency: *" --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -336,6 +337,20 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_synthcapi PROPERTIES LABELS "synth;c-api;lifecycle")
+
+# C-API instrument surface (issue #178). Drives the sampler / VA / FM instrument
+# voices and their loadable assets (SFZ instrument + DX7 bank) entirely through
+# the flat C ABI under an offline engine (yse_system_init_offline), then
+# yse_system_close(). Isolated in its own process for the same reason as
+# yse_tests_synthcapi: System::close() tears down process-global state (thread
+# pools) the rest of the suite assumes stays up (#298). initOffline() needs no
+# audio hardware, so it runs in CI.
+add_test(
+  NAME    yse_tests_instrumentcapi
+  COMMAND yse_tests --test-suite=instrumentcapi
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_instrumentcapi PROPERTIES LABELS "synth;c-api;lifecycle")
 
 add_test(
   NAME    yse_tests_midi

--- a/Tests/synth/test_c_api_instrument.cpp
+++ b/Tests/synth/test_c_api_instrument.cpp
@@ -1,0 +1,474 @@
+// C-API instrument surface tests (issue #178) — exercises the sampler / VA / FM
+// instrument voices and their loadable assets (YseEngine/c_api/yse_instrument.*
+// and the #178 growth of yse_synth.*) entirely through the flat C ABI, with no
+// engine C++ headers. Mirrors the DSP-level coverage in test_sampler_voice.cpp
+// / test_va_voice.cpp / test_dx7_sysex.cpp at the C surface.
+//
+// The engine is driven offline (yse_system_init_offline + render_offline), so no
+// audio hardware is needed and the suite runs in CI. Because it calls
+// yse_system_close() it lives in its own TEST_SUITE("instrumentcapi") and its
+// own ctest process (see Tests/CMakeLists.txt) — the same isolation the
+// synthcapi / midisynth / playersynth suites use, keeping System::close()'s
+// process-global teardown out of the crowded combined suite (#298/#304).
+//
+// Coverage against the #178 acceptance:
+//   - SFZ fixture loads and plays through the sampler voice group,
+//   - a VA patch is dialled in via the per-parameter setters and rendered,
+//   - a DX7 bank fixture is imported, enumerated, a patch selected, and rendered,
+//   - handle lifetime is enforced: double free and use-after-destroy are logged
+//     no-ops, not crashes,
+//   - PARITY: every VA vaParams field and every FM headline param has a C setter
+//     (exercised here; the full FM voice is reached via DX7 patch import).
+
+#include <doctest/doctest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "yse_c/yse_instrument.h"
+#include "yse_c/yse_synth.h"
+#include "yse_c/yse_sound.h"
+#include "yse_c/yse_system.h"
+
+#ifndef YSE_TEST_FIXTURES_DIR
+#define YSE_TEST_FIXTURES_DIR "../../Tests/support/fixtures"
+#endif
+
+using namespace std::chrono_literals;
+
+namespace {
+
+  std::string fixturesDir() {
+    return std::string(YSE_TEST_FIXTURES_DIR);
+  }
+
+  // Pump the engine offline until the synth has cloned `expected` voices, or the
+  // budget expires. Same drain helper the synthcapi suite uses.
+  bool drainUntilVoices(YseSystem* sys, YseSynth* syn, int expected,
+                        std::chrono::milliseconds budget = 3000ms) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 1);
+      if (yse_synth_get_num_voices(syn) >= expected) return true;
+      std::this_thread::sleep_for(2ms);
+    }
+    return yse_synth_get_num_voices(syn) >= expected;
+  }
+
+  void render(YseSystem* sys, int blocks) {
+    for (int i = 0; i < blocks; ++i) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 1);
+    }
+  }
+
+  void drainFor(YseSystem* sys, std::chrono::milliseconds budget) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      yse_system_update(sys);
+      yse_system_render_offline(sys, 1);
+      std::this_thread::sleep_for(2ms);
+    }
+  }
+
+  // ─── DX7 SysEx fixture generation (raw bytes, no engine headers) ────────────
+  // Deterministically build a valid 32-voice packed bulk dump whose slot 0 is an
+  // audible single-carrier voice named "YSE Capi". The packed byte layout is the
+  // documented DX7 format (see test_dx7_sysex.cpp::packVoice, the importer's
+  // inverse); we hand-roll it here so the TU stays pure-C-ABI. No copyrighted
+  // factory bank is committed.
+
+  void packCarrierVoice(uint8_t out[128]) {
+    for (int i = 0; i < 128; ++i)
+      out[i] = 0;
+    // OP1 (index 0) is the carrier: instant envelope holding at full level.
+    uint8_t* d = out; // op 0 base = 0
+    d[0] = d[1] = d[2] = d[3] = 99; // egRate R1..R4
+    d[4] = d[5] = d[6] = 99; // egLevel L1..L3 (sustain high)
+    d[7] = 0; // L4 (post-release)
+    d[12] = static_cast<uint8_t>((0 & 0x07) | ((7 & 0x0f) << 3)); // rateScaling|detune(centre)
+    d[14] = 99; // outputLevel
+    d[15] = static_cast<uint8_t>((0 & 0x01) | ((1 & 0x1f) << 1)); // oscMode ratio, coarse 1
+    // OP2..OP6 stay silent (outputLevel 0), so only OP1 sounds — a clean sine.
+
+    uint8_t* g = out + 102; // global block
+    g[0] = g[1] = g[2] = g[3] = 99; // pitch EG rates (instant)
+    g[4] = g[5] = g[6] = g[7] = 50; // pitch EG levels (50 = centre, no bend)
+    g[8] = 0; // algorithm 0 (DX7 algo 1 — OP1 carrier)
+    g[15] = 24; // transpose 24 = no transpose
+    const char name[10] = {'Y', 'S', 'E', ' ', 'C', 'a', 'p', 'i', ' ', ' '};
+    for (int i = 0; i < 10; ++i)
+      g[16 + i] = static_cast<uint8_t>(name[i]);
+  }
+
+  uint8_t sysexChecksum(const uint8_t* p, size_t n) {
+    unsigned sum = 0;
+    for (size_t i = 0; i < n; ++i)
+      sum += p[i];
+    return static_cast<uint8_t>((0x80u - (sum & 0x7fu)) & 0x7fu);
+  }
+
+  // Write a framed 32-voice packed bulk dump to `path`. Returns false on I/O
+  // failure. slot 0 = carrier, slots 1..31 = zeroed (silent) voices.
+  bool writeDx7Fixture(const std::string& path) {
+    std::vector<uint8_t> payload(4096, 0);
+    packCarrierVoice(payload.data()); // slot 0
+    std::vector<uint8_t> msg;
+    msg.push_back(0xF0);
+    msg.push_back(0x43);
+    msg.push_back(0x00); // sub-status / channel
+    msg.push_back(0x09); // format: 32-voice packed
+    msg.push_back(static_cast<uint8_t>((4096 >> 7) & 0x7f)); // byte-count MS
+    msg.push_back(static_cast<uint8_t>(4096 & 0x7f)); // byte-count LS
+    msg.insert(msg.end(), payload.begin(), payload.end());
+    msg.push_back(sysexChecksum(payload.data(), payload.size()));
+    msg.push_back(0xF7);
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f) return false;
+    f.write(reinterpret_cast<const char*>(msg.data()), static_cast<std::streamsize>(msg.size()));
+    return static_cast<bool>(f);
+  }
+
+} // namespace
+
+TEST_SUITE("instrumentcapi") {
+
+  // ─── NULL-handle safety across the whole new surface (no engine) ───────────
+
+  TEST_CASE("c-api instrument: NULL handles are null-safe") {
+    // Loaders reject NULL / missing input with a NULL return, not a crash.
+    CHECK(yse_sfz_load(nullptr) == nullptr);
+    CHECK(yse_sfz_load("this/does/not/exist.sfz") == nullptr);
+    CHECK(yse_sfz_load_config(nullptr) == nullptr);
+    CHECK(yse_dx7_import_sysex(nullptr) == nullptr);
+    CHECK(yse_dx7_import_sysex("this/does/not/exist.syx") == nullptr);
+
+    // Query / destroy of NULL asset handles are safe no-ops.
+    CHECK(yse_sfz_is_valid(nullptr) == 0);
+    CHECK(yse_dx7_get_patch_count(nullptr) == 0);
+    char buf[32];
+    CHECK(yse_dx7_get_patch_name(nullptr, 0, buf, sizeof(buf)) == 0);
+    yse_sfz_destroy(nullptr);
+    yse_dx7_destroy(nullptr);
+
+    // add-voices reject NULL / invalid arguments.
+    CHECK(yse_synth_add_voices_sampler(nullptr, nullptr, 4) == YSE_ERR_INVALID_HANDLE);
+    CHECK(yse_synth_add_voices_va(nullptr, 4) == YSE_ERR_INVALID_HANDLE);
+    CHECK(yse_synth_add_voices_fm(nullptr, 4) == YSE_ERR_INVALID_HANDLE);
+    CHECK(yse_synth_fm_set_patch(nullptr, nullptr, 0) == YSE_ERR_INVALID_HANDLE);
+
+    // Every VA + FM setter is a null-safe no-op on a NULL synth.
+    yse_synth_va_set_osc_wave(nullptr, 0, YSE_VA_SAW);
+    yse_synth_va_set_osc_detune(nullptr, 0, 0.1f);
+    yse_synth_va_set_osc_level(nullptr, 0, 1.0f);
+    yse_synth_va_set_osc_pulse_width(nullptr, 0, 0.5f);
+    yse_synth_va_set_wavetable_position(nullptr, 0.5f);
+    yse_synth_va_set_cutoff(nullptr, 1000.f);
+    yse_synth_va_set_resonance(nullptr, 0.2f);
+    yse_synth_va_set_key_tracking(nullptr, 0.5f);
+    yse_synth_va_set_filter_env_amount(nullptr, 1.f);
+    yse_synth_va_set_filter_vel_amount(nullptr, 1.f);
+    yse_synth_va_set_amp_attack(nullptr, 0.01f);
+    yse_synth_va_set_amp_decay(nullptr, 0.1f);
+    yse_synth_va_set_amp_sustain(nullptr, 0.8f);
+    yse_synth_va_set_amp_release(nullptr, 0.2f);
+    yse_synth_va_set_amp_vel_amount(nullptr, 0.5f);
+    yse_synth_va_set_filter_attack(nullptr, 0.01f);
+    yse_synth_va_set_filter_decay(nullptr, 0.1f);
+    yse_synth_va_set_filter_sustain(nullptr, 0.5f);
+    yse_synth_va_set_filter_release(nullptr, 0.2f);
+    yse_synth_va_set_lfo_type(nullptr, YSE_LFO_SINE);
+    yse_synth_va_set_lfo_rate(nullptr, 5.f);
+    yse_synth_va_set_lfo_to_pitch(nullptr, 0.1f);
+    yse_synth_va_set_lfo_to_cutoff(nullptr, 0.5f);
+    yse_synth_va_set_lfo_to_wavetable(nullptr, 0.3f);
+    yse_synth_va_set_gain(nullptr, 0.8f);
+    float cycle[4] = {0.f, 1.f, 0.f, -1.f};
+    yse_synth_va_load_wavetable(nullptr, 0, cycle, 4);
+    yse_synth_fm_set_algorithm(nullptr, 5);
+    yse_synth_fm_set_feedback(nullptr, 4);
+    yse_synth_fm_set_transpose(nullptr, 24);
+    yse_synth_fm_set_lfo_speed(nullptr, 40);
+    yse_synth_fm_set_lfo_delay(nullptr, 0);
+    yse_synth_fm_set_lfo_waveform(nullptr, 4);
+    yse_synth_fm_set_lfo_pitch_mod_depth(nullptr, 20);
+    yse_synth_fm_set_lfo_amp_mod_depth(nullptr, 0);
+    yse_synth_fm_set_pitch_mod_sens(nullptr, 3);
+    yse_synth_fm_set_op_output_level(nullptr, 0, 99);
+    yse_synth_fm_set_op_freq_coarse(nullptr, 0, 1);
+    yse_synth_fm_set_op_freq_fine(nullptr, 0, 0);
+    yse_synth_fm_set_op_detune(nullptr, 0, 7);
+    yse_synth_fm_set_op_osc_mode(nullptr, 0, 0);
+    yse_synth_fm_set_op_enabled(nullptr, 0, 1);
+  }
+
+  // ─── handle lifetime: double-free / use-after-destroy are logged no-ops ────
+  // No engine required — the assets are independent of engine lifetime.
+
+  TEST_CASE("c-api instrument: SFZ handle lifetime is enforced") {
+    YseSfzInstrument* inst = yse_sfz_load((fixturesDir() + "/sfz_dedup.sfz").c_str());
+    REQUIRE(inst != nullptr);
+    CHECK(yse_sfz_is_valid(inst) == 1);
+
+    yse_sfz_destroy(inst);
+    // Use-after-destroy: a logged no-op, not a crash — the handle is retired.
+    CHECK(yse_sfz_is_valid(inst) == 0);
+    // Double free: a logged no-op, not a double delete.
+    yse_sfz_destroy(inst);
+    yse_sfz_destroy(inst);
+  }
+
+  TEST_CASE("c-api instrument: DX7 bank handle lifetime is enforced") {
+    const std::string path = "capi_dx7_lifetime.syx";
+    REQUIRE(writeDx7Fixture(path));
+
+    YseDx7Bank* bank = yse_dx7_import_sysex(path.c_str());
+    REQUIRE(bank != nullptr);
+    CHECK(yse_dx7_get_patch_count(bank) == 32);
+    char name[32] = {0};
+    CHECK(yse_dx7_get_patch_name(bank, 0, name, sizeof(name)) > 0);
+    CHECK(std::string(name) == "YSE Capi");
+
+    yse_dx7_destroy(bank);
+    // Use-after-destroy: queries fall back to safe zero/empty, no crash.
+    CHECK(yse_dx7_get_patch_count(bank) == 0);
+    CHECK(yse_dx7_get_patch_name(bank, 0, name, sizeof(name)) == 0);
+    // Double free is a logged no-op.
+    yse_dx7_destroy(bank);
+    yse_dx7_destroy(bank);
+
+    std::remove(path.c_str());
+  }
+
+  TEST_CASE("c-api instrument: a destroyed instrument cannot be added to a synth") {
+    // add-voices with an already-destroyed instrument handle is rejected (logged),
+    // not a use-after-free. No engine needed to reach the guard.
+    YseSfzInstrument* inst = yse_sfz_load((fixturesDir() + "/sfz_dedup.sfz").c_str());
+    REQUIRE(inst != nullptr);
+    yse_sfz_destroy(inst);
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    CHECK(yse_synth_add_voices_sampler(syn, inst, 4) == YSE_ERR_INVALID_ARGUMENT);
+    yse_synth_destroy(syn);
+  }
+
+  // ─── SFZ sampler: fixture loads, attaches, and plays ───────────────────────
+
+  TEST_CASE("c-api instrument: SFZ sampler loads a fixture and plays") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return; // unavailable → skip
+
+    // sfz_dedup.sfz names the real test_mono_44100.wav (audible PCM).
+    YseSfzInstrument* inst = yse_sfz_load((fixturesDir() + "/sfz_dedup.sfz").c_str());
+    REQUIRE(inst != nullptr);
+    CHECK(yse_sfz_is_valid(inst) == 1);
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    REQUIRE(yse_synth_add_voices_sampler(syn, inst, 4) == YSE_OK);
+    // The voice group retains its own share — safe to drop the handle now.
+    yse_sfz_destroy(inst);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.9f) == YSE_OK);
+    yse_sound_play(snd);
+    REQUIRE(drainUntilVoices(sys, syn, 4));
+    CHECK(yse_synth_get_num_voices(syn) == 4);
+
+    // Play a couple of notes across the key range and render.
+    yse_synth_note_on(syn, 1, 60, 1.0f);
+    yse_synth_note_on(syn, 1, 72, 0.8f);
+    render(sys, 6);
+    yse_synth_all_notes_off(syn, 0);
+    render(sys, 8);
+
+    CHECK(yse_synth_is_valid(syn) == 1);
+    CHECK(yse_synth_get_num_voices(syn) == 4);
+
+    yse_sound_destroy(snd);
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms);
+    yse_system_close(sys);
+  }
+
+  // ─── VA voice: full parameter set dialled from C, then rendered ────────────
+
+  TEST_CASE("c-api instrument: VA patch set through every setter and rendered") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) return;
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    REQUIRE(yse_synth_add_voices_va(syn, 6) == YSE_OK);
+
+    // PARITY: exercise every vaParams field through its C setter. Setters are
+    // glitch-free atomics, so this may run before or during play.
+    for (int osc = 0; osc < 3; ++osc) {
+      yse_synth_va_set_osc_wave(syn, osc, YSE_VA_SAW);
+      yse_synth_va_set_osc_detune(syn, osc, 0.05f * osc);
+      yse_synth_va_set_osc_level(syn, osc, osc == 0 ? 1.0f : 0.4f);
+      yse_synth_va_set_osc_pulse_width(syn, osc, 0.5f);
+    }
+    yse_synth_va_set_osc_wave(syn, 2, YSE_VA_WAVETABLE);
+    yse_synth_va_set_wavetable_position(syn, 0.3f);
+    yse_synth_va_set_cutoff(syn, 4000.f);
+    yse_synth_va_set_resonance(syn, 0.3f);
+    yse_synth_va_set_key_tracking(syn, 0.5f);
+    yse_synth_va_set_filter_env_amount(syn, 1.5f);
+    yse_synth_va_set_filter_vel_amount(syn, 0.5f);
+    yse_synth_va_set_amp_attack(syn, 0.005f);
+    yse_synth_va_set_amp_decay(syn, 0.05f);
+    yse_synth_va_set_amp_sustain(syn, 0.8f);
+    yse_synth_va_set_amp_release(syn, 0.1f);
+    yse_synth_va_set_amp_vel_amount(syn, 0.6f);
+    yse_synth_va_set_filter_attack(syn, 0.01f);
+    yse_synth_va_set_filter_decay(syn, 0.08f);
+    yse_synth_va_set_filter_sustain(syn, 0.4f);
+    yse_synth_va_set_filter_release(syn, 0.15f);
+    yse_synth_va_set_lfo_type(syn, YSE_LFO_SINE);
+    yse_synth_va_set_lfo_rate(syn, 4.f);
+    yse_synth_va_set_lfo_to_pitch(syn, 0.1f);
+    yse_synth_va_set_lfo_to_cutoff(syn, 0.5f);
+    yse_synth_va_set_lfo_to_wavetable(syn, 0.2f);
+    yse_synth_va_set_gain(syn, 0.8f);
+    // A single-cycle table into the morph bank (setup-thread, before play).
+    std::vector<float> cycle(64);
+    for (int i = 0; i < 64; ++i)
+      cycle[i] = (i < 32) ? 1.f : -1.f; // square-ish
+    yse_synth_va_load_wavetable(syn, 0, cycle.data(), cycle.size());
+
+    // Out-of-range osc index is ignored, not a crash.
+    yse_synth_va_set_osc_level(syn, 99, 1.0f);
+    yse_synth_va_set_osc_level(syn, -1, 1.0f);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    yse_sound_play(snd);
+    REQUIRE(drainUntilVoices(sys, syn, 6));
+
+    yse_synth_note_on(syn, 1, 57, 1.0f); // A3
+    yse_synth_note_on(syn, 1, 60, 0.8f);
+    render(sys, 6);
+    // Live tweak while sounding — must stay glitch-free (no crash / no invalidation).
+    yse_synth_va_set_cutoff(syn, 8000.f);
+    yse_synth_va_set_resonance(syn, 0.6f);
+    render(sys, 4);
+    yse_synth_all_notes_off(syn, 0);
+    render(sys, 8);
+
+    CHECK(yse_synth_is_valid(syn) == 1);
+    CHECK(yse_synth_get_num_voices(syn) == 6);
+
+    yse_sound_destroy(snd);
+    yse_synth_destroy(syn);
+    drainFor(sys, 300ms);
+    yse_system_close(sys);
+  }
+
+  // ─── FM voice: DX7 bank imported, patch selected, headline params, rendered ─
+
+  TEST_CASE("c-api instrument: DX7 bank imported, patch selected, and rendered") {
+    const std::string path = "capi_dx7_render.syx";
+    REQUIRE(writeDx7Fixture(path));
+
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+    yse_system_close(sys);
+    if (yse_system_init_offline(sys) != YSE_OK) {
+      std::remove(path.c_str());
+      return;
+    }
+
+    YseDx7Bank* bank = yse_dx7_import_sysex(path.c_str());
+    REQUIRE(bank != nullptr);
+    CHECK(yse_dx7_get_patch_count(bank) == 32);
+    char name[32] = {0};
+    CHECK(yse_dx7_get_patch_name(bank, 0, name, sizeof(name)) > 0);
+    CHECK(std::string(name) == "YSE Capi");
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    REQUIRE(yse_synth_add_voices_fm(syn, 4) == YSE_OK);
+
+    // Select the imported patch — the way the full 155-parameter DX7 voice is
+    // reached from C. Out-of-range / destroyed-bank guards return errors.
+    REQUIRE(yse_synth_fm_set_patch(syn, bank, 0) == YSE_OK);
+    CHECK(yse_synth_fm_set_patch(syn, bank, 999) == YSE_ERR_INVALID_ARGUMENT);
+
+    // PARITY: the headline FM params, reachable directly from C.
+    yse_synth_fm_set_algorithm(syn, 0);
+    yse_synth_fm_set_feedback(syn, 3);
+    yse_synth_fm_set_transpose(syn, 24);
+    yse_synth_fm_set_lfo_speed(syn, 35);
+    yse_synth_fm_set_lfo_delay(syn, 0);
+    yse_synth_fm_set_lfo_waveform(syn, 4);
+    yse_synth_fm_set_lfo_pitch_mod_depth(syn, 10);
+    yse_synth_fm_set_lfo_amp_mod_depth(syn, 0);
+    yse_synth_fm_set_pitch_mod_sens(syn, 3);
+    for (int op = 0; op < 6; ++op) {
+      yse_synth_fm_set_op_output_level(syn, op, op == 0 ? 99 : 0);
+      yse_synth_fm_set_op_freq_coarse(syn, op, 1);
+      yse_synth_fm_set_op_freq_fine(syn, op, 0);
+      yse_synth_fm_set_op_detune(syn, op, 7);
+      yse_synth_fm_set_op_osc_mode(syn, op, 0);
+      yse_synth_fm_set_op_enabled(syn, op, 1);
+    }
+    // Out-of-range op index is ignored, not a crash.
+    yse_synth_fm_set_op_output_level(syn, 99, 50);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    yse_sound_play(snd);
+    REQUIRE(drainUntilVoices(sys, syn, 4));
+
+    yse_synth_note_on(syn, 1, 57, 1.0f);
+    render(sys, 8);
+    yse_synth_all_notes_off(syn, 0);
+    render(sys, 8);
+
+    CHECK(yse_synth_is_valid(syn) == 1);
+    CHECK(yse_synth_get_num_voices(syn) == 4);
+
+    yse_sound_destroy(snd);
+    yse_synth_destroy(syn);
+    yse_dx7_destroy(bank);
+    drainFor(sys, 300ms);
+    yse_system_close(sys);
+    std::remove(path.c_str());
+  }
+
+  // ─── one-region samplerConfig convenience creator ──────────────────────────
+
+  TEST_CASE("c-api instrument: samplerConfig creator builds a one-region instrument") {
+    YseSamplerConfig cfg = {};
+    cfg.name = "capi-oneshot";
+    std::string wav = fixturesDir() + "/test_mono_44100.wav";
+    cfg.file = wav.c_str();
+    cfg.root = 60;
+    cfg.low = 0;
+    cfg.high = 127;
+    cfg.attack = 0.0f;
+    cfg.release = 0.1f;
+    cfg.max_length = 5.0f;
+
+    YseSfzInstrument* inst = yse_sfz_load_config(&cfg);
+    REQUIRE(inst != nullptr);
+    CHECK(yse_sfz_is_valid(inst) == 1);
+    yse_sfz_destroy(inst);
+  }
+
+} // TEST_SUITE("instrumentcapi")

--- a/YseEngine/c_api/CMakeLists.txt
+++ b/YseEngine/c_api/CMakeLists.txt
@@ -27,6 +27,7 @@ set(YSE_C_API_SRCS
   yse_midi.cpp
   yse_music.cpp
   yse_synth.cpp
+  yse_instrument.cpp
   yse_log.cpp
   yse_buffer_io.cpp
   yse_python.cpp

--- a/YseEngine/c_api/include/yse_c/yse_all.h
+++ b/YseEngine/c_api/include/yse_c/yse_all.h
@@ -19,6 +19,7 @@
 #include "yse_patcher.h"
 #include "yse_midi.h"
 #include "yse_music.h"
+#include "yse_instrument.h"
 #include "yse_synth.h"
 #include "yse_log.h"
 #include "yse_buffer_io.h"

--- a/YseEngine/c_api/include/yse_c/yse_enums.h
+++ b/YseEngine/c_api/include/yse_c/yse_enums.h
@@ -56,6 +56,17 @@ typedef enum YseLfoType {
   YSE_LFO_RANDOM = 6
 } YseLfoType;
 
+/* Mirrors YSE::SYNTH::VA_WAVEFORM in synth/vaVoice.hpp — the oscillator
+   waveform selector for the virtual-analog voice (yse_synth_va_set_osc_wave). */
+typedef enum YseVaWaveform {
+  YSE_VA_SAW = 0, /* Band-limited sawtooth. */
+  YSE_VA_PULSE = 1, /* Band-limited pulse with variable width (PWM). */
+  YSE_VA_TRIANGLE = 2, /* Band-limited triangle. */
+  YSE_VA_SINE = 3, /* Sine. */
+  YSE_VA_NOISE = 4, /* White noise. */
+  YSE_VA_WAVETABLE = 5 /* Morph across the wavetable bank. */
+} YseVaWaveform;
+
 /* Mirrors YSE::DSP::MODULES::sweepFilter::SHAPE. */
 typedef enum YseDspSweepShape {
   YSE_SWEEP_TRIANGLE = 0,

--- a/YseEngine/c_api/include/yse_c/yse_instrument.h
+++ b/YseEngine/c_api/include/yse_c/yse_instrument.h
@@ -1,0 +1,115 @@
+/*
+  yse_instrument.h — loadable instrument assets for the synth voice pool.
+  C ABI mirror of the SFZ sampler instrument (YseEngine/synth/samplerVoice.hpp,
+  YSE::SYNTH::samplerInstrument / samplerConfig, issue #174) and the DX7 SysEx
+  bank importer (YseEngine/dsp/fm/dx7Sysex.hpp, YSE::SYNTH::dx7Bank / dx7SysEx,
+  issue #177).
+
+  These are the SHAREABLE, engine-lifetime-independent assets a synth renders:
+  a loaded SFZ instrument (region table + resident PCM) and a parsed DX7 bank
+  (a list of FM patches). Build one here, then hand it to a synth voice group
+  with yse_synth_add_voices_sampler() / yse_synth_fm_set_patch() (see
+  yse_synth.h). Loading and parsing happen on the CALLING (setup / control)
+  thread — never the audio thread; both read files and allocate.
+
+  Ownership: an instrument / bank handle is OWNED by the caller — release it
+  with yse_sfz_destroy() / yse_dx7_destroy(). The handles are reference-counted
+  assets independent of the engine: a voice group that renders one retains its
+  own share, so it is safe to destroy the handle right after add-voices, and it
+  is safe to hold or destroy a handle across yse_system_close(). Every handle is
+  tracked in a live-handle registry, so a double free or a use of an
+  already-destroyed handle is a LOGGED NO-OP, never a crash (the engine's
+  warning log records the misuse and the call is ignored).
+
+  Convention: every void-returning function is a null-safe no-op on a NULL
+  handle; loaders return NULL on failure with yse_last_error() set; status
+  queries return 0 / empty on NULL or invalid handles.
+*/
+
+#ifndef YSE_C_INSTRUMENT_H_INCLUDED
+#define YSE_C_INSTRUMENT_H_INCLUDED
+
+#include "yse_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Owned — release with yse_sfz_destroy. A reference-counted SFZ instrument
+   (region table + resident PCM). Share it across any number of synth voice
+   groups via yse_synth_add_voices_sampler; each group retains its own share,
+   so destroying this handle afterwards does not free the PCM until the last
+   group is gone. Safe to destroy across yse_system_close(). */
+typedef struct YseSfzInstrument YseSfzInstrument;
+
+/* Owned — release with yse_dx7_destroy. A parsed DX7 SysEx bank (a list of FM
+   patches, 1 or 32). Select a patch into a synth's FM voice group with
+   yse_synth_fm_set_patch; the patch is copied into the synth, so the bank may
+   be destroyed afterwards. Safe to destroy across yse_system_close(). */
+typedef struct YseDx7Bank YseDx7Bank;
+
+/* ─── SFZ sampler instrument ─────────────────────────────────────────────── */
+
+/* Load and preload an .sfz file into a shareable instrument. Parses the file
+   and decodes every unique sample into RAM on the calling thread (off the
+   audio thread). Returns NULL on failure (unreadable / empty file, no playable
+   region) with yse_last_error() set. */
+YSE_C_API YseSfzInstrument* yse_sfz_load(const char* path);
+
+/* One-region convenience creator — the samplerConfig facade (spec §11) as a
+   flat, ffigen-friendly param struct. Builds a single-region instrument around
+   one sample file without an .sfz text file, decoding the sample on the calling
+   thread. `name` may be NULL (identification only). `file` is the absolute
+   sample path. `root` is the key that plays the sample untransposed; `low` /
+   `high` bound the playable key range. `attack` / `release` are the amplitude
+   envelope times in seconds; `max_length` caps a non-looping one-shot in
+   seconds. Mirrors YSE::SYNTH::samplerConfig. */
+typedef struct YseSamplerConfig {
+  const char* name; /* Instrument label (may be NULL). */
+  const char* file; /* Absolute path to the sample file (sample=). */
+  int root; /* Root note (key that plays untransposed). */
+  int low; /* Lowest playable key. */
+  int high; /* Highest playable key. */
+  float attack; /* Amplitude-envelope attack, seconds. */
+  float release; /* Amplitude-envelope release, seconds. */
+  float max_length; /* One-shot length cap, seconds (non-looping regions). */
+} YseSamplerConfig;
+
+/* Build a one-region instrument from a YseSamplerConfig. Returns NULL on
+   failure (NULL cfg, missing / unreadable sample) with yse_last_error() set. */
+YSE_C_API YseSfzInstrument* yse_sfz_load_config(const YseSamplerConfig* cfg);
+
+/* Whether the instrument is playable (valid region table + at least one
+   resident sample). 0 on a NULL or already-destroyed handle. */
+YSE_C_API int yse_sfz_is_valid(YseSfzInstrument* h);
+
+/* Release an instrument handle. A double free or a NULL handle is a logged
+   no-op, not a crash. */
+YSE_C_API void yse_sfz_destroy(YseSfzInstrument* h);
+
+/* ─── DX7 SysEx bank ─────────────────────────────────────────────────────── */
+
+/* Load and parse a DX7 .syx file into a bank. A 32-voice packed bulk dump
+   yields 32 patches; a single-voice dump yields 1. Reads the file on the
+   calling thread. Returns NULL on failure (file not found / unreadable, bad
+   header, wrong length, checksum mismatch) with yse_last_error() set. */
+YSE_C_API YseDx7Bank* yse_dx7_import_sysex(const char* path);
+
+/* Number of patches in the bank. 0 on a NULL or already-destroyed handle. */
+YSE_C_API int yse_dx7_get_patch_count(YseDx7Bank* h);
+
+/* Write the (space-trimmed) name of patch `index` into `buf` as a
+   NUL-terminated string, snprintf-style; returns the length that would have
+   been written (excluding the NUL), or 0 for an out-of-range index or a NULL /
+   destroyed handle. `buf` may be NULL to query the length. */
+YSE_C_API size_t yse_dx7_get_patch_name(YseDx7Bank* h, int index, char* buf, size_t cap);
+
+/* Release a bank handle. A double free or a NULL handle is a logged no-op,
+   not a crash. */
+YSE_C_API void yse_dx7_destroy(YseDx7Bank* h);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/YseEngine/c_api/include/yse_c/yse_synth.h
+++ b/YseEngine/c_api/include/yse_c/yse_synth.h
@@ -12,12 +12,29 @@
   yse_synth_get_num_voices() for the cloned count) — exactly like a
   file-backed sound is not playable until its buffer finishes loading.
 
-  Scope: only the BUILT-IN reference voice (sine + ADSR, issue #152) is
-  exposed, via yse_synth_add_voices_sine. Defining a custom dspVoice
-  subclass from C is deliberately DEFERRED — it needs the same audio-thread
-  dspSourceObject callback plumbing that keeps dspSourceObject unwrapped
-  (see yse_dsp.h and docs/design/synth_core.md §1 non-goals). Instrument
-  voices (#148) will add more yse_synth_add_voices_* variants later.
+  Scope: the BUILT-IN voice types are exposed via yse_synth_add_voices_*: the
+  reference sine + ADSR voice (issue #152), and the three instruments (issue
+  #178) — the SFZ sampler (add_voices_sampler, fed a YseSfzInstrument loaded
+  through yse_instrument.h), the virtual-analog + wavetable voice
+  (add_voices_va, with per-parameter setters below), and the DX7-class 6-op FM
+  voice (add_voices_fm, patched from a YseDx7Bank or the headline setters
+  below). Defining a CUSTOM dspVoice subclass from C is deliberately DEFERRED —
+  it needs the same audio-thread dspSourceObject callback plumbing that keeps
+  dspSourceObject unwrapped (see yse_dsp.h and docs/design/synth_core.md §1
+  non-goals).
+
+  Parameter reach (parity, #178): the VA voice's live patch (YSE::SYNTH::vaParams)
+  is fully covered by the yse_synth_va_set_* setters below — every field is a
+  glitch-free atomic, so each setter is safe to call while voices play. The FM
+  voice's patch (YSE::SYNTH::fmPatch) is plain DX7 voice data; its full 155-
+  parameter set is authored by importing a DX7 bank and selecting a patch
+  (yse_synth_fm_set_patch), and the headline globals + per-operator level/
+  frequency are also reachable directly via the yse_synth_fm_set_* setters. FM
+  patch edits take effect on the NEXT note-on (the FM core bakes operator state
+  at key-down, like the hardware between notes), so the FM setters are not
+  glitch-free mid-note — unlike the VA ones. The sampler voice has no live tone
+  parameters: its sound is the immutable SFZ instrument, authored at load time
+  through yse_instrument.h (yse_sfz_load / yse_sfz_load_config).
 
   Per-note 3D positioning (issue #171, §14 of
   docs/design/per_note_positioning.md) is exposed by the same policy: only the
@@ -43,7 +60,8 @@
 #define YSE_C_SYNTH_H_INCLUDED
 
 #include "yse_common.h"
-#include "yse_enums.h" /* YseSynthPositionHandler, YseSynthHandlerParam */
+#include "yse_enums.h" /* YseSynthPositionHandler, YseSynthHandlerParam, YseVaWaveform, YseLfoType */
+#include "yse_instrument.h" /* YseSfzInstrument, YseDx7Bank (sampler / FM assets) */
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,6 +115,107 @@ YSE_C_API int yse_synth_is_valid(YseSynth* h);
 YSE_C_API YseStatus yse_synth_add_voices_sine(YseSynth* h, int num_voices, int channel,
                                               int lowest_note, int highest_note, float attack,
                                               float decay, float sustain, float release);
+
+/* ─── instrument voice groups (issue #178) ────────────────────────────────
+   Each adds `num_voices` clones of the named built-in instrument voice,
+   responding omni (all channels) across the full key range — the SFZ regions /
+   patch decide how a note actually sounds. Like add_voices_sine, they must be
+   called BEFORE the synth is played; adding voices after the pool is built is
+   rejected. Return YseStatus; on failure yse_last_error() is set and no group
+   is added. */
+
+/* Add a group of SFZ sampler voices rendering `instrument` (loaded via
+   yse_sfz_load / yse_sfz_load_config). The instrument's region table and PCM
+   are shared with the voice group, which retains its own reference — so the
+   YseSfzInstrument handle may be destroyed right after this returns.
+   YSE_ERR_INVALID_ARGUMENT if `instrument` is NULL or already destroyed. */
+YSE_C_API YseStatus yse_synth_add_voices_sampler(YseSynth* h, YseSfzInstrument* instrument,
+                                                 int num_voices);
+
+/* Add a group of virtual-analog + wavetable voices with a fresh default patch.
+   This establishes the synth's VA patch; the yse_synth_va_set_* setters below
+   steer it. Call once per synth (a second call replaces which patch the setters
+   target — layering multiple VA groups is out of scope for the C API). */
+YSE_C_API YseStatus yse_synth_add_voices_va(YseSynth* h, int num_voices);
+
+/* Add a group of DX7-class 6-operator FM voices with the built-in sine test
+   patch. This establishes the synth's FM patch; select a DX7 voice into it with
+   yse_synth_fm_set_patch, or dial the headline params with yse_synth_fm_set_*.
+   Call once per synth (see add_voices_va's note). */
+YSE_C_API YseStatus yse_synth_add_voices_fm(YseSynth* h, int num_voices);
+
+/* ─── VA patch parameters (issue #178) ─────────────────────────────────────
+   Steer the synth's VA patch (established by yse_synth_add_voices_va). Every
+   value is a glitch-free atomic read on the audio thread, so these are safe to
+   call while voices play. All are null-safe no-ops on a NULL handle or a synth
+   with no VA group. `osc` is the oscillator index 0..2 (out-of-range ignored).
+   Times are in seconds; sustains and normalised depths in [0, 1] unless noted. */
+YSE_C_API void yse_synth_va_set_osc_wave(YseSynth* h, int osc, YseVaWaveform wave);
+YSE_C_API void yse_synth_va_set_osc_detune(YseSynth* h, int osc, float semitones);
+YSE_C_API void yse_synth_va_set_osc_level(YseSynth* h, int osc, float level);
+YSE_C_API void yse_synth_va_set_osc_pulse_width(YseSynth* h, int osc, float width);
+YSE_C_API void yse_synth_va_set_wavetable_position(YseSynth* h, float position);
+YSE_C_API void yse_synth_va_set_cutoff(YseSynth* h, float hz);
+YSE_C_API void yse_synth_va_set_resonance(YseSynth* h, float resonance);
+YSE_C_API void yse_synth_va_set_key_tracking(YseSynth* h, float amount);
+YSE_C_API void yse_synth_va_set_filter_env_amount(YseSynth* h, float octaves);
+YSE_C_API void yse_synth_va_set_filter_vel_amount(YseSynth* h, float octaves);
+YSE_C_API void yse_synth_va_set_amp_attack(YseSynth* h, float seconds);
+YSE_C_API void yse_synth_va_set_amp_decay(YseSynth* h, float seconds);
+YSE_C_API void yse_synth_va_set_amp_sustain(YseSynth* h, float level);
+YSE_C_API void yse_synth_va_set_amp_release(YseSynth* h, float seconds);
+YSE_C_API void yse_synth_va_set_amp_vel_amount(YseSynth* h, float amount);
+YSE_C_API void yse_synth_va_set_filter_attack(YseSynth* h, float seconds);
+YSE_C_API void yse_synth_va_set_filter_decay(YseSynth* h, float seconds);
+YSE_C_API void yse_synth_va_set_filter_sustain(YseSynth* h, float level);
+YSE_C_API void yse_synth_va_set_filter_release(YseSynth* h, float seconds);
+YSE_C_API void yse_synth_va_set_lfo_type(YseSynth* h, YseLfoType type);
+YSE_C_API void yse_synth_va_set_lfo_rate(YseSynth* h, float hz);
+YSE_C_API void yse_synth_va_set_lfo_to_pitch(YseSynth* h, float semitones);
+YSE_C_API void yse_synth_va_set_lfo_to_cutoff(YseSynth* h, float octaves);
+YSE_C_API void yse_synth_va_set_lfo_to_wavetable(YseSynth* h, float amount);
+YSE_C_API void yse_synth_va_set_gain(YseSynth* h, float gain);
+
+/* Install a single-cycle waveform into the VA wavetable morph bank at `slot`
+   (used by YSE_VA_WAVETABLE mode). `cycle` points to `length` normalised
+   samples (one period). SETUP-THREAD only — this reshapes table storage; call
+   before the synth is played, not while voices render. Null-safe no-op on a
+   NULL handle / cycle, an empty length, or a synth with no VA group. */
+YSE_C_API void yse_synth_va_load_wavetable(YseSynth* h, int slot, const float* cycle,
+                                           size_t length);
+
+/* ─── FM patch (issue #178) ────────────────────────────────────────────────
+   Author the synth's FM patch (established by yse_synth_add_voices_fm). Edits
+   take effect on the NEXT note-on (the FM core bakes operator state at key-
+   down), so these are not glitch-free mid-note. All are null-safe no-ops on a
+   NULL handle or a synth with no FM group. */
+
+/* Copy patch `index` from a DX7 bank (imported via yse_dx7_import_sysex) into
+   the synth's FM patch — the way to reach the full 155-parameter DX7 voice from
+   C. The patch is copied, so `bank` may be destroyed afterwards.
+   YSE_ERR_INVALID_ARGUMENT for a NULL / destroyed bank or an out-of-range
+   index; YSE_ERR_INVALID_HANDLE for a NULL synth or one with no FM group. */
+YSE_C_API YseStatus yse_synth_fm_set_patch(YseSynth* h, YseDx7Bank* bank, int index);
+
+/* Headline global params (DX7 ranges; clamped defensively engine-side). */
+YSE_C_API void yse_synth_fm_set_algorithm(YseSynth* h, int algorithm); /* 0..31 */
+YSE_C_API void yse_synth_fm_set_feedback(YseSynth* h, int feedback); /* 0..7  */
+YSE_C_API void yse_synth_fm_set_transpose(YseSynth* h, int transpose); /* 0..48, 24 = none */
+YSE_C_API void yse_synth_fm_set_lfo_speed(YseSynth* h, int speed); /* 0..99 */
+YSE_C_API void yse_synth_fm_set_lfo_delay(YseSynth* h, int delay); /* 0..99 */
+YSE_C_API void yse_synth_fm_set_lfo_waveform(YseSynth* h, int waveform); /* 0..5  */
+YSE_C_API void yse_synth_fm_set_lfo_pitch_mod_depth(YseSynth* h, int depth); /* 0..99 */
+YSE_C_API void yse_synth_fm_set_lfo_amp_mod_depth(YseSynth* h, int depth); /* 0..99 */
+YSE_C_API void yse_synth_fm_set_pitch_mod_sens(YseSynth* h, int sensitivity); /* 0..7 */
+
+/* Headline per-operator params. `op` is the operator index 0..5 (OP1..OP6);
+   out-of-range is ignored. */
+YSE_C_API void yse_synth_fm_set_op_output_level(YseSynth* h, int op, int level); /* 0..99 */
+YSE_C_API void yse_synth_fm_set_op_freq_coarse(YseSynth* h, int op, int coarse); /* 0..31 */
+YSE_C_API void yse_synth_fm_set_op_freq_fine(YseSynth* h, int op, int fine); /* 0..99 */
+YSE_C_API void yse_synth_fm_set_op_detune(YseSynth* h, int op, int detune); /* 0..14, 7 = centre */
+YSE_C_API void yse_synth_fm_set_op_osc_mode(YseSynth* h, int op, int mode); /* 0 ratio, 1 fixed */
+YSE_C_API void yse_synth_fm_set_op_enabled(YseSynth* h, int op, int enabled); /* 0/1 */
 
 /* Total number of allocated (cloned) voices across every group. Zero until
    the setup pool finishes cloning; poll it to know the synth is playable. */

--- a/YseEngine/c_api/yse_enums_check.cpp
+++ b/YseEngine/c_api/yse_enums_check.cpp
@@ -19,6 +19,7 @@
 #include "../patcher/pEnums.h"
 #include "../synth/positionHandler.hpp"
 #include "../synth/positionHandlers.hpp"
+#include "../synth/vaVoice.hpp"
 
 #include <type_traits>
 
@@ -63,6 +64,14 @@ namespace {
   YSE_ASSERT_ENUM(YSE_LFO_SINE, YSE::DSP::LFO_SINE);
   YSE_ASSERT_ENUM(YSE_LFO_SQUARE, YSE::DSP::LFO_SQUARE);
   YSE_ASSERT_ENUM(YSE_LFO_RANDOM, YSE::DSP::LFO_RANDOM);
+
+  // YseVaWaveform ↔ YSE::SYNTH::VA_WAVEFORM
+  YSE_ASSERT_ENUM(YSE_VA_SAW, YSE::SYNTH::VA_SAW);
+  YSE_ASSERT_ENUM(YSE_VA_PULSE, YSE::SYNTH::VA_PULSE);
+  YSE_ASSERT_ENUM(YSE_VA_TRIANGLE, YSE::SYNTH::VA_TRIANGLE);
+  YSE_ASSERT_ENUM(YSE_VA_SINE, YSE::SYNTH::VA_SINE);
+  YSE_ASSERT_ENUM(YSE_VA_NOISE, YSE::SYNTH::VA_NOISE);
+  YSE_ASSERT_ENUM(YSE_VA_WAVETABLE, YSE::SYNTH::VA_WAVETABLE);
 
   // YseDspSweepShape ↔ YSE::DSP::MODULES::sweepFilter::SHAPE
   YSE_ASSERT_ENUM(YSE_SWEEP_TRIANGLE, YSE::DSP::MODULES::sweepFilter::TRIANGLE);

--- a/YseEngine/c_api/yse_instrument.cpp
+++ b/YseEngine/c_api/yse_instrument.cpp
@@ -1,0 +1,253 @@
+#include "yse_c/yse_instrument.h"
+#include "yse_c_internal.hpp"
+#include "yse_instrument_internal.hpp"
+
+#include "../synth/samplerVoice.hpp"
+#include "../dsp/fm/dx7Sysex.hpp"
+#include "../implementations/logImplementation.h"
+#include "../headers/enums.hpp"
+
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+// The instrument-asset handles (SFZ instrument + DX7 bank) are the one place in
+// the C API that must survive double-free and use-after-destroy as LOGGED
+// no-ops rather than crashes (issue #178 acceptance). The engine's own create/
+// destroy handles trust the caller; these do not. Both live entirely on the
+// control / setup thread — loading an SFZ or a bank already allocates and reads
+// files — so a mutex-guarded live-handle registry here is fine (it is NOT on
+// any audio-thread path, so the c-api-extend "no mutex in RT bridges" rule does
+// not apply). Every handle is registered on create and validated on every use;
+// an unknown pointer is ignored and logged.
+
+namespace {
+
+  // Impl structs — layout owned by this TU only.
+  struct SfzInstrumentImpl {
+    std::shared_ptr<YSE::SYNTH::samplerInstrument> inst;
+  };
+  struct Dx7BankImpl {
+    YSE::SYNTH::dx7Bank bank;
+  };
+
+  // Live-handle registry. Separate sets per kind so passing a bank where an
+  // instrument is expected (or vice versa) is caught, not misinterpreted.
+  std::mutex& registryMutex() {
+    static std::mutex m;
+    return m;
+  }
+  std::unordered_set<const void*>& liveSfz() {
+    static std::unordered_set<const void*> s;
+    return s;
+  }
+  std::unordered_set<const void*>& liveBank() {
+    static std::unordered_set<const void*> s;
+    return s;
+  }
+
+  void logIgnored(const char* what) {
+    YSE::INTERNAL::LogImpl().emit(YSE::E_WARNING, std::string(what));
+  }
+
+  // Register a freshly created handle.
+  void registerSfz(const void* p) {
+    std::lock_guard<std::mutex> lk(registryMutex());
+    liveSfz().insert(p);
+  }
+  void registerBank(const void* p) {
+    std::lock_guard<std::mutex> lk(registryMutex());
+    liveBank().insert(p);
+  }
+
+  // Erase on destroy; returns true if the handle was live (so the caller frees
+  // it), false if it was NULL / unknown / already destroyed (logged no-op).
+  bool retireSfz(const void* p) {
+    if (!p) return false;
+    std::lock_guard<std::mutex> lk(registryMutex());
+    return liveSfz().erase(p) != 0;
+  }
+  bool retireBank(const void* p) {
+    if (!p) return false;
+    std::lock_guard<std::mutex> lk(registryMutex());
+    return liveBank().erase(p) != 0;
+  }
+
+  // Validate for use; true only for a live registered handle of the right kind.
+  bool isLiveSfz(const void* p) {
+    if (!p) return false;
+    std::lock_guard<std::mutex> lk(registryMutex());
+    return liveSfz().count(p) != 0;
+  }
+  bool isLiveBank(const void* p) {
+    if (!p) return false;
+    std::lock_guard<std::mutex> lk(registryMutex());
+    return liveBank().count(p) != 0;
+  }
+
+  inline SfzInstrumentImpl* toSfz(YseSfzInstrument* h) {
+    return reinterpret_cast<SfzInstrumentImpl*>(h);
+  }
+  inline Dx7BankImpl* toBank(YseDx7Bank* h) {
+    return reinterpret_cast<Dx7BankImpl*>(h);
+  }
+
+  size_t copy_string(const std::string& src, char* buf, size_t cap) {
+    if (buf && cap > 0) {
+      size_t n = src.size() < cap - 1 ? src.size() : cap - 1;
+      std::memcpy(buf, src.data(), n);
+      buf[n] = '\0';
+    }
+    return src.size();
+  }
+
+} // namespace
+
+// Cross-TU accessors (declared in yse_instrument_internal.hpp) — validate the
+// handle against the registry, then hand yse_synth.cpp the engine payload.
+namespace yse_c {
+
+  std::shared_ptr<YSE::SYNTH::samplerInstrument>
+  sampler_instrument_from_handle(YseSfzInstrument* h) {
+    if (!isLiveSfz(h)) {
+      logIgnored("yse_synth_add_voices_sampler: unknown or destroyed instrument handle (ignored)");
+      return nullptr;
+    }
+    return toSfz(h)->inst;
+  }
+
+  const YSE::SYNTH::dx7Bank* dx7_bank_from_handle(YseDx7Bank* h) {
+    if (!isLiveBank(h)) {
+      logIgnored("yse_synth_fm_set_patch: unknown or destroyed bank handle (ignored)");
+      return nullptr;
+    }
+    return &toBank(h)->bank;
+  }
+
+} // namespace yse_c
+
+extern "C" {
+
+// ─── SFZ sampler instrument ──────────────────────────────────────────────
+
+YSE_C_API YseSfzInstrument* yse_sfz_load(const char* path) {
+  if (!path) {
+    yse_c::set_last_error("yse_sfz_load: null path");
+    return nullptr;
+  }
+  try {
+    // Load through the tested public loader on a throwaway prototype, then keep
+    // its shared instrument (region table + resident PCM). Setup-thread work.
+    YSE::SYNTH::samplerVoice v;
+    if (!v.loadSFZ(path)) {
+      yse_c::set_last_error(std::string("yse_sfz_load: no playable instrument in: ") + path);
+      return nullptr;
+    }
+    auto* impl = new SfzInstrumentImpl();
+    impl->inst = v.instrument();
+    registerSfz(impl);
+    return reinterpret_cast<YseSfzInstrument*>(impl);
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("yse_sfz_load: unknown C++ exception");
+    return nullptr;
+  }
+}
+
+YSE_C_API YseSfzInstrument* yse_sfz_load_config(const YseSamplerConfig* cfg) {
+  if (!cfg || !cfg->file) {
+    yse_c::set_last_error("yse_sfz_load_config: null config or file");
+    return nullptr;
+  }
+  try {
+    YSE::SYNTH::samplerConfig sc;
+    if (cfg->name) sc.name(cfg->name);
+    sc.file(cfg->file)
+        .root(static_cast<U8>(cfg->root))
+        .range(static_cast<U8>(cfg->low), static_cast<U8>(cfg->high))
+        .envelope(cfg->attack, cfg->release, cfg->max_length);
+    YSE::SYNTH::samplerVoice v;
+    if (!v.configure(sc)) {
+      yse_c::set_last_error(std::string("yse_sfz_load_config: could not build instrument from: ") +
+                            cfg->file);
+      return nullptr;
+    }
+    auto* impl = new SfzInstrumentImpl();
+    impl->inst = v.instrument();
+    registerSfz(impl);
+    return reinterpret_cast<YseSfzInstrument*>(impl);
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("yse_sfz_load_config: unknown C++ exception");
+    return nullptr;
+  }
+}
+
+YSE_C_API int yse_sfz_is_valid(YseSfzInstrument* h) {
+  if (!isLiveSfz(h)) return 0;
+  auto& inst = toSfz(h)->inst;
+  return (inst && inst->valid()) ? 1 : 0;
+}
+
+YSE_C_API void yse_sfz_destroy(YseSfzInstrument* h) {
+  if (!retireSfz(h)) {
+    if (h) logIgnored("yse_sfz_destroy: unknown or double-freed instrument handle (ignored)");
+    return;
+  }
+  delete toSfz(h);
+}
+
+// ─── DX7 SysEx bank ──────────────────────────────────────────────────────
+
+YSE_C_API YseDx7Bank* yse_dx7_import_sysex(const char* path) {
+  if (!path) {
+    yse_c::set_last_error("yse_dx7_import_sysex: null path");
+    return nullptr;
+  }
+  try {
+    auto* impl = new Dx7BankImpl();
+    if (!YSE::SYNTH::dx7SysEx::loadBank(path, impl->bank) || impl->bank.empty()) {
+      delete impl;
+      yse_c::set_last_error(std::string("yse_dx7_import_sysex: could not parse bank: ") + path);
+      return nullptr;
+    }
+    registerBank(impl);
+    return reinterpret_cast<YseDx7Bank*>(impl);
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("yse_dx7_import_sysex: unknown C++ exception");
+    return nullptr;
+  }
+}
+
+YSE_C_API int yse_dx7_get_patch_count(YseDx7Bank* h) {
+  if (!isLiveBank(h)) return 0;
+  return static_cast<int>(toBank(h)->bank.size());
+}
+
+YSE_C_API size_t yse_dx7_get_patch_name(YseDx7Bank* h, int index, char* buf, size_t cap) {
+  if (!isLiveBank(h) || index < 0) {
+    if (buf && cap > 0) buf[0] = '\0';
+    return 0;
+  }
+  return copy_string(toBank(h)->bank.name(static_cast<size_t>(index)), buf, cap);
+}
+
+YSE_C_API void yse_dx7_destroy(YseDx7Bank* h) {
+  if (!retireBank(h)) {
+    if (h) logIgnored("yse_dx7_destroy: unknown or double-freed bank handle (ignored)");
+    return;
+  }
+  delete toBank(h);
+}
+
+} // extern "C"

--- a/YseEngine/c_api/yse_instrument_internal.hpp
+++ b/YseEngine/c_api/yse_instrument_internal.hpp
@@ -1,0 +1,42 @@
+/*
+  yse_instrument_internal.hpp — private cross-TU accessors for the instrument
+  asset handles (YseSfzInstrument / YseDx7Bank). Not installed; never included
+  by a C ABI consumer.
+
+  The handle impl structs and the live-handle registry live in
+  yse_instrument.cpp (the only TU that owns their layout and lifetime). These
+  accessors let yse_synth.cpp reach the engine payload behind a handle WITHOUT
+  duplicating the registry or the impl struct — each accessor validates the
+  handle against the registry and returns nullptr (logging the misuse) for a
+  NULL or already-destroyed handle, exactly like the public entry points.
+
+  Both engine headers are included here so the accessor signatures name the
+  real engine types; keep this out of yse_c_internal.hpp so that shared header
+  stays free of engine includes.
+*/
+
+#ifndef YSE_C_INSTRUMENT_INTERNAL_HPP
+#define YSE_C_INSTRUMENT_INTERNAL_HPP
+
+#include <memory>
+
+#include "include/yse_c/yse_instrument.h"
+#include "../synth/samplerVoice.hpp"
+#include "../dsp/fm/dx7Sysex.hpp"
+
+namespace yse_c {
+
+  // The shared SFZ instrument behind a live handle, or nullptr (logged) for a
+  // NULL / already-destroyed handle. Returned by value so the caller retains a
+  // share (setInstrument keeps the PCM alive independently of the handle).
+  std::shared_ptr<YSE::SYNTH::samplerInstrument>
+  sampler_instrument_from_handle(YseSfzInstrument* h);
+
+  // The parsed DX7 bank behind a live handle, or nullptr (logged) for a NULL /
+  // already-destroyed handle. Borrowed — the bank stays owned by the handle;
+  // callers copy the patch they select out of it.
+  const YSE::SYNTH::dx7Bank* dx7_bank_from_handle(YseDx7Bank* h);
+
+} // namespace yse_c
+
+#endif

--- a/YseEngine/c_api/yse_synth.cpp
+++ b/YseEngine/c_api/yse_synth.cpp
@@ -1,15 +1,23 @@
 #include "yse_c/yse_synth.h"
 #include "yse_c_internal.hpp"
+#include "yse_instrument_internal.hpp"
 
 #include "../synth/synthInterface.hpp"
 #include "../synth/sineVoice.hpp"
+#include "../synth/samplerVoice.hpp"
+#include "../synth/vaVoice.hpp"
 #include "../synth/dspVoice.hpp"
 #include "../synth/positionHandler.hpp"
 #include "../synth/positionHandlers.hpp"
+#include "../dsp/fm/fmVoice.hpp"
+#include "../dsp/fm/fmPatch.hpp"
+#include "../dsp/lfo.hpp"
 #include "../sound/soundInterface.hpp"
 #include "../channel/channelInterface.hpp"
 #include "../utils/vector.hpp"
 
+#include <algorithm>
+#include <atomic>
 #include <exception>
 #include <memory>
 #include <vector>
@@ -33,6 +41,15 @@ namespace {
     // the single attached prototype and frees it on destroy. Allocated on the
     // control thread only.
     std::unique_ptr<YSE::SYNTH::positionHandler> positionHandler;
+
+    // The live, shared patch of the synth's VA / FM voice group (issue #178),
+    // if one was added. add_voices_va / add_voices_fm record the prototype's
+    // shared patch here so the yse_synth_va_set_* / yse_synth_fm_set_* setters
+    // can steer it after the prototype has been cloned. The voice clones share
+    // the same patch object, so a setter reaches every voice. Null until the
+    // matching add-voices is called.
+    std::shared_ptr<YSE::SYNTH::vaParams> vaPatch;
+    std::shared_ptr<YSE::SYNTH::fmPatch> fmPatch;
   };
 
   inline YseSynthImpl* to_impl(YseSynth* h) {
@@ -109,6 +126,271 @@ YSE_C_API YseStatus yse_synth_add_voices_sine(YseSynth* h, int num_voices, int c
   } catch (...) {
     yse_c::set_last_error("yse_synth_add_voices_sine: unknown C++ exception");
     return YSE_ERR_EXCEPTION;
+  }
+}
+
+// ─── instrument voice groups (issue #178) ──────────────────────────────
+
+YSE_C_API YseStatus yse_synth_add_voices_sampler(YseSynth* h, YseSfzInstrument* instrument,
+                                                 int num_voices) {
+  if (!h) return YSE_ERR_INVALID_HANDLE;
+  if (num_voices <= 0) return YSE_ERR_INVALID_ARGUMENT;
+  // Validated against the instrument-handle registry; a NULL / destroyed handle
+  // returns nullptr (and is logged) rather than dereferencing junk.
+  auto inst = yse_c::sampler_instrument_from_handle(instrument);
+  if (!inst) return YSE_ERR_INVALID_ARGUMENT;
+  try {
+    auto* impl = to_impl(h);
+    // Same prototype-ownership discipline as the sine path: build the prototype,
+    // hand ownership to the handle BEFORE addVoices records its raw pointer. The
+    // clones share the immutable region table + resident PCM (never duplicated).
+    auto proto = std::make_unique<YSE::SYNTH::samplerVoice>();
+    proto->setInstrument(inst);
+    YSE::SYNTH::dspVoice* raw = proto.get();
+    impl->prototypes.push_back(std::move(proto));
+    impl->synth.addVoices(*raw, num_voices, 0, 0, 127);
+    return YSE_OK;
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return YSE_ERR_EXCEPTION;
+  } catch (...) {
+    yse_c::set_last_error("yse_synth_add_voices_sampler: unknown C++ exception");
+    return YSE_ERR_EXCEPTION;
+  }
+}
+
+YSE_C_API YseStatus yse_synth_add_voices_va(YseSynth* h, int num_voices) {
+  if (!h) return YSE_ERR_INVALID_HANDLE;
+  if (num_voices <= 0) return YSE_ERR_INVALID_ARGUMENT;
+  try {
+    auto* impl = to_impl(h);
+    auto proto = std::make_unique<YSE::SYNTH::vaVoice>();
+    // Record the shared patch so the va setters can steer it after cloning; the
+    // clones share this same vaParams (carried across clone() by shared_ptr).
+    impl->vaPatch = proto->patch();
+    YSE::SYNTH::dspVoice* raw = proto.get();
+    impl->prototypes.push_back(std::move(proto));
+    impl->synth.addVoices(*raw, num_voices, 0, 0, 127);
+    return YSE_OK;
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return YSE_ERR_EXCEPTION;
+  } catch (...) {
+    yse_c::set_last_error("yse_synth_add_voices_va: unknown C++ exception");
+    return YSE_ERR_EXCEPTION;
+  }
+}
+
+YSE_C_API YseStatus yse_synth_add_voices_fm(YseSynth* h, int num_voices) {
+  if (!h) return YSE_ERR_INVALID_HANDLE;
+  if (num_voices <= 0) return YSE_ERR_INVALID_ARGUMENT;
+  try {
+    auto* impl = to_impl(h);
+    auto proto = std::make_unique<YSE::SYNTH::fmVoice>();
+    impl->fmPatch = proto->patch();
+    YSE::SYNTH::dspVoice* raw = proto.get();
+    impl->prototypes.push_back(std::move(proto));
+    impl->synth.addVoices(*raw, num_voices, 0, 0, 127);
+    return YSE_OK;
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return YSE_ERR_EXCEPTION;
+  } catch (...) {
+    yse_c::set_last_error("yse_synth_add_voices_fm: unknown C++ exception");
+    return YSE_ERR_EXCEPTION;
+  }
+}
+
+// ─── VA patch parameters (issue #178) ──────────────────────────────────
+
+namespace {
+  // The synth's VA patch, or nullptr for a NULL handle / no VA group. Setters
+  // below no-op on nullptr, matching the header's null-safe contract.
+  inline YSE::SYNTH::vaParams* va(YseSynth* h) {
+    return h ? to_impl(h)->vaPatch.get() : nullptr;
+  }
+  inline bool oscInRange(int osc) {
+    return osc >= 0 && osc < YSE::SYNTH::vaParams::kNumOsc;
+  }
+} // namespace
+
+YSE_C_API void yse_synth_va_set_osc_wave(YseSynth* h, int osc, YseVaWaveform wave) {
+  auto* p = va(h);
+  if (p && oscInRange(osc))
+    p->oscWave[osc].store(static_cast<int>(wave), std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_osc_detune(YseSynth* h, int osc, float semitones) {
+  auto* p = va(h);
+  if (p && oscInRange(osc)) p->oscDetune[osc].store(semitones, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_osc_level(YseSynth* h, int osc, float level) {
+  auto* p = va(h);
+  if (p && oscInRange(osc)) p->oscLevel[osc].store(level, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_osc_pulse_width(YseSynth* h, int osc, float width) {
+  auto* p = va(h);
+  if (p && oscInRange(osc)) p->oscPulseWidth[osc].store(width, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_wavetable_position(YseSynth* h, float position) {
+  if (auto* p = va(h)) p->wavetablePosition.store(position, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_cutoff(YseSynth* h, float hz) {
+  if (auto* p = va(h)) p->cutoff.store(hz, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_resonance(YseSynth* h, float resonance) {
+  if (auto* p = va(h)) p->resonance.store(resonance, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_key_tracking(YseSynth* h, float amount) {
+  if (auto* p = va(h)) p->keyTracking.store(amount, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_filter_env_amount(YseSynth* h, float octaves) {
+  if (auto* p = va(h)) p->filterEnvAmount.store(octaves, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_filter_vel_amount(YseSynth* h, float octaves) {
+  if (auto* p = va(h)) p->filterVelAmount.store(octaves, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_amp_attack(YseSynth* h, float seconds) {
+  if (auto* p = va(h)) p->ampAttack.store(seconds, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_amp_decay(YseSynth* h, float seconds) {
+  if (auto* p = va(h)) p->ampDecay.store(seconds, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_amp_sustain(YseSynth* h, float level) {
+  if (auto* p = va(h)) p->ampSustain.store(level, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_amp_release(YseSynth* h, float seconds) {
+  if (auto* p = va(h)) p->ampRelease.store(seconds, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_amp_vel_amount(YseSynth* h, float amount) {
+  if (auto* p = va(h)) p->ampVelAmount.store(amount, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_filter_attack(YseSynth* h, float seconds) {
+  if (auto* p = va(h)) p->filterAttack.store(seconds, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_filter_decay(YseSynth* h, float seconds) {
+  if (auto* p = va(h)) p->filterDecay.store(seconds, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_filter_sustain(YseSynth* h, float level) {
+  if (auto* p = va(h)) p->filterSustain.store(level, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_filter_release(YseSynth* h, float seconds) {
+  if (auto* p = va(h)) p->filterRelease.store(seconds, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_lfo_type(YseSynth* h, YseLfoType type) {
+  if (auto* p = va(h)) p->lfoType.store(static_cast<int>(type), std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_lfo_rate(YseSynth* h, float hz) {
+  if (auto* p = va(h)) p->lfoRate.store(hz, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_lfo_to_pitch(YseSynth* h, float semitones) {
+  if (auto* p = va(h)) p->lfoToPitch.store(semitones, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_lfo_to_cutoff(YseSynth* h, float octaves) {
+  if (auto* p = va(h)) p->lfoToCutoff.store(octaves, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_lfo_to_wavetable(YseSynth* h, float amount) {
+  if (auto* p = va(h)) p->lfoToWavetable.store(amount, std::memory_order_relaxed);
+}
+YSE_C_API void yse_synth_va_set_gain(YseSynth* h, float gain) {
+  if (auto* p = va(h)) p->gain.store(gain, std::memory_order_relaxed);
+}
+
+YSE_C_API void yse_synth_va_load_wavetable(YseSynth* h, int slot, const float* cycle,
+                                           size_t length) {
+  auto* p = va(h);
+  if (!p || !cycle || length == 0 || slot < 0) return;
+  // Setup-thread reshape of the morph bank; copy into a vector for the engine
+  // API. Off the audio thread by contract (documented in the header).
+  std::vector<Flt> cyc(cycle, cycle + length);
+  p->loadWavetable(slot, cyc);
+}
+
+// ─── FM patch (issue #178) ─────────────────────────────────────────────
+
+namespace {
+  inline YSE::SYNTH::fmPatch* fm(YseSynth* h) {
+    return h ? to_impl(h)->fmPatch.get() : nullptr;
+  }
+  // Clamp a C int into a DX7 byte field's valid range before storing, so a
+  // stray C value can never overflow the uint8_t or index a routing table out
+  // of bounds (the header documents the ranges; the engine also clamps).
+  inline U8 clampByte(int v, int lo, int hi) {
+    return static_cast<U8>(v < lo ? lo : (v > hi ? hi : v));
+  }
+  inline bool fmOpInRange(int op) {
+    return op >= 0 && op < 6;
+  }
+} // namespace
+
+YSE_C_API YseStatus yse_synth_fm_set_patch(YseSynth* h, YseDx7Bank* bank, int index) {
+  if (!h) return YSE_ERR_INVALID_HANDLE;
+  auto* p = fm(h);
+  if (!p) return YSE_ERR_INVALID_HANDLE; // no FM group established
+  const YSE::SYNTH::dx7Bank* b = yse_c::dx7_bank_from_handle(bank);
+  if (!b) return YSE_ERR_INVALID_ARGUMENT; // NULL / destroyed bank (logged)
+  if (index < 0 || static_cast<size_t>(index) >= b->voices.size()) {
+    yse_c::set_last_error("yse_synth_fm_set_patch: patch index out of range");
+    return YSE_ERR_INVALID_ARGUMENT;
+  }
+  *p = b->voices[static_cast<size_t>(index)]; // plain-data copy; next note-on bakes it
+  return YSE_OK;
+}
+
+YSE_C_API void yse_synth_fm_set_algorithm(YseSynth* h, int algorithm) {
+  if (auto* p = fm(h)) p->algorithm = clampByte(algorithm, 0, 31);
+}
+YSE_C_API void yse_synth_fm_set_feedback(YseSynth* h, int feedback) {
+  if (auto* p = fm(h)) p->feedback = clampByte(feedback, 0, 7);
+}
+YSE_C_API void yse_synth_fm_set_transpose(YseSynth* h, int transpose) {
+  if (auto* p = fm(h)) p->transpose = clampByte(transpose, 0, 48);
+}
+YSE_C_API void yse_synth_fm_set_lfo_speed(YseSynth* h, int speed) {
+  if (auto* p = fm(h)) p->lfoSpeed = clampByte(speed, 0, 99);
+}
+YSE_C_API void yse_synth_fm_set_lfo_delay(YseSynth* h, int delay) {
+  if (auto* p = fm(h)) p->lfoDelay = clampByte(delay, 0, 99);
+}
+YSE_C_API void yse_synth_fm_set_lfo_waveform(YseSynth* h, int waveform) {
+  if (auto* p = fm(h)) p->lfoWaveform = clampByte(waveform, 0, 5);
+}
+YSE_C_API void yse_synth_fm_set_lfo_pitch_mod_depth(YseSynth* h, int depth) {
+  if (auto* p = fm(h)) p->lfoPitchModDepth = clampByte(depth, 0, 99);
+}
+YSE_C_API void yse_synth_fm_set_lfo_amp_mod_depth(YseSynth* h, int depth) {
+  if (auto* p = fm(h)) p->lfoAmpModDepth = clampByte(depth, 0, 99);
+}
+YSE_C_API void yse_synth_fm_set_pitch_mod_sens(YseSynth* h, int sensitivity) {
+  if (auto* p = fm(h)) p->pitchModSens = clampByte(sensitivity, 0, 7);
+}
+YSE_C_API void yse_synth_fm_set_op_output_level(YseSynth* h, int op, int level) {
+  auto* p = fm(h);
+  if (p && fmOpInRange(op)) p->op[op].outputLevel = clampByte(level, 0, 99);
+}
+YSE_C_API void yse_synth_fm_set_op_freq_coarse(YseSynth* h, int op, int coarse) {
+  auto* p = fm(h);
+  if (p && fmOpInRange(op)) p->op[op].freqCoarse = clampByte(coarse, 0, 31);
+}
+YSE_C_API void yse_synth_fm_set_op_freq_fine(YseSynth* h, int op, int fine) {
+  auto* p = fm(h);
+  if (p && fmOpInRange(op)) p->op[op].freqFine = clampByte(fine, 0, 99);
+}
+YSE_C_API void yse_synth_fm_set_op_detune(YseSynth* h, int op, int detune) {
+  auto* p = fm(h);
+  if (p && fmOpInRange(op)) p->op[op].detune = clampByte(detune, 0, 14);
+}
+YSE_C_API void yse_synth_fm_set_op_osc_mode(YseSynth* h, int op, int mode) {
+  auto* p = fm(h);
+  if (p && fmOpInRange(op)) p->op[op].oscMode = clampByte(mode, 0, 1);
+}
+YSE_C_API void yse_synth_fm_set_op_enabled(YseSynth* h, int op, int enabled) {
+  auto* p = fm(h);
+  if (p && fmOpInRange(op)) {
+    U8 bit = static_cast<U8>(1u << op);
+    if (enabled)
+      p->opEnabled = static_cast<U8>(p->opEnabled | bit);
+    else
+      p->opEnabled = static_cast<U8>(p->opEnabled & ~bit);
   }
 }
 


### PR DESCRIPTION
## Summary

Grows the #157 synth C-API surface with the three built-in instrument voices — SFZ **sampler**, virtual-analog **VA**, and DX7-class **FM** — and their loadable assets, all reachable through the flat C ABI. Follows the `c-api-extend` conventions (opaque handles, null-safe no-ops, exception→YseStatus, enum drift guard).

Closes #178

## Changes

**New `yse_instrument.{h,cpp}` — loadable assets (SFZ instrument + DX7 bank):**
- `yse_sfz_load(path)` and the `samplerConfig` facade `yse_sfz_load_config(cfg)` → `YseSfzInstrument`
- `yse_dx7_import_sysex(path)` → `YseDx7Bank`, with `yse_dx7_get_patch_count` / `yse_dx7_get_patch_name` enumeration
- Both handles are **owned** and reference-counted, independent of engine lifetime. A live-handle registry makes **double-free and use-after-destroy logged no-ops, not crashes** (an explicit acceptance criterion). The registry mutex is control-thread only — never a callback bridge — so the `c-api-extend` "no mutex in RT bridges" rule does not apply (documented at the top of the .cpp).

**Grown `yse_synth.{h,cpp}`:**
- `yse_synth_add_voices_sampler(synth, instrument, n)`, `add_voices_va(synth, n)`, `add_voices_fm(synth, n)`
- **VA parity:** one setter per `vaParams` field (osc wave/detune/level/pulse-width, wavetable position, cutoff/resonance/key-track, filter env/vel amount, both ADSRs, LFO routing, gain, `load_wavetable`). Every field is a glitch-free atomic, so setters are safe mid-note.
- **FM:** `yse_synth_fm_set_patch(synth, bank, index)` reaches the full DX7 155-parameter voice; headline globals + per-operator level/frequency direct setters on top.

**Enum mirror:** `YseVaWaveform` added to `yse_enums.h` + drift guard in `yse_enums_check.cpp` (`YseLfoType` was already mirrored, reused for the VA LFO setter).

## Parity audit (acceptance: every C++ instrument parameter reachable from C)
- **VA** — full: every settable `vaParams` field has a C setter (25 params incl. the 4 per-osc arrays); `loadWavetable` covered. Read-only source tables and getters are introspection, not parameters.
- **Sampler** — full: the sound is the immutable SFZ instrument, authored at load via `yse_sfz_load` / `yse_sfz_load_config` (mirrors `loadSFZ` / `samplerConfig`). No live per-parameter surface exists in C++. `samplerConfig::channel()` only feeds the C++ addVoices convenience (add-voices here is omni), so it is intentionally omitted.
- **FM** — the full `fmPatch` (155 DX7 params, plain data) is reachable via DX7 bank import + `fm_set_patch`; the issue-scoped **headline** globals and per-operator level/frequency also have direct setters. Per-op envelope/scaling bytes are authored via patch import (the intended path; FM edits only apply on next note-on), matching the issue's explicit "direct setters for the headline params" FM scope.

**Non-goals** (not built): custom voices from C, preset browsing.

## Test plan
- [x] `python yse.py format` — clean (only this PR's files touched)
- [x] `python yse.py analyze <changed .cpp>` — no new user-code findings (all suppressed: non-user/vendored code or baseline)
- [x] Full suite **28/28 ctest entries pass** (`python yse.py test`), including the new isolated `yse_tests_instrumentcapi` process and the embedded-Python suite
- [x] New pure-C-ABI suite `Tests/synth/test_c_api_instrument.cpp` (suite `instrumentcapi`): SFZ fixture loads and plays; VA patch dialled through **every** setter and rendered; DX7 bank fixture (generated deterministically in-test — no copyrighted factory bank committed) imported, enumerated, patch selected, rendered; handle-lifetime enforcement (double-free / use-after-destroy / add-destroyed-instrument are logged no-ops); NULL-handle safety across the whole new surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
