### PR TITLE
INFRA: docs, tutorials, and bench sweep for synths & effects (#181)

### DIFF
--- a/Bench/CMakeLists.txt
+++ b/Bench/CMakeLists.txt
@@ -14,9 +14,11 @@ add_executable(yse_benchmarks
   dsp/bench_plate_reverb.cpp
   dsp/bench_va_voice.cpp
   dsp/bench_sampler_voice.cpp
+  dsp/bench_fm_voice.cpp
   internal/bench_mpmcqueue.cpp
   patcher/bench_patcher.cpp
   integration/bench_mixing.cpp
+  integration/bench_synth_effects.cpp
   integration/bench_yse_dsl.cpp
 )
 

--- a/Bench/dsp/bench_fm_voice.cpp
+++ b/Bench/dsp/bench_fm_voice.cpp
@@ -1,0 +1,74 @@
+// Microbenchmarks for the DX7-class 6-operator FM voice (issue #176):
+//   - a pure single-carrier sine patch (algorithm 32, cheapest FM case),
+//   - a 2-operator FM patch (one modulator, sidebands), and
+//   - a full six-operator brass patch (worst-case per-voice cost),
+// each next to the reference sineVoice so the FM core's per-voice cost is
+// tracked relative to the cheapest voice (issue #181 acceptance: "FM per-voice").
+// A regression in the ported MSFA inner loop (operator envelopes, LFO, the
+// fixed-point oscillator bank) is then visible against a stable baseline.
+
+#include "dsp/buffer.hpp"
+#include "dsp/fm/fmPatch.hpp"
+#include "dsp/fm/fmVoice.hpp"
+#include "headers/constants.hpp"
+#include "headers/enums.hpp"
+#include "synth/sineVoice.hpp"
+
+#include <benchmark/benchmark.h>
+
+namespace {
+
+  // Drive one FM voice through a full block after warming it to sustain, the
+  // same shape as bench_va_voice / bench_sampler_voice so the per-voice numbers
+  // sit side by side.
+  void runFm(benchmark::State& state, const YSE::SYNTH::fmPatch& patch) {
+    YSE::SYNTH::fmVoice v;
+    v.setPatch(patch); // applied on the next note-on
+    v.frequency(60.0f);
+    v.velocity(0.9f);
+
+    YSE::SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 8; ++i)
+      v.process(intent); // reach sustain (patch is baked at key-down)
+
+    for (auto _ : state) {
+      v.process(intent); // one STANDARD_BUFFERSIZE block, PLAYING
+      benchmark::DoNotOptimize(v.samples[0].getPtr());
+    }
+    state.SetItemsProcessed(state.iterations() * YSE::STANDARD_BUFFERSIZE);
+  }
+
+  void BM_FmVoice_Sine(benchmark::State& s) {
+    runFm(s, YSE::SYNTH::fmPatch::sine());
+  }
+  BENCHMARK(BM_FmVoice_Sine);
+
+  void BM_FmVoice_2Op(benchmark::State& s) {
+    runFm(s, YSE::SYNTH::fmPatch::fm2op());
+  }
+  BENCHMARK(BM_FmVoice_2Op);
+
+  void BM_FmVoice_Brass6Op(benchmark::State& s) {
+    runFm(s, YSE::SYNTH::fmPatch::brass());
+  }
+  BENCHMARK(BM_FmVoice_Brass6Op);
+
+  // Reference baseline: the cheapest voice, same block, same warm-up.
+  void BM_SineVoice_FmReference(benchmark::State& state) {
+    YSE::SYNTH::sineVoice v;
+    v.frequency(60.0f);
+    v.velocity(0.9f);
+    YSE::SOUND_STATUS intent = YSE::SS_WANTSTOPLAY;
+    v.process(intent);
+    for (int i = 0; i < 8; ++i)
+      v.process(intent);
+    for (auto _ : state) {
+      v.process(intent);
+      benchmark::DoNotOptimize(v.samples[0].getPtr());
+    }
+    state.SetItemsProcessed(state.iterations() * YSE::STANDARD_BUFFERSIZE);
+  }
+  BENCHMARK(BM_SineVoice_FmReference);
+
+} // namespace

--- a/Bench/integration/bench_synth_effects.cpp
+++ b/Bench/integration/bench_synth_effects.cpp
@@ -1,0 +1,295 @@
+// Tier 3 macro scenarios — audio-thread cost of the synth & effects surface
+// (issue #181 bench sweep, closing epic #149). Every case drives the real
+// audio-callback body via YSE::System().renderOffline(blocks) — the same path
+// PortAudio drives in production — so the numbers are the per-block cost the
+// audio thread actually pays.
+//
+// Covered here:
+//   - voice-count scaling      BM_Engine_SynthVoiceScaling/<N>   (N sounding voices)
+//   - channel insert-chain cost BM_Engine_ChannelInsertChain*    (EQ→comp→chorus insert)
+//   - send fan-in cost          BM_Engine_SendFanIn/<N>          (N channels → one return)
+//   - N positioned notes        BM_Engine_PositionedNotes/<N>    (orbit-handler voices)
+//
+// The per-voice DSP cost of individual voice types (sine / VA / FM / sampler)
+// lives in the Tier 1 benches (dsp/bench_va_voice.cpp, bench_fm_voice.cpp,
+// bench_sampler_voice.cpp); this file measures how those costs compose through
+// the engine's mix tree, polyphony allocator, insert chain and send graph.
+//
+// Isolation caveat: yse_benchmarks is one process with one process-global
+// engine, so a scene left alive by an earlier benchmark (e.g. the static
+// sound pool in bench_mixing.cpp) renders alongside these. Each scenario below
+// tears its own scene down and drains before returning, so it does not pollute
+// later benchmarks; and because registration order is stable per build, any
+// constant offset from a sibling benchmark is the same across commits, so the
+// scaling deltas these report stay a faithful regression signal.
+
+#include "yse.hpp"
+#include "channel/channelInterface.hpp"
+#include "dsp/modules/chorus.hpp"
+#include "dsp/modules/compressor.hpp"
+#include "dsp/modules/parametricEQ.hpp"
+#include "dsp/modules/plateReverb.hpp"
+#include "sound/soundInterface.hpp"
+#include "synth/positionHandlers.hpp"
+#include "synth/sineVoice.hpp"
+#include "synth/synthInterface.hpp"
+
+#include "support/bench_helpers.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace {
+
+  constexpr int kBlocksPerIter = 64;
+  constexpr int kMidiChannel = 1;
+
+  // Pump the control plane so create / addVoices / noteOn messages reach the
+  // audio side, then render one block — the offline analogue of one engine tick.
+  void pump(int blocks) {
+    for (int b = 0; b < blocks; ++b) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+    }
+  }
+
+  // Bring an attached synth up to its full voice count (cloning is async on the
+  // setup pool, which runs on its own thread). Yield to that thread between
+  // checks — a tight spin starves it and the count never advances. Wall-clock
+  // bounded so a failed content/setup path can never hang the bench.
+  bool bringReady(YSE::synth& syn, int expectedVoices) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+      YSE::System().update();
+      YSE::System().renderOffline(1);
+      if (syn.getNumVoices() == expectedVoices) return true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return syn.getNumVoices() == expectedVoices;
+  }
+
+  // A spread of note numbers around middle C so `count` distinct voices sound.
+  std::vector<int> chordNotes(int count) {
+    std::vector<int> notes;
+    notes.reserve(count);
+    for (int i = 0; i < count; ++i)
+      notes.push_back(48 + (i % 36)); // C3..B5, wrapping for large counts
+    return notes;
+  }
+
+  // ── voice-count scaling ──────────────────────────────────────────────────────
+  //
+  // One synth of N sine voices behind one sound, with N notes held at sustain.
+  // Measures how the audio-thread render cost grows with polyphony through the
+  // real synth aggregate + sound-render + master-mix path.
+
+  void BM_Engine_SynthVoiceScaling(benchmark::State& state) {
+    if (!BenchHelpers::engineInitOffline()) {
+      state.SkipWithError("YSE::System().initOffline() failed");
+      return;
+    }
+    const int voices = static_cast<int>(state.range(0));
+
+    YSE::SYNTH::sineVoice proto;
+    proto.attack(0.005f).decay(0.05f).sustain(0.8f).release(0.2f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(proto, voices);
+      YSE::sound snd;
+      snd.create(syn);
+      if (!bringReady(syn, voices)) {
+        state.SkipWithError("synth did not reach expected voice count");
+        return;
+      }
+      snd.play();
+      for (int n : chordNotes(voices))
+        syn.noteOn(kMidiChannel, n, 0.8f);
+      pump(16); // let every note reach sustain before timing
+
+      for (auto _ : state) {
+        YSE::System().renderOffline(kBlocksPerIter);
+        benchmark::ClobberMemory();
+      }
+      state.SetItemsProcessed(state.iterations() * kBlocksPerIter * YSE::STANDARD_BUFFERSIZE);
+
+      syn.allNotesOff();
+      snd.stop();
+      pump(8); // stop + release before the objects destruct (sound before synth)
+    }
+    pump(32); // drain deletes so the next benchmark starts from a clean tree
+  }
+  BENCHMARK(BM_Engine_SynthVoiceScaling)->Arg(1)->Arg(4)->Arg(8)->Arg(16)->Arg(32)->Arg(64);
+
+  // ── channel insert-chain cost ────────────────────────────────────────────────
+  //
+  // The cost the audio thread pays running a channel's pre-fader insert chain on
+  // every device output channel. A single looping source drives the channel; the
+  // baseline case runs the same scene with no insert so the chain cost is the
+  // delta between the two. The insert modules process the full device layout, so
+  // the reported cost already reflects "N device channels" for the open layout.
+
+  YSE::DSP::buffer& insertSource() {
+    static YSE::DSP::buffer buf(4096);
+    static bool init = false;
+    if (!init) {
+      buf = 0.25f;
+      init = true;
+    }
+    return buf;
+  }
+
+  void runInsertChain(benchmark::State& state, bool withInserts) {
+    if (!BenchHelpers::engineInitOffline()) {
+      state.SkipWithError("YSE::System().initOffline() failed");
+      return;
+    }
+    {
+      YSE::channel ch;
+      ch.create("bench.inserts", YSE::ChannelMaster());
+
+      YSE::DSP::MODULES::parametricEQ eq;
+      YSE::DSP::MODULES::compressor comp;
+      YSE::DSP::MODULES::chorus chorus;
+      if (withInserts) {
+        eq.gain(YSE::DSP::MODULES::EQ_LOW_SHELF, 4.0f);
+        eq.frequency(YSE::DSP::MODULES::EQ_PEAK_1, 900.f).gain(YSE::DSP::MODULES::EQ_PEAK_1, -3.0f);
+        comp.threshold(-18.f).ratio(4.f).attack(10.f).release(120.f).makeup(4.f);
+        chorus.mode(YSE::DSP::MODULES::MODE_CHORUS).rate(0.6f).depth(0.4f).impact(0.4f);
+        eq.link(comp);
+        comp.link(chorus);
+        ch.setDSP(&eq);
+      }
+
+      YSE::sound src;
+      src.create(insertSource(), &ch, /*loop=*/true, /*volume=*/0.6f);
+      src.play();
+      pump(16);
+
+      for (auto _ : state) {
+        YSE::System().renderOffline(kBlocksPerIter);
+        benchmark::ClobberMemory();
+      }
+      state.SetItemsProcessed(state.iterations() * kBlocksPerIter * YSE::STANDARD_BUFFERSIZE);
+
+      src.stop();
+      pump(8);
+      ch.setDSP(nullptr); // detach before the modules destruct
+    }
+    pump(32);
+  }
+
+  void BM_Engine_ChannelInsertChain_Baseline(benchmark::State& s) {
+    runInsertChain(s, /*withInserts=*/false);
+  }
+  BENCHMARK(BM_Engine_ChannelInsertChain_Baseline);
+
+  void BM_Engine_ChannelInsertChain_EqCompChorus(benchmark::State& s) {
+    runInsertChain(s, /*withInserts=*/true);
+  }
+  BENCHMARK(BM_Engine_ChannelInsertChain_EqCompChorus);
+
+  // ── send fan-in cost ─────────────────────────────────────────────────────────
+  //
+  // N source channels each feeding one shared plate-reverb return bus, post-fader.
+  // Measures the cost of the send accumulation + the single return's DSP as the
+  // fan-in count grows.
+
+  void BM_Engine_SendFanIn(benchmark::State& state) {
+    if (!BenchHelpers::engineInitOffline()) {
+      state.SkipWithError("YSE::System().initOffline() failed");
+      return;
+    }
+    const int sources = static_cast<int>(state.range(0));
+    {
+      YSE::channel ret;
+      ret.makeReturn("bench.return");
+      YSE::DSP::MODULES::plateReverb plate;
+      plate.decay(0.6f).damping(6000.f).preDelay(20.f).impact(1.0f);
+      ret.setDSP(&plate);
+
+      std::vector<std::unique_ptr<YSE::channel>> chans;
+      std::vector<std::unique_ptr<YSE::sound>> srcs;
+      chans.reserve(sources);
+      srcs.reserve(sources);
+      for (int i = 0; i < sources; ++i) {
+        auto c = std::make_unique<YSE::channel>();
+        c->create("bench.src", YSE::ChannelMaster());
+        c->send(0, ret, 0.4f);
+        auto s = std::make_unique<YSE::sound>();
+        s->create(insertSource(), c.get(), /*loop=*/true, /*volume=*/0.4f);
+        s->play();
+        chans.push_back(std::move(c));
+        srcs.push_back(std::move(s));
+      }
+      pump(16);
+
+      for (auto _ : state) {
+        YSE::System().renderOffline(kBlocksPerIter);
+        benchmark::ClobberMemory();
+      }
+      state.SetItemsProcessed(state.iterations() * kBlocksPerIter * YSE::STANDARD_BUFFERSIZE);
+
+      for (auto& s : srcs)
+        s->stop();
+      pump(8);
+      for (auto& c : chans)
+        c->clearSend(0);
+      ret.setDSP(nullptr);
+      pump(8);
+    }
+    pump(32);
+  }
+  BENCHMARK(BM_Engine_SendFanIn)->Arg(1)->Arg(4)->Arg(8)->Arg(16)->Arg(32);
+
+  // ── N positioned notes (per-note 3D swarm) ───────────────────────────────────
+  //
+  // One synth of N sine voices with an orbit position handler, N notes held, so
+  // the per-note positioning route steers and pans independent voices against the
+  // listener every block. Measures the audio-thread cost of the positioned
+  // (Route 2) path as the held-note count grows — the counterpart to the
+  // handler-free BM_Engine_SynthVoiceScaling above.
+
+  void BM_Engine_PositionedNotes(benchmark::State& state) {
+    if (!BenchHelpers::engineInitOffline()) {
+      state.SkipWithError("YSE::System().initOffline() failed");
+      return;
+    }
+    const int voices = static_cast<int>(state.range(0));
+
+    YSE::SYNTH::sineVoice proto;
+    proto.attack(0.005f).decay(0.05f).sustain(0.8f).release(0.2f);
+    YSE::SYNTH::orbitHandler handler;
+    handler.radius(1.0f).velocityRadius(2.0f).rate(2.5f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(proto, voices).positionHandler(handler);
+      YSE::sound snd;
+      snd.create(syn);
+      if (!bringReady(syn, voices)) {
+        state.SkipWithError("synth did not reach expected voice count");
+        return;
+      }
+      snd.play();
+      for (int n : chordNotes(voices))
+        syn.noteOn(kMidiChannel, n, 0.8f);
+      pump(16);
+
+      for (auto _ : state) {
+        YSE::System().renderOffline(kBlocksPerIter);
+        benchmark::ClobberMemory();
+      }
+      state.SetItemsProcessed(state.iterations() * kBlocksPerIter * YSE::STANDARD_BUFFERSIZE);
+
+      syn.allNotesOff();
+      snd.stop();
+      pump(8);
+    }
+    pump(32);
+  }
+  BENCHMARK(BM_Engine_PositionedNotes)->Arg(1)->Arg(4)->Arg(8)->Arg(16)->Arg(32);
+
+} // namespace

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,6 +1,6 @@
 <!-- META
-last_updated_commit: dc8fb40
-last_updated_at: 2026-05-22
+last_updated_commit: ce0fe64
+last_updated_at: 2026-07-14
 -->
 
 # YSE Sound Engine — Project Overview
@@ -30,8 +30,9 @@ Demo.Windows.Native/             # 22 C++ console demos (Demo00–Demo21 + Test0
 Yse.Windows.Native/              # Legacy Windows static/shared lib build (Visual Studio project)
 documentation/                   # Doxygen + Sphinx + Breathe (sphinx-book-theme); published to GitHub Pages
   source/intro/                  # Install + hello-sound + mental-model
-  source/tutorials/              # 6 tutorial pages (play, properties, 3D, channels, reverb, patcher)
-  source/api/                    # Breathe-driven API reference (12 grouped pages)
+  source/tutorials/              # 11 tutorial pages (play, properties, 3D, channels, reverb, patcher,
+                                 # first-synth, custom-voice, instruments, mixing, per-note-3D)
+  source/api/                    # Breathe-driven API reference (14 grouped pages, incl. synth + effects)
   source/_data/                  # Committed data snapshots consumed by Sphinx hooks (patcher_objects.json)
   source/_templates/             # Jinja templates rendered by the pre-build hook in conf.py
 tools/ci-linux/                  # Docker images for local Linux CI reproduction (Dockerfile, Dockerfile.audio)
@@ -198,7 +199,8 @@ Application
     ├── player                 polyphonic note sequencer
     ├── patcher                modular DSP graph (Max/MSP-style)
     ├── MIDI                   file + (optionally) device I/O
-    └── (synth)                polyphonic sampler/DSP synth — implemented but not exposed (commented out in yse.hpp)
+    └── synth                  polyphonic instrument host (sine / VA / SFZ sampler / DX7 FM voices,
+                               per-note 3D handlers) ──→ sound ──→ channel
 ```
 
 ---
@@ -251,6 +253,8 @@ The callback runs on the **control thread** (inside `System().update()`), once p
 
 Channels form a **tree** rooted at `MainMix`, with five pre-made leaves (`FX`, `Music`, `Ambient`, `Voice`, `GUI`) and arbitrary user-created children. Sounds can be reparented via `moveTo` at runtime. Sounds beyond a distance threshold are virtualized to save CPU.
 
+Each channel also carries a pre-fader **insert** DSP chain (`setDSP`) and up to N **aux sends** to **return buses** (`makeReturn` / `send` / `setSendLevel` / `clearSend`), plus pre/post-fader peak metering (linear + dBFS, combined and per-output). See the signal-path diagram below for how inserts and sends sit in the mix. Send levels are ramped internally, so they are click-free to set every control tick.
+
 Issue [#82](https://github.com/yvanvds/yse-soundengine/issues/82) added measured-callback-timing-based `cpuLoad` and fixed a fast-pool dispatch overhead for empty child channels.
 
 ---
@@ -298,8 +302,11 @@ class dspSourceObject {    // audio generator (replaces file)
 | Math | clip, sqrt, rSqrt, wrap, midiToFreq, freqToMidi, dbToRms, rmsToDb |
 | Spectral | Hilbert transformer, ring modulator |
 | Granular | granulator |
-| FM | difference (FM pair) |
+| FM | difference (FM pair); 6-operator DX7-class engine under `dsp/fm/` (`fmVoice`, `fmPatch`, `dx7Sysex`, MSFA core) |
+| Mix / channel-strip | parametric EQ, compressor, chorus/flanger, plate reverb (Dattorro), feedback delay — N-channel `dspObject` modules for channel inserts and return buses |
 | Fourier | fft.cpp + mayer.cpp (real-input FFT) |
+
+`dspObject` carries an N-channel processing contract (issue #158): `process(std::vector<DSP::buffer>&)` handles the full device layout, so inserts and return effects work at any output width.
 
 ---
 
@@ -404,11 +411,15 @@ Polyphonic note player with scale constraints, motif sequencing, and randomised 
 
 ---
 
-### 13. Synth (Implemented but unexposed)
+### 13. Synth (Polyphonic instrument host)
 
-**Files:** `synth/` — `synthInterface.hpp/.cpp`, `synthManager.h/.cpp`, `synthImplementation.h/.cpp`, `dspVoice.hpp` (voice base), and built-in voices `sineVoice.hpp/.cpp` (reference sine + ADSR) and `vaVoice.hpp/.cpp` (virtual-analog + wavetable: multi-oscillator → `DSP::ladderFilter` → amp/filter ADSR + LFO, with a live-settable shared `vaParams` patch)
+**Files:** `synth/` — `synthInterface.hpp/.cpp`, `synthManager.h/.cpp`, `synthImplementation.h/.cpp`, `synthMessage.h`, `dspVoice.hpp` (voice base), `positionHandler.hpp` + `positionHandlers.hpp/.cpp` (per-note 3D). Built-in voices: `sineVoice.hpp/.cpp` (reference sine + ADSR), `vaVoice.hpp/.cpp` (virtual-analog + wavetable → `DSP::ladderFilter` → amp/filter ADSR + LFO, live `vaParams` patch), `samplerVoice.hpp/.cpp` (SFZ sampler), and the FM voice under `dsp/fm/` (`fmVoice`, `fmPatch`, `dx7Sysex` importer, MSFA core in `dsp/fm/msfa/`).
 
-Polyphonic sampler/DSP synth. The source files compile into the library; the public interface (`synth.hpp`, `synthInterface.hpp`, `dspVoice.hpp`) is commented out in [yse.hpp](YseEngine/yse.hpp) and not yet part of the public API.
+The synth subsystem (epics [#145](https://github.com/yvanvds/yse-soundengine/issues/145)–[#149](https://github.com/yvanvds/yse-soundengine/issues/149)) is now public. A `YSE::synth` owns a pool of voices, note allocation, voice stealing and full keyboard state (pedals, controllers, pitch wheel, aftertouch); a `SYNTH::dspVoice` subclass owns only what one note sounds like. Build the pool with `create().addVoices(prototype, n)`, attach behind a positioned `YSE::sound` via `sound::create(synth&, …)`, then drive with `noteOn` / `noteOff`. Cloning happens off the audio thread on the setup pool (the synth becomes playable a moment after `addVoices`, like a file-backed sound). Voice `process()` / `clone()` follow the RT contract: allocate in the constructor / `clone()` (setup thread), never in `process()` (audio thread).
+
+**Per-note 3D positioning (Route 2, #169–#171).** Attach a `SYNTH::positionHandler` prototype with `synth::positionHandler(...)` to give every voice its own 3D position, updated per block — the "swarm". Ship-in handlers: `staticHandler`, `randomSpreadHandler`, `orbitHandler`. Steer the whole swarm from the control thread with `handlerParam(index, value)` (indices 0..2 = centre) or place a note imperatively with `notePosition(...)`; both are bounded, allocation-free messages.
+
+Instruments load from portable formats off the audio thread: `samplerVoice::loadSFZ(path)` (SFZ region model in `dsp/sfzModel.hpp` / `dsp/sfzParser`), and `dx7SysEx::loadBank(path, bank)` → `fmVoice::setPatch(...)` (applied on the next note-on). The C API mirror lives in `c_api/include/yse_c/yse_synth.h` + `yse_instrument.h` (built-in voices / handlers only; custom C-side voices are deferred).
 
 ---
 
@@ -416,16 +427,21 @@ Polyphonic sampler/DSP synth. The source files compile into the library; the pub
 
 ```
 sound.play()
-    └── DSP source (file buffer / dspSourceObject / patcher)
+    └── DSP source (file buffer / dspSourceObject / patcher / synth voice pool)
          └── speed / pitch shifting
               └── user DSP chain (dspObject link list)
-                   └── 3D attenuation + pan (distance, angle)
+                   └── 3D attenuation + pan (distance, angle)  [per-voice with a position handler]
                         └── doppler pitch adjustment
                              └── occlusion low-pass filter
-                                  └── channel volume (tree)
-                                       └── reverb blend
-                                            └── device output (PortAudio / Oboe)
+                                  └── channel insert chain (pre-fader, setDSP)
+                                       └── channel volume / fader (tree)
+                                            ├── aux sends ──→ return bus (makeReturn) ──┐
+                                            │                   └── return insert (e.g. plate reverb)
+                                            └── reverb blend  ◄─────────────────────────┘
+                                                 └── device output (PortAudio / Oboe)
 ```
+
+Channel routing (epic [#146](https://github.com/yvanvds/yse-soundengine/issues/146)): each `YSE::channel` carries an optional pre-fader **insert** chain (`setDSP`, a linked `dspObject` list) and up to N **aux sends** to **return buses** (`makeReturn` / `send` / `setSendLevel`). Returns are ordinary channels flagged as returns — they keep their own inserts and may send onward to other returns (the send graph must stay acyclic). Mix-grade effect modules for these slots live in `dsp/modules/` (`parametricEQ`, `compressor`, `chorus`, `plateReverb`, `delay/feedbackDelay`).
 
 ---
 
@@ -516,11 +532,15 @@ Exposed via `YSE_TEST_FIXTURES_DIR` compile definition:
 Layout:
 ```
 Bench/
-  dsp/         (bench_buffer, bench_delay, bench_filters, bench_math, bench_oscillators, bench_reverb)
+  dsp/         (bench_buffer, bench_delay, bench_filters, bench_math, bench_oscillators, bench_reverb,
+               bench_plate_reverb, bench_va_voice, bench_sampler_voice, bench_fm_voice)
+  internal/    (bench_mpmcqueue)
   patcher/     (bench_patcher)
-  integration/ (bench_mixing)
+  integration/ (bench_mixing, bench_synth_effects, bench_yse_dsl)
   support/     (bench_helpers.hpp)
 ```
+
+The synth & effects sweep (issue [#181](https://github.com/yvanvds/yse-soundengine/issues/181)) adds per-voice Tier-1 benches (`bench_fm_voice`, alongside the existing `bench_va_voice` / `bench_sampler_voice`, each with a `sineVoice` reference baseline) and Tier-3 macro scenarios in `bench_synth_effects` (voice-count scaling, channel insert-chain cost, send fan-in, N positioned notes), all driven offline via `System().renderOffline(blocks)`.
 
 ---
 
@@ -538,9 +558,10 @@ documentation/
     conf.py                        # Reads VERSION from YseEngine/system.hpp (PR #89)
     index.rst                      # Landing page
     intro/                         # install, hello_sound, mental_model
-    tutorials/                     # 6 pages: play, properties, 3D, channels, reverb, patcher
-    api/                           # 12 grouped pages: core, sounds, channels, dsp, dsp_modules,
-                                   # devices, midi, music, patcher, player, utils, index
+    tutorials/                     # 11 pages: play, properties, 3D, channels, reverb, patcher,
+                                   # first-synth, custom-voice, instruments, mixing, per-note-3D
+    api/                           # 14 grouped pages: core, sounds, channels, dsp, dsp_modules,
+                                   # synth, effects, devices, midi, music, patcher, player, utils, index
 ```
 
 The version string in `conf.py` is auto-synced from `YseEngine/system.hpp` so the published docs always match the released library.

--- a/documentation/source/api/c_api.rst
+++ b/documentation/source/api/c_api.rst
@@ -74,6 +74,15 @@ DSP and patcher
 .. doxygenfile:: c_api/include/yse_c/yse_patcher.h
    :project: libYSE
 
+Synth and instruments
+---------------------
+
+.. doxygenfile:: c_api/include/yse_c/yse_synth.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_instrument.h
+   :project: libYSE
+
 MIDI and music
 --------------
 

--- a/documentation/source/api/effects.rst
+++ b/documentation/source/api/effects.rst
@@ -1,0 +1,52 @@
+Mixing effects
+==============
+
+Mix-grade effect modules for building channel strips and effect returns.
+Each is a :cpp:class:`YSE::DSP::dspObject` subclass, so it chains with
+``dspObject::link`` and mixes wet/dry through the inherited ``impact``.
+
+Routing them is a channel-level concern:
+
+- **Inserts** — attach a (chained) module to a channel's pre-fader insert
+  slot with :cpp:func:`YSE::channel::setDSP`. Every sound on the channel is
+  processed through the chain before the fader.
+- **Sends and returns** — create a return bus with
+  :cpp:func:`YSE::channel::makeReturn`, attach an effect to it with
+  ``setDSP``, then feed it from any channel with
+  :cpp:func:`YSE::channel::send` / :cpp:func:`YSE::channel::setSendLevel`.
+
+Both are documented on the :doc:`channels` page. The
+:doc:`/tutorials/09_mixing_inserts_sends` tutorial walks through a complete
+console mixer built from these pieces.
+
+Parametric EQ
+-------------
+
+.. doxygenfile:: dsp/modules/parametricEQ.hpp
+   :project: libYSE
+
+Compressor
+----------
+
+.. doxygenfile:: dsp/modules/compressor.hpp
+   :project: libYSE
+
+Chorus / flanger
+----------------
+
+.. doxygenfile:: dsp/modules/chorus.hpp
+   :project: libYSE
+
+Feedback delay
+--------------
+
+.. doxygenfile:: dsp/modules/delay/feedbackDelay.hpp
+   :project: libYSE
+
+Plate reverb
+------------
+
+A Dattorro-style plate reverb, well suited to a send/return bus.
+
+.. doxygenfile:: dsp/modules/plateReverb.hpp
+   :project: libYSE

--- a/documentation/source/api/index.rst
+++ b/documentation/source/api/index.rst
@@ -29,10 +29,17 @@ The pages below are generated from the source code by Doxygen + Breathe.
 
 .. toctree::
    :maxdepth: 1
+   :caption: Synthesis
+
+   synth
+
+.. toctree::
+   :maxdepth: 1
    :caption: DSP
 
    dsp
    dsp_modules
+   effects
 
 .. toctree::
    :maxdepth: 1

--- a/documentation/source/api/synth.rst
+++ b/documentation/source/api/synth.rst
@@ -1,0 +1,85 @@
+Synthesis
+=========
+
+The synth subsystem turns libYSE from a sample player into a polyphonic
+instrument host. A :cpp:class:`YSE::synth` owns a pool of voices, note
+allocation, voice stealing and full keyboard state (pedals, controllers,
+pitch wheel, aftertouch); a voice — a :cpp:class:`YSE::SYNTH::dspVoice`
+subclass — owns only what a single note sounds like. The synth is rendered
+behind an ordinary positioned :cpp:class:`YSE::sound`, so everything the
+spatial engine already does (3D panning, channels, reverb) applies to it.
+
+See the tutorials for worked, compilable walk-throughs:
+:doc:`/tutorials/06_first_synth`,
+:doc:`/tutorials/07_custom_dspvoice`,
+:doc:`/tutorials/08_instruments`, and
+:doc:`/tutorials/10_per_note_3d`.
+
+The synth
+---------
+
+.. doxygenfile:: synth/synth.hpp
+   :project: libYSE
+
+.. doxygenfile:: synth/synthInterface.hpp
+   :project: libYSE
+
+The voice model
+---------------
+
+Derive from :cpp:class:`YSE::SYNTH::dspVoice` to define a custom voice, or
+use one of the built-in voices below.
+
+.. doxygenfile:: synth/dspVoice.hpp
+   :project: libYSE
+
+.. doxygenfile:: synth/sineVoice.hpp
+   :project: libYSE
+
+Virtual-analog voice
+--------------------
+
+A multi-oscillator virtual-analog + wavetable voice with a Moog-style ladder
+filter and a live-editable shared patch.
+
+.. doxygenfile:: synth/vaVoice.hpp
+   :project: libYSE
+
+SFZ sampler voice
+-----------------
+
+Loads an SFZ instrument (region map + resident PCM) and plays it as a
+multi-layer sampler voice. See :doc:`/tutorials/08_instruments`.
+
+.. doxygenfile:: synth/samplerVoice.hpp
+   :project: libYSE
+
+FM voice and DX7 banks
+----------------------
+
+A DX7-class 6-operator FM voice driven by an :cpp:struct:`YSE::SYNTH::fmPatch`,
+plus the SysEx importer that fills patches from a vintage DX7 bank dump.
+
+.. doxygenfile:: dsp/fm/fmVoice.hpp
+   :project: libYSE
+
+.. doxygenfile:: dsp/fm/fmPatch.hpp
+   :project: libYSE
+
+.. doxygenfile:: dsp/fm/dx7Sysex.hpp
+   :project: libYSE
+
+Per-note 3D positioning
+-----------------------
+
+Attach a :cpp:class:`YSE::SYNTH::positionHandler` to give every voice its own
+3D position and movement — the basis of the "swarm" effect. Steer the whole
+swarm live with :cpp:func:`YSE::synth::handlerParam`, or place a single note
+imperatively with :cpp:func:`YSE::synth::notePosition`. See
+:doc:`/tutorials/10_per_note_3d`.
+
+.. doxygenfile:: synth/positionHandler.hpp
+   :project: libYSE
+
+.. doxygenfile:: synth/positionHandlers.hpp
+   :project: libYSE

--- a/documentation/source/tutorials/06_first_synth.rst
+++ b/documentation/source/tutorials/06_first_synth.rst
@@ -1,0 +1,96 @@
+Your first synth
+================
+
+Goal: build a polyphonic synthesiser, attach it behind a sound, and play
+notes on it.
+
+Up to now every sound has come from a file or a hand-built DSP source. A
+:cpp:class:`YSE::synth` is different: it owns a *pool of voices* and turns
+note-on / note-off events into sound, handling polyphony, voice allocation
+and voice stealing for you. This tutorial walks through
+``Demo18_FMKeyboard`` — a 16-voice FM synth played from a MIDI keyboard or
+the console note keys.
+
+Source: `Demo18_FMKeyboard.cpp
+<https://github.com/yvanvds/yse-soundengine/blob/master/Demo.Windows.Native/Demo18_FMKeyboard.cpp>`_.
+
+Mental model
+------------
+
+Three objects cooperate:
+
+- A **voice prototype** — any :cpp:class:`YSE::SYNTH::dspVoice` subclass
+  (here :cpp:class:`YSE::SYNTH::fmVoice`). It describes what *one* note
+  sounds like. The synth clones it once per voice.
+- The **synth** — :cpp:class:`YSE::synth`. It owns the cloned voices and the
+  keyboard state, and receives your ``noteOn`` / ``noteOff`` calls.
+- A **sound** — an ordinary positioned :cpp:class:`YSE::sound`. The synth is
+  rendered *behind* it, so 3D panning, channels and reverb all apply exactly
+  as they do to a file-backed sound.
+
+Building the synth
+------------------
+
+Create a prototype voice, hand it to ``synth::addVoices`` to size the pool,
+then attach the synth to a sound and start it:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo18_FMKeyboard.cpp
+   :language: cpp
+   :lines: 47-55
+
+``create()`` registers the synth with the engine. ``addVoices(prototype,
+16)`` clones the prototype 16 times — that is the polyphony. Cloning happens
+off the audio thread on the engine's setup pool, so the synth becomes
+playable a moment after ``addVoices`` returns, exactly like a file-backed
+sound is not playable until its buffer finishes loading. ``sound::create``
+calls ``synth::create`` for you if you have not, and takes the same optional
+``channel`` and ``volume`` arguments as any other sound.
+
+.. note::
+
+   The prototype must outlive ``addVoices`` — the engine reads it to clone
+   but neither copies nor owns it. In the demo it is a member
+   (``proto_``), so it lives as long as the synth.
+
+Playing notes
+-------------
+
+Once the synth is playing, drive it with note events. ``noteOn`` /
+``noteOff`` take a MIDI channel (1–16, or 0 for omni), a note number, and a
+velocity in [0, 1]:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo18_FMKeyboard.cpp
+   :language: cpp
+   :lines: 162-173
+
+``allNotesOff(channel)`` releases everything on a channel (0 = all
+channels); the voices enter their normal release, they are not cut.
+
+Tearing it down safely
+----------------------
+
+A synth is attached to a sound, and the sound must stop and be reclaimed
+*before* the synth (and then the prototype) go away — the same lifetime
+discipline a file-backed sound follows. The demo stops the sound, pumps a
+few engine updates so the slow pool reclaims it, then releases the synth:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo18_FMKeyboard.cpp
+   :language: cpp
+   :lines: 79-93
+
+What you learned
+----------------
+
+- A synth is a pool of voices behind an ordinary positioned sound.
+- ``create().addVoices(prototype, n)`` sizes the polyphony; the prototype
+  must outlive the call.
+- Drive it with ``noteOn`` / ``noteOff`` / ``allNotesOff``.
+- Destroy the sound before the synth before the prototype.
+
+Next
+----
+
+- :doc:`07_custom_dspvoice` — write your own voice from scratch.
+- :doc:`08_instruments` — load SFZ instruments and DX7 banks.
+- :doc:`10_per_note_3d` — give every note its own position.
+- :doc:`/api/synth` — the full synth API reference.

--- a/documentation/source/tutorials/07_custom_dspvoice.rst
+++ b/documentation/source/tutorials/07_custom_dspvoice.rst
@@ -1,0 +1,119 @@
+Writing a custom dspVoice
+=========================
+
+Goal: implement your own synthesiser voice by subclassing
+:cpp:class:`YSE::SYNTH::dspVoice`.
+
+The built-in voices (sine, virtual-analog, sampler, FM) cover a lot of
+ground, but the whole point of the voice model is that *you* can define what
+a note sounds like while the engine keeps owning polyphony, allocation and
+lifecycle. This tutorial dissects the reference voice,
+:cpp:class:`YSE::SYNTH::sineVoice` — one sine oscillator shaped by an ADSR
+envelope. It is the smallest legal voice, and every synth test builds on it.
+
+Source: `sineVoice.hpp
+<https://github.com/yvanvds/yse-soundengine/blob/master/YseEngine/synth/sineVoice.hpp>`_
+and `sineVoice.cpp
+<https://github.com/yvanvds/yse-soundengine/blob/master/YseEngine/synth/sineVoice.cpp>`_.
+
+The contract
+------------
+
+A ``dspVoice`` is a ``DSP::dspSourceObject`` — it already owns the
+``samples`` output buffers — extended with the two methods you **must**
+implement:
+
+.. literalinclude:: ../../../YseEngine/synth/sineVoice.hpp
+   :language: cpp
+   :lines: 76-86
+
+- ``process(SOUND_STATUS& intent)`` fills one block of ``samples`` on the
+  **audio thread**. It must be allocation-free, lock-free and non-blocking.
+- ``clone()`` returns a fresh, fully-allocated heap copy of your voice. It
+  runs only on the **setup thread**, so allocation there is fine — and
+  necessary, because everything ``process()`` touches must already exist.
+
+Reading note state
+------------------
+
+The engine delivers the current note's parameters as atomics you read inside
+``process()``: ``getFrequency()`` (Hz), ``getVelocity()`` ([0, 1]),
+``getAftertouch()`` and ``getPitchWheel()`` ([-1, 1]). You never write them.
+
+Allocate everything up front
+----------------------------
+
+The voice builds its oscillator and envelope in the constructor and in the
+(off-thread) setter methods — never in ``process()``:
+
+.. literalinclude:: ../../../YseEngine/synth/sineVoice.cpp
+   :language: cpp
+   :lines: 38-46
+
+``clone()`` is then a one-liner that copy-constructs, and the copy
+constructor rebuilds independent state so a clone shares nothing mutable with
+its prototype:
+
+.. literalinclude:: ../../../YseEngine/synth/sineVoice.cpp
+   :language: cpp
+   :lines: 107-109
+
+.. literalinclude:: ../../../YseEngine/synth/sineVoice.cpp
+   :language: cpp
+   :lines: 48-59
+
+Honouring the intent
+--------------------
+
+``process()``'s ``intent`` argument *is* this voice's ``SOUND_STATUS``. You
+read it to drive your envelope and — crucially — you **write it back** to
+tell the engine what the voice is doing:
+
+.. literalinclude:: ../../../YseEngine/synth/sineVoice.cpp
+   :language: cpp
+   :lines: 111-175
+
+The lifecycle in that block:
+
+- ``SS_WANTSTOPLAY`` (note start) → restart the oscillator and envelope
+  attack, then settle the intent to ``SS_PLAYING``.
+- ``SS_PLAYING`` → hold the sustain plateau.
+- ``SS_WANTSTOSTOP`` (note off) → take the release transition, then tail out.
+- When the release tail reaches zero, set ``intent = SS_STOPPED`` so the
+  allocator can free the slot. **If you never settle to ``SS_STOPPED`` the
+  voice is never reclaimed.**
+
+Using it
+--------
+
+A custom voice is used exactly like a built-in one — it *is* a
+``dspVoice``:
+
+.. code-block:: cpp
+
+   MyVoice proto;
+   proto.attack(0.01f).release(0.2f);   // your own setters
+
+   YSE::synth syn;
+   syn.create().addVoices(proto, 8);
+
+   YSE::sound snd;
+   snd.create(syn);
+   snd.play();
+   syn.noteOn(1, 60, 0.9f);
+
+What you learned
+----------------
+
+- Subclass ``dspVoice`` and implement ``process()`` (audio thread) and
+  ``clone()`` (setup thread).
+- Allocate in the constructor / setters, never in ``process()``.
+- Read note state with ``getFrequency()`` / ``getVelocity()`` / etc.
+- Drive the envelope off ``intent`` and settle it to ``SS_STOPPED`` when the
+  release tail ends.
+
+Next
+----
+
+- :doc:`06_first_synth` — the synth basics this builds on.
+- :doc:`/api/synth` — the ``dspVoice`` and built-in-voice reference.

--- a/documentation/source/tutorials/08_instruments.rst
+++ b/documentation/source/tutorials/08_instruments.rst
@@ -1,0 +1,83 @@
+Loading SFZ instruments and DX7 banks
+=====================================
+
+Goal: play a sampled instrument from an SFZ file, and an FM instrument from a
+vintage DX7 SysEx bank.
+
+The synth voice model ships two instrument voices that load their sound from
+standard, portable formats rather than being coded in C++:
+
+- :cpp:class:`YSE::SYNTH::samplerVoice` reads an **SFZ** instrument — a text
+  file mapping key/velocity regions to PCM samples.
+- :cpp:class:`YSE::SYNTH::fmVoice` plays a **DX7** voice; the
+  :cpp:class:`YSE::SYNTH::dx7SysEx` importer fills its patch from a ``.syx``
+  bank dump.
+
+Both draw on the optional bundled content pack; the demos degrade with a
+clear message when it is absent.
+
+Sources: `Demo19_SfzPiano.cpp
+<https://github.com/yvanvds/yse-soundengine/blob/master/Demo.Windows.Native/Demo19_SfzPiano.cpp>`_
+and `Demo18_FMKeyboard.cpp
+<https://github.com/yvanvds/yse-soundengine/blob/master/Demo.Windows.Native/Demo18_FMKeyboard.cpp>`_.
+
+Loading an SFZ instrument
+-------------------------
+
+Construct a :cpp:class:`YSE::SYNTH::samplerVoice`, load an SFZ file into it,
+then use it as the prototype for a synth. ``loadSFZ`` parses the file and
+decodes every referenced sample into memory off the audio thread; it returns
+``false`` if the instrument is not playable:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo19_SfzPiano.cpp
+   :language: cpp
+   :lines: 40-52
+
+From here it is an ordinary synth: ``noteOn`` plays a mapped region,
+pitch-shifting and layering as the SFZ describes.
+
+The sustain pedal
+-----------------
+
+Sampled instruments feel right only with pedals. The synth handles CC 64
+(sustain) for you — while it is down, note-offs are deferred until the pedal
+lifts:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo19_SfzPiano.cpp
+   :language: cpp
+   :lines: 146-151
+
+``sostenuto`` (CC 66) and ``softPedal`` (CC 67) work the same way; see
+:cpp:class:`YSE::synth`.
+
+Loading a DX7 bank
+------------------
+
+An FM instrument comes from a DX7 SysEx bank. Parse the ``.syx`` file into a
+:cpp:class:`YSE::SYNTH::dx7Bank`, then apply one of its patches to an
+:cpp:class:`YSE::SYNTH::fmVoice` prototype with ``setPatch``:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo18_FMKeyboard.cpp
+   :language: cpp
+   :lines: 40-51
+
+A bank holds up to 32 voices; ``bank_.size()`` and ``bank_.name(i)`` let you
+browse them. Because the FM core bakes operator state at key-down, a
+``setPatch`` takes effect on the *next* note-on — so switching patches while
+notes ring does not glitch the held voices; retrigger to hear the change.
+
+What you learned
+----------------
+
+- ``samplerVoice::loadSFZ(path)`` builds a multi-layer sampled instrument;
+  check the return value.
+- The synth handles the sustain / sostenuto / soft pedals as CC 64 / 66 / 67.
+- ``dx7SysEx::loadBank(path, bank)`` parses a DX7 ``.syx``; apply a patch to
+  an ``fmVoice`` with ``setPatch``, which lands on the next note-on.
+
+Next
+----
+
+- :doc:`06_first_synth` — the synth basics.
+- :doc:`09_mixing_inserts_sends` — run instruments through a mixer.
+- :doc:`/api/synth` — sampler, FM and importer reference.

--- a/documentation/source/tutorials/09_mixing_inserts_sends.rst
+++ b/documentation/source/tutorials/09_mixing_inserts_sends.rst
@@ -1,0 +1,103 @@
+Mixing with inserts and sends
+=============================
+
+Goal: build a console-style mixer — a channel with an insert effect chain,
+and a shared reverb fed by aux sends.
+
+:doc:`03_channels` introduced the channel tree for grouping sounds under
+shared volume. Channels also carry the two routing primitives every mixer
+needs:
+
+- an **insert chain** — a pre-fader :cpp:class:`YSE::DSP::dspObject` chain
+  that processes everything on the channel (:cpp:func:`YSE::channel::setDSP`);
+- **aux sends** to a **return bus** — a scaled copy of the channel routed to
+  a shared effect (:cpp:func:`YSE::channel::makeReturn`,
+  :cpp:func:`YSE::channel::send`).
+
+This tutorial walks through ``Demo21_Mixer``: a music channel running
+EQ → compressor → chorus, plus a plate reverb both channels send into.
+
+Source: `Demo21_Mixer.cpp
+<https://github.com/yvanvds/yse-soundengine/blob/master/Demo.Windows.Native/Demo21_Mixer.cpp>`_.
+
+Two source channels
+-------------------
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo21_Mixer.cpp
+   :language: cpp
+   :lines: 20-21
+
+Building an insert chain
+------------------------
+
+Configure the effect modules, chain them with ``dspObject::link``, then
+attach the head of the chain to the channel. The whole chain runs pre-fader
+on the summed channel signal:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo21_Mixer.cpp
+   :language: cpp
+   :lines: 23-31
+
+Each module is an ordinary :cpp:class:`YSE::DSP::dspObject`, so it has the
+inherited ``bypass`` / ``impact`` (wet/dry) controls on top of its own
+parameters. The mix-grade modules — :cpp:class:`parametric EQ
+<YSE::DSP::MODULES::parametricEQ>`,
+:cpp:class:`compressor <YSE::DSP::MODULES::compressor>`,
+:cpp:class:`chorus <YSE::DSP::MODULES::chorus>` — are documented on the
+:doc:`/api/effects` page.
+
+A shared reverb via send / return
+---------------------------------
+
+Create a return bus with ``makeReturn``, attach an effect to it, then feed it
+from any channel with ``send(slot, returnBus, level)``. Here both the music
+and drum channels send into one plate reverb, post-fader:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo21_Mixer.cpp
+   :language: cpp
+   :lines: 33-38
+
+A return bus is just a channel that has been flagged with ``makeReturn`` — it
+keeps its own inserts and can even send onward to other returns (the graph
+must stay acyclic).
+
+Driving it live
+---------------
+
+Toggling an insert chain and riding the send levels is glitch-free — send
+levels are ramped internally, so they are safe to set every control tick:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo21_Mixer.cpp
+   :language: cpp
+   :lines: 83-98
+
+Passing ``nullptr`` to ``setDSP`` detaches the insert chain; the engine takes
+no ownership of the modules, so they must outlive the channel.
+
+Tearing down routing
+--------------------
+
+Because the audio thread walks the insert chain and sends every block, tear
+the routing down — ``clearSend`` and ``setDSP(nullptr)`` — *before* the
+channels and effect objects destruct:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo21_Mixer.cpp
+   :language: cpp
+   :lines: 59-68
+
+What you learned
+----------------
+
+- ``channel::setDSP(head)`` installs a pre-fader insert chain; chain modules
+  with ``dspObject::link``.
+- ``channel::makeReturn`` turns a channel into a return bus;
+  ``channel::send`` / ``setSendLevel`` feed it from other channels.
+- The engine never owns insert or return effects — they must outlive the
+  channel, and routing should be torn down before they destruct.
+
+Next
+----
+
+- :doc:`/api/effects` — the mixing-effect module reference.
+- :doc:`/api/channels` — channel routing, sends and metering.
+- :doc:`10_per_note_3d` — spatial positioning per note.

--- a/documentation/source/tutorials/10_per_note_3d.rst
+++ b/documentation/source/tutorials/10_per_note_3d.rst
@@ -1,0 +1,90 @@
+Per-note 3D: position handlers and swarms
+=========================================
+
+Goal: give every note its own position in space, so a single chord becomes a
+swarm of independently-moving sound sources orbiting the listener.
+
+A synth is rendered behind one positioned :cpp:class:`YSE::sound`, so by
+default every voice shares that one position. Attach a
+:cpp:class:`YSE::SYNTH::positionHandler` and each voice gets its *own* 3D
+position, updated every block — the basis of the "swarm" effect. libYSE ships
+three handlers: :cpp:class:`static <YSE::SYNTH::staticHandler>`,
+:cpp:class:`random-spread <YSE::SYNTH::randomSpreadHandler>` and
+:cpp:class:`orbit <YSE::SYNTH::orbitHandler>` (the swarm workhorse), or you
+can derive your own.
+
+This tutorial walks through ``Demo20_Swarm``: a chord of sine voices orbiting
+the listener, steerable live.
+
+Source: `Demo20_Swarm.cpp
+<https://github.com/yvanvds/yse-soundengine/blob/master/Demo.Windows.Native/Demo20_Swarm.cpp>`_.
+
+Attaching a handler
+-------------------
+
+Build a voice prototype *and* a handler prototype, then chain
+``positionHandler`` after ``addVoices``. The synth clones the handler once
+per voice slot, so each voice steers independently:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo20_Swarm.cpp
+   :language: cpp
+   :lines: 24-36
+
+The :cpp:class:`orbit handler <YSE::SYNTH::orbitHandler>` reads its base
+radius from ``radius``, widens with note velocity (``velocityRadius``) and
+aftertouch (``aftertouchWiden``), spins at ``rate`` radians per second, and
+slows on release (``releaseSlow``). Like a voice, a handler prototype must
+outlive setup — the engine reads it to clone but neither copies nor owns it.
+
+.. note::
+
+   With no handler attached, ``positionHandler`` is simply never called and
+   every voice uses the synth's aggregate position — so adding per-note
+   positioning is purely additive to the :doc:`06_first_synth` flow.
+
+Steering the swarm live
+-----------------------
+
+Two live controls, both bounded and allocation-free, so they are safe to call
+every frame:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo20_Swarm.cpp
+   :language: cpp
+   :lines: 82-99
+
+- ``handlerParam(index, value)`` sets a *shared* handler parameter every live
+  handler reads next block. Indices 0–2 are the swarm centre
+  (:cpp:enumerator:`YSE::SYNTH::HP_CENTER_X` and friends), so one call
+  recentres the entire swarm.
+- ``aftertouch(channel, -1, value)`` applies channel-wide pressure; the orbit
+  handler widens the radius with it.
+
+To place a single note explicitly instead (app-driven trajectories rather
+than a handler), use :cpp:func:`YSE::synth::notePosition`.
+
+Reading a voice back
+--------------------
+
+``getVoicePosition`` returns a best-effort snapshot of where a sounding voice
+currently is — handy for driving visuals off the audio:
+
+.. literalinclude:: ../../../Demo.Windows.Native/Demo20_Swarm.cpp
+   :language: cpp
+   :lines: 63-68
+
+What you learned
+----------------
+
+- Attach a ``positionHandler`` with ``synth::positionHandler(prototype)`` to
+  give every voice its own 3D position; the prototype must outlive setup.
+- The ``orbitHandler`` makes a chord orbit the listener; velocity and
+  aftertouch shape the radius.
+- Steer the whole swarm with ``handlerParam`` (centre at indices 0–2), place
+  one note with ``notePosition``, and read a voice back with
+  ``getVoicePosition``.
+
+Next
+----
+
+- :doc:`/api/synth` — position-handler reference.
+- :doc:`01_3d_positioning` — the listener and 3D basics this builds on.

--- a/documentation/source/tutorials/index.rst
+++ b/documentation/source/tutorials/index.rst
@@ -99,6 +99,21 @@ Other demos in this phase:
 - ``Demo17_MidiPatcher`` — pipe MIDI messages into a patcher graph through
   ``.noteon`` / ``.noteoff`` / ``.controlchange`` objects.
 
+Phase 6 — Synths, instruments, and effects
+------------------------------------------
+
+Polyphonic synthesis, custom and sampled/FM instruments, channel-strip
+mixing, and per-note 3D. These correspond to ``Demo18``–``Demo21``.
+
+.. toctree::
+   :maxdepth: 1
+
+   06_first_synth
+   07_custom_dspvoice
+   08_instruments
+   09_mixing_inserts_sends
+   10_per_note_3d
+
 How to follow along
 -------------------
 


### PR DESCRIPTION
## Summary

Closing docs + benchmark sweep for the synth/effects effort (epic #149).
The Doxygen comments on the new public surfaces already landed with their
feature PRs; this issue exposes them through reference pages, adds the
tutorials and the benchmark entries promised across the epics, and brings
PROJECT_OVERVIEW.md up to the post-epic architecture.

Builds on the freshly-merged #179 (content pack) and #180 (Demo18-21 +
synthdemos suite) — the tutorials `literalinclude` directly from those
demos so they stay in sync.

## Linked issue

Closes #181

## Changes

**Docs (Sphinx + Breathe)**
- `api/synth.rst` — synth, `dspVoice` + built-in voices (sine, VA, SFZ
  sampler, DX7 FM), DX7 importer, per-note position handlers.
- `api/effects.rst` — mix-grade modules (parametric EQ, compressor,
  chorus, feedback delay, plate reverb) with insert/send routing notes.
- Wired both into `api/index.rst`; added `yse_synth.h` + `yse_instrument.h`
  to the C API page.
- Five tutorials (`06`–`10`): your first synth, writing a custom
  `dspVoice`, loading SFZ/DX7 instruments, mixing with inserts and sends,
  per-note 3D swarms — indexed as a new "Phase 6".

**Benches**
- `dsp/bench_fm_voice.cpp` — FM per-voice (sine / 2-op / 6-op) + sine
  reference.
- `integration/bench_synth_effects.cpp` — Tier-3 offline macros:
  voice-count scaling, channel insert-chain cost, send fan-in, N
  positioned notes. Sampler-vs-sine was already covered by
  `bench_sampler_voice.cpp`.

**PROJECT_OVERVIEW.md** — §13 synth revival, signal path gains
inserts/sends, channel + DSP-module sections, docs/bench counts, META bump.

## Test plan

- [x] `clang-format --dry-run --Werror` clean on the new bench sources.
- [x] `clang-tidy` (build-bench compile DB) on the new benches: only the
  `for (auto _ : state)` DeadStores finding, which is the google-benchmark
  idiom present suite-wide (8× in existing benches) — no new findings.
- [x] `make html` equivalent (Doxygen 1.9.x + Sphinx 7.4/Breathe) builds
  **clean** (exit 0): new synth/effects/tutorial pages render, all
  cross-references resolve, no `literalinclude` range errors, warning set
  unchanged from baseline (pre-existing Breathe duplicate-declaration
  noise only). Note: local Doxygen 1.17 crashes Breathe on `<sect2>` XML —
  a pre-existing toolchain mismatch, unrelated to this PR; CI's apt
  Doxygen (1.9.x) is unaffected.
- [x] `python yse.py bench` — the new benches build and run; voice-count,
  send fan-in and FM-voice cases show clean scaling.
- [x] `python yse.py test` — 29/30 isolated suites pass; `yse_tests_synthcapi`
  flaked once under parallel load and passes 3/3 in isolation (known
  intermittent teardown flakiness, #298/#304). This PR touches no
  engine/test source.

**On integration tests:** the user-visible change is documentation +
benchmarks. The `make html` build and the runnable benchmark binary are
themselves the executable verification; the tutorial code paths
(synth create/addVoices/play, custom voice, SFZ/DX7 load, inserts/sends,
position handlers) are already exercised end-to-end by the merged
`synthdemos` integration suite (#180). No new integration test is
warranted — no new runtime behaviour is introduced.
