### PR TITLE
INFRA: synth & effects end-to-end demos (#180)

### DIFF
--- a/Demo.Windows.Native/CMakeLists.txt
+++ b/Demo.Windows.Native/CMakeLists.txt
@@ -27,6 +27,16 @@ target_compile_definitions(yse_demo_common PUBLIC
   "YSE_TEST_RESOURCES_DIR=\"${CMAKE_SOURCE_DIR}/TestResources\""
 )
 
+# Inject the content-pack root (issue #179) as a string-literal macro too, so the
+# synth & effects demos (issue #180) can find the bundled DX7 bank / SFZ
+# instrument regardless of the binary's working directory. YSE_CONTENT_PACK_DIR
+# is defined by cmake/YseContentPack.cmake (a CACHE PATH, so it is visible here
+# whatever the add_subdirectory order). The demos degrade with a clear message
+# when an asset under this root is absent.
+target_compile_definitions(yse_demo_common PUBLIC
+  "YSE_CONTENT_PACK_DIR=\"${YSE_CONTENT_PACK_DIR}\""
+)
+
 # ── Demo builder function ─────────────────────────────────────────────────────
 # Creates a standalone demo executable from a single Demo*.cpp source.
 # A minimal main() is generated from cmake/demo_main.cpp.in; it calls
@@ -79,6 +89,15 @@ if(YSE_ENABLE_MIDI_DEVICE)
 endif()
 add_yse_demo(Demo17 Demo17_MidiPatcher DemoMidiPatcher)
 
+# Synth & effects end-to-end demos (issue #180). These wire up the FM, sampler,
+# position-handler and channel-effect epics; MIDI-device input is used only
+# behind YSE_ENABLE_MIDI_DEVICE guards, so all four build regardless of that
+# option and degrade with a clear message when the content pack is absent.
+add_yse_demo(Demo18 Demo18_FMKeyboard DemoFMKeyboard)
+add_yse_demo(Demo19 Demo19_SfzPiano   DemoSfzPiano)
+add_yse_demo(Demo20 Demo20_Swarm      DemoSwarm)
+add_yse_demo(Demo21 Demo21_Mixer      DemoMixer)
+
 # ── Combined Demo executable (all pages via menu) ─────────────────────────────
 add_executable(Demo
   demo_main.cpp
@@ -86,6 +105,7 @@ add_executable(Demo
   MenuBasics.cpp
   MenuDsp.cpp
   MenuOther.cpp
+  MenuSynth.cpp
   Demo00_PlaySound.cpp
   Demo01_SoundProperties.cpp
   Demo02_3D.cpp
@@ -104,6 +124,10 @@ add_executable(Demo
   Demo15_RestartAudio.cpp
   Demo16_Midi.cpp
   Demo17_MidiPatcher.cpp
+  Demo18_FMKeyboard.cpp
+  Demo19_SfzPiano.cpp
+  Demo20_Swarm.cpp
+  Demo21_Mixer.cpp
   Test01_Pitch.cpp
 )
 target_compile_features(Demo PRIVATE cxx_std_17)

--- a/Demo.Windows.Native/Demo18_FMKeyboard.cpp
+++ b/Demo.Windows.Native/Demo18_FMKeyboard.cpp
@@ -1,0 +1,180 @@
+#include "stdafx.h"
+
+#include "Demo18_FMKeyboard.h"
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+  // The bundled CC0 FM bank shipped with the content pack (issue #179).
+  const char* kBankPath = YSE_CONTENT_PACK_DIR "/fm/original/yse_originals.syx";
+
+  // A C-major triad, used to audition the current patch without a keyboard.
+  constexpr int kChord[3] = {60, 64, 67};
+  constexpr int kMidiChannel = 1;
+
+  bool fileExists(const char* path) {
+    std::ifstream f(path, std::ios::binary);
+    return f.good();
+  }
+} // namespace
+
+DemoFMKeyboard::DemoFMKeyboard() {
+  SetTitle("FM + MIDI Keyboard");
+
+  AddAction('1', "List MIDI ports", std::bind(&DemoFMKeyboard::ListMidiPorts, this));
+  AddAction('2', "Open first MIDI input port", std::bind(&DemoFMKeyboard::OpenMidiPort, this));
+  AddAction('q', "Next patch", std::bind(&DemoFMKeyboard::NextPatch, this));
+  AddAction('a', "Previous patch", std::bind(&DemoFMKeyboard::PrevPatch, this));
+  AddAction('z', "Play/hold C-major chord", std::bind(&DemoFMKeyboard::PlayChord, this));
+  AddAction('x', "Release C-major chord", std::bind(&DemoFMKeyboard::ReleaseChord, this));
+  AddAction('c', "All notes off", std::bind(&DemoFMKeyboard::AllNotesOff, this));
+
+  if (!fileExists(kBankPath)) {
+    std::cout << "The bundled FM bank was not found at:\n  " << kBankPath << "\n"
+              << "Build with the content pack present (issue #179) to run this demo." << std::endl;
+    return;
+  }
+
+  if (!YSE::SYNTH::dx7SysEx::loadBank(kBankPath, bank_) || bank_.empty()) {
+    std::cout << "Failed to parse the bundled DX7 bank at:\n  " << kBankPath << std::endl;
+    return;
+  }
+
+  // Build a 16-voice FM synth from the first bank patch and attach it behind a
+  // positioned sound. The prototype must outlive addVoices (it is a member).
+  proto_ = std::make_unique<YSE::SYNTH::fmVoice>();
+  proto_->setPatch(bank_.voices[patchIndex_]);
+
+  synth_ = std::make_unique<YSE::synth>();
+  synth_->create().addVoices(*proto_, 16);
+
+  sound_ = std::make_unique<YSE::sound>();
+  sound_->create(*synth_);
+  sound_->play();
+
+  available_ = true;
+
+#if YSE_ENABLE_MIDI_DEVICE
+  midi_ = std::make_unique<YSE::midiIn>();
+  // Auto-connect the first available MIDI input so a plugged-in keyboard just
+  // works; the console note keys remain a hardware-free fallback.
+  if (YSE::System().getNumMidiInDevices() > 0) {
+    midi_->create(0);
+    midi_->connect(*synth_); // omni
+    midiConnected_ = true;
+  }
+#endif
+
+  std::cout << "Loaded FM bank with " << bank_.size() << " patches. Current: 0 (" << bank_.name(0)
+            << ")." << std::endl;
+}
+
+DemoFMKeyboard::~DemoFMKeyboard() {
+#if YSE_ENABLE_MIDI_DEVICE
+  if (midi_ && synth_ && midiConnected_) midi_->disconnect(*synth_);
+  midi_.reset();
+#endif
+  if (synth_) synth_->allNotesOff();
+  if (sound_) sound_->stop();
+  // Let the sound release and the slow pool reclaim it before the synth (and
+  // then the prototype) go away, honouring the synth lifetime contract.
+  for (int i = 0; i < 5; i++) {
+    YSE::System().update();
+    YSE::System().sleep(20);
+  }
+  sound_.reset();
+  for (int i = 0; i < 5; i++) {
+    YSE::System().update();
+    YSE::System().sleep(20);
+  }
+  synth_.reset();
+  proto_.reset();
+}
+
+void DemoFMKeyboard::ExplainDemo() {
+  std::cout << "A 6-operator FM synth (DX7-class) driven by a MIDI keyboard or the" << std::endl;
+  std::cout << "console note keys. Patches come from the bundled DX7 SysEx bank." << std::endl;
+  if (!available_) {
+    std::cout << "\n[content pack absent — nothing to play]" << std::endl;
+  }
+}
+
+void DemoFMKeyboard::ShowStatus() {}
+
+void DemoFMKeyboard::ListMidiPorts() {
+#if YSE_ENABLE_MIDI_DEVICE
+  int in = YSE::System().getNumMidiInDevices();
+  std::cout << "MIDI input ports: " << in << std::endl;
+  for (int i = 0; i < in; i++) {
+    std::cout << "  " << i << ": " << YSE::System().getMidiInDeviceName(i) << std::endl;
+  }
+#else
+  std::cout << "MIDI device backend disabled at build time (YSE_ENABLE_MIDI_DEVICE=OFF)."
+            << std::endl;
+#endif
+}
+
+void DemoFMKeyboard::OpenMidiPort() {
+#if YSE_ENABLE_MIDI_DEVICE
+  if (!available_) {
+    std::cout << "Synth unavailable — cannot connect MIDI." << std::endl;
+    return;
+  }
+  if (YSE::System().getNumMidiInDevices() == 0) {
+    std::cout << "No MIDI input ports available." << std::endl;
+    return;
+  }
+  if (midiConnected_) midi_->disconnect(*synth_);
+  midi_->close();
+  midi_->create(0);
+  midi_->connect(*synth_); // omni
+  midiConnected_ = true;
+  std::cout << "Connected MIDI port 0 to the FM synth (omni)." << std::endl;
+#else
+  std::cout << "MIDI device backend disabled at build time (YSE_ENABLE_MIDI_DEVICE=OFF)."
+            << std::endl;
+#endif
+}
+
+void DemoFMKeyboard::applyPatch() {
+  if (!available_) return;
+  proto_->setPatch(bank_.voices[patchIndex_]);
+  // Retrigger held notes so the new patch is audible immediately.
+  synth_->allNotesOff();
+  chordDown_ = false;
+  std::cout << "Patch " << patchIndex_ << ": " << bank_.name(patchIndex_) << std::endl;
+}
+
+void DemoFMKeyboard::NextPatch() {
+  if (!available_) return;
+  patchIndex_ = (patchIndex_ + 1) % static_cast<int>(bank_.size());
+  applyPatch();
+}
+
+void DemoFMKeyboard::PrevPatch() {
+  if (!available_) return;
+  patchIndex_ = (patchIndex_ + static_cast<int>(bank_.size()) - 1) % static_cast<int>(bank_.size());
+  applyPatch();
+}
+
+void DemoFMKeyboard::PlayChord() {
+  if (!available_) return;
+  for (int n : kChord)
+    synth_->noteOn(kMidiChannel, n, 0.8f);
+  chordDown_ = true;
+}
+
+void DemoFMKeyboard::ReleaseChord() {
+  if (!available_) return;
+  for (int n : kChord)
+    synth_->noteOff(kMidiChannel, n);
+  chordDown_ = false;
+}
+
+void DemoFMKeyboard::AllNotesOff() {
+  if (!available_) return;
+  synth_->allNotesOff();
+  chordDown_ = false;
+}

--- a/Demo.Windows.Native/Demo18_FMKeyboard.h
+++ b/Demo.Windows.Native/Demo18_FMKeyboard.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <memory>
+
+#include "basePage.h"
+#include "../YseEngine/yse.hpp"
+#include "../YseEngine/dsp/fm/fmVoice.hpp"
+#include "../YseEngine/dsp/fm/dx7Sysex.hpp"
+
+#if YSE_ENABLE_MIDI_DEVICE
+#include "../YseEngine/midi/device.hpp"
+#endif
+
+// Demo18 — FM + MIDI (issue #180, epic #145/#149).
+//
+// A hardware MIDI keyboard drives a 6-operator DX7-class FM synth loaded from
+// the bundled DX7 SysEx bank (content/fm/original/yse_originals.syx). Patches
+// are switched from the console, extending the Demo16/17 MIDI lineage into the
+// synth engine. Without the content pack the page prints a clear message and
+// offers nothing to play; without a MIDI device the console note keys still
+// exercise the whole FM path.
+class DemoFMKeyboard : public basePage {
+public:
+  DemoFMKeyboard();
+  ~DemoFMKeyboard();
+
+  void ExplainDemo() override;
+  void ShowStatus() override;
+
+private:
+  void ListMidiPorts();
+  void OpenMidiPort();
+  void NextPatch();
+  void PrevPatch();
+  void PlayChord();
+  void ReleaseChord();
+  void AllNotesOff();
+  void applyPatch();
+
+  bool available_ = false; // content pack present and synth built
+  bool chordDown_ = false;
+
+  YSE::SYNTH::dx7Bank bank_;
+  int patchIndex_ = 0;
+
+  std::unique_ptr<YSE::SYNTH::fmVoice> proto_;
+  std::unique_ptr<YSE::synth> synth_;
+  std::unique_ptr<YSE::sound> sound_;
+
+#if YSE_ENABLE_MIDI_DEVICE
+  std::unique_ptr<YSE::midiIn> midi_;
+  bool midiConnected_ = false;
+#endif
+};

--- a/Demo.Windows.Native/Demo19_SfzPiano.cpp
+++ b/Demo.Windows.Native/Demo19_SfzPiano.cpp
@@ -1,0 +1,156 @@
+#include "stdafx.h"
+
+#include "Demo19_SfzPiano.h"
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+  // The bundled CC0 SFZ instrument shipped with the content pack (issue #179).
+  // The opt-in fetch path may replace this with a full Salamander/VSCO piano at
+  // the same location; this demo plays whatever instrument is present.
+  const char* kSfzPath = YSE_CONTENT_PACK_DIR "/sfz/yse_pulse.sfz";
+
+  constexpr int kChord[3] = {60, 64, 67};
+  constexpr int kMidiChannel = 1;
+
+  bool fileExists(const char* path) {
+    std::ifstream f(path, std::ios::binary);
+    return f.good();
+  }
+} // namespace
+
+DemoSfzPiano::DemoSfzPiano() {
+  SetTitle("SFZ Piano");
+
+  AddAction('1', "List MIDI ports", std::bind(&DemoSfzPiano::ListMidiPorts, this));
+  AddAction('2', "Open first MIDI input port", std::bind(&DemoSfzPiano::OpenMidiPort, this));
+  AddAction('z', "Play C-major chord", std::bind(&DemoSfzPiano::PlayChord, this));
+  AddAction('x', "Release C-major chord", std::bind(&DemoSfzPiano::ReleaseChord, this));
+  AddAction('s', "Toggle sustain pedal (CC 64)", std::bind(&DemoSfzPiano::ToggleSustain, this));
+  AddAction('c', "All notes off", std::bind(&DemoSfzPiano::AllNotesOff, this));
+
+  if (!fileExists(kSfzPath)) {
+    std::cout << "The bundled SFZ instrument was not found at:\n  " << kSfzPath << "\n"
+              << "Build with the content pack present (issue #179) to run this demo." << std::endl;
+    return;
+  }
+
+  proto_ = std::make_unique<YSE::SYNTH::samplerVoice>();
+  if (!proto_->loadSFZ(kSfzPath)) {
+    std::cout << "Failed to load the SFZ instrument at:\n  " << kSfzPath << std::endl;
+    proto_.reset();
+    return;
+  }
+
+  synth_ = std::make_unique<YSE::synth>();
+  synth_->create().addVoices(*proto_, 24);
+
+  sound_ = std::make_unique<YSE::sound>();
+  sound_->create(*synth_);
+  sound_->play();
+
+  available_ = true;
+
+#if YSE_ENABLE_MIDI_DEVICE
+  midi_ = std::make_unique<YSE::midiIn>();
+  if (YSE::System().getNumMidiInDevices() > 0) {
+    midi_->create(0);
+    midi_->connect(*synth_); // omni
+    midiConnected_ = true;
+  }
+#endif
+
+  std::cout << "SFZ instrument loaded and ready to play." << std::endl;
+}
+
+DemoSfzPiano::~DemoSfzPiano() {
+#if YSE_ENABLE_MIDI_DEVICE
+  if (midi_ && synth_ && midiConnected_) midi_->disconnect(*synth_);
+  midi_.reset();
+#endif
+  if (synth_) synth_->allNotesOff();
+  if (sound_) sound_->stop();
+  for (int i = 0; i < 5; i++) {
+    YSE::System().update();
+    YSE::System().sleep(20);
+  }
+  sound_.reset();
+  for (int i = 0; i < 5; i++) {
+    YSE::System().update();
+    YSE::System().sleep(20);
+  }
+  synth_.reset();
+  proto_.reset();
+}
+
+void DemoSfzPiano::ExplainDemo() {
+  std::cout << "A bundled SFZ instrument played from a MIDI keyboard or the console" << std::endl;
+  std::cout << "note keys. Hold the sustain pedal (CC 64) and release keys — the notes"
+            << std::endl;
+  std::cout << "keep ringing until the pedal lifts." << std::endl;
+  if (!available_) {
+    std::cout << "\n[content pack absent — nothing to play]" << std::endl;
+  }
+}
+
+void DemoSfzPiano::ListMidiPorts() {
+#if YSE_ENABLE_MIDI_DEVICE
+  int in = YSE::System().getNumMidiInDevices();
+  std::cout << "MIDI input ports: " << in << std::endl;
+  for (int i = 0; i < in; i++) {
+    std::cout << "  " << i << ": " << YSE::System().getMidiInDeviceName(i) << std::endl;
+  }
+#else
+  std::cout << "MIDI device backend disabled at build time (YSE_ENABLE_MIDI_DEVICE=OFF)."
+            << std::endl;
+#endif
+}
+
+void DemoSfzPiano::OpenMidiPort() {
+#if YSE_ENABLE_MIDI_DEVICE
+  if (!available_) {
+    std::cout << "Instrument unavailable — cannot connect MIDI." << std::endl;
+    return;
+  }
+  if (YSE::System().getNumMidiInDevices() == 0) {
+    std::cout << "No MIDI input ports available." << std::endl;
+    return;
+  }
+  if (midiConnected_) midi_->disconnect(*synth_);
+  midi_->close();
+  midi_->create(0);
+  midi_->connect(*synth_); // omni
+  midiConnected_ = true;
+  std::cout << "Connected MIDI port 0 to the SFZ instrument (omni)." << std::endl;
+#else
+  std::cout << "MIDI device backend disabled at build time (YSE_ENABLE_MIDI_DEVICE=OFF)."
+            << std::endl;
+#endif
+}
+
+void DemoSfzPiano::PlayChord() {
+  if (!available_) return;
+  for (int n : kChord)
+    synth_->noteOn(kMidiChannel, n, 0.8f);
+}
+
+void DemoSfzPiano::ReleaseChord() {
+  if (!available_) return;
+  // With sustain down these note-offs are deferred until the pedal lifts.
+  for (int n : kChord)
+    synth_->noteOff(kMidiChannel, n);
+}
+
+void DemoSfzPiano::ToggleSustain() {
+  if (!available_) return;
+  sustainDown_ = !sustainDown_;
+  synth_->sustain(kMidiChannel, sustainDown_);
+  std::cout << "Sustain pedal " << (sustainDown_ ? "DOWN" : "UP") << "." << std::endl;
+}
+
+void DemoSfzPiano::AllNotesOff() {
+  if (!available_) return;
+  synth_->allNotesOff();
+}

--- a/Demo.Windows.Native/Demo19_SfzPiano.h
+++ b/Demo.Windows.Native/Demo19_SfzPiano.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <memory>
+
+#include "basePage.h"
+#include "../YseEngine/yse.hpp"
+#include "../YseEngine/synth/samplerVoice.hpp"
+
+#if YSE_ENABLE_MIDI_DEVICE
+#include "../YseEngine/midi/device.hpp"
+#endif
+
+// Demo19 — SFZ piano (issue #180, epic #145/#149).
+//
+// The bundled SFZ instrument played from a MIDI keyboard or the console note
+// keys, with the sustain pedal (CC 64) demonstrated: while sustain is down,
+// released keys keep ringing until the pedal lifts. The seed content pack ships
+// a small CC0 SFZ (content/sfz/yse_pulse.sfz); the opt-in fetch path can drop a
+// full Salamander/VSCO piano at the same location. Without the content pack the
+// page prints a clear message and offers nothing to play.
+class DemoSfzPiano : public basePage {
+public:
+  DemoSfzPiano();
+  ~DemoSfzPiano();
+
+  void ExplainDemo() override;
+
+private:
+  void ListMidiPorts();
+  void OpenMidiPort();
+  void PlayChord();
+  void ReleaseChord();
+  void ToggleSustain();
+  void AllNotesOff();
+
+  bool available_ = false;
+  bool sustainDown_ = false;
+
+  std::unique_ptr<YSE::SYNTH::samplerVoice> proto_;
+  std::unique_ptr<YSE::synth> synth_;
+  std::unique_ptr<YSE::sound> sound_;
+
+#if YSE_ENABLE_MIDI_DEVICE
+  std::unique_ptr<YSE::midiIn> midi_;
+  bool midiConnected_ = false;
+#endif
+};

--- a/Demo.Windows.Native/Demo20_Swarm.cpp
+++ b/Demo.Windows.Native/Demo20_Swarm.cpp
@@ -1,0 +1,100 @@
+#include "stdafx.h"
+
+#include "Demo20_Swarm.h"
+
+#include <iostream>
+
+namespace {
+  // A four-note chord spread across an octave, so the swarm has several voices
+  // orbiting at once.
+  constexpr int kChord[4] = {60, 64, 67, 72};
+  constexpr int kMidiChannel = 1;
+} // namespace
+
+DemoSwarm::DemoSwarm() {
+  SetTitle("Swarm (orbiting notes)");
+
+  AddAction('z', "Play swarm chord", std::bind(&DemoSwarm::PlaySwarm, this));
+  AddAction('x', "Stop swarm", std::bind(&DemoSwarm::StopSwarm, this));
+  AddAction('q', "Move swarm centre left", std::bind(&DemoSwarm::CenterLeft, this));
+  AddAction('w', "Move swarm centre right", std::bind(&DemoSwarm::CenterRight, this));
+  AddAction('a', "More aftertouch (widen radius)", std::bind(&DemoSwarm::MoreAftertouch, this));
+  AddAction('s', "Less aftertouch (narrow radius)", std::bind(&DemoSwarm::LessAftertouch, this));
+
+  voiceProto_ = std::make_unique<YSE::SYNTH::sineVoice>();
+  voiceProto_->attack(0.02f).decay(0.1f).sustain(0.7f).release(0.4f);
+
+  handlerProto_ = std::make_unique<YSE::SYNTH::orbitHandler>();
+  handlerProto_->radius(1.0f).velocityRadius(2.0f).aftertouchWiden(1.5f).rate(2.5f).releaseSlow(
+      0.5f);
+
+  synth_ = std::make_unique<YSE::synth>();
+  synth_->create().addVoices(*voiceProto_, 8).positionHandler(*handlerProto_);
+
+  sound_ = std::make_unique<YSE::sound>();
+  sound_->create(*synth_);
+  sound_->play();
+}
+
+DemoSwarm::~DemoSwarm() {
+  if (synth_) synth_->allNotesOff();
+  if (sound_) sound_->stop();
+  for (int i = 0; i < 5; i++) {
+    YSE::System().update();
+    YSE::System().sleep(20);
+  }
+  sound_.reset();
+  for (int i = 0; i < 5; i++) {
+    YSE::System().update();
+    YSE::System().sleep(20);
+  }
+  synth_.reset();
+  handlerProto_.reset();
+  voiceProto_.reset();
+}
+
+void DemoSwarm::ExplainDemo() {
+  std::cout << "A chord of notes orbiting the listener via the swarm position handler."
+            << std::endl;
+  std::cout << "Steer the swarm centre left/right and raise aftertouch to widen the orbit."
+            << std::endl;
+}
+
+void DemoSwarm::ShowStatus() {
+  if (!playing_) return;
+  YSE::Pos p = synth_->getVoicePosition(kMidiChannel, kChord[0]);
+  std::cout << "\rcentreX=" << centerX_ << "  aftertouch=" << aftertouch_ << "  voice[" << kChord[0]
+            << "] pos=(" << p.x << ", " << p.z << ")        " << std::flush;
+}
+
+void DemoSwarm::PlaySwarm() {
+  for (int n : kChord)
+    synth_->noteOn(kMidiChannel, n, 0.9f);
+  playing_ = true;
+}
+
+void DemoSwarm::StopSwarm() {
+  synth_->allNotesOff();
+  playing_ = false;
+  std::cout << std::endl;
+}
+
+void DemoSwarm::CenterLeft() {
+  centerX_ -= 1.0f;
+  synth_->handlerParam(YSE::SYNTH::HP_CENTER_X, centerX_);
+}
+
+void DemoSwarm::CenterRight() {
+  centerX_ += 1.0f;
+  synth_->handlerParam(YSE::SYNTH::HP_CENTER_X, centerX_);
+}
+
+void DemoSwarm::MoreAftertouch() {
+  aftertouch_ = aftertouch_ + 0.2f > 1.0f ? 1.0f : aftertouch_ + 0.2f;
+  synth_->aftertouch(kMidiChannel, -1, aftertouch_); // channel-wide
+}
+
+void DemoSwarm::LessAftertouch() {
+  aftertouch_ = aftertouch_ - 0.2f < 0.0f ? 0.0f : aftertouch_ - 0.2f;
+  synth_->aftertouch(kMidiChannel, -1, aftertouch_);
+}

--- a/Demo.Windows.Native/Demo20_Swarm.h
+++ b/Demo.Windows.Native/Demo20_Swarm.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+
+#include "basePage.h"
+#include "../YseEngine/yse.hpp"
+#include "../YseEngine/synth/sineVoice.hpp"
+#include "../YseEngine/synth/positionHandlers.hpp"
+
+// Demo20 — Swarm (issue #180, epic #148 spatial showcase).
+//
+// A polyphonic synth whose per-note position handler is the orbit/swarm handler
+// (#170): every held note orbits a shared, steerable centre, so a chord is
+// heard circling the listener. Aftertouch widens the swarm radius. The console
+// keys steer the swarm centre and apply channel-wide aftertouch so the effect is
+// audible without a controller. This scene needs no bundled asset — it always
+// runs.
+class DemoSwarm : public basePage {
+public:
+  DemoSwarm();
+  ~DemoSwarm();
+
+  void ExplainDemo() override;
+  void ShowStatus() override;
+
+private:
+  void PlaySwarm();
+  void StopSwarm();
+  void CenterLeft();
+  void CenterRight();
+  void MoreAftertouch();
+  void LessAftertouch();
+
+  bool playing_ = false;
+  float centerX_ = 0.f;
+  float aftertouch_ = 0.f;
+
+  std::unique_ptr<YSE::SYNTH::sineVoice> voiceProto_;
+  std::unique_ptr<YSE::SYNTH::orbitHandler> handlerProto_;
+  std::unique_ptr<YSE::synth> synth_;
+  std::unique_ptr<YSE::sound> sound_;
+};

--- a/Demo.Windows.Native/Demo21_Mixer.cpp
+++ b/Demo.Windows.Native/Demo21_Mixer.cpp
@@ -1,0 +1,114 @@
+#include "stdafx.h"
+
+#include "Demo21_Mixer.h"
+
+#include <iostream>
+
+DemoMixer::DemoMixer() {
+  SetTitle("Mix (insert chain + send/return reverb)");
+
+  AddAction('1', "Toggle music insert chain (EQ/comp/chorus)",
+            std::bind(&DemoMixer::ToggleInserts, this));
+  AddAction('q', "Reverb send up", std::bind(&DemoMixer::SendUp, this));
+  AddAction('a', "Reverb send down", std::bind(&DemoMixer::SendDown, this));
+  AddAction('w', "Music volume up", std::bind(&DemoMixer::MusicVolUp, this));
+  AddAction('s', "Music volume down", std::bind(&DemoMixer::MusicVolDown, this));
+  AddAction('e', "Drum volume up", std::bind(&DemoMixer::DrumVolUp, this));
+  AddAction('d', "Drum volume down", std::bind(&DemoMixer::DrumVolDown, this));
+
+  // Two source channels under the master.
+  musicCh_.create("music", YSE::ChannelMaster());
+  drumCh_.create("drums", YSE::ChannelMaster());
+
+  // Build the music channel's insert chain: EQ -> compressor -> chorus.
+  eq_.gain(YSE::DSP::MODULES::EQ_LOW_SHELF, 4.0f);
+  eq_.frequency(YSE::DSP::MODULES::EQ_PEAK_1, 900.f).gain(YSE::DSP::MODULES::EQ_PEAK_1, -3.0f);
+  eq_.gain(YSE::DSP::MODULES::EQ_HIGH_SHELF, 3.0f);
+  comp_.threshold(-18.f).ratio(4.f).attack(10.f).release(120.f).makeup(4.f);
+  chorus_.mode(YSE::DSP::MODULES::MODE_CHORUS).rate(0.6f).depth(0.4f).impact(0.4f);
+  eq_.link(comp_);
+  comp_.link(chorus_);
+  musicCh_.setDSP(&eq_);
+
+  // A shared plate-reverb return bus fed post-fader from both channels.
+  reverbReturn_.makeReturn("reverb");
+  plate_.decay(0.6f).damping(6000.f).preDelay(20.f).impact(1.0f);
+  reverbReturn_.setDSP(&plate_);
+  musicCh_.send(0, reverbReturn_, sendLevel_);
+  drumCh_.send(0, reverbReturn_, sendLevel_);
+
+  // Looping source material from the always-present TestResources.
+  musicLoop_ = std::make_unique<YSE::sound>();
+  musicLoop_->create(YSE_TEST_RESOURCES_DIR "/pulse1.ogg", &musicCh_, true);
+  musicLoop_->play();
+
+  drumLoop_ = std::make_unique<YSE::sound>();
+  drumLoop_->create(YSE_TEST_RESOURCES_DIR "/kick.ogg", &drumCh_, true);
+  drumLoop_->play();
+}
+
+DemoMixer::~DemoMixer() {
+  if (musicLoop_) musicLoop_->stop();
+  if (drumLoop_) drumLoop_->stop();
+  for (int i = 0; i < 5; i++) {
+    YSE::System().update();
+    YSE::System().sleep(20);
+  }
+  musicLoop_.reset();
+  drumLoop_.reset();
+  // Tear down the routing before the channels/effects destruct so the audio
+  // thread stops touching the insert chain and sends first.
+  musicCh_.clearSend(0);
+  drumCh_.clearSend(0);
+  musicCh_.setDSP(nullptr);
+  reverbReturn_.setDSP(nullptr);
+  for (int i = 0; i < 5; i++) {
+    YSE::System().update();
+    YSE::System().sleep(20);
+  }
+}
+
+void DemoMixer::ExplainDemo() {
+  std::cout << "A console mixer: the music channel runs an EQ -> compressor -> chorus" << std::endl;
+  std::cout << "insert chain, and both channels feed a shared plate-reverb send/return."
+            << std::endl;
+}
+
+void DemoMixer::ShowStatus() {
+  std::cout << "\rinserts=" << (insertsOn_ ? "ON " : "OFF") << "  send=" << sendLevel_
+            << "  music=" << musicCh_.getVolume() << "  drums=" << drumCh_.getVolume()
+            << "  comp GR=" << comp_.gainReductionDb() << " dB        " << std::flush;
+}
+
+void DemoMixer::ToggleInserts() {
+  insertsOn_ = !insertsOn_;
+  musicCh_.setDSP(insertsOn_ ? &eq_ : nullptr);
+}
+
+void DemoMixer::SendUp() {
+  sendLevel_ = sendLevel_ + 0.1f > 1.0f ? 1.0f : sendLevel_ + 0.1f;
+  musicCh_.setSendLevel(0, sendLevel_);
+  drumCh_.setSendLevel(0, sendLevel_);
+}
+
+void DemoMixer::SendDown() {
+  sendLevel_ = sendLevel_ - 0.1f < 0.0f ? 0.0f : sendLevel_ - 0.1f;
+  musicCh_.setSendLevel(0, sendLevel_);
+  drumCh_.setSendLevel(0, sendLevel_);
+}
+
+void DemoMixer::MusicVolUp() {
+  musicCh_.setVolume(musicCh_.getVolume() + 0.1f);
+}
+
+void DemoMixer::MusicVolDown() {
+  musicCh_.setVolume(musicCh_.getVolume() - 0.1f);
+}
+
+void DemoMixer::DrumVolUp() {
+  drumCh_.setVolume(drumCh_.getVolume() + 0.1f);
+}
+
+void DemoMixer::DrumVolDown() {
+  drumCh_.setVolume(drumCh_.getVolume() - 0.1f);
+}

--- a/Demo.Windows.Native/Demo21_Mixer.h
+++ b/Demo.Windows.Native/Demo21_Mixer.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <memory>
+
+#include "basePage.h"
+#include "../YseEngine/yse.hpp"
+#include "../YseEngine/dsp/modules/parametricEQ.hpp"
+#include "../YseEngine/dsp/modules/compressor.hpp"
+#include "../YseEngine/dsp/modules/chorus.hpp"
+#include "../YseEngine/dsp/modules/plateReverb.hpp"
+
+// Demo21 — Mix (issue #180, epic #146/#147 showcase).
+//
+// A miniature DAW mixer session in the console: two source channels (a music
+// loop and a drum loop) with a pre-fader insert chain (parametric EQ ->
+// compressor -> chorus) on the music channel, plus a shared send/return plate
+// reverb bus fed post-fader from both channels. The console adjusts send levels,
+// channel faders, and bypasses the insert chain, while the compressor's live
+// gain reduction is metered. Uses the always-present TestResources loops, so it
+// runs without the content pack.
+class DemoMixer : public basePage {
+public:
+  DemoMixer();
+  ~DemoMixer();
+
+  void ExplainDemo() override;
+  void ShowStatus() override;
+
+private:
+  void ToggleInserts();
+  void SendUp();
+  void SendDown();
+  void MusicVolUp();
+  void MusicVolDown();
+  void DrumVolUp();
+  void DrumVolDown();
+
+  bool insertsOn_ = true;
+  float sendLevel_ = 0.3f;
+
+  // Effects — declared first so they outlive the channels that reference them.
+  YSE::DSP::MODULES::parametricEQ eq_;
+  YSE::DSP::MODULES::compressor comp_;
+  YSE::DSP::MODULES::chorus chorus_;
+  YSE::DSP::MODULES::plateReverb plate_;
+
+  // Channels — destroyed before the effects, after the sounds.
+  YSE::channel musicCh_;
+  YSE::channel drumCh_;
+  YSE::channel reverbReturn_;
+
+  // Sounds — declared last so they are destroyed first.
+  std::unique_ptr<YSE::sound> musicLoop_;
+  std::unique_ptr<YSE::sound> drumLoop_;
+};

--- a/Demo.Windows.Native/MenuSynth.cpp
+++ b/Demo.Windows.Native/MenuSynth.cpp
@@ -1,0 +1,40 @@
+
+#include "stdafx.h"
+
+#include "MenuSynth.h"
+#include "Demo18_FMKeyboard.h"
+#include "Demo19_SfzPiano.h"
+#include "Demo20_Swarm.h"
+#include "Demo21_Mixer.h"
+
+MenuSynth::MenuSynth() {
+  SetTitle("Synth & Effects Examples");
+  AddAction('1', "FM + MIDI keyboard", std::bind(&MenuSynth::FMKeyboardDemo, this));
+  AddAction('2', "SFZ piano", std::bind(&MenuSynth::SfzPianoDemo, this));
+  AddAction('3', "Swarm (orbiting notes)", std::bind(&MenuSynth::SwarmDemo, this));
+  AddAction('4', "Mix (insert chain + send/return reverb)", std::bind(&MenuSynth::MixerDemo, this));
+}
+
+void MenuSynth::FMKeyboardDemo() {
+  DemoFMKeyboard demo;
+  demo.Run();
+  ShowMenu();
+}
+
+void MenuSynth::SfzPianoDemo() {
+  DemoSfzPiano demo;
+  demo.Run();
+  ShowMenu();
+}
+
+void MenuSynth::SwarmDemo() {
+  DemoSwarm demo;
+  demo.Run();
+  ShowMenu();
+}
+
+void MenuSynth::MixerDemo() {
+  DemoMixer demo;
+  demo.Run();
+  ShowMenu();
+}

--- a/Demo.Windows.Native/MenuSynth.h
+++ b/Demo.Windows.Native/MenuSynth.h
@@ -1,0 +1,16 @@
+
+#pragma once
+
+#include "basePage.h"
+
+// Synth & effects end-to-end demos (issue #180). Groups the four epic showcase
+// scenes: FM + MIDI, SFZ piano, swarm positioning, and the mixer session.
+class MenuSynth : public basePage {
+public:
+  MenuSynth();
+
+  void FMKeyboardDemo();
+  void SfzPianoDemo();
+  void SwarmDemo();
+  void MixerDemo();
+};

--- a/Demo.Windows.Native/MenuTop.cpp
+++ b/Demo.Windows.Native/MenuTop.cpp
@@ -5,6 +5,7 @@
 #include "MenuBasics.h"
 #include "MenuOther.h"
 #include "MenuDsp.h"
+#include "MenuSynth.h"
 
 TopMenu::TopMenu()
 {
@@ -15,6 +16,7 @@ TopMenu::TopMenu()
 	AddAction('3', "Composition Examples", std::bind(&TopMenu::ComposerExamples, this));
 	AddAction('4', "File Manipulation Examples", std::bind(&TopMenu::FileExamples, this));
 	AddAction('5', "Other Examples", std::bind(&TopMenu::OtherExamples, this));
+	AddAction('6', "Synth & Effects Examples", std::bind(&TopMenu::SynthExamples, this));
 }
 
 void TopMenu::BasicAudioExamples()
@@ -42,6 +44,13 @@ void TopMenu::FileExamples()
 void TopMenu::OtherExamples()
 {
   OtherMenu menu;
+  menu.Run();
+  ShowMenu();
+}
+
+void TopMenu::SynthExamples()
+{
+  MenuSynth menu;
   menu.Run();
   ShowMenu();
 }

--- a/Demo.Windows.Native/MenuTop.h
+++ b/Demo.Windows.Native/MenuTop.h
@@ -13,5 +13,6 @@ public:
 	void ComposerExamples();
 	void FileExamples();
 	void OtherExamples();
+	void SynthExamples();
 };
 

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -26,7 +26,7 @@ Tests/                           # doctest suite (~863 TEST_CASEs across 46 TUs)
   TEST_PLAN.md                   # Phased roadmap (utils → DSP → patcher → … → device)
 Bench/                           # google-benchmark suite — gated by YSE_BUILD_BENCHMARKS
   dsp/ patcher/ integration/     # bench_* TUs; results pushed to the `bench-history` orphan branch by CI
-Demo.Windows.Native/             # 18 C++ console demos (Demo00–Demo17 + Test01_Pitch + combined Demo)
+Demo.Windows.Native/             # 22 C++ console demos (Demo00–Demo21 + Test01_Pitch + combined Demo)
 Yse.Windows.Native/              # Legacy Windows static/shared lib build (Visual Studio project)
 documentation/                   # Doxygen + Sphinx + Breathe (sphinx-book-theme); published to GitHub Pages
   source/intro/                  # Install + hello-sound + mental-model
@@ -449,19 +449,21 @@ sound.play()
 ## Demo Applications
 
 **Location:** [Demo.Windows.Native/](Demo.Windows.Native/) — Windows-only (uses Windows console APIs and relies on RtMidi for MIDI demos).
-18 demos (Demo00–Demo17) plus `Test01_Pitch` and a combined `Demo` executable that wires every page through `MenuTop.cpp`.
+22 demos (Demo00–Demo21) plus `Test01_Pitch` and a combined `Demo` executable that wires every page through `MenuTop.cpp`. Demo18–Demo21 are the synth & effects end-to-end showcases (issue #180); they read bundled assets from the optional content pack (issue #179) and degrade with a clear message when it is absent.
 
 | Demo | Topic | Demo | Topic |
 |------|-------|------|-------|
-| Demo00 | Basic playback (`drone.ogg`) | Demo09 | Streaming |
-| Demo01 | Sound properties | Demo10 | File position |
-| Demo02 | 3D positioning | Demo11 | Virtual I/O |
-| Demo03 | Virtual sounds | Demo12 | AudioTest |
-| Demo04 | Channel mixer | Demo13 | Patcher synthesis |
-| Demo05 | Reverb zones | Demo14 | Load patcher from JSON |
-| Demo06 | Device enumeration | Demo15 | Audio device restart |
-| Demo07 | DSP source | Demo16 | MIDI device output |
-| Demo08 | Occlusion | Demo17 | MIDI patcher |
+| Demo00 | Basic playback (`drone.ogg`) | Demo11 | Virtual I/O |
+| Demo01 | Sound properties | Demo12 | AudioTest |
+| Demo02 | 3D positioning | Demo13 | Patcher synthesis |
+| Demo03 | Virtual sounds | Demo14 | Load patcher from JSON |
+| Demo04 | Channel mixer | Demo15 | Audio device restart |
+| Demo05 | Reverb zones | Demo16 | MIDI device output |
+| Demo06 | Device enumeration | Demo17 | MIDI patcher |
+| Demo07 | DSP source | Demo18 | FM + MIDI keyboard (DX7 bank) |
+| Demo08 | Occlusion | Demo19 | SFZ piano (sustain pedal) |
+| Demo09 | Streaming | Demo20 | Swarm (orbiting notes) |
+| Demo10 | File position | Demo21 | Mixer (insert chain + send/return reverb) |
 | Test01_Pitch | Pitch test | | |
 
 Each standalone executable is generated from a per-target `main_<Demo>.cpp` produced by `configure_file()` against `cmake/demo_main.cpp.in`. Shared menu/page infrastructure lives in the `yse_demo_common` static library.

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -107,6 +107,7 @@ set(YSE_TEST_SOURCES
   system/test_lifecycle.cpp
   integration/test_device.cpp
   integration/test_content_pack.cpp
+  integration/test_synth_demos.cpp
   python/test_c_api_python.cpp
 )
 
@@ -214,7 +215,7 @@ add_test(
   # `channelcapi` (issue #166 C-API channel-DSP/send surface) is excluded for
   # the same reason — it drives yse_system_init_offline() and runs in its own
   # process (yse_tests_channelcapi).
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi "--test-case-exclude=* concurrency: *" --duration=true
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos "--test-case-exclude=* concurrency: *" --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -370,6 +371,18 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_midisynth PROPERTIES LABELS "midi;synth;lifecycle")
+
+# Synth & effects demo scenes (issue #180). Isolated in its own process for the
+# same reason as yse_tests_midisynth: it drives System::initOffline()/close() and
+# builds the synth + channel managers, whose static teardown must not leak into
+# other suites (issue #298). Loads the bundled content pack (skips gracefully if
+# absent) and uses initOffline(), so it runs in CI.
+add_test(
+  NAME    yse_tests_synthdemos
+  COMMAND yse_tests --test-suite=synthdemos
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_synthdemos PROPERTIES LABELS "synth;infra;lifecycle")
 
 add_test(
   NAME    yse_tests_music

--- a/Tests/integration/test_synth_demos.cpp
+++ b/Tests/integration/test_synth_demos.cpp
@@ -1,0 +1,328 @@
+// End-to-end coverage for the synth & effects demo scenes (issue #180).
+//
+// The interactive Demo18–Demo21 console pages (FM+MIDI keyboard, SFZ piano,
+// swarm, mixer) cannot be driven headless — they need a MIDI keyboard, an audio
+// device and a human at the keys. What *is* testable, and what actually breaks,
+// is the engine wiring each scene sets up: a bundled DX7 bank loaded into an FM
+// synth and played; the bundled SFZ loaded into a sampler synth with the sustain
+// pedal engaged; the swarm/orbit position handler moving voices around the
+// listener; and a channel insert chain (EQ→compressor→chorus) plus a send/return
+// plate reverb. These cases drive exactly those paths, offline, against the real
+// content pack — the "demos are living integration tests" contract from the
+// issue, minus the parts that require hardware.
+//
+// ISOLATION: like the `midisynth` / `synthpositioning` suites these drive
+// System::initOffline()/close() (process-global engine state), so they run in a
+// dedicated ctest process (`synthdemos`), excluded from the combined run.
+// initOffline() needs no audio hardware, so they run in CI. Content assets that
+// are only present after the opt-in fetch are skipped gracefully; the committed
+// CC0 seed guarantees the FM bank and the SFZ instrument, so those cases always
+// exercise a real load.
+
+#include <doctest/doctest.h>
+
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "channel/channelInterface.hpp"
+#include "sound/soundInterface.hpp"
+#include "synth/sineVoice.hpp"
+#include "synth/samplerVoice.hpp"
+#include "synth/synthInterface.hpp"
+#include "synth/positionHandlers.hpp"
+#include "dsp/fm/fmVoice.hpp"
+#include "dsp/fm/dx7Sysex.hpp"
+#include "dsp/modules/parametricEQ.hpp"
+#include "dsp/modules/compressor.hpp"
+#include "dsp/modules/chorus.hpp"
+#include "dsp/modules/plateReverb.hpp"
+
+#ifndef YSE_CONTENT_PACK_DIR
+#define YSE_CONTENT_PACK_DIR "../../content"
+#endif
+
+using namespace std::chrono_literals;
+
+namespace {
+
+  // onNoteEvent is a captureless function pointer, so it logs into this
+  // process-static buffer. The offline render loop is single-threaded (the test
+  // thread), so no synchronisation is needed.
+  struct NoteLogEntry {
+    bool on;
+    int note;
+  };
+  std::vector<NoteLogEntry> g_noteLog;
+
+  void logNote(bool on, float* noteNumber, float* /*velocity*/) {
+    g_noteLog.push_back({on, static_cast<int>(std::lround(*noteNumber))});
+  }
+
+  bool fileExists(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    return f.good();
+  }
+
+  std::string contentPath(const char* rel) {
+    return std::string(YSE_CONTENT_PACK_DIR) + "/" + rel;
+  }
+
+  // Bring a synth attached to a sound up to OBJECT_READY (voice cloning is async
+  // on the slow pool). Returns true once its voices are allocated.
+  bool bringReady(YSE::synth& syn, int expectedVoices) {
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (std::chrono::steady_clock::now() < deadline) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+      if (syn.getNumVoices() == expectedVoices) return true;
+      std::this_thread::sleep_for(5ms);
+    }
+    return syn.getNumVoices() == expectedVoices;
+  }
+
+  // Advance the offline engine by n blocks. update() before each render flushes
+  // control-thread messages (note events, pedal, handler params) to the audio
+  // side — without it a directly-driven noteOn never reaches the voices.
+  void pump(int n) {
+    for (int b = 0; b < n; ++b) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+    }
+  }
+
+  // Drain the engine so released impls are fully deleted before teardown.
+  void drain(std::chrono::milliseconds budget = 500ms) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+      std::this_thread::sleep_for(2ms);
+    }
+  }
+
+  double planarRadius(const YSE::Pos& p) {
+    return std::sqrt(static_cast<double>(p.x) * p.x + static_cast<double>(p.z) * p.z);
+  }
+
+} // namespace
+
+TEST_SUITE("synthdemos") {
+
+  // ─── Demo18: FM + MIDI keyboard ─────────────────────────────────────────────
+
+  TEST_CASE("synthdemos: bundled DX7 bank drives an FM synth end-to-end") {
+    const std::string bankPath = contentPath("fm/original/yse_originals.syx");
+    if (!fileExists(bankPath)) {
+      MESSAGE("FM bank absent at " << bankPath << " — skipping");
+      return;
+    }
+    YSE::SYNTH::dx7Bank bank;
+    REQUIRE(YSE::SYNTH::dx7SysEx::loadBank(bankPath.c_str(), bank));
+    REQUIRE_FALSE(bank.empty());
+
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+    g_noteLog.clear();
+
+    YSE::SYNTH::fmVoice proto; // declared first: outlives the synth
+    proto.setPatch(bank.voices[0]);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(proto, 8);
+      syn.onNoteEvent(logNote);
+      {
+        YSE::sound snd;
+        snd.create(syn);
+        REQUIRE(bringReady(syn, 8));
+        snd.play();
+
+        syn.noteOn(1, 60, 0.8f);
+        pump(16);
+        syn.noteOff(1, 60);
+        pump(16);
+
+        snd.stop();
+        pump(8);
+      }
+      drain();
+    }
+    drain();
+    YSE::System().close();
+
+    REQUIRE(g_noteLog.size() == 2);
+    CHECK(g_noteLog[0].on == true);
+    CHECK(g_noteLog[0].note == 60);
+    CHECK(g_noteLog[1].on == false);
+    CHECK(g_noteLog[1].note == 60);
+  }
+
+  // ─── Demo19: SFZ piano with sustain pedal ───────────────────────────────────
+
+  TEST_CASE("synthdemos: bundled SFZ instrument plays through a synth with sustain") {
+    const std::string sfzPath = contentPath("sfz/yse_pulse.sfz");
+    if (!fileExists(sfzPath)) {
+      MESSAGE("SFZ instrument absent at " << sfzPath << " — skipping");
+      return;
+    }
+
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+    g_noteLog.clear();
+
+    YSE::SYNTH::samplerVoice proto; // declared first: outlives the synth
+    REQUIRE(proto.loadSFZ(sfzPath));
+    REQUIRE(proto.instrument()->valid());
+    {
+      YSE::synth syn;
+      syn.create().addVoices(proto, 8);
+      syn.onNoteEvent(logNote);
+      {
+        YSE::sound snd;
+        snd.create(syn);
+        REQUIRE(bringReady(syn, 8));
+        snd.play();
+
+        // Pedal down, play and release a note: the note-off is deferred by the
+        // sustain state (unit-tested in `synth keyboard`), but the whole demo
+        // path — instrument load, synth build, pedal + note events — runs here.
+        syn.sustain(1, true);
+        syn.noteOn(1, 60, 0.8f);
+        pump(16);
+        syn.noteOff(1, 60);
+        pump(8);
+        syn.sustain(1, false);
+        pump(16);
+
+        snd.stop();
+        pump(8);
+      }
+      drain();
+    }
+    drain();
+    YSE::System().close();
+
+    REQUIRE(g_noteLog.size() == 2);
+    CHECK(g_noteLog[0].on == true);
+    CHECK(g_noteLog[0].note == 60);
+    CHECK(g_noteLog[1].on == false);
+    CHECK(g_noteLog[1].note == 60);
+  }
+
+  // ─── Demo20: swarm / orbit position handler ─────────────────────────────────
+
+  TEST_CASE("synthdemos: swarm handler orbits voices around the listener") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YSE::SYNTH::sineVoice voiceProto; // declared first: outlives the synth
+    voiceProto.attack(0.02f).release(0.3f);
+    YSE::SYNTH::orbitHandler handlerProto;
+    handlerProto.radius(1.0f).velocityRadius(2.0f).rate(2.5f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(voiceProto, 8).positionHandler(handlerProto);
+      {
+        YSE::sound snd;
+        snd.create(syn);
+        REQUIRE(bringReady(syn, 8));
+        snd.play();
+
+        syn.noteOn(1, 60, 0.9f);
+        syn.noteOn(1, 64, 0.9f);
+        syn.noteOn(1, 67, 0.9f);
+        pump(8);
+
+        const YSE::Pos before = syn.getVoicePosition(1, 60);
+        pump(64);
+        const YSE::Pos after = syn.getVoicePosition(1, 60);
+
+        // The voice orbits: it sits off the origin and its position moves.
+        CHECK(planarRadius(before) > 0.01);
+        CHECK((before.x != after.x || before.z != after.z));
+
+        syn.allNotesOff();
+        snd.stop();
+        pump(8);
+      }
+      drain();
+    }
+    drain();
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ─── Demo21: mixer — insert chain + send/return plate reverb ─────────────────
+
+  TEST_CASE("synthdemos: mixer insert chain and send/return reverb wire and render") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    // Effects declared first so they outlive the channels that reference them.
+    YSE::DSP::MODULES::parametricEQ eq;
+    YSE::DSP::MODULES::compressor comp;
+    YSE::DSP::MODULES::chorus chorus;
+    YSE::DSP::MODULES::plateReverb plate;
+
+    YSE::SYNTH::sineVoice voiceProto;
+    voiceProto.attack(0.01f).release(0.2f);
+    {
+      YSE::channel musicCh;
+      YSE::channel reverbReturn;
+      musicCh.create("music", YSE::ChannelMaster());
+
+      // Insert chain: EQ -> compressor -> chorus.
+      comp.threshold(-18.f).ratio(4.f).makeup(4.f);
+      chorus.impact(0.4f);
+      eq.link(comp);
+      comp.link(chorus);
+      musicCh.setDSP(&eq);
+
+      // Send/return plate reverb.
+      reverbReturn.makeReturn("reverb");
+      plate.decay(0.6f).impact(1.0f);
+      reverbReturn.setDSP(&plate);
+      musicCh.send(0, reverbReturn, 0.3f);
+
+      // Wiring assertions — deterministic, through the public surface.
+      CHECK(reverbReturn.isReturn());
+      CHECK_FALSE(musicCh.isReturn());
+      CHECK(musicCh.getDSP() == &eq);
+      CHECK(reverbReturn.getDSP() == &plate);
+      CHECK(musicCh.getSendLevel(0) == doctest::Approx(0.3f));
+
+      {
+        // Drive audio through the whole chain: a synth-backed sound on the music
+        // channel, sending into the plate reverb. Exercises every process()
+        // path (EQ, compressor, chorus, plate) — the ASan/TSan value of the run.
+        YSE::synth syn;
+        syn.create().addVoices(voiceProto, 4);
+        YSE::sound snd;
+        snd.create(syn, &musicCh);
+        REQUIRE(bringReady(syn, 4));
+        snd.play();
+        syn.noteOn(1, 60, 0.9f);
+        pump(64);
+        syn.noteOff(1, 60);
+        pump(16);
+        snd.stop();
+        pump(8);
+        drain();
+      }
+
+      // Tear down routing before the channels/effects go out of scope.
+      musicCh.clearSend(0);
+      musicCh.setDSP(nullptr);
+      reverbReturn.setDSP(nullptr);
+      drain();
+    }
+    drain();
+    YSE::System().close();
+    CHECK(true);
+  }
+
+} // TEST_SUITE("synthdemos")


### PR DESCRIPTION
## Summary

Adds the four synth & effects end-to-end demo scenes named as downstream proof by epics #145–#149, following the existing `Demo00`–`Demo17` `basePage`/menu pattern. Each is a standalone executable (`python yse.py run Demo18`…`Demo21`) and is also wired into a new "Synth & Effects Examples" menu in the combined `Demo`.

- **Demo18 — FM + MIDI keyboard:** the bundled DX7 SysEx bank drives a 6-operator FM synth; patch switching from the console; MIDI-in auto-connects when a device is present, with console note keys as a hardware-free fallback.
- **Demo19 — SFZ piano:** the bundled SFZ instrument played from the keyboard/console, with the sustain pedal (CC 64) demonstrated.
- **Demo20 — Swarm:** `sineVoice` + `orbitHandler` — a chord of notes audibly circling the listener; aftertouch widens the swarm radius; the swarm centre is steerable from the console. Needs no bundled asset, so it always runs.
- **Demo21 — Mix:** a miniature console session — an EQ → compressor → chorus insert chain on the music channel plus a shared send/return plate-reverb bus, with live compressor gain-reduction metering.

The demos locate the optional content pack (#179) via a new `YSE_CONTENT_PACK_DIR` string-literal macro injected into `yse_demo_common` (mirroring `YSE_TEST_RESOURCES_DIR`), and degrade with a clear message when an asset is absent.

## Linked issue

Closes #180

## Changes

- New demo pages `Demo18`–`Demo21` (`.h`/`.cpp`) + `MenuSynth` submenu, wired into `MenuTop`.
- `Demo.Windows.Native/CMakeLists.txt`: inject `YSE_CONTENT_PACK_DIR`; register the four standalone demos and add them + `MenuSynth.cpp` to the combined `Demo`.
- `Tests/integration/test_synth_demos.cpp`: new isolated `synthdemos` ctest suite (registered + excluded from the combined run like the other `initOffline()/close()` suites).
- `PROJECT_OVERVIEW.md`: demo table + directory count updated (18 → 22 demos).

## Test plan

- [x] `clang-format --dry-run --Werror` clean on all changed C++ files.
- [x] `clang-tidy` (`yse.py analyze`) clean on the new test (build-tests db) and on the four demo TUs + `MenuSynth.cpp` (build-debug db) — one real finding (unused `using`) fixed.
- [x] Unit/suite tests: full `ctest` on the `tests-debug` preset — **30/30 suites pass**.
- [x] Integration/e2e: new `synthdemos` suite (4 cases, 27 assertions) passes, driving each scene's engine wiring **offline against the real bundled content pack** — DX7 bank → FM synth note events, SFZ → sampler synth with sustain, orbit handler moving voices off-origin over time, and the mixer insert + send/return chain rendered end-to-end.
- Note on integration scope (per Step 4a): the demos' *interactive* surface (a live MIDI keyboard, an audio device, and a human at the console) is genuinely infeasible to drive headless. The `synthdemos` suite covers the feasible end-to-end path — the exact engine wiring each scene sets up, exercised offline through the public API against the committed content-pack seed. The Windows-console I/O layer (`_kbhit`/`_getch`) is the only untested part and is unchanged shared infrastructure.
