### PR TITLE
Domain clocks: per-domain beat accumulators with rampable, playable tempo (#249)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -411,6 +411,16 @@ Polyphonic note player with scale constraints, motif sequencing, and randomised 
 
 ---
 
+### 12b. Domain Clocks
+
+**Files:** [clock/domainClock.h](YseEngine/clock/domainClock.h) / [.cpp](YseEngine/clock/domainClock.cpp), [clock/clockManager.h](YseEngine/clock/clockManager.h) / [.cpp](YseEngine/clock/clockManager.cpp)
+
+A set of named musical (beat) clocks derived from the single sample clock (issue [#249](https://github.com/yvanvds/yse-soundengine/issues/249), a capability request from Phi's polytemporal timing model). Each clock is a **beat accumulator**: `CLOCK::Manager().update(blockSeconds)` runs every audio callback (wired into `deviceManager::doOnCallback`, alongside `PLAYER::Manager().update`) and advances each clock by `blockSeconds × tempo / 60`, so beat position is the running integral of tempo — no absolute-time schedule. Because every clock derives from the one audio callback, polytemporal relationships stay exact and deterministic.
+
+Tempo is a **playable, rampable control**: `setTempo(name, bpm, rampSeconds)` slews linearly (instant when `rampSeconds` is 0) and is never clamped (0 pauses, negative runs backward). Clocks are created/destroyed/queried by name at runtime. The manager follows the PLAYER lock-free lifecycle (canonical `forward_list` under a mutex → SPSC inbox → audio-owned `inUse` working list → slow-pool delete job); the audio thread never allocates, locks, or frees. `beatPosition` / `currentTempo` read published atomics and are safe to poll from the UI thread at frame rate (playhead display). Public surface: `YSE::system::createClock / destroyClock / clockExists / setTempo / beatPosition / currentTempo`, mirrored in the C ABI as `yse_system_*_clock` / `yse_system_set_tempo` / `yse_system_beat_position` / `yse_system_current_tempo`. Clip transports that bind to these clocks are a separate issue.
+
+---
+
 ### 13. Synth (Polyphonic instrument host)
 
 **Files:** `synth/` — `synthInterface.hpp/.cpp`, `synthManager.h/.cpp`, `synthImplementation.h/.cpp`, `synthMessage.h`, `dspVoice.hpp` (voice base), `positionHandler.hpp` + `positionHandlers.hpp/.cpp` (per-note 3D). Built-in voices: `sineVoice.hpp/.cpp` (reference sine + ADSR), `vaVoice.hpp/.cpp` (virtual-analog + wavetable → `DSP::ladderFilter` → amp/filter ADSR + LFO, live `vaParams` patch), `samplerVoice.hpp/.cpp` (SFZ sampler), and the FM voice under `dsp/fm/` (`fmVoice`, `fmPatch`, `dx7Sysex` importer, MSFA core in `dsp/fm/msfa/`).

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -105,6 +105,7 @@ set(YSE_TEST_SOURCES
   system/test_named_bus.cpp
   system/test_system_active_state.cpp
   system/test_lifecycle.cpp
+  clock/test_domain_clocks.cpp
   integration/test_device.cpp
   integration/test_content_pack.cpp
   integration/test_synth_demos.cpp
@@ -215,7 +216,11 @@ add_test(
   # `channelcapi` (issue #166 C-API channel-DSP/send surface) is excluded for
   # the same reason — it drives yse_system_init_offline() and runs in its own
   # process (yse_tests_channelcapi).
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos "--test-case-exclude=* concurrency: *" --duration=true
+  # `clock` (issue #249 domain clocks) is excluded too: its cases drive
+  # CLOCK::Manager().update() directly on the test thread to advance beats
+  # deterministically, which would race a live audio thread from another suite
+  # in this shared process. It runs isolated in yse_tests_clock.
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos,clock "--test-case-exclude=* concurrency: *" --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -237,6 +242,17 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_dsp PROPERTIES LABELS dsp)
+
+# Domain clocks (issue #249). Isolated in its own process: the cases drive
+# CLOCK::Manager().update() directly to advance beats deterministically, so
+# they must not share a process with a suite that runs a live audio thread
+# (which would also tick the clock manager). No audio device needed.
+add_test(
+  NAME    yse_tests_clock
+  COMMAND yse_tests --test-suite=clock
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_clock PROPERTIES LABELS clock)
 
 add_test(
   NAME    yse_tests_utils

--- a/Tests/clock/test_domain_clocks.cpp
+++ b/Tests/clock/test_domain_clocks.cpp
@@ -1,0 +1,223 @@
+// Tests for domain clocks (issue #249): per-domain beat accumulators with
+// rampable, playable tempo.
+//
+// Domain clocks advance on the audio callback via CLOCK::Manager().update(delta)
+// (wired into deviceManager::doOnCallback). These tests drive that tick
+// directly on the test thread with explicit block durations, which makes beat
+// integration and tempo ramps fully deterministic without needing an audio
+// device. This suite is registered as its own CTest process (yse_tests_clock)
+// and excluded from the crowded monolithic run, so no other suite's audio
+// thread can also call CLOCK::Manager().update() and race these direct ticks.
+//
+// Each case uses a unique clock name: the CLOCK manager is a process-global
+// singleton that persists across cases, and update() advances every live clock,
+// so distinct names keep the cases independent (a case only ever reads the
+// clock it created, and only its own update() calls move that clock).
+
+#include <doctest/doctest.h>
+#include "yse.hpp"
+#include "clock/clockManager.h"
+#include "yse_c/yse_system.h"
+
+namespace {
+  // One audio-block tick of `seconds` at the current tempo of every live clock.
+  void tick(float seconds) {
+    YSE::CLOCK::Manager().update(seconds);
+  }
+} // namespace
+
+TEST_SUITE("clock") {
+
+  // ─── Lifecycle: create / exists / destroy ───────────────────────────────────
+
+  TEST_CASE("clock: create, query, and destroy by name") {
+    auto& mgr = YSE::CLOCK::Manager();
+
+    CHECK(mgr.createClock("clk.life", 120.f));
+    CHECK(mgr.clockExists("clk.life"));
+
+    // A second live clock cannot claim the same name — first registration wins.
+    CHECK_FALSE(mgr.createClock("clk.life", 90.f));
+
+    // Empty names are rejected.
+    CHECK_FALSE(mgr.createClock("", 120.f));
+
+    mgr.destroyClock("clk.life");
+    // Destruction removes the clock from queries immediately.
+    CHECK_FALSE(mgr.clockExists("clk.life"));
+
+    // A name freed by destroy can be reused even before the reap runs.
+    CHECK(mgr.createClock("clk.life", 100.f));
+    mgr.destroyClock("clk.life");
+    tick(0.01f); // let the audio-side retire it
+  }
+
+  TEST_CASE("clock: queries on an unknown name return zero") {
+    auto& mgr = YSE::CLOCK::Manager();
+    CHECK_FALSE(mgr.clockExists("clk.nope"));
+    CHECK(mgr.beatPosition("clk.nope") == doctest::Approx(0.0));
+    CHECK(mgr.currentTempo("clk.nope") == doctest::Approx(0.0f));
+  }
+
+  // ─── Initial state ───────────────────────────────────────────────────────────
+
+  TEST_CASE("clock: starts at its initial tempo and beat zero") {
+    auto& mgr = YSE::CLOCK::Manager();
+    REQUIRE(mgr.createClock("clk.init", 100.f));
+    // Published even before the first tick.
+    CHECK(mgr.currentTempo("clk.init") == doctest::Approx(100.0f));
+    CHECK(mgr.beatPosition("clk.init") == doctest::Approx(0.0));
+  }
+
+  // ─── Beat = running integral of tempo ────────────────────────────────────────
+
+  TEST_CASE("clock: beat position is the integral of tempo over time") {
+    auto& mgr = YSE::CLOCK::Manager();
+    REQUIRE(mgr.createClock("clk.beat", 120.f)); // 120 BPM = 2 beats / second
+
+    // Advance a total of 2 seconds in four 0.5 s blocks → 4 beats.
+    for (int i = 0; i < 4; ++i)
+      tick(0.5f);
+
+    CHECK(mgr.beatPosition("clk.beat") == doctest::Approx(4.0));
+    CHECK(mgr.currentTempo("clk.beat") == doctest::Approx(120.0f));
+  }
+
+  // ─── Instant tempo change (ramp = 0) ─────────────────────────────────────────
+
+  TEST_CASE("clock: instant tempo change takes effect on the next block") {
+    auto& mgr = YSE::CLOCK::Manager();
+    REQUIRE(mgr.createClock("clk.instant", 120.f));
+
+    mgr.setTempo("clk.instant", 60.f, 0.f);
+    tick(0.1f); // consumes the request, then integrates the block at 60 BPM
+
+    CHECK(mgr.currentTempo("clk.instant") == doctest::Approx(60.0f));
+    // 60 BPM = 1 beat / second → 0.1 s = 0.1 beat.
+    CHECK(mgr.beatPosition("clk.instant") == doctest::Approx(0.1));
+  }
+
+  // ─── Linear tempo ramp ───────────────────────────────────────────────────────
+
+  TEST_CASE("clock: tempo ramps linearly toward the target and then holds") {
+    auto& mgr = YSE::CLOCK::Manager();
+    REQUIRE(mgr.createClock("clk.ramp", 100.f));
+
+    // Ramp 100 → 200 BPM over 1 s: +100 BPM/s.
+    mgr.setTempo("clk.ramp", 200.f, 1.f);
+
+    tick(0.25f);
+    CHECK(mgr.currentTempo("clk.ramp") == doctest::Approx(125.0f));
+    tick(0.25f);
+    CHECK(mgr.currentTempo("clk.ramp") == doctest::Approx(150.0f));
+    tick(0.25f);
+    CHECK(mgr.currentTempo("clk.ramp") == doctest::Approx(175.0f));
+    tick(0.25f);
+    CHECK(mgr.currentTempo("clk.ramp") == doctest::Approx(200.0f));
+    // Held at target after the ramp completes.
+    tick(0.25f);
+    CHECK(mgr.currentTempo("clk.ramp") == doctest::Approx(200.0f));
+  }
+
+  TEST_CASE("clock: beat during a ramp is the midpoint integral") {
+    auto& mgr = YSE::CLOCK::Manager();
+    REQUIRE(mgr.createClock("clk.rampbeat", 0.f));
+
+    // Ramp 0 → 120 BPM over 1 s in a single 1 s block. The exact beat integral
+    // is the average tempo (60 BPM = 1 beat/s) × 1 s = 1 beat.
+    mgr.setTempo("clk.rampbeat", 120.f, 1.f);
+    tick(1.0f);
+
+    CHECK(mgr.currentTempo("clk.rampbeat") == doctest::Approx(120.0f));
+    CHECK(mgr.beatPosition("clk.rampbeat") == doctest::Approx(1.0));
+  }
+
+  // ─── Playable tempo: pause and reverse are not clamped ───────────────────────
+
+  TEST_CASE("clock: zero tempo pauses and negative tempo runs backward") {
+    auto& mgr = YSE::CLOCK::Manager();
+    REQUIRE(mgr.createClock("clk.play", 120.f));
+
+    tick(1.0f); // +2 beats
+    const double afterForward = mgr.beatPosition("clk.play");
+    CHECK(afterForward == doctest::Approx(2.0));
+
+    mgr.setTempo("clk.play", 0.f, 0.f);
+    tick(1.0f); // paused → no change
+    CHECK(mgr.beatPosition("clk.play") == doctest::Approx(afterForward));
+
+    mgr.setTempo("clk.play", -120.f, 0.f);
+    tick(1.0f); // -2 beats → back to 0
+    CHECK(mgr.beatPosition("clk.play") == doctest::Approx(0.0));
+  }
+
+  // ─── Destroyed clocks stop advancing ─────────────────────────────────────────
+
+  TEST_CASE("clock: a destroyed clock stops advancing and reads zero") {
+    auto& mgr = YSE::CLOCK::Manager();
+    REQUIRE(mgr.createClock("clk.gone", 120.f));
+    tick(1.0f);
+    CHECK(mgr.beatPosition("clk.gone") == doctest::Approx(2.0));
+
+    mgr.destroyClock("clk.gone");
+    tick(1.0f); // audio thread retires it this tick
+    // No longer visible to queries.
+    CHECK_FALSE(mgr.clockExists("clk.gone"));
+    CHECK(mgr.beatPosition("clk.gone") == doctest::Approx(0.0));
+  }
+
+  // ─── C API mirror ────────────────────────────────────────────────────────────
+
+  TEST_CASE("clock: C API create/exists/destroy round-trip") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+
+    CHECK(yse_system_create_clock(sys, "clk.capi", 90.f) == 1);
+    CHECK(yse_system_clock_exists(sys, "clk.capi") == 1);
+    // Duplicate + empty names rejected.
+    CHECK(yse_system_create_clock(sys, "clk.capi", 90.f) == 0);
+    CHECK(yse_system_create_clock(sys, "", 90.f) == 0);
+
+    CHECK(yse_system_current_tempo(sys, "clk.capi") == doctest::Approx(90.0f));
+    CHECK(yse_system_beat_position(sys, "clk.capi") == doctest::Approx(0.0));
+
+    yse_system_destroy_clock(sys, "clk.capi");
+    CHECK(yse_system_clock_exists(sys, "clk.capi") == 0);
+  }
+
+  TEST_CASE("clock: C API tempo + beat mirror the C++ values") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(sys != nullptr);
+
+    REQUIRE(yse_system_create_clock(sys, "clk.capi2", 120.f) == 1);
+    yse_system_set_tempo(sys, "clk.capi2", 60.f, 0.f);
+    tick(0.5f); // drive one block so the request is applied and beat advances
+
+    CHECK(yse_system_current_tempo(sys, "clk.capi2") == doctest::Approx(60.0f));
+    CHECK(yse_system_current_tempo(sys, "clk.capi2") ==
+          doctest::Approx(YSE::CLOCK::Manager().currentTempo("clk.capi2")));
+    // 60 BPM for 0.5 s → 0.5 beat.
+    CHECK(yse_system_beat_position(sys, "clk.capi2") == doctest::Approx(0.5));
+    CHECK(yse_system_beat_position(sys, "clk.capi2") ==
+          doctest::Approx(YSE::CLOCK::Manager().beatPosition("clk.capi2")));
+
+    yse_system_destroy_clock(sys, "clk.capi2");
+    tick(0.01f);
+  }
+
+  TEST_CASE("clock: C API guards NULL system and name") {
+    YseSystem* sys = yse_system_get();
+    CHECK(yse_system_create_clock(nullptr, "x", 120.f) == 0);
+    CHECK(yse_system_create_clock(sys, nullptr, 120.f) == 0);
+    CHECK(yse_system_clock_exists(nullptr, "x") == 0);
+    CHECK(yse_system_clock_exists(sys, nullptr) == 0);
+    CHECK(yse_system_beat_position(nullptr, "x") == doctest::Approx(0.0));
+    CHECK(yse_system_current_tempo(nullptr, "x") == doctest::Approx(0.0f));
+    // Void functions must simply not crash on NULL args.
+    yse_system_destroy_clock(nullptr, "x");
+    yse_system_destroy_clock(sys, nullptr);
+    yse_system_set_tempo(nullptr, "x", 120.f, 0.f);
+    yse_system_set_tempo(sys, nullptr, 120.f, 0.f);
+  }
+
+} // TEST_SUITE("clock")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -8,6 +8,8 @@ set(YSE_SRCS
   channel/channelImplementation.cpp
   channel/channelInterface.cpp
   channel/channelManager.cpp
+  clock/domainClock.cpp
+  clock/clockManager.cpp
   device/androidDeviceManager.cpp
   device/deviceInterface.cpp
   device/deviceManager.cpp

--- a/YseEngine/c_api/include/yse_c/yse_system.h
+++ b/YseEngine/c_api/include/yse_c/yse_system.h
@@ -81,6 +81,41 @@ YSE_C_API size_t yse_system_midi_in_device_name(YseSystem* sys, unsigned int id,
 YSE_C_API size_t yse_system_midi_out_device_name(YseSystem* sys, unsigned int id, char* buf,
                                                  size_t cap);
 
+/* Domain clocks (issue #249). A set of named musical (beat) clocks, each a
+   beat accumulator derived from the audio callback: every audio block a clock
+   advances by blockSeconds * tempo / 60 at its current tempo, so beat position
+   is the running integral of tempo (no absolute-time schedule). All clocks
+   derive from the single sample clock, keeping polytemporal relationships
+   exact. Tempo is a playable, rampable control and is not clamped: 0 pauses a
+   clock, a negative tempo runs it backwards.
+
+   Threading: create/destroy/set_tempo are control-thread calls; beat_position
+   and current_tempo may be read from the UI thread at frame rate. None run on
+   or block the audio callback. `name` is a NUL-terminated UTF-8 string. */
+
+/* Returns 1 on success, 0 if `sys`/`name` is NULL, the name is empty, or a
+   live clock already owns the name (first registration wins). */
+YSE_C_API int yse_system_create_clock(YseSystem* sys, const char* name, float initial_tempo);
+
+/* Destroy the named clock. No-op for an unknown name or NULL args. */
+YSE_C_API void yse_system_destroy_clock(YseSystem* sys, const char* name);
+
+/* Returns 1 if a live clock with `name` exists, else 0. */
+YSE_C_API int yse_system_clock_exists(YseSystem* sys, const char* name);
+
+/* Ramp the named clock's tempo toward `bpm` over `ramp_seconds` (0 = instant).
+   No-op for an unknown name or NULL args. */
+YSE_C_API void yse_system_set_tempo(YseSystem* sys, const char* name, float bpm,
+                                    float ramp_seconds);
+
+/* Current beat position (running integral of tempo) of the named clock, or 0
+   for an unknown name or NULL args. */
+YSE_C_API double yse_system_beat_position(YseSystem* sys, const char* name);
+
+/* Current tempo in BPM of the named clock, or 0 for an unknown name or NULL
+   args. */
+YSE_C_API float yse_system_current_tempo(YseSystem* sys, const char* name);
+
 /* Global reverb — fallback wherever no positioned reverb zone reaches.
    Returned pointer is borrowed; never destroy. */
 YSE_C_API YseReverb* yse_system_get_global_reverb(YseSystem* sys);

--- a/YseEngine/c_api/yse_system.cpp
+++ b/YseEngine/c_api/yse_system.cpp
@@ -142,6 +142,68 @@ YSE_C_API int yse_system_get_max_sounds(YseSystem* sys) {
   return to_cpp(sys)->maxSounds();
 }
 
+YSE_C_API int yse_system_create_clock(YseSystem* sys, const char* name, float initial_tempo) {
+  if (!sys || !name) return 0;
+  try {
+    return to_cpp(sys)->createClock(name, initial_tempo) ? 1 : 0;
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return 0;
+  } catch (...) {
+    yse_c::set_last_error("unknown C++ exception in yse_system_create_clock");
+    return 0;
+  }
+}
+
+YSE_C_API void yse_system_destroy_clock(YseSystem* sys, const char* name) {
+  if (!sys || !name) return;
+  try {
+    to_cpp(sys)->destroyClock(name);
+  } catch (...) {
+    yse_c::set_last_error("unknown C++ exception in yse_system_destroy_clock");
+  }
+}
+
+YSE_C_API int yse_system_clock_exists(YseSystem* sys, const char* name) {
+  if (!sys || !name) return 0;
+  try {
+    return to_cpp(sys)->clockExists(name) ? 1 : 0;
+  } catch (...) {
+    yse_c::set_last_error("unknown C++ exception in yse_system_clock_exists");
+    return 0;
+  }
+}
+
+YSE_C_API void yse_system_set_tempo(YseSystem* sys, const char* name, float bpm,
+                                    float ramp_seconds) {
+  if (!sys || !name) return;
+  try {
+    to_cpp(sys)->setTempo(name, bpm, ramp_seconds);
+  } catch (...) {
+    yse_c::set_last_error("unknown C++ exception in yse_system_set_tempo");
+  }
+}
+
+YSE_C_API double yse_system_beat_position(YseSystem* sys, const char* name) {
+  if (!sys || !name) return 0.0;
+  try {
+    return to_cpp(sys)->beatPosition(name);
+  } catch (...) {
+    yse_c::set_last_error("unknown C++ exception in yse_system_beat_position");
+    return 0.0;
+  }
+}
+
+YSE_C_API float yse_system_current_tempo(YseSystem* sys, const char* name) {
+  if (!sys || !name) return 0.0f;
+  try {
+    return to_cpp(sys)->currentTempo(name);
+  } catch (...) {
+    yse_c::set_last_error("unknown C++ exception in yse_system_current_tempo");
+    return 0.0f;
+  }
+}
+
 YSE_C_API void yse_system_audio_test(YseSystem* sys, int on) {
   if (!sys) return;
   to_cpp(sys)->AudioTest(on != 0);

--- a/YseEngine/clock/clockManager.cpp
+++ b/YseEngine/clock/clockManager.cpp
@@ -1,0 +1,139 @@
+/*
+  ==============================================================================
+
+    clockManager.cpp
+    Created for issue #249 — domain clocks.
+
+  ==============================================================================
+*/
+
+#include "../internalHeaders.h"
+
+YSE::CLOCK::managerObject& YSE::CLOCK::Manager() {
+  static managerObject m;
+  return m;
+}
+
+YSE::CLOCK::managerObject::managerObject() : mgrDelete(this), runDelete(false) {}
+
+YSE::CLOCK::managerObject::~managerObject() noexcept {
+  try {
+    // Wait for any in-flight delete job before tearing down the lists it reads.
+    mgrDelete.join();
+
+    // Drain any pointers still queued for the audio thread; they reference
+    // clocks owned by `implementations` and are freed when that list is cleared.
+    domainClock* drained;
+    while (toLoadInbox.try_pop(drained)) {
+      (void)drained;
+    }
+
+    inUse.clear();
+    implementations.clear();
+  } catch (...) {
+    INTERNAL::LogImpl().emit(E_ERROR, "CLOCK::Manager destructor swallowed exception");
+  }
+}
+
+YSE::CLOCK::domainClock* YSE::CLOCK::managerObject::findLive(const std::string& name) {
+  for (auto& c : implementations) {
+    if (!c.isReleased() && c.getName() == name) return &c;
+  }
+  return nullptr;
+}
+
+bool YSE::CLOCK::managerObject::createClock(const std::string& name, Flt initialTempo) {
+  if (name.empty()) return false;
+  std::scoped_lock lk(implementationsMutex);
+  if (findLive(name) != nullptr) return false; // first registration wins
+  implementations.emplace_front(name, initialTempo);
+  domainClock* clock = &implementations.front();
+  // Hand the clock off to the audio thread via the lock-free inbox. The audio
+  // thread owns `inUse`, so it — not the control thread — decides when the clock
+  // starts advancing.
+  toLoadInbox.push(clock);
+  return true;
+}
+
+void YSE::CLOCK::managerObject::destroyClock(const std::string& name) {
+  std::scoped_lock lk(implementationsMutex);
+  domainClock* clock = findLive(name);
+  if (clock != nullptr) clock->release();
+}
+
+bool YSE::CLOCK::managerObject::clockExists(const std::string& name) {
+  std::scoped_lock lk(implementationsMutex);
+  return findLive(name) != nullptr;
+}
+
+void YSE::CLOCK::managerObject::setTempo(const std::string& name, Flt bpm, Flt rampSeconds) {
+  std::scoped_lock lk(implementationsMutex);
+  domainClock* clock = findLive(name);
+  if (clock != nullptr) clock->requestTempo(bpm, rampSeconds);
+}
+
+Dbl YSE::CLOCK::managerObject::beatPosition(const std::string& name) {
+  std::scoped_lock lk(implementationsMutex);
+  domainClock* clock = findLive(name);
+  return clock != nullptr ? clock->beatPosition() : 0.0;
+}
+
+Flt YSE::CLOCK::managerObject::currentTempo(const std::string& name) {
+  std::scoped_lock lk(implementationsMutex);
+  domainClock* clock = findLive(name);
+  return clock != nullptr ? clock->currentTempo() : 0.f;
+}
+
+void YSE::CLOCK::managerObject::update(Flt delta) {
+  ///////////////////////////////////////////
+  // drain the control->audio inbox of newly-created clocks into the working list
+  ///////////////////////////////////////////
+  {
+    domainClock* p;
+    while (toLoadInbox.try_pop(p))
+      inUse.emplace_front(p);
+  }
+
+  ///////////////////////////////////////////
+  // enqueue the slow-pool delete job for clocks retired on the previous tick.
+  // Deferring by a tick guarantees the orphan is already out of `inUse` before
+  // the slow pool can free it — no audio-thread free, no dangling `inUse` entry.
+  ///////////////////////////////////////////
+  if (runDelete && !mgrDelete.isQueued()) {
+    INTERNAL::Global().addSlowJob(&mgrDelete);
+  }
+  runDelete = false;
+
+  ///////////////////////////////////////////
+  // advance each clock, and retire released clocks from the working list. A
+  // retired clock is flagged OBJECT_DELETE and left in `implementations` for the
+  // slow-pool deleteJob to reap — it is never freed on the audio thread.
+  ///////////////////////////////////////////
+  auto previous = inUse.before_begin();
+  for (auto i = inUse.begin(); i != inUse.end();) {
+    if (!(*i)->update(delta)) {
+      domainClock* ptr = *i;
+      i = inUse.erase_after(previous);
+      ptr->setStatus(OBJECT_DELETE);
+      runDelete = true;
+      continue;
+    }
+    previous = i;
+    ++i;
+  }
+}
+
+void YSE::CLOCK::managerObject::clear() {
+  try {
+    mgrDelete.join();
+    domainClock* drained;
+    while (toLoadInbox.try_pop(drained)) {
+      (void)drained;
+    }
+    inUse.clear();
+    std::scoped_lock lk(implementationsMutex);
+    implementations.clear();
+  } catch (...) {
+    INTERNAL::LogImpl().emit(E_ERROR, "CLOCK::Manager clear swallowed exception");
+  }
+}

--- a/YseEngine/clock/clockManager.h
+++ b/YseEngine/clock/clockManager.h
@@ -1,0 +1,116 @@
+/*
+  ==============================================================================
+
+    clockManager.h
+    Created for issue #249 — domain clocks.
+
+  ==============================================================================
+*/
+
+#ifndef CLOCKMANAGER_H_INCLUDED
+#define CLOCKMANAGER_H_INCLUDED
+
+#include <forward_list>
+#include <mutex>
+#include <string>
+
+#include "domainClock.h"
+#include "../internal/managerJobs.hpp"
+#include "../utils/lfQueue.hpp"
+
+namespace YSE {
+  namespace CLOCK {
+
+    // Owns every domain clock and drives their beat/tempo advancement.
+    //
+    // Lifecycle follows the lock-free main->audio handoff the PLAYER / MIDI-file
+    // managers use (#156 / #190): the control thread emplaces a clock into the
+    // canonical list under `implementationsMutex` and hands it to the audio
+    // thread through a lock-free inbox; the audio thread owns the `inUse`
+    // working list, advances each clock every callback, and — when a clock is
+    // released — retires it for the slow-pool delete job. The audio thread never
+    // allocates, locks, or frees.
+    //
+    // Domain clocks are addressed by name, not by an interface handle, so the
+    // control-thread queries (createClock / destroyClock / setTempo /
+    // beatPosition / currentTempo) look the clock up by name under the mutex.
+    // Those readers run on the control/UI thread (beatPosition at frame rate for
+    // playhead display) and only touch atomics, so they never contend with the
+    // audio callback.
+    class managerObject {
+    public:
+      using ImplementationType = domainClock;
+
+      managerObject();
+      ~managerObject() noexcept;
+
+      /** Create a clock named `name` starting at `initialTempo` BPM. Returns
+          false if the name is empty or a live clock already owns it (first
+          registration wins). Control thread only. */
+      bool createClock(const std::string& name, Flt initialTempo);
+
+      /** Flag the named clock for destruction. It stops being visible to queries
+          immediately; the audio thread retires it and the slow pool reaps it.
+          A no-op for an unknown name. Control thread only. */
+      void destroyClock(const std::string& name);
+
+      /** Whether a live clock with `name` exists. Control thread only. */
+      bool clockExists(const std::string& name);
+
+      /** Ramp the named clock toward `bpm` over `rampSeconds` (0 = instant).
+          A no-op for an unknown name. Control thread only. */
+      void setTempo(const std::string& name, Flt bpm, Flt rampSeconds);
+
+      /** Current beat position (running integral of tempo) of the named clock,
+          or 0 for an unknown name. Control/UI thread. */
+      Dbl beatPosition(const std::string& name);
+
+      /** Current tempo in BPM of the named clock, or 0 for an unknown name.
+          Control/UI thread. */
+      Flt currentTempo(const std::string& name);
+
+      /** Audio-thread tick, driven every callback with the block duration in
+          seconds. Drains newly-created clocks, advances each live clock, and
+          retires released clocks for slow-pool deletion. */
+      void update(Flt delta);
+
+      /** Session teardown from INTERNAL::global::close(): join any in-flight
+          delete job and clear every clock so no state persists across an
+          init/close cycle. Called after the audio device is closed and both
+          thread pools are joined. */
+      void clear();
+
+    private:
+      // Find a live (non-released) clock by name. Caller holds implementationsMutex.
+      domainClock* findLive(const std::string& name);
+
+      // Canonical owner of every clock. Mutated only by the control thread
+      // (createClock) and the slow-pool deleteJob (remove_if); guarded by
+      // implementationsMutex. The audio thread never iterates it.
+      std::forward_list<domainClock> implementations;
+      std::mutex implementationsMutex;
+
+      // Lock-free SPSC handoff: the control thread pushes a newly-created clock
+      // here; the audio thread drains it into `inUse` at the top of update().
+      lfQueue<domainClock*> toLoadInbox;
+
+      // Audio-thread-owned working list. update() iterates and erases from this
+      // list only; the clocks it points at live in `implementations`.
+      std::forward_list<domainClock*> inUse;
+
+      // Reaps clocks flagged OBJECT_DELETE off the audio thread on the slow pool.
+      INTERNAL::managerDeleteJob<managerObject> mgrDelete;
+
+      // Set by the audio thread when it retires a released clock from `inUse`;
+      // drives the deleteJob enqueue on the following tick.
+      aBool runDelete;
+
+      friend class INTERNAL::managerDeleteJob<managerObject>;
+    };
+
+    managerObject& Manager();
+
+  } // namespace CLOCK
+} // namespace YSE
+
+#endif // CLOCKMANAGER_H_INCLUDED

--- a/YseEngine/clock/domainClock.cpp
+++ b/YseEngine/clock/domainClock.cpp
@@ -1,0 +1,81 @@
+/*
+  ==============================================================================
+
+    domainClock.cpp
+    Created for issue #249 — domain clocks.
+
+  ==============================================================================
+*/
+
+#include "../internalHeaders.h"
+
+// The published beat position must be readable from the control/UI thread
+// while the audio thread writes it, so it has to be a genuinely lock-free
+// atomic — a spinlock on the audio thread would violate RT discipline. All
+// supported engine targets are 64-bit (Windows/Linux x64, Android arm64-v8a +
+// x86_64), where an 8-byte atomic is always lock-free.
+static_assert(std::atomic<Dbl>::is_always_lock_free,
+              "domain clocks need a lock-free atomic<double> for cross-thread beat reads");
+
+YSE::CLOCK::domainClock::domainClock(const std::string& name, Flt initialTempo)
+  : name(name),
+    beat(0.0),
+    tempo(initialTempo),
+    tempoTarget(initialTempo),
+    tempoRate(0.0),
+    ramping(false),
+    beatOut(0.0),
+    tempoOut(initialTempo),
+    reqTempo(0.f),
+    reqRamp(0.f),
+    reqDirty(false),
+    released(false),
+    objectStatus(OBJECT_READY) {}
+
+void YSE::CLOCK::domainClock::requestTempo(Flt bpm, Flt rampSeconds) {
+  reqTempo.store(bpm, std::memory_order_relaxed);
+  reqRamp.store(rampSeconds < 0.f ? 0.f : rampSeconds, std::memory_order_relaxed);
+  // Publish the two operands before flagging the request so the audio thread,
+  // which acquires on the flag, observes both.
+  reqDirty.store(true, std::memory_order_release);
+}
+
+bool YSE::CLOCK::domainClock::update(Flt delta) {
+  if (released.load(std::memory_order_acquire)) return false;
+
+  // Consume a pending setTempo. The acquire on the flag pairs with the release
+  // in requestTempo so the operands below are visible.
+  if (reqDirty.exchange(false, std::memory_order_acquire)) {
+    const Dbl target = static_cast<Dbl>(reqTempo.load(std::memory_order_relaxed));
+    const Dbl ramp = static_cast<Dbl>(reqRamp.load(std::memory_order_relaxed));
+    tempoTarget = target;
+    if (ramp > 0.0) {
+      tempoRate = (target - tempo) / ramp;
+      ramping = (tempoRate != 0.0);
+    } else {
+      tempo = target;
+      tempoRate = 0.0;
+      ramping = false;
+    }
+  }
+
+  const Dbl tempoBefore = tempo;
+  if (ramping) {
+    tempo += tempoRate * static_cast<Dbl>(delta);
+    // Stop exactly on the target when this block crosses it.
+    if ((tempoRate > 0.0 && tempo >= tempoTarget) || (tempoRate < 0.0 && tempo <= tempoTarget)) {
+      tempo = tempoTarget;
+      tempoRate = 0.0;
+      ramping = false;
+    }
+  }
+  const Dbl tempoAfter = tempo;
+
+  // Beat is the integral of tempo/60 over the block. Tempo is piecewise-linear
+  // within a block, so the exact integral is the midpoint (average) tempo.
+  beat += static_cast<Dbl>(delta) * (tempoBefore + tempoAfter) * 0.5 / 60.0;
+
+  beatOut.store(beat, std::memory_order_release);
+  tempoOut.store(static_cast<Flt>(tempoAfter), std::memory_order_release);
+  return true;
+}

--- a/YseEngine/clock/domainClock.h
+++ b/YseEngine/clock/domainClock.h
@@ -1,0 +1,122 @@
+/*
+  ==============================================================================
+
+    domainClock.h
+    Created for issue #249 — domain clocks.
+
+  ==============================================================================
+*/
+
+#ifndef DOMAINCLOCK_H_INCLUDED
+#define DOMAINCLOCK_H_INCLUDED
+
+#include "../headers/types.hpp"
+#include "../headers/enums.hpp"
+#include <atomic>
+#include <string>
+
+namespace YSE {
+  namespace CLOCK {
+
+    /** @brief One named musical (beat) clock, derived from the audio callback.
+     *
+     *  A domain clock is a *beat accumulator*: every audio block it advances by
+     *  ``blockSeconds × tempo / 60`` at its current tempo. Beat position is the
+     *  running integral of tempo — there is no absolute-time schedule anywhere,
+     *  which is what lets polytemporal domains keep exact, deterministic
+     *  relationships (they all derive from the single sample clock).
+     *
+     *  Tempo is a playable, rampable control: ``requestTempo(bpm, rampSeconds)``
+     *  slews toward a new tempo linearly over ``rampSeconds`` (instant when the
+     *  ramp is 0). Tempo is not clamped — 0 pauses the clock, a negative tempo
+     *  runs it backwards — because the primitive stays dumb; the UI steers it.
+     *
+     *  Threading: ``update()`` runs on the audio thread and owns the
+     *  authoritative accumulator state. ``requestTempo`` / ``release`` are called
+     *  from the control thread and hand their intent over through atomics; the
+     *  cross-thread readers (``beatPosition`` / ``currentTempo``) read published
+     *  snapshots and never touch the audio-thread-owned members.
+     */
+    class domainClock {
+    public:
+      domainClock(const std::string& name, Flt initialTempo);
+
+      /** @brief Audio-thread tick. Advance ``delta`` seconds of beat + tempo.
+       *
+       *  Consumes a pending ``requestTempo`` first, ramps the tempo, integrates
+       *  the beat position over the block (linear-tempo midpoint), and publishes
+       *  the snapshots read by the control thread. Returns ``false`` once the
+       *  clock has been released (``destroyClock``) so the manager can retire it
+       *  from its working list — mirrors ``PLAYER::implementationObject::update``.
+       */
+      bool update(Flt delta);
+
+      /** @brief Control-thread. Queue a new tempo target reached over
+       *         ``rampSeconds`` (clamped to ``>= 0``; 0 is instant). */
+      void requestTempo(Flt bpm, Flt rampSeconds);
+
+      /** @brief Control-thread. Flag the clock for retirement by the manager. */
+      void release() {
+        released.store(true, std::memory_order_release);
+      }
+
+      /** @brief Immutable domain name. Read on the control thread under the
+       *         manager mutex. */
+      const std::string& getName() const {
+        return name;
+      }
+
+      /** @brief Cross-thread read: running beat position (integral of tempo). */
+      Dbl beatPosition() const {
+        return beatOut.load(std::memory_order_acquire);
+      }
+
+      /** @brief Cross-thread read: current tempo in BPM. */
+      Flt currentTempo() const {
+        return tempoOut.load(std::memory_order_acquire);
+      }
+
+      /** @brief Whether ``release`` has been called (control thread). */
+      bool isReleased() const {
+        return released.load(std::memory_order_acquire);
+      }
+
+      // ---- slow-pool delete handoff (mirrors PLAYER / the manager templates) --
+      void setStatus(OBJECT_IMPLEMENTATION_STATE value) {
+        objectStatus.store(value);
+      }
+      static bool canBeDeleted(const domainClock& c) {
+        return c.objectStatus.load() == OBJECT_DELETE;
+      }
+
+    private:
+      std::string name; // immutable after construction
+
+      // Authoritative state — only touched on the audio thread in update().
+      Dbl beat;
+      Dbl tempo;
+      Dbl tempoTarget;
+      Dbl tempoRate; // BPM per second, signed; 0 when not ramping
+      bool ramping;
+
+      // Published snapshots for cross-thread reads.
+      std::atomic<Dbl> beatOut;
+      aFlt tempoOut;
+
+      // setTempo request handoff (control -> audio).
+      aFlt reqTempo;
+      aFlt reqRamp;
+      aBool reqDirty;
+
+      // Lifecycle. `released` is set by destroyClock on the control thread;
+      // `objectStatus` reaches OBJECT_DELETE once the audio thread has retired
+      // the clock from the manager's working list, at which point the slow-pool
+      // delete job may reap it. The audio thread never frees a clock.
+      aBool released;
+      std::atomic<OBJECT_IMPLEMENTATION_STATE> objectStatus;
+    };
+
+  } // namespace CLOCK
+} // namespace YSE
+
+#endif // DOMAINCLOCK_H_INCLUDED

--- a/YseEngine/device/deviceManager.cpp
+++ b/YseEngine/device/deviceManager.cpp
@@ -44,6 +44,11 @@ bool YSE::DEVICE::deviceManager::doOnCallback(int numSamples) {
   // between two buffer updates and should have the least latency possible
   INTERNAL::DeviceTime().update();
   PLAYER::Manager().update((Flt)numSamples / (Flt)SAMPLERATE);
+  // Advance every domain clock by this block's duration (issue #249). Domain
+  // clocks derive from the single sample clock, so they tick here — every audio
+  // callback, regardless of whether any sound is playing — and are advanced
+  // before the empty()-sounds early-out below.
+  CLOCK::Manager().update((Flt)numSamples / (Flt)SAMPLERATE);
   // MIDI file playback is advanced every block too (issue #155) so events reach
   // the connected synths block-accurately, before the synths render this block.
   MIDI::Manager().updatePlayback(numSamples);

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -155,6 +155,11 @@ void YSE::INTERNAL::global::close() {
   // so a subsequent System::init() can re-create it instead of asserting
   // (issue #132).
   REVERB::Manager().destroy();
+  // Clear every domain clock (issue #249) so no beat/tempo state persists into
+  // the next session. Safe to tear down synchronously here: the device is
+  // already closed and both pools are joined, so no audio thread can advance a
+  // clock and no slow job can reap one.
+  CLOCK::Manager().clear();
   // Tear down the bus last — by this point the audio device is already
   // closed (system::close() ran DEVICE::Manager().close() before us), so
   // no audio-thread producer can still be enqueuing publish() messages.

--- a/YseEngine/internalHeaders.h
+++ b/YseEngine/internalHeaders.h
@@ -41,6 +41,9 @@
 #include "music/motif/motifManager.h"
 #include "music/motif/motifMessage.h"
 
+#include "clock/domainClock.h"
+#include "clock/clockManager.h"
+
 #include "midi/midiDeviceManager.h"
 
 #include "midi/midifileImplementation.h"

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -208,6 +208,31 @@ Flt YSE::system::cpuLoad() {
   return DEVICE::Manager().cpuLoad();
 }
 
+bool YSE::system::createClock(const std::string& name, float initialTempo) {
+  return CLOCK::Manager().createClock(name, initialTempo);
+}
+
+void YSE::system::destroyClock(const std::string& name) {
+  CLOCK::Manager().destroyClock(name);
+}
+
+bool YSE::system::clockExists(const std::string& name) {
+  return CLOCK::Manager().clockExists(name);
+}
+
+YSE::system& YSE::system::setTempo(const std::string& name, float bpm, float rampSeconds) {
+  CLOCK::Manager().setTempo(name, bpm, rampSeconds);
+  return *this;
+}
+
+double YSE::system::beatPosition(const std::string& name) {
+  return CLOCK::Manager().beatPosition(name);
+}
+
+float YSE::system::currentTempo(const std::string& name) {
+  return CLOCK::Manager().currentTempo(name);
+}
+
 double YSE::system::getSampleRate() {
   // The session lock is set at the end of initShared(); before that, SAMPLERATE
   // still holds its 44100 default and reporting it would mislead hosts that

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -287,6 +287,57 @@ namespace YSE {
      */
     void sleep(unsigned int ms);
 
+    /// @name Domain clocks (issue #249)
+    /// A set of named musical (beat) clocks, each a beat accumulator derived
+    /// from the audio callback. Every audio block a clock advances by
+    /// ``blockSeconds × tempo / 60`` at its current tempo, so beat position is
+    /// the running integral of tempo — no absolute-time schedule. Because all
+    /// clocks derive from the single sample clock, polytemporal relationships
+    /// stay exact and deterministic. Tempo is a playable, rampable control.
+    ///
+    /// **Threading.** ``createClock`` / ``destroyClock`` / ``setTempo`` are
+    /// control-thread operations; ``beatPosition`` / ``currentTempo`` may be
+    /// read from the UI thread at frame rate (e.g. for a playhead). None of
+    /// them run on or block the audio callback.
+    /// @{
+
+    /** @brief Create a domain clock.
+     *
+     *  @param name         Unique domain name. Empty names are rejected.
+     *  @param initialTempo Starting tempo in BPM (default 120).
+     *  @return ``true`` on success; ``false`` if the name is empty or a live
+     *          clock already owns it (first registration wins).
+     */
+    bool createClock(const std::string& name, float initialTempo = 120.f);
+
+    /** @brief Destroy a domain clock. No-op for an unknown name.
+     *
+     *  The clock stops being visible to queries immediately; its beat/tempo
+     *  advancement stops on the next audio callback.
+     */
+    void destroyClock(const std::string& name);
+
+    /** @brief Whether a live domain clock with ``name`` exists. */
+    bool clockExists(const std::string& name);
+
+    /** @brief Ramp a domain clock's tempo toward ``bpm`` over ``rampSeconds``.
+     *
+     *  Instant when ``rampSeconds`` is 0; otherwise linear. Tempo is a played
+     *  control signal — call it as often as you like. It is not clamped: 0
+     *  pauses the clock and a negative tempo runs it backwards. No-op for an
+     *  unknown name.
+     */
+    system& setTempo(const std::string& name, float bpm, float rampSeconds = 0.f);
+
+    /** @brief Current beat position (running integral of tempo) of a clock, or
+     *         0 for an unknown name. */
+    double beatPosition(const std::string& name);
+
+    /** @brief Current tempo in BPM of a clock, or 0 for an unknown name. */
+    float currentTempo(const std::string& name);
+
+    /// @}
+
     /** @brief libYSE version string. */
     std::string Version() const {
       return VERSION;


### PR DESCRIPTION
## Summary

Adds **domain clocks** (issue #249, a capability request from Phi's polytemporal timing model): a set of named musical (beat) clocks, each derived from the single sample clock. Every audio callback a clock advances by `blockSeconds × tempo / 60` at its current tempo, so **beat position is the running integral of tempo** — there is no absolute-time schedule anywhere, which keeps polytemporal relationships exact and deterministic. Tempo is a **playable, rampable control** (linear ramp; instant when `rampSeconds == 0`) and is deliberately not clamped: `0` pauses a clock, a negative tempo runs it backward.

## Linked issue

Closes #249

## Changes

- **New subsystem `YseEngine/clock/`** — `CLOCK::domainClock` (beat accumulator + tempo ramp + published atomics) and `CLOCK::Manager`. The manager follows the PLAYER lock-free lifecycle: canonical `forward_list` under a mutex → SPSC inbox → audio-owned `inUse` working list → slow-pool delete job. The audio thread never allocates, locks, or frees; `beatPosition` / `currentTempo` read lock-free atomics and are safe to poll from the UI thread at frame rate (playhead display).
- **Per-block tick** wired into `deviceManager::doOnCallback`, alongside `PLAYER::Manager().update`, before the empty-sounds early-out — clocks advance every callback regardless of whether anything is playing.
- **Beat integral** uses the exact midpoint (average tempo) over each block, so it stays correct across tempo ramps.
- **Public C++ API** on `YSE::system`: `createClock` / `destroyClock` / `clockExists` / `setTempo` / `beatPosition` / `currentTempo`.
- **C ABI mirror** in `yse_system.h/.cpp`: `yse_system_create_clock` / `_destroy_clock` / `_clock_exists` / `_set_tempo` / `_beat_position` / `_current_tempo`, with NULL-handle/name guards and exception-safe boundaries.
- **Session teardown** clears all clocks from `INTERNAL::global::close()` so no beat/tempo state persists across an init/close cycle.
- `PROJECT_OVERVIEW.md` updated with a Domain Clocks subsystem section.

Scope note: clip transports that bind to these clocks are explicitly a separate issue and are not included here.

## Test plan

- [x] `clang-format --dry-run --Werror` (v22.1.4) clean on all changed files
- [x] `python yse.py analyze` clean on changed sources — the one new finding (`bugprone-empty-catch` in the manager destructor) was resolved by logging like `PLAYER::Manager`; the remaining `deviceManager.cpp` finding is pre-existing (destructor `close()`, untouched by this change)
- [x] Unit + C-API tests: `Tests/clock/test_domain_clocks.cpp` — **12 cases / 55 assertions**, covering create/exists/destroy, unknown-name zeros, beat-as-integral, instant + linear tempo ramps, midpoint beat integral, pause/reverse, destroyed-clock stop, and the full C ABI mirror + NULL guards
- [x] Full suite green: `ctest --preset tests-debug` → **100% (31/31)**, including the isolated `yse_tests_clock` process
- [x] `python yse.py build` (shared library + all demos) links clean

Not user-visible (no rendered UI/flow): this is an engine timing primitive fully exercised by the unit + C-API suite driving the real per-block tick deterministically, so no separate integration/e2e test applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
