### PR TITLE
DSP: skip duplicate gain computation for spread==0 multichannel sounds (#215)

### DIFF
--- a/Tests/sound/test_sound_impl.cpp
+++ b/Tests/sound/test_sound_impl.cpp
@@ -82,6 +82,25 @@ namespace {
     void frequency(float) override {}
   };
 
+  // Stereo variant of DcSource for the spread==0 multichannel dedup test (#215).
+  // Both source channels carry the same constant DC, so with spread==0 they pan
+  // through the identical per-speaker gains; the summed per-output peak is then a
+  // clean readout of that shared pan, and two source channels exercise the
+  // gain-column replication path computeFinalGains() takes when spread==0.
+  struct StereoDcSource : YSE::DSP::dspSourceObject {
+    StereoDcSource() : YSE::DSP::dspSourceObject(2) {}
+    void process(YSE::SOUND_STATUS& intent) override {
+      for (UInt c = 0; c < samples.size(); ++c) {
+        float* p = samples[c].getPtr();
+        UInt len = samples[c].getLength();
+        for (UInt i = 0; i < len; i++)
+          p[i] = 0.5f;
+      }
+      intent = YSE::SS_PLAYING;
+    }
+    void frequency(float) override {}
+  };
+
   // Shared file-scope instances reused across tests.  These are stateless, so
   // sharing is safe; each test sets the position / volume / etc. it needs.
   SilentSource g_src;
@@ -89,6 +108,7 @@ namespace {
   NopDsp g_dsp;
   NopDsp g_dsp2;
   DcSource g_dc;
+  StereoDcSource g_dcStereo;
 
   // Drive SOUND::Manager().update() several times, with short sleeps so the
   // async setupJob has a chance to call setup() on freshly created sounds and
@@ -1370,6 +1390,64 @@ TEST_SUITE("sound") {
     s.pos(YSE::Pos(5.f, 0.f, 0.f));
     YSE::System().update();
     YSE::System().renderOffline(2); // >50 samples: smoothing ramp fully settles
+    const float rightL = leftPeak();
+    const float rightR = rightPeak();
+    CHECK(rightR > 0.05f);
+    CHECK(rightL < rightR * 0.1f);
+
+    s.stop();
+  }
+
+  // ─── spread == 0 multichannel gain dedup (#215) ──────────────────────────────
+  //
+  // computeFinalGains() derives a per-speaker gain column for each source
+  // channel. With the default spread == 0 every source channel maps to the
+  // identical angle, so all columns are bit-identical; the optimisation computes
+  // column 0 once and replicates it to the rest. This must not change the
+  // rendered output: a stereo source panned hard-left must still land on the
+  // left output with the right output near-silent. Same offline, audio-paused
+  // driving as the #212 case; the only difference is the two-channel source,
+  // which is the path the replication loop covers.
+  TEST_CASE("gain dedup: a stereo source with spread==0 pans as one point source (#215)") {
+    if (!TestHelpers::engineInit()) return;
+
+    YSE::channel ch;
+    ch.create("gaindedup215", YSE::ChannelMaster());
+
+    YSE::sound s;
+    s.create(g_dcStereo, &ch);
+    if (!s.isValid()) return;
+    s.relative(true); // angle straight from position, listener ignored
+    s.size(10.f); // near field: rolloff clamps to 1
+    CHECK(s.spread() == doctest::Approx(0.f)); // default: the deduped path
+    s.pos(YSE::Pos(-5.f, 0.f, 0.f)); // hard left -> output 0 dominates
+    s.play();
+
+    auto leftPeak = [&]() { return ch.getPeakLinearPre(0); };
+    auto rightPeak = [&]() { return ch.getPeakLinearPre(1); };
+    auto audible = [&]() { return leftPeak() > 1e-4f || rightPeak() > 1e-4f; };
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < deadline && !audible()) {
+      YSE::System().update();
+      YSE::System().renderOffline(2);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    if (!audible()) return;
+
+    // Both source channels sum through the same left-dominant gains: left output
+    // carries the signal, right stays near-silent. A broken replication (garbage
+    // column, wrong bounds) would unbalance or silence this.
+    const float leftL = leftPeak();
+    const float leftR = rightPeak();
+    CHECK(leftL > 0.05f);
+    CHECK(leftR < leftL * 0.1f);
+
+    // Re-pan hard-right through a fresh tick: the deduped columns must still
+    // follow the source, proving the replication tracks per-tick updates.
+    s.pos(YSE::Pos(5.f, 0.f, 0.f));
+    YSE::System().update();
+    YSE::System().renderOffline(2);
     const float rightL = leftPeak();
     const float rightR = rightPeak();
     CHECK(rightR > 0.05f);

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -872,7 +872,20 @@ void YSE::SOUND::implementationObject::computeFinalGains() {
   Flt correctPower = 1 / std::pow(dist, (2 * INTERNAL::Settings().rolloffScale));
   if (correctPower > 1) correctPower = 1;
 
-  for (UInt x = 0; x < buffer->size(); x++) {
+  // With the default spread == 0 every source channel maps to the identical
+  // angle (spreadAdjust == 0 for all x), so the whole pan / normalisation /
+  // rolloff derivation below yields a bit-identical gain column for every
+  // source channel. Compute that column once and replicate it, instead of
+  // redoing the cos / pow / sqrt work C times per update tick (issue #215). A
+  // multichannel buffer with a non-zero spread still runs the full per-channel
+  // loop. This dedups only the cached gains — toChannels()'s per-source-channel
+  // mix pass and its separate lastGain ramp states are untouched (the further
+  // pre-sum step interacts with mix-loop fusion and is out of scope, #213/#215).
+  const UInt sourceChannels = static_cast<UInt>(buffer->size());
+  const bool spreadCollapsed = (spread == 0.f) || (sourceChannels <= 1);
+  const UInt channelsToCompute = spreadCollapsed ? 1u : sourceChannels;
+
+  for (UInt x = 0; x < channelsToCompute; x++) {
     // calculate spread value for multichannel sounds
     Flt spreadAdjust = 0;
     if (buffer->size() > 1)
@@ -911,6 +924,18 @@ void YSE::SOUND::implementationObject::computeFinalGains() {
       // add volume control now
       if (occlusionActive) finalGain *= 1 - occlusion_dsp;
       finalGainCache[j][x] = finalGain;
+    }
+  }
+
+  // spread == 0 (or a mono source): column 0 holds the gains every source
+  // channel shares, so fan it out to the rest instead of recomputing identical
+  // values. Skip the LFE outputs — their columns are never read by toChannels()
+  // and never written by the loop above, so they stay untouched here too.
+  if (spreadCollapsed) {
+    for (UInt j = 0; j < parent->out.size(); ++j) {
+      if (parent->outConf[j].isLFE) continue;
+      for (UInt x = 1; x < sourceChannels; x++)
+        finalGainCache[j][x] = finalGainCache[j][0];
     }
   }
 }

--- a/YseEngine/sound/soundImplementation.cpp
+++ b/YseEngine/sound/soundImplementation.cpp
@@ -883,7 +883,11 @@ void YSE::SOUND::implementationObject::computeFinalGains() {
   // pre-sum step interacts with mix-loop fusion and is out of scope, #213/#215).
   const UInt sourceChannels = static_cast<UInt>(buffer->size());
   const bool spreadCollapsed = (spread == 0.f) || (sourceChannels <= 1);
-  const UInt channelsToCompute = spreadCollapsed ? 1u : sourceChannels;
+  // Guard the empty-buffer transient: with no source channels there is nothing
+  // to compute, and finalGainCache columns are zero-length — the original
+  // `x < buffer->size()` loop ran zero passes there, so the collapsed path must
+  // too (a bare `1` would write finalGainCache[j][0] out of bounds).
+  const UInt channelsToCompute = (spreadCollapsed && sourceChannels > 0) ? 1u : sourceChannels;
 
   for (UInt x = 0; x < channelsToCompute; x++) {
     // calculate spread value for multichannel sounds


### PR DESCRIPTION
## Summary

`computeFinalGains()` derives a per-speaker gain column for every source channel of a sound. With the default `spread == 0`, the source-channel offset `spreadAdjust` collapses to `0` for **every** channel, so all columns come out bit-identical — yet the `cos`/`pow`/`sqrt` pan/normalisation/rolloff derivation was still run once per source channel on each `gainDirty` update tick, maintaining C identical columns.

This computes the gain column **once** and replicates it to the remaining source channels when `spread == 0` (or the source is mono). A non-zero spread still runs the full per-channel loop unchanged.

## Linked issue

Closes #215

## Changes

- `YseEngine/sound/soundImplementation.cpp` — in `computeFinalGains()`, gate the per-source-channel loop to a single column when `spread == 0` (or the buffer is mono), then fan `finalGainCache[j][0]` out to the remaining columns. LFE outputs stay untouched (never read by `toChannels()`). Builds on the #214 float-transcendentals path.
- `Tests/sound/test_sound_impl.cpp` — add a stereo-DC-source end-to-end case (`#215`) proving a multichannel source with `spread == 0` still pans as one point source through the replicated columns, and re-pans on a fresh tick.

## Scope / non-goals

- **Pure dedup, not an approximation.** For `spread == 0` the replicated column equals what the per-channel loop computed bit-for-bit (`spreadAdjust == 0.f` → `angle + 0.f == angle`), so rendered output is unchanged.
- **RT-safe:** no allocation / lock / I/O added — the loop only writes into the already-sized `finalGainCache`.
- The optional further step (pre-summing source channels into one buffer for a single mix pass) is deliberately **not** done: it changes `lastGain` bookkeeping and interacts with the separately-filed mix-loop-fusion enhancement (#213). `toChannels()`'s per-source-channel mix pass and its `lastGain` ramp states are left untouched.
- Spread semantics and the default spread value are unchanged.

## Test plan

- [x] `clang-format` clean (`python yse.py format`)
- [x] `clang-tidy` clean on the changed source — no new findings in modified code (the 2 reported findings are pre-existing baseline at lines 190/709, untouched)
- [x] Unit/DSP tests pass: `yse_tests_sound`, `yse_tests_dsp`, `yse_tests_listener`, `yse_tests_synthpositioning` — 4/4 suites pass
- [x] New `#215` case runs all 5 assertions (not the no-audio early return): stereo source pans hard-left then hard-right correctly through the deduped columns
- Not a user-visible behaviour change (pure internal dedup with bit-identical output), so no separate integration test beyond the end-to-end sound render case added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)