### PR TITLE
ENGINE: initialise channel impl objectStatus in ctor (#336)

### DIFF
--- a/Tests/channel/test_channel_concurrency.cpp
+++ b/Tests/channel/test_channel_concurrency.cpp
@@ -20,10 +20,13 @@
 #include <doctest/doctest.h>
 #include <atomic>
 #include <chrono>
+#include <cstring>
+#include <new>
 #include <string>
 #include <thread>
 #include "yse.hpp"
 #include "channel/channelInterface.hpp"
+#include "channel/channelImplementation.h"
 #include "channel/channelManager.h"
 #include "sound/soundManager.h"
 #include "internal/time.h"
@@ -45,6 +48,36 @@ namespace {
 } // namespace
 
 TEST_SUITE("channel") {
+
+  // ─── Regression: a freshly constructed impl is never seen as deletable ───────
+
+  TEST_CASE("channel concurrency: fresh impl status is OBJECT_CONSTRUCTED "
+            "regardless of prior memory (issue #336)") {
+    // Root cause of the flaky channel two-thread churn hang/segfault: the
+    // channel implementationObject ctor left `objectStatus` (a C++17
+    // std::atomic, whose default ctor does NOT zero the value) uninitialised.
+    // channel::create() emplaces the impl into the mutex-guarded
+    // `implementations` list (addImplementation) and only AFTERWARDS calls
+    // Manager().setup(), which sets OBJECT_CREATED. During that window the
+    // slow-pool deleteJob runs `implementations.remove_if(canBeDeleted)` with
+    // canBeDeleted == (objectStatus == OBJECT_DELETE). If the recycled heap slot
+    // happened to hold the OBJECT_DELETE bit-pattern, the job freed the node the
+    // worker thread was still constructing — a heap-layout-dependent UAF (crash)
+    // or corrupted intrusive list (hang). SOUND/REVERB already initialised
+    // objectStatus in their ctors; CHANNEL was the outlier.
+    //
+    // Poison the storage, then placement-construct an impl over it: with the ctor
+    // fix objectStatus reads OBJECT_CONSTRUCTED; without it the poison survives
+    // and the impl presents as some other (possibly deletable) state. This is
+    // deterministic — it fails on the unpatched ctor and passes with the fix.
+    alignas(YSE::CHANNEL::implementationObject) unsigned char
+        storage[sizeof(YSE::CHANNEL::implementationObject)];
+    std::memset(storage, 0xFF, sizeof(storage));
+    auto* impl = new (storage) YSE::CHANNEL::implementationObject(nullptr);
+    CHECK(impl->getStatus() == YSE::OBJECT_CONSTRUCTED);
+    CHECK_FALSE(YSE::CHANNEL::implementationObject::canBeDeleted(*impl));
+    impl->~implementationObject();
+  }
 
   // ─── Single-thread churn: many channel create→destroy cycles ─────────────────
 

--- a/YseEngine/channel/channelImplementation.cpp
+++ b/YseEngine/channel/channelImplementation.cpp
@@ -12,6 +12,19 @@
 
 YSE::CHANNEL::implementationObject::implementationObject(channel* head)
   : head(head),
+    // Initialise objectStatus in the ctor, not left to the first setStatus():
+    // addImplementation() emplaces this impl into the mutex-guarded
+    // `implementations` list BEFORE create() calls Manager().setup() (which sets
+    // OBJECT_CREATED). In C++17 std::atomic's default ctor leaves the value
+    // indeterminate, so during that window the slow-pool deleteJob —
+    // `implementations.remove_if(canBeDeleted)`, canBeDeleted == (status ==
+    // OBJECT_DELETE) — could read the garbage bytes as OBJECT_DELETE and free
+    // the node the worker thread is still constructing (heap-layout-dependent
+    // UAF / hang, issue #336). emplace_front runs under implementationsMutex and
+    // the setup/delete jobs read under the same mutex, so this OBJECT_CONSTRUCTED
+    // write is published before either job can observe the impl. SOUND and REVERB
+    // already initialise objectStatus this way; CHANNEL was the outlier.
+    objectStatus(OBJECT_CONSTRUCTED),
     newVolume(1.f),
     lastVolume(1.f),
     parent(nullptr),


### PR DESCRIPTION
## Summary

Fixes the flaky hang/segfault in the `yse_tests_channel` concurrency stress test (and the same family in the crowded monolithic `yse_unit_tests`, #304).

**Root cause:** `CHANNEL::implementationObject`'s constructor never initialised `objectStatus`. The project builds **C++17**, where `std::atomic`'s default constructor leaves the value *indeterminate*. `channel::create()` emplaces the impl into the mutex-guarded `implementations` list (`addImplementation`) **before** calling `Manager().setup()`, which sets `OBJECT_CREATED`. During that window the slow-pool `mgrDelete` job runs `implementations.remove_if(canBeDeleted)` where `canBeDeleted == (objectStatus == OBJECT_DELETE)`. If the recycled heap slot happened to hold the `OBJECT_DELETE` bit-pattern, the job freed the node the worker thread was still constructing → a heap-layout-dependent use-after-free (local SIGSEGV) or corrupted intrusive list (CI hang). This matches the issue exactly: pre-existing on `dev`, ~20–40% local trip rate, flips with any unrelated binary-layout change, and specific to the channel target.

**Why channel only:** `SOUND` and `REVERB` already initialise `objectStatus(OBJECT_CONSTRUCTED)` in their constructors. `CHANNEL` was the sole outlier. The fix mirrors them — a one-line init, published under `implementationsMutex` (the ctor runs inside `emplace_front`, and the setup/delete jobs read under the same lock), so neither job can observe the impl until `create()` has set `OBJECT_CREATED`.

## Linked issue
Closes #336

## Changes
- `YseEngine/channel/channelImplementation.cpp` — initialise `objectStatus(OBJECT_CONSTRUCTED)` in the ctor init list, with a comment explaining the create/delete window.
- `Tests/channel/test_channel_concurrency.cpp` — deterministic regression test: poison the storage with `0xFF`, placement-construct an impl over it, assert `getStatus() == OBJECT_CONSTRUCTED` and `!canBeDeleted`. Fails on the unpatched ctor (reads the poison → `4294967295`), passes with the fix.

## Test plan
- [x] Regression test **fails without the fix** (`getStatus()` → `4294967295`), **passes with it** — verified by temporarily reverting the ctor init.
- [x] `--test-suite=channel` (the `yse_tests_channel` target) looped **40× → 0 failures**.
- [x] Monolithic `yse_unit_tests` scenario (#304) run **5× → 0 failures**.
- [x] channel (81), sound (161), reverb (47), and all-`concurrency` (17) suites pass.
- [x] `clang-tidy` on both changed files — no new findings.
- [x] `clang-format --dry-run --Werror` clean.

**Integration test:** not applicable — this is a control-plane teardown/concurrency race with no user-visible rendering flow to drive end-to-end. Coverage is the deterministic unit regression above plus the existing channel concurrency stress cases (now reliably green under looping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)