### PR TITLE
PERF: float transcendentals + x*x in the panner hot path (#214)

### DIFF
--- a/YseEngine/dsp/panner.cpp
+++ b/YseEngine/dsp/panner.cpp
@@ -55,7 +55,11 @@ namespace YSE {
       constexpr Flt minPower = 1e-9f;
       if (speakerCount == 0) return 0.f;
       if (!(power > minPower)) return 1.f / static_cast<Flt>(speakerCount);
-      return static_cast<Flt>(::pow(initGain, 2) / power);
+      // Trivial squaring: initGain * initGain instead of a double ::pow(initGain, 2)
+      // (#214). This is the per-speaker "ratio loop" squaring the issue calls out;
+      // it moved here from SOUND::implementationObject when #169 consolidated the
+      // panner math into this shared helper.
+      return initGain * initGain / power;
     }
 
     Flt panner::computeSourceAngle(bool relative, const Pos& dir, const Pos& listenerForward) {

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -13,6 +13,8 @@
 #include "../patcher/patcherImplementation.h"
 #include "../dsp/panner.hpp"
 
+#include <cmath> // std::cos / std::pow float overloads in the panner hot path (#214)
+
 namespace {
   // Time constant (ms) over which the doppler playback-rate ratio is slewed in
   // dsp(). Long enough to iron out the stepwise, jittery update-tick target
@@ -863,7 +865,11 @@ void YSE::SOUND::implementationObject::computeFinalGains() {
   // yields the same value the old per-x computation did, bit-for-bit.
   Flt dist = distance - size;
   if (dist < 0) dist = 0;
-  Flt correctPower = 1 / pow(dist, (2 * INTERNAL::Settings().rolloffScale));
+  // std::pow with an Flt (float) exponent selects the single-precision overload;
+  // the bare pow(...) would promote the args to double (#214). dist and
+  // rolloffScale are both Flt, so this is a genuine powf, computed once per
+  // update tick (this whole function only runs when gainDirty).
+  Flt correctPower = 1 / std::pow(dist, (2 * INTERNAL::Settings().rolloffScale));
   if (correctPower > 1) correctPower = 1;
 
   for (UInt x = 0; x < buffer->size(); x++) {
@@ -880,7 +886,7 @@ void YSE::SOUND::implementationObject::computeFinalGains() {
       // near-zenith source (-> 0) collapses the cosine term, leaving a flat 0.5
       // for every speaker — an equal-power omni spread instead of a wild sweep.
       Flt initPan =
-          (1 + horizFraction * cos(parent->outConf[i].angle - (angle + spreadAdjust))) * 0.5f;
+          (1 + horizFraction * std::cos(parent->outConf[i].angle - (angle + spreadAdjust))) * 0.5f;
       // The speaker-density term effective[i] depends only on the speaker
       // geometry, so it is precomputed once on layout change in
       // CHANNEL::implementationObject::computeEffectiveSpeakerWeights() instead
@@ -892,7 +898,8 @@ void YSE::SOUND::implementationObject::computeFinalGains() {
     Flt power = 0;
     for (UInt i = 0; i < parent->outConf.size(); i++) {
       if (parent->outConf[i].isLFE) continue;
-      power += static_cast<Flt>(pow(initGainScratch[i], 2));
+      // Trivial squaring: g * g instead of a double pow(g, 2) (#214).
+      power += initGainScratch[i] * initGainScratch[i];
     }
 
     // final gain assignment


### PR DESCRIPTION
## Summary

Replaces double-precision `cos`/`pow` with single-precision `std::cos`/`std::pow` and trivial `x*x` squaring in the panner gain computation. Unqualified `cos(...)`/`pow(...)` on `Flt` args promote to the `double` `::cos`/`::pow`, costing ~2x the float overload for precision the pan gains don't need. RT-critical audio-thread hot path; perf-only, no audible output change.

## Linked issue

Closes #214

## Changes

- `SOUND::implementationObject::computeFinalGains` (`soundImplementation.cpp`):
  - `cos(...)` -> `std::cos(...)`
  - `pow(dist, 2*rolloffScale)` -> `std::pow(...)` (float overload; `dist` and `rolloffScale` are both `Flt`). Already hoisted out of the source-channel loop and only recomputed when `gainDirty`, i.e. once per update tick.
  - power loop `pow(g, 2)` -> `g * g`
  - added `#include <cmath>` for the `std::` overloads
- `DSP::panner::computePanRatio` (`panner.cpp`): the per-speaker "ratio loop" squaring #214 calls out (relocated here from `SOUND::implementationObject` by #169): `::pow(initGain, 2)` -> `initGain * initGain`.

Scope: the sibling synth-voice path `DSP::panner::computeFinalGains` has the same pattern but was not named in #214 (added later by #169); filed as **#341** to keep this PR focused. No allocation/locking/blocking added to the audio path.

## Test plan

- [x] `yse.py format` clean (no files reformatted beyond the intended change)
- [x] `yse.py analyze` on both changed files clean in modified code (only 2 pre-existing findings in `soundImplementation.cpp` at lines 190/709, outside this change; `panner.cpp` no user-code findings)
- [x] Full `yse.py test` suite: 30/30 test binaries pass, 0 failed (incl. `yse_tests_dsp` panner, `yse_tests_sound`, `yse_tests_channel`, `yse_tests_listener`)
- [x] Not user-visible behavior: perf-only change, gain math tolerates float precision so the mix is unchanged audibly — no new integration test warranted; covered by the existing panner/sound/channel-layout DSP suites which still pass.