### PR TITLE
Clip transport: loop a beat-timed note list against a domain clock (#250)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -371,7 +371,7 @@ c_api/include/yse_c/         # Public C headers — Dart's ffigen entry point
   yse_all.h                  # Aggregate header (includes the rest)
   yse_system.h yse_listener.h yse_channel.h yse_sound.h yse_reverb.h
   yse_device.h yse_dsp.h yse_dsp_modules.h yse_patcher.h yse_midi.h
-  yse_music.h yse_log.h yse_buffer_io.h yse_common.h yse_enums.h
+  yse_clip.h yse_music.h yse_log.h yse_buffer_io.h yse_common.h yse_enums.h
 c_api/                       # Wrappers (yse_*.cpp) and the internal helper header yse_c_internal.hpp
 ```
 
@@ -417,7 +417,19 @@ Polyphonic note player with scale constraints, motif sequencing, and randomised 
 
 A set of named musical (beat) clocks derived from the single sample clock (issue [#249](https://github.com/yvanvds/yse-soundengine/issues/249), a capability request from Phi's polytemporal timing model). Each clock is a **beat accumulator**: `CLOCK::Manager().update(blockSeconds)` runs every audio callback (wired into `deviceManager::doOnCallback`, alongside `PLAYER::Manager().update`) and advances each clock by `blockSeconds × tempo / 60`, so beat position is the running integral of tempo — no absolute-time schedule. Because every clock derives from the one audio callback, polytemporal relationships stay exact and deterministic.
 
-Tempo is a **playable, rampable control**: `setTempo(name, bpm, rampSeconds)` slews linearly (instant when `rampSeconds` is 0) and is never clamped (0 pauses, negative runs backward). Clocks are created/destroyed/queried by name at runtime. The manager follows the PLAYER lock-free lifecycle (canonical `forward_list` under a mutex → SPSC inbox → audio-owned `inUse` working list → slow-pool delete job); the audio thread never allocates, locks, or frees. `beatPosition` / `currentTempo` read published atomics and are safe to poll from the UI thread at frame rate (playhead display). Public surface: `YSE::system::createClock / destroyClock / clockExists / setTempo / beatPosition / currentTempo`, mirrored in the C ABI as `yse_system_*_clock` / `yse_system_set_tempo` / `yse_system_beat_position` / `yse_system_current_tempo`. Clip transports that bind to these clocks are a separate issue.
+Tempo is a **playable, rampable control**: `setTempo(name, bpm, rampSeconds)` slews linearly (instant when `rampSeconds` is 0) and is never clamped (0 pauses, negative runs backward). Clocks are created/destroyed/queried by name at runtime. The manager follows the PLAYER lock-free lifecycle (canonical `forward_list` under a mutex → SPSC inbox → audio-owned `inUse` working list → slow-pool delete job); the audio thread never allocates, locks, or frees. `beatPosition` / `currentTempo` read published atomics and are safe to poll from the UI thread at frame rate (playhead display). Public surface: `YSE::system::createClock / destroyClock / clockExists / setTempo / beatPosition / currentTempo`, mirrored in the C ABI as `yse_system_*_clock` / `yse_system_set_tempo` / `yse_system_beat_position` / `yse_system_current_tempo`. Clip transports that bind to these clocks are [§12c](#12c-clip-transport).
+
+---
+
+### 12c. Clip Transport
+
+**Files:** [clip/clip.hpp](YseEngine/clip/clip.hpp) (public `YSE::clip` + `YSE::clipEvent`), [clip/clipTransport.h](YseEngine/clip/clipTransport.h) / [.cpp](YseEngine/clip/clipTransport.cpp) (audio-thread timing impl), [clip/clipManager.h](YseEngine/clip/clipManager.h) / [.cpp](YseEngine/clip/clipManager.cpp), [clip/clipInterface.cpp](YseEngine/clip/clipInterface.cpp)
+
+A `YSE::clip` loops a flat, immutable list of beat-timed note events (`clipEvent`: `startBeat`, `durationBeats`, `channel`, `pitch`, `velocity`, optional per-note `pitchBend`) against a bound [domain clock](#12b-domain-clocks), dispatched from the audio thread so the UI never dispatches a note (issue [#250](https://github.com/yvanvds/yse-soundengine/issues/250), a Phi capability request). Every audio block, `CLIP::Manager().update()` (wired into `deviceManager::doOnCallback` right after `CLOCK::Manager().update()`, so the clocks are already advanced) converts the block's beat boundaries into a `(from, to]` window on the clock and fires exactly the events whose crossings fall inside it — events are *evaluated per block*, never scheduled ahead in absolute time, so tempo changes on the clock bend the clip immediately with no rescheduling. `startBeat` is taken modulo the loop length, so events repeat every loop.
+
+The event list is **replaceable while playing**: `setEvents` publishes a new immutable list that the audio thread swaps in at the next block boundary through an atomic single-slot handoff plus a lock-free `retired` queue the control thread reclaims — no allocation, lock, or free on the audio thread. **Sounding-note bookkeeping survives the swap**: each note-on records its own absolute off-beat in a bounded audio-thread-owned set, so a note that vanished from the new list still gets its note-off on time. `play` / `stop` / `isPlaying`; `stop` releases everything sounding. Multiple clips run concurrently, each on its own clock.
+
+Output currently targets one or more `YSE::synth` instances — the RT-safe internal event-queue sink, reached through the same `SYNTH::interfaceObject` note API MIDI-file playback uses. The transport is agnostic to the sink (its firing core is templated over the sink type, unit-tested against a recording sink), so an external MIDI-out sink can be added on the same seam. Lifecycle mirrors the CLOCK / MIDI-file managers (canonical `forward_list` under a mutex → SPSC inbox → audio-owned `inUse` working list → slow-pool delete job). Public surface mirrored in the C ABI as `yse_clip_*` ([clip/clip.hpp](YseEngine/clip/clip.hpp) → [c_api/include/yse_c/yse_clip.h](YseEngine/c_api/include/yse_c/yse_clip.h)). Bound clocks are caller-owned and must outlive the clip (same contract as MIDI-file → synth binding).
 
 ---
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -106,6 +106,7 @@ set(YSE_TEST_SOURCES
   system/test_system_active_state.cpp
   system/test_lifecycle.cpp
   clock/test_domain_clocks.cpp
+  clip/test_clip_transport.cpp
   integration/test_device.cpp
   integration/test_content_pack.cpp
   integration/test_synth_demos.cpp
@@ -220,7 +221,10 @@ add_test(
   # CLOCK::Manager().update() directly on the test thread to advance beats
   # deterministically, which would race a live audio thread from another suite
   # in this shared process. It runs isolated in yse_tests_clock.
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos,clock "--test-case-exclude=* concurrency: *" --duration=true
+  # `clip` (issue #250 clip transport) is excluded for the same reason as
+  # `clock`: its cases drive CLOCK::Manager().update() / CLIP::Manager().update()
+  # directly on the test thread. It runs isolated in yse_tests_clip.
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos,clock,clip "--test-case-exclude=* concurrency: *" --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -253,6 +257,16 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_clock PROPERTIES LABELS clock)
+
+# Clip transport (issue #250). Isolated for the same reason as the clock suite:
+# the cases drive CLOCK::Manager().update() / CLIP::Manager().update() directly
+# on the test thread. No audio device needed.
+add_test(
+  NAME    yse_tests_clip
+  COMMAND yse_tests --test-suite=clip
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_clip PROPERTIES LABELS clip)
 
 add_test(
   NAME    yse_tests_utils

--- a/Tests/clip/test_clip_transport.cpp
+++ b/Tests/clip/test_clip_transport.cpp
@@ -1,0 +1,281 @@
+// Tests for the clip transport (issue #250): loop a beat-timed note-event list
+// against a domain clock, dispatched from the audio thread.
+//
+// Two layers:
+//   * The timing core — transport::evaluateWindow() / releaseAll() — is a pure
+//     function of the audio-thread-owned state (event list, loop length,
+//     sounding-note set). It is driven here with explicit beat windows against a
+//     recording sink, with no engine, clock, or audio device, so every firing
+//     rule is deterministic and isolated.
+//   * A manager + clock integration smoke test drives CLOCK::Manager().update()
+//     and CLIP::Manager().update() directly on the test thread (like the domain
+//     clock suite), exercising bind + the create/advance handoff end-to-end.
+//
+// The suite runs in its own process (yse_tests_clip): it ticks the clock/clip
+// managers directly, which must not share a process with a live audio thread.
+
+#include <doctest/doctest.h>
+#include <vector>
+
+#include "yse.hpp"
+#include "clip/clip.hpp"
+#include "clip/clipTransport.h"
+#include "clip/clipManager.h"
+#include "clock/clockManager.h"
+
+namespace {
+
+  // Records every sink call the transport makes so a test can assert the exact
+  // firing. Matches the YSE::synth note-API shape the real fan-out targets.
+  struct RecordingSink {
+    enum Kind { NoteOn, NoteOff, PitchWheel };
+    struct Call {
+      Kind kind;
+      int channel;
+      int pitch;
+      float value;
+    };
+    std::vector<Call> calls;
+
+    void noteOn(int ch, int pitch, float vel) {
+      calls.push_back({NoteOn, ch, pitch, vel});
+    }
+    void noteOff(int ch, int pitch, float vel) {
+      calls.push_back({NoteOff, ch, pitch, vel});
+    }
+    void pitchWheel(int ch, float val) {
+      calls.push_back({PitchWheel, ch, 0, val});
+    }
+
+    int count(Kind k) const {
+      int n = 0;
+      for (const auto& c : calls)
+        if (c.kind == k) ++n;
+      return n;
+    }
+  };
+
+  YSE::clipEvent ev(double start, double dur, int ch, int pitch, float vel = 0.8f,
+                    float bend = 0.f) {
+    YSE::clipEvent e;
+    e.startBeat = start;
+    e.durationBeats = dur;
+    e.channel = ch;
+    e.pitch = pitch;
+    e.velocity = vel;
+    e.pitchBend = bend;
+    return e;
+  }
+
+} // namespace
+
+TEST_SUITE("clip") {
+
+  // ─── timing core: note-on firing ─────────────────────────────────────────
+
+  TEST_CASE("clip: a note fires exactly once when its start crosses the window") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(4.0);
+    t.adoptEventsForTest({ev(1.0, 1.0, 1, 60)});
+
+    RecordingSink s;
+    t.evaluateWindow(s, 0.0, 2.0); // window (0, 2] contains beat 1
+    REQUIRE(s.calls.size() == 1);
+    CHECK(s.calls[0].kind == RecordingSink::NoteOn);
+    CHECK(s.calls[0].channel == 1);
+    CHECK(s.calls[0].pitch == 60);
+    CHECK(s.calls[0].value == doctest::Approx(0.8f));
+  }
+
+  TEST_CASE("clip: a note whose start is outside the window does not fire") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(4.0);
+    t.adoptEventsForTest({ev(3.0, 1.0, 1, 60)});
+
+    RecordingSink s;
+    t.evaluateWindow(s, 0.0, 2.0); // beat 3 not in (0, 2]
+    CHECK(s.calls.empty());
+  }
+
+  TEST_CASE("clip: the window is half-open — a start exactly on `from` waits") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(4.0);
+    t.adoptEventsForTest({ev(1.0, 1.0, 1, 60)});
+
+    RecordingSink s;
+    t.evaluateWindow(s, 1.0, 2.0); // from == 1.0, start 1.0 is not > from
+    CHECK(s.calls.empty());
+    t.evaluateWindow(s, 0.0, 1.0); // to == 1.0, start 1.0 <= to -> fires
+    CHECK(s.count(RecordingSink::NoteOn) == 1);
+  }
+
+  // ─── timing core: note-off scheduling ────────────────────────────────────
+
+  TEST_CASE("clip: a note-off fires when the note's duration elapses") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(8.0);
+    t.adoptEventsForTest({ev(1.0, 1.0, 1, 60)}); // on at 1, off at 2
+
+    RecordingSink s;
+    t.evaluateWindow(s, 0.0, 1.5); // fires the note-on
+    CHECK(s.count(RecordingSink::NoteOn) == 1);
+    CHECK(s.count(RecordingSink::NoteOff) == 0);
+
+    t.evaluateWindow(s, 1.5, 3.0); // off-beat 2 falls in this window
+    CHECK(s.count(RecordingSink::NoteOff) == 1);
+    const auto& off = s.calls.back();
+    CHECK(off.channel == 1);
+    CHECK(off.pitch == 60);
+  }
+
+  // ─── looping ──────────────────────────────────────────────────────────────
+
+  TEST_CASE("clip: an event repeats every loop length") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(4.0);
+    t.adoptEventsForTest({ev(1.0, 0.5, 1, 60)});
+
+    RecordingSink s;
+    // Beats 0.5 .. 9.0 — the event at loop-phase 1 recurs at absolute beats
+    // 1, 5 and 9.
+    t.evaluateWindow(s, 0.5, 9.0);
+    CHECK(s.count(RecordingSink::NoteOn) == 3);
+  }
+
+  TEST_CASE("clip: firing works across a loop boundary") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(4.0);
+    t.adoptEventsForTest({ev(1.0, 0.5, 1, 60)});
+
+    RecordingSink s;
+    // Window (3, 6] spans the loop boundary at beat 4; the next occurrence is
+    // the second loop's phase-1 hit at absolute beat 5.
+    t.evaluateWindow(s, 3.0, 6.0);
+    CHECK(s.count(RecordingSink::NoteOn) == 1);
+  }
+
+  TEST_CASE("clip: loop length <= 0 fires each event at most once") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(0.0);
+    t.adoptEventsForTest({ev(2.0, 1.0, 1, 60)});
+
+    RecordingSink s;
+    t.evaluateWindow(s, 0.0, 5.0);
+    CHECK(s.count(RecordingSink::NoteOn) == 1);
+    t.evaluateWindow(s, 5.0, 10.0); // no repeat
+    CHECK(s.count(RecordingSink::NoteOn) == 1);
+  }
+
+  // ─── list swap survival ─────────────────────────────────────────────────
+
+  TEST_CASE("clip: a sounding note gets its note-off even after it leaves the list") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(8.0);
+    t.adoptEventsForTest({ev(1.0, 2.0, 1, 60)}); // on at 1, off at 3
+
+    RecordingSink s;
+    t.evaluateWindow(s, 0.5, 1.5); // note-on
+    REQUIRE(s.count(RecordingSink::NoteOn) == 1);
+
+    // The event vanishes from the list mid-note.
+    t.adoptEventsForTest({});
+
+    t.evaluateWindow(s, 1.5, 3.5); // off-beat 3 still fires from the sounding set
+    CHECK(s.count(RecordingSink::NoteOff) == 1);
+    CHECK(s.calls.back().pitch == 60);
+  }
+
+  // ─── pitch bend ──────────────────────────────────────────────────────────
+
+  TEST_CASE("clip: a per-note pitch bend is emitted just before the note-on") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(4.0);
+    t.adoptEventsForTest({ev(1.0, 1.0, 2, 64, 0.5f, 0.25f)});
+
+    RecordingSink s;
+    t.evaluateWindow(s, 0.5, 1.5);
+    REQUIRE(s.calls.size() == 2);
+    CHECK(s.calls[0].kind == RecordingSink::PitchWheel);
+    CHECK(s.calls[0].channel == 2);
+    CHECK(s.calls[0].value == doctest::Approx(0.25f));
+    CHECK(s.calls[1].kind == RecordingSink::NoteOn);
+    CHECK(s.calls[1].pitch == 64);
+  }
+
+  TEST_CASE("clip: a zero pitch bend emits no pitch-wheel message") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(4.0);
+    t.adoptEventsForTest({ev(1.0, 1.0, 1, 60, 0.8f, 0.f)});
+
+    RecordingSink s;
+    t.evaluateWindow(s, 0.5, 1.5);
+    CHECK(s.count(RecordingSink::PitchWheel) == 0);
+    CHECK(s.count(RecordingSink::NoteOn) == 1);
+  }
+
+  // ─── releaseAll (stop) ───────────────────────────────────────────────────
+
+  TEST_CASE("clip: releaseAll emits a note-off for everything sounding") {
+    YSE::CLIP::transport t(nullptr);
+    t.setLoopForTest(8.0);
+    t.adoptEventsForTest({ev(1.0, 4.0, 1, 60), ev(1.0, 4.0, 1, 64)});
+
+    RecordingSink s;
+    t.evaluateWindow(s, 0.5, 1.5); // both notes on
+    REQUIRE(s.count(RecordingSink::NoteOn) == 2);
+
+    t.releaseAll(s);
+    CHECK(s.count(RecordingSink::NoteOff) == 2);
+
+    // Idempotent: nothing left sounding.
+    RecordingSink s2;
+    t.releaseAll(s2);
+    CHECK(s2.calls.empty());
+  }
+
+  // ─── manager + clock integration ─────────────────────────────────────────
+
+  TEST_CASE("clip: bind resolves a live clock and rejects an unknown name") {
+    auto& clocks = YSE::CLOCK::Manager();
+    REQUIRE(clocks.createClock("clip.bind", 120.f));
+
+    YSE::CLIP::transport t(nullptr);
+    CHECK(t.bind("clip.bind"));
+    CHECK_FALSE(t.bind("clip.bind.nope"));
+
+    clocks.destroyClock("clip.bind");
+    clocks.update(0.01f); // let the audio side retire it
+  }
+
+  TEST_CASE("clip: create -> play -> stop through the manager and a real clock") {
+    auto& clocks = YSE::CLOCK::Manager();
+    REQUIRE(clocks.createClock("clip.run", 60.f)); // 60 BPM -> 1 beat / second
+
+    YSE::clip c;
+    REQUIRE(c.create("clip.run"));
+    c.loopLength(4.0);
+    c.setEvents({ev(1.0, 1.0, 1, 60), ev(2.0, 1.0, 1, 64)});
+    CHECK_FALSE(c.isPlaying());
+
+    c.play();
+    // Drive a few blocks: clocks first (as in deviceManager::doOnCallback), then
+    // the clip transports. This exercises the create->inbox->inUse handoff, the
+    // bind, and advance() reading the clock — no synth attached, so we only
+    // assert the transport survives and reports the right play state.
+    for (int i = 0; i < 8; ++i) {
+      clocks.update(0.25f);
+      YSE::CLIP::Manager().update();
+    }
+    CHECK(c.isPlaying());
+    CHECK(clocks.beatPosition("clip.run") > 0.0);
+
+    c.stop();
+    clocks.update(0.25f);
+    YSE::CLIP::Manager().update();
+    CHECK_FALSE(c.isPlaying());
+
+    clocks.destroyClock("clip.run");
+    clocks.update(0.01f);
+  }
+
+} // TEST_SUITE("clip")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -10,6 +10,9 @@ set(YSE_SRCS
   channel/channelManager.cpp
   clock/domainClock.cpp
   clock/clockManager.cpp
+  clip/clipInterface.cpp
+  clip/clipManager.cpp
+  clip/clipTransport.cpp
   device/androidDeviceManager.cpp
   device/deviceInterface.cpp
   device/deviceManager.cpp

--- a/YseEngine/c_api/CMakeLists.txt
+++ b/YseEngine/c_api/CMakeLists.txt
@@ -25,6 +25,7 @@ set(YSE_C_API_SRCS
   yse_dsp_modules.cpp
   yse_patcher.cpp
   yse_midi.cpp
+  yse_clip.cpp
   yse_music.cpp
   yse_synth.cpp
   yse_instrument.cpp

--- a/YseEngine/c_api/include/yse_c/yse_all.h
+++ b/YseEngine/c_api/include/yse_c/yse_all.h
@@ -18,6 +18,7 @@
 #include "yse_dsp_modules.h"
 #include "yse_patcher.h"
 #include "yse_midi.h"
+#include "yse_clip.h"
 #include "yse_music.h"
 #include "yse_instrument.h"
 #include "yse_synth.h"

--- a/YseEngine/c_api/include/yse_c/yse_clip.h
+++ b/YseEngine/c_api/include/yse_c/yse_clip.h
@@ -1,0 +1,69 @@
+/*
+  yse_clip.h — clip transport (issue #250).
+  C ABI mirror of YseEngine/clip/clip.hpp.
+
+  A clip transport loops a flat, beat-timed note-event list against a domain
+  clock (see yse_system_create_clock in yse_system.h), dispatched from the audio
+  thread — so the FFI/UI side never dispatches a note. The event list is
+  replaceable while playing; the swap is lock-free with respect to the audio
+  thread and sounding notes still receive their note-off across the swap.
+
+  Output currently targets one or more YseSynth instances (RT-safe internal
+  event queues). Channels are 1..16; pitches are 0..127; velocity and pitch bend
+  are normalized (see YseClipEvent).
+*/
+
+#ifndef YSE_C_CLIP_H_INCLUDED
+#define YSE_C_CLIP_H_INCLUDED
+
+#include "yse_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Owned — release with yse_clip_destroy. */
+typedef struct YseClip YseClip;
+/* Opaque synth handle (defined in yse_synth.h). */
+typedef struct YseSynth YseSynth;
+
+/* One timed note event, positioned in beats on the bound domain clock.
+   Layout-compatible with YSE::clipEvent. */
+typedef struct YseClipEvent {
+  double start_beat; /* beat within the loop at which the note starts (>= 0) */
+  double duration_beats; /* note length in beats */
+  int channel; /* MIDI channel, 1..16 */
+  int pitch; /* MIDI note number, 0..127 */
+  float velocity; /* normalized to [0, 1] */
+  float pitch_bend; /* optional per-note bend, [-1, 1]; 0 = none */
+} YseClipEvent;
+
+YSE_C_API YseClip* yse_clip_create(void);
+YSE_C_API void yse_clip_destroy(YseClip* c);
+
+/* Bind the clip to a live domain clock by name. Returns 1 on success, 0 if no
+   live clock owns the name (or on NULL args). The bound clock must outlive the
+   clip. */
+YSE_C_API int yse_clip_bind(YseClip* c, const char* clock_name);
+
+/* Replace the event list (copied). Takes effect at the next audio block
+   boundary. `events` may be NULL only when `count` is 0 (clears the list). */
+YSE_C_API void yse_clip_set_events(YseClip* c, const YseClipEvent* events, size_t count);
+
+/* Loop length in beats. Values <= 0 disable looping (events fire once). */
+YSE_C_API void yse_clip_set_loop_length(YseClip* c, double beats);
+
+/* Route this clip's playback into a synth (may be called for several synths).
+   The synth must outlive the connection. */
+YSE_C_API void yse_clip_connect_synth(YseClip* c, YseSynth* synth);
+YSE_C_API void yse_clip_disconnect_synth(YseClip* c, YseSynth* synth);
+
+YSE_C_API void yse_clip_play(YseClip* c);
+YSE_C_API void yse_clip_stop(YseClip* c);
+YSE_C_API int yse_clip_is_playing(YseClip* c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/YseEngine/c_api/yse_clip.cpp
+++ b/YseEngine/c_api/yse_clip.cpp
@@ -1,0 +1,98 @@
+#include "yse_c/yse_clip.h"
+#include "yse_c_internal.hpp"
+
+#include "../clip/clip.hpp"
+
+#include <exception>
+#include <vector>
+
+namespace {
+  inline YSE::clip* to_cpp(YseClip* c) {
+    return reinterpret_cast<YSE::clip*>(c);
+  }
+} // namespace
+
+extern "C" {
+
+YSE_C_API YseClip* yse_clip_create(void) {
+  try {
+    return reinterpret_cast<YseClip*>(new YSE::clip());
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("yse_clip_create: unknown C++ exception");
+    return nullptr;
+  }
+}
+
+YSE_C_API void yse_clip_destroy(YseClip* c) {
+  if (c) delete to_cpp(c);
+}
+
+YSE_C_API int yse_clip_bind(YseClip* c, const char* clock_name) {
+  if (!c || !clock_name) return 0;
+  try {
+    return to_cpp(c)->create(clock_name) ? 1 : 0;
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return 0;
+  } catch (...) {
+    yse_c::set_last_error("yse_clip_bind: unknown C++ exception");
+    return 0;
+  }
+}
+
+YSE_C_API void yse_clip_set_events(YseClip* c, const YseClipEvent* events, size_t count) {
+  if (!c) return;
+  if (!events && count != 0) return;
+  try {
+    std::vector<YSE::clipEvent> list;
+    list.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+      YSE::clipEvent e;
+      e.startBeat = events[i].start_beat;
+      e.durationBeats = events[i].duration_beats;
+      e.channel = events[i].channel;
+      e.pitch = events[i].pitch;
+      e.velocity = events[i].velocity;
+      e.pitchBend = events[i].pitch_bend;
+      list.push_back(e);
+    }
+    to_cpp(c)->setEvents(list);
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+  } catch (...) {
+    yse_c::set_last_error("yse_clip_set_events: unknown C++ exception");
+  }
+}
+
+YSE_C_API void yse_clip_set_loop_length(YseClip* c, double beats) {
+  if (c) to_cpp(c)->loopLength(beats);
+}
+
+YSE_C_API void yse_clip_connect_synth(YseClip* c, YseSynth* synth) {
+  if (!c) return;
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_cpp(c)->connect(*s);
+}
+
+YSE_C_API void yse_clip_disconnect_synth(YseClip* c, YseSynth* synth) {
+  if (!c) return;
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_cpp(c)->disconnect(*s);
+}
+
+YSE_C_API void yse_clip_play(YseClip* c) {
+  if (c) to_cpp(c)->play();
+}
+
+YSE_C_API void yse_clip_stop(YseClip* c) {
+  if (c) to_cpp(c)->stop();
+}
+
+YSE_C_API int yse_clip_is_playing(YseClip* c) {
+  return (c && to_cpp(c)->isPlaying()) ? 1 : 0;
+}
+
+} // extern "C"

--- a/YseEngine/clip/clip.hpp
+++ b/YseEngine/clip/clip.hpp
@@ -1,0 +1,134 @@
+/*
+  ==============================================================================
+
+    clip.hpp
+    Created for issue #250 — clip transport.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_CLIP_CLIP_HPP
+#define YSE_CLIP_CLIP_HPP
+
+#include <string>
+#include <vector>
+
+#include "../headers/defines.hpp"
+#include "../synth/synth.hpp" // YSE::synth (for connect/disconnect)
+
+namespace YSE {
+
+  /**
+   *  @brief One timed note event in a clip, positioned in *beats*.
+   *
+   *  Times are beat offsets on the clip's bound domain clock, not absolute
+   *  seconds — the transport evaluates them against the clock every audio
+   *  block, so a tempo change on the clock bends the clip immediately with no
+   *  rescheduling. ``startBeat`` is taken modulo the clip's loop length, so an
+   *  event repeats every loop.
+   */
+  struct clipEvent {
+    /** Beat within the loop at which the note starts (>= 0). */
+    double startBeat = 0.0;
+    /** Note length in beats. The note-off fires ``durationBeats`` after each
+        note-on, independent of the event list — so a note still sounding when
+        the list is swapped is released on time even if it vanished from the new
+        list. */
+    double durationBeats = 0.0;
+    /** MIDI channel, 1..16. */
+    int channel = 1;
+    /** MIDI note number, 0..127. */
+    int pitch = 60;
+    /** Velocity, normalized to [0, 1]. */
+    float velocity = 0.8f;
+    /** Optional per-note pitch bend, normalized to [-1, 1] (0 = none). Emitted
+        as a channel pitch-wheel just before the note-on — Phi voices fractional
+        / microtonal pitch as nearest semitone + bend. */
+    float pitchBend = 0.0f;
+  };
+
+  /// @cond INTERNAL
+  namespace CLIP {
+    class transport;
+  }
+  /// @endcond
+
+  /**
+   *  @brief A looping clip transport: plays a timed note-event list against a
+   *         domain clock, dispatched from the audio thread.
+   *
+   *  The clip binds to a named domain clock (see ``System().createClock``). It
+   *  owns an immutable list of ``clipEvent`` and a loop length in beats. Every
+   *  audio block it converts that block's boundaries into a beat window on the
+   *  clock and fires exactly the events whose crossings fall inside it — so the
+   *  UI thread never dispatches a note, and tempo changes on the clock bend the
+   *  clip with no rescheduling.
+   *
+   *  The event list is replaceable while playing: ``setEvents`` publishes a new
+   *  list that the transport swaps in at the next block boundary, lock-free with
+   *  respect to the audio thread. Sounding-note bookkeeping survives the swap —
+   *  a note that vanished from the new list still gets its note-off on time.
+   *
+   *  Output currently targets one or more ``YSE::synth`` instances (block-
+   *  accurate, on the audio thread), the RT-safe internal event-queue target;
+   *  the transport itself is agnostic to the sink, so an external MIDI-out sink
+   *  can be added on the same seam.
+   *
+   *  Multiple clips run concurrently, each on its own clock. Non-copyable /
+   *  non-movable — wrap in a ``unique_ptr`` if you need transferable ownership.
+   */
+  class API clip {
+  public:
+    clip();
+    ~clip();
+
+    clip(const clip&) = delete;
+    clip& operator=(const clip&) = delete;
+    clip(clip&&) = delete;
+    clip& operator=(clip&&) = delete;
+
+    /** @brief Bind the clip to a domain clock by name.
+     *
+     *  @param clockName Name of a live domain clock (``System().createClock``).
+     *  @return ``true`` on success; ``false`` if no live clock owns the name.
+     *
+     *  The bound clock must outlive the clip (destroy the clip before the
+     *  clock). Control thread only. */
+    bool create(const std::string& clockName);
+
+    /** @brief Replace the event list. Takes effect at the next block boundary,
+     *         lock-free with respect to the audio thread. Control thread only. */
+    clip& setEvents(const std::vector<clipEvent>& events);
+
+    /** @brief Set the loop length in beats. Values <= 0 disable looping (events
+     *         fire once). Control thread only. */
+    clip& loopLength(double beats);
+
+    /** @brief Route this clip's playback into a synth. Every note / pitch-bend
+     *         it fires is delivered to ``synth`` block-accurately on the audio
+     *         thread. May be called for several synths.
+     *
+     *  @warning ``synth`` must outlive the connection: ``disconnect`` it (or
+     *           destroy this clip) before destroying the synth. Control thread
+     *           only. */
+    clip& connect(YSE::synth& synth);
+
+    /** @brief Stop routing this clip's playback into ``synth``. */
+    clip& disconnect(YSE::synth& synth);
+
+    /** @brief Start (or restart) playback from the clock's current beat. */
+    clip& play();
+
+    /** @brief Stop playback; emits note-offs for everything currently sounding. */
+    clip& stop();
+
+    /** @brief Whether the clip is currently playing. */
+    bool isPlaying() const;
+
+  private:
+    CLIP::transport* pimpl;
+  };
+
+} // namespace YSE
+
+#endif // YSE_CLIP_CLIP_HPP

--- a/YseEngine/clip/clipInterface.cpp
+++ b/YseEngine/clip/clipInterface.cpp
@@ -1,0 +1,62 @@
+/*
+  ==============================================================================
+
+    clipInterface.cpp
+    Created for issue #250 — clip transport.
+
+    Public YSE::clip handle. Mirrors MIDI::file: the constructor registers an
+    audio-thread impl through the manager, and the destructor orphans it for the
+    slow pool to reap. All setters forward to the impl.
+
+  ==============================================================================
+*/
+
+#include "clip.hpp"
+#include "clipTransport.h"
+#include "clipManager.h"
+
+YSE::clip::clip() : pimpl(nullptr) {
+  pimpl = CLIP::Manager().addImplementation(this);
+}
+
+YSE::clip::~clip() {
+  if (pimpl != nullptr) pimpl->removeInterface();
+}
+
+bool YSE::clip::create(const std::string& clockName) {
+  return pimpl->bind(clockName);
+}
+
+YSE::clip& YSE::clip::setEvents(const std::vector<clipEvent>& events) {
+  pimpl->setEvents(events);
+  return *this;
+}
+
+YSE::clip& YSE::clip::loopLength(double beats) {
+  pimpl->loopLength(beats);
+  return *this;
+}
+
+YSE::clip& YSE::clip::connect(YSE::synth& synth) {
+  pimpl->connect(&synth);
+  return *this;
+}
+
+YSE::clip& YSE::clip::disconnect(YSE::synth& synth) {
+  pimpl->disconnect(&synth);
+  return *this;
+}
+
+YSE::clip& YSE::clip::play() {
+  pimpl->play();
+  return *this;
+}
+
+YSE::clip& YSE::clip::stop() {
+  pimpl->stop();
+  return *this;
+}
+
+bool YSE::clip::isPlaying() const {
+  return pimpl->isPlaying();
+}

--- a/YseEngine/clip/clipManager.cpp
+++ b/YseEngine/clip/clipManager.cpp
@@ -1,0 +1,99 @@
+/*
+  ==============================================================================
+
+    clipManager.cpp
+    Created for issue #250 — clip transport.
+
+  ==============================================================================
+*/
+
+#include "../internalHeaders.h"
+
+YSE::CLIP::managerObject& YSE::CLIP::Manager() {
+  static managerObject m;
+  return m;
+}
+
+YSE::CLIP::managerObject::managerObject() : mgrDelete(this), runDelete(false) {}
+
+YSE::CLIP::managerObject::~managerObject() noexcept {
+  try {
+    mgrDelete.join();
+    transport* drained;
+    while (toLoadInbox.try_pop(drained)) {
+      (void)drained;
+    }
+    inUse.clear();
+    implementations.clear();
+  } catch (...) {
+    INTERNAL::LogImpl().emit(E_ERROR, "CLIP::Manager destructor swallowed exception");
+  }
+}
+
+YSE::CLIP::transport* YSE::CLIP::managerObject::addImplementation(clip* head) {
+  transport* impl = nullptr;
+  {
+    std::scoped_lock lk(implementationsMutex);
+    implementations.emplace_front(head);
+    impl = &implementations.front();
+  }
+  // Hand the impl to the audio thread via the lock-free inbox — the audio
+  // thread owns `inUse` and decides when the transport starts advancing.
+  toLoadInbox.push(impl);
+  return impl;
+}
+
+void YSE::CLIP::managerObject::update() {
+  ///////////////////////////////////////////
+  // drain the control->audio inbox of newly-created transports
+  ///////////////////////////////////////////
+  {
+    transport* p;
+    while (toLoadInbox.try_pop(p))
+      inUse.emplace_front(p);
+  }
+
+  ///////////////////////////////////////////
+  // enqueue the slow-pool delete job for transports retired last tick. The
+  // one-tick defer guarantees the orphan is out of `inUse` before the slow pool
+  // can free it — no audio-thread free, no dangling `inUse` entry.
+  ///////////////////////////////////////////
+  if (runDelete && !mgrDelete.isQueued()) {
+    INTERNAL::Global().addSlowJob(&mgrDelete);
+  }
+  runDelete = false;
+
+  ///////////////////////////////////////////
+  // advance each transport; retire orphans (interface destroyed) from the
+  // working list. A retired transport is flagged OBJECT_DELETE and left in
+  // `implementations` for the slow-pool deleteJob to reap.
+  ///////////////////////////////////////////
+  auto previous = inUse.before_begin();
+  for (auto i = inUse.begin(); i != inUse.end();) {
+    if (!(*i)->hasInterface()) {
+      transport* ptr = *i;
+      i = inUse.erase_after(previous);
+      ptr->setStatus(OBJECT_DELETE);
+      runDelete = true;
+      continue;
+    }
+    (*i)->advance();
+    previous = i;
+    ++i;
+  }
+}
+
+void YSE::CLIP::managerObject::clear() {
+  try {
+    mgrDelete.join();
+    transport* drained;
+    while (toLoadInbox.try_pop(drained)) {
+      (void)drained;
+    }
+    inUse.clear();
+    std::scoped_lock lk(implementationsMutex);
+    implementations.clear();
+  } catch (...) {
+    INTERNAL::LogImpl().emit(E_ERROR, "CLIP::Manager clear swallowed exception");
+  }
+}

--- a/YseEngine/clip/clipManager.h
+++ b/YseEngine/clip/clipManager.h
@@ -1,0 +1,82 @@
+/*
+  ==============================================================================
+
+    clipManager.h
+    Created for issue #250 — clip transport.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_CLIP_CLIPMANAGER_H
+#define YSE_CLIP_CLIPMANAGER_H
+
+#include <forward_list>
+#include <mutex>
+
+#include "clipTransport.h"
+#include "../internal/managerJobs.hpp"
+#include "../utils/lfQueue.hpp"
+
+namespace YSE {
+  namespace CLIP {
+
+    // Owns every clip transport and advances them from the audio callback.
+    //
+    // Lifecycle follows the lock-free main->audio handoff the CLOCK / MIDI-file
+    // managers use (#249 / #190): the control thread emplaces a transport into
+    // the canonical list under `implementationsMutex` and hands it to the audio
+    // thread through a lock-free inbox; the audio thread owns the `inUse`
+    // working list, advances each transport every callback, and — once the
+    // interface is destroyed — retires it for the slow-pool delete job. The
+    // audio thread never allocates, locks, or frees.
+    class managerObject {
+    public:
+      using ImplementationType = transport;
+
+      managerObject();
+      ~managerObject() noexcept;
+
+      /** Create a transport bound to a public `clip` interface. Control thread. */
+      transport* addImplementation(clip* head);
+
+      /** Audio-thread tick, driven every callback after the clocks advance:
+          drains newly-created transports, advances each live transport (which
+          reads its clock's fresh beat window), and retires orphaned ones. */
+      void update();
+
+      /** Session teardown from INTERNAL::global::close(): join any in-flight
+          delete job and clear every transport. Called after the audio device is
+          closed and both thread pools are joined. */
+      void clear();
+
+    private:
+      // Canonical owner of every transport. Mutated only by the control thread
+      // (addImplementation) and the slow-pool deleteJob (remove_if); guarded by
+      // implementationsMutex. The audio thread never iterates it.
+      std::forward_list<transport> implementations;
+      std::mutex implementationsMutex;
+
+      // Lock-free SPSC handoff: control thread pushes a new transport here; the
+      // audio thread drains it into `inUse` at the top of update().
+      lfQueue<transport*> toLoadInbox;
+
+      // Audio-thread-owned working list.
+      std::forward_list<transport*> inUse;
+
+      // Reaps transports flagged OBJECT_DELETE off the audio thread on the slow
+      // pool.
+      INTERNAL::managerDeleteJob<managerObject> mgrDelete;
+
+      // Set by the audio thread when it retires an orphan from `inUse`; drives
+      // the deleteJob enqueue on the following tick.
+      aBool runDelete;
+
+      friend class INTERNAL::managerDeleteJob<managerObject>;
+    };
+
+    managerObject& Manager();
+
+  } // namespace CLIP
+} // namespace YSE
+
+#endif // YSE_CLIP_CLIPMANAGER_H

--- a/YseEngine/clip/clipTransport.cpp
+++ b/YseEngine/clip/clipTransport.cpp
@@ -1,0 +1,151 @@
+/*
+  ==============================================================================
+
+    clipTransport.cpp
+    Created for issue #250 — clip transport.
+
+  ==============================================================================
+*/
+
+#include "clipTransport.h"
+
+#include "../clock/clockManager.h"
+#include "../clock/domainClock.h"
+#include "../synth/synthInterface.hpp"
+
+namespace {
+
+  // Audio-thread sink that fans one fired note out to every connected synth.
+  // Reads the transport's atomic synth table; each synth call is a lock-free
+  // push onto the synth's inbox (RT-safe, mirrors MIDI-file playback).
+  struct synthFanout {
+    std::array<std::atomic<YSE::SYNTH::interfaceObject*>, 8>* synths;
+
+    void noteOn(int channel, int pitch, float velocity) {
+      for (auto& slot : *synths) {
+        YSE::SYNTH::interfaceObject* s = slot.load(std::memory_order_acquire);
+        if (s != nullptr) s->noteOn(channel, pitch, velocity);
+      }
+    }
+    void noteOff(int channel, int pitch, float velocity) {
+      for (auto& slot : *synths) {
+        YSE::SYNTH::interfaceObject* s = slot.load(std::memory_order_acquire);
+        if (s != nullptr) s->noteOff(channel, pitch, velocity);
+      }
+    }
+    void pitchWheel(int channel, float value) {
+      for (auto& slot : *synths) {
+        YSE::SYNTH::interfaceObject* s = slot.load(std::memory_order_acquire);
+        if (s != nullptr) s->pitchWheel(channel, value);
+      }
+    }
+  };
+
+} // namespace
+
+YSE::CLIP::transport::transport(clip* head)
+  : head(head), objectStatus(OBJECT_READY), intent(SS_STOPPED), loopBeats(0.0), incoming(nullptr) {
+  // std::atomic has no zero-initializing default constructor (pre-C++20), so the
+  // synth table must be explicitly cleared before the audio thread reads it.
+  for (auto& slot : synths)
+    slot.store(nullptr, std::memory_order_relaxed);
+}
+
+YSE::CLIP::transport::~transport() {
+  // The impl is only freed by the slow-pool delete job once the audio thread
+  // has retired it from `inUse`, so nothing on the audio thread still touches
+  // these buffers — safe to free here.
+  reclaimRetired();
+  delete current;
+  current = nullptr;
+  delete incoming.exchange(nullptr, std::memory_order_acquire);
+}
+
+bool YSE::CLIP::transport::bind(const std::string& clockName) {
+  clock = CLOCK::Manager().lookup(clockName);
+  return clock != nullptr;
+}
+
+void YSE::CLIP::transport::reclaimRetired() {
+  const EventList* p;
+  while (retired.try_pop(p))
+    delete p;
+}
+
+void YSE::CLIP::transport::setEvents(const EventList& events) {
+  // Reclaim any buffers the audio thread has already displaced.
+  reclaimRetired();
+  auto* fresh = new EventList(events);
+  // Publish. If a previous list was still pending (never adopted by the audio
+  // thread) exchange returns it — delete it right away; the audio thread never
+  // saw it.
+  const EventList* stale = incoming.exchange(fresh, std::memory_order_release);
+  delete stale;
+}
+
+void YSE::CLIP::transport::connect(SYNTH::interfaceObject* target) {
+  if (target == nullptr) return;
+  int freeIdx = -1;
+  for (std::size_t i = 0; i < kMaxSynths; ++i) {
+    SYNTH::interfaceObject* cur = synths[i].load(std::memory_order_acquire);
+    if (cur == target) return; // already connected
+    if (cur == nullptr && freeIdx < 0) freeIdx = static_cast<int>(i);
+  }
+  if (freeIdx < 0) return; // table full — ignore rather than grow a lock-free table
+  synths[static_cast<std::size_t>(freeIdx)].store(target, std::memory_order_release);
+}
+
+void YSE::CLIP::transport::disconnect(SYNTH::interfaceObject* target) {
+  if (target == nullptr) return;
+  for (auto& slot : synths) {
+    if (slot.load(std::memory_order_acquire) == target) {
+      slot.store(nullptr, std::memory_order_release);
+      return;
+    }
+  }
+}
+
+void YSE::CLIP::transport::advance() {
+  synthFanout sink{&synths};
+
+  switch (intent.load(std::memory_order_acquire)) {
+  case SS_WANTSTOPLAY:
+    started = false; // reseed the beat window on the first playing block
+    intent.store(SS_PLAYING, std::memory_order_release);
+    break;
+  case SS_PLAYING:
+    break;
+  case SS_WANTSTOSTOP:
+    releaseAll(sink);
+    started = false;
+    intent.store(SS_STOPPED, std::memory_order_release);
+    return;
+  default: // SS_STOPPED / paused — idle
+    return;
+  }
+
+  // Adopt a pending event list at this block boundary. Push the displaced
+  // buffer to `retired` for the control thread to delete — never free here.
+  const EventList* pending = incoming.exchange(nullptr, std::memory_order_acquire);
+  if (pending != nullptr) {
+    if (current != nullptr) retired.try_push(current);
+    current = pending;
+  }
+
+  if (clock == nullptr) return;
+
+  const double curBeat = clock->beatPosition();
+  if (!started) {
+    lastBeat = curBeat;
+    started = true;
+    return; // no firing on the seeding block
+  }
+  if (curBeat <= lastBeat) {
+    // Clock paused (tempo 0) or running backwards: resync without firing.
+    lastBeat = curBeat;
+    return;
+  }
+
+  evaluateWindow(sink, lastBeat, curBeat);
+  lastBeat = curBeat;
+}

--- a/YseEngine/clip/clipTransport.h
+++ b/YseEngine/clip/clipTransport.h
@@ -1,0 +1,228 @@
+/*
+  ==============================================================================
+
+    clipTransport.h
+    Created for issue #250 — clip transport.
+
+  ==============================================================================
+*/
+
+#ifndef YSE_CLIP_CLIPTRANSPORT_H
+#define YSE_CLIP_CLIPTRANSPORT_H
+
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "clip.hpp"
+#include "../headers/enums.hpp"
+#include "../utils/lfQueue.hpp"
+#include "../synth/synth.hpp"
+
+namespace YSE {
+  namespace CLOCK {
+    class domainClock;
+  }
+
+  namespace CLIP {
+
+    /** @brief Audio-thread-owned playback engine for one clip.
+     *
+     *  Mirrors the MIDI-file playback impl (``MIDI::fileImpl``): the control
+     *  thread creates it through the manager and hands it over lock-free, the
+     *  audio thread owns the working state and advances it every block, and a
+     *  slow-pool job reaps it once the interface is destroyed. The transport
+     *  never allocates, locks, or blocks on the audio thread.
+     */
+    class transport {
+    public:
+      using EventList = std::vector<clipEvent>;
+
+      explicit transport(clip* head);
+      ~transport();
+
+      // ---- control thread --------------------------------------------------
+
+      /** Bind to a domain clock by name. Returns false for an unknown name. */
+      bool bind(const std::string& clockName);
+
+      /** Publish a new event list; the audio thread swaps it in at the next
+          block boundary. Reclaims buffers the audio thread has retired. */
+      void setEvents(const EventList& events);
+
+      void loopLength(double beats) {
+        loopBeats.store(beats, std::memory_order_relaxed);
+      }
+
+      void connect(SYNTH::interfaceObject* target);
+      void disconnect(SYNTH::interfaceObject* target);
+
+      void play() {
+        intent.store(SS_WANTSTOPLAY, std::memory_order_release);
+      }
+      void stop() {
+        intent.store(SS_WANTSTOSTOP, std::memory_order_release);
+      }
+      bool isPlaying() const {
+        const SOUND_STATUS s = intent.load(std::memory_order_acquire);
+        return s == SS_PLAYING || s == SS_WANTSTOPLAY;
+      }
+
+      // ---- audio thread ----------------------------------------------------
+
+      /** Advance one audio block: read the clock's beat window and fire the
+          events (and note-offs) that fall inside it. */
+      void advance();
+
+      // ---- lifecycle (mirrors MIDI::fileImpl) ------------------------------
+
+      void removeInterface() {
+        head.store(nullptr);
+      }
+      bool hasInterface() const {
+        return head.load() != nullptr;
+      }
+      void setStatus(OBJECT_IMPLEMENTATION_STATE value) {
+        objectStatus.store(value);
+      }
+      static bool canBeDeleted(const transport& t) {
+        return t.objectStatus.load() == OBJECT_DELETE;
+      }
+
+      // ---- timing core (audio thread; templated for unit tests) ------------
+
+      /** Fire every note-off and note-on whose crossing falls in the half-open
+          beat window ``(from, to]`` on ``sink``. Note-offs are emitted before
+          note-ons so a same-block retrigger releases the old note first.
+          ``sink`` must expose the YSE::synth note API (noteOn / noteOff /
+          pitchWheel) — the real audio path passes a synth fan-out; tests pass a
+          recording sink. Pure function of the audio-thread-owned state; no
+          allocation, no locking. */
+      template <class Sink> void evaluateWindow(Sink& sink, double from, double to) {
+        const double loop = loopBeats.load(std::memory_order_relaxed);
+
+        // 1) Release notes whose scheduled off-beat has passed. Driven by each
+        //    note's own recorded off-beat, so a note dropped from a swapped-in
+        //    list is still released on time.
+        for (auto& n : sounding) {
+          if (n.active && n.offBeat <= to) {
+            sink.noteOff(n.channel, n.pitch, 0.f);
+            n.active = false;
+          }
+        }
+
+        // 2) Fire note-ons for every event occurrence in (from, to].
+        if (current == nullptr) return;
+        for (const clipEvent& e : *current) {
+          if (loop > 0.0) {
+            double s0 = std::fmod(e.startBeat, loop);
+            if (s0 < 0.0) s0 += loop;
+            // First occurrence strictly greater than `from`.
+            double k = std::floor((from - s0) / loop) + 1.0;
+            for (int guard = 0; guard < kMaxOccurrencesPerBlock; ++guard) {
+              const double occ = s0 + k * loop;
+              if (occ > to) break;
+              fireNoteOn(sink, e, occ + e.durationBeats);
+              k += 1.0;
+            }
+          } else {
+            // No looping: fire once when its absolute start falls in the window.
+            if (e.startBeat > from && e.startBeat <= to)
+              fireNoteOn(sink, e, e.startBeat + e.durationBeats);
+          }
+        }
+      }
+
+      /** Release every sounding note (stop / teardown). */
+      template <class Sink> void releaseAll(Sink& sink) {
+        for (auto& n : sounding) {
+          if (n.active) {
+            sink.noteOff(n.channel, n.pitch, 0.f);
+            n.active = false;
+          }
+        }
+      }
+
+      // Test seam: drive the audio-thread window directly.
+      void setLoopForTest(double beats) {
+        loopBeats.store(beats, std::memory_order_relaxed);
+      }
+      void adoptEventsForTest(const EventList& events) {
+        delete current;
+        current = new EventList(events);
+      }
+
+    private:
+      struct soundingNote {
+        bool active = false;
+        int channel = 0;
+        int pitch = 0;
+        double offBeat = 0.0;
+      };
+
+      // Bounded — no allocation on the audio thread. 256 simultaneous notes is
+      // far beyond any musical clip; extra note-ons past capacity are dropped.
+      static constexpr std::size_t kMaxSounding = 256;
+      std::array<soundingNote, kMaxSounding> sounding;
+      // Caps the per-event occurrence loop so a pathological tiny loop length /
+      // huge tempo can't spin unbounded on the audio thread.
+      static constexpr int kMaxOccurrencesPerBlock = 64;
+
+      template <class Sink> void fireNoteOn(Sink& sink, const clipEvent& e, double offBeat) {
+        soundingNote* slot = nullptr;
+        for (auto& n : sounding) {
+          if (!n.active) {
+            slot = &n;
+            break;
+          }
+        }
+        if (slot == nullptr) return; // table full — drop rather than allocate
+        if (e.pitchBend != 0.f) sink.pitchWheel(e.channel, e.pitchBend);
+        sink.noteOn(e.channel, e.pitch, e.velocity);
+        slot->active = true;
+        slot->channel = e.channel;
+        slot->pitch = e.pitch;
+        slot->offBeat = offBeat;
+      }
+
+      // Drain the audio-thread-retired buffers and delete them (control thread).
+      void reclaimRetired();
+
+      // Interface backpointer. Nulled by the control thread in removeInterface()
+      // while the audio thread reads it in hasInterface() (mirrors #190).
+      std::atomic<clip*> head;
+      std::atomic<OBJECT_IMPLEMENTATION_STATE> objectStatus;
+
+      // Bound domain clock. Resolved on the control thread in bind(); read
+      // (beatPosition) on the audio thread. Caller guarantees it outlives us.
+      CLOCK::domainClock* clock = nullptr;
+
+      // Play intent (control -> audio), same handshake as MIDI::fileImpl.
+      std::atomic<SOUND_STATUS> intent;
+      bool started = false; // audio-thread: has playback been seeded this run?
+      double lastBeat = 0.0; // audio-thread: window start (previous block end)
+
+      std::atomic<double> loopBeats;
+
+      // ---- event-list double buffer ----------------------------------------
+      // Control thread publishes into `incoming`; the audio thread swaps it into
+      // `current` at a block boundary and pushes the displaced buffer into
+      // `retired` for the control thread to delete. No free ever on the audio
+      // thread.
+      std::atomic<const EventList*> incoming;
+      const EventList* current = nullptr; // audio-thread owned
+      lfQueue<const EventList*> retired;
+
+      // Connected synths (caller-owned lifetime; fixed atomic table so
+      // connect/disconnect never lock and advance() never allocates).
+      static constexpr std::size_t kMaxSynths = 8;
+      std::array<std::atomic<SYNTH::interfaceObject*>, kMaxSynths> synths;
+    };
+
+  } // namespace CLIP
+} // namespace YSE
+
+#endif // YSE_CLIP_CLIPTRANSPORT_H

--- a/YseEngine/clock/clockManager.cpp
+++ b/YseEngine/clock/clockManager.cpp
@@ -84,6 +84,11 @@ Flt YSE::CLOCK::managerObject::currentTempo(const std::string& name) {
   return clock != nullptr ? clock->currentTempo() : 0.f;
 }
 
+YSE::CLOCK::domainClock* YSE::CLOCK::managerObject::lookup(const std::string& name) {
+  std::scoped_lock lk(implementationsMutex);
+  return findLive(name);
+}
+
 void YSE::CLOCK::managerObject::update(Flt delta) {
   ///////////////////////////////////////////
   // drain the control->audio inbox of newly-created clocks into the working list

--- a/YseEngine/clock/clockManager.h
+++ b/YseEngine/clock/clockManager.h
@@ -69,6 +69,18 @@ namespace YSE {
           Control/UI thread. */
       Flt currentTempo(const std::string& name);
 
+      /** Resolve a live clock by name to a stable pointer a clip transport can
+          hold and read (``beatPosition``) every audio block. Returns nullptr
+          for an unknown name. Control thread only.
+
+          Lifetime is caller-managed, matching the engine's other cross-object
+          bindings (MIDI file -> synth, MIDI device -> synth): the bound clock
+          must outlive every transport bound to it — destroy or unbind the
+          transport before ``destroyClock``. The returned pointer references an
+          object owned by ``implementations`` and only reads its published
+          atomics, so it is safe to poll from the audio thread. */
+      domainClock* lookup(const std::string& name);
+
       /** Audio-thread tick, driven every callback with the block duration in
           seconds. Drains newly-created clocks, advances each live clock, and
           retires released clocks for slow-pool deletion. */

--- a/YseEngine/device/deviceManager.cpp
+++ b/YseEngine/device/deviceManager.cpp
@@ -49,6 +49,10 @@ bool YSE::DEVICE::deviceManager::doOnCallback(int numSamples) {
   // callback, regardless of whether any sound is playing — and are advanced
   // before the empty()-sounds early-out below.
   CLOCK::Manager().update((Flt)numSamples / (Flt)SAMPLERATE);
+  // Clip transports (issue #250) are advanced right after the clocks, every
+  // audio callback, so each transport reads its bound clock's freshly-updated
+  // beat window and fires the note events that fall inside this block.
+  CLIP::Manager().update();
   // MIDI file playback is advanced every block too (issue #155) so events reach
   // the connected synths block-accurately, before the synths render this block.
   MIDI::Manager().updatePlayback(numSamples);

--- a/YseEngine/internal/global.cpp
+++ b/YseEngine/internal/global.cpp
@@ -159,6 +159,10 @@ void YSE::INTERNAL::global::close() {
   // the next session. Safe to tear down synchronously here: the device is
   // already closed and both pools are joined, so no audio thread can advance a
   // clock and no slow job can reap one.
+  // Clear clip transports (issue #250) before the clocks they bind to, so no
+  // transport can reference a clock past teardown. Safe synchronously here: the
+  // device is closed and both pools are joined.
+  CLIP::Manager().clear();
   CLOCK::Manager().clear();
   // Tear down the bus last — by this point the audio device is already
   // closed (system::close() ran DEVICE::Manager().close() before us), so

--- a/YseEngine/internalHeaders.h
+++ b/YseEngine/internalHeaders.h
@@ -44,6 +44,9 @@
 #include "clock/domainClock.h"
 #include "clock/clockManager.h"
 
+#include "clip/clipTransport.h"
+#include "clip/clipManager.h"
+
 #include "midi/midiDeviceManager.h"
 
 #include "midi/midifileImplementation.h"

--- a/YseEngine/yse.hpp
+++ b/YseEngine/yse.hpp
@@ -118,6 +118,8 @@
 #include "synth/positionHandlers.hpp"
 #include "synth/synthInterface.hpp"
 
+#include "clip/clip.hpp"
+
 #include "midi/midifile.hpp"
 #include "midi/midiMessage.hpp"
 #include "midi/midiNote.hpp"


### PR DESCRIPTION
## Summary

Implements #250: a **clip transport** — an engine object that loops a flat, immutable list of beat-timed note events against a bound [domain clock](https://github.com/yvanvds/yse-soundengine/issues/249), dispatched entirely from the audio thread so the UI thread never dispatches a note. Built on the domain-clock subsystem merged for #249.

Each audio block, `CLIP::Manager().update()` (ticked from `deviceManager::doOnCallback` right after the clocks advance) converts the block's beat boundaries into a `(from, to]` window on the bound clock and fires exactly the events whose crossings fall inside it. Events are **evaluated per block, never scheduled ahead in absolute time**, so a tempo change on the clock bends the clip immediately with no rescheduling.

## Linked issue

Closes #250

## Changes

- **`YseEngine/clip/`** — new subsystem:
  - `YSE::clip` handle + `YSE::clipEvent` (`startBeat`, `durationBeats`, `channel`, `pitch`, `velocity`, optional per-note `pitchBend`).
  - `CLIP::transport` — audio-thread timing impl: per-block beat-window evaluation, looping (`startBeat` taken modulo the loop length, wrap handled), bounded audio-owned sounding-note set.
  - `CLIP::Manager` — lock-free lifecycle mirroring the CLOCK / MIDI-file managers (canonical `forward_list` under a mutex → SPSC inbox → audio-owned `inUse` list → slow-pool delete job).
- **Hot-swappable event list**: `setEvents` publishes a new immutable list swapped in at the next block boundary via an atomic single-slot handoff plus a lock-free `retired` queue the control thread reclaims — no allocation, lock, or free on the audio thread. **Sounding notes survive the swap**: each note-on records its own absolute off-beat, so a note dropped from the new list still gets its note-off on time.
- **Output** targets one or more `YSE::synth` instances (RT-safe internal event-queue sink, via the same `SYNTH::interfaceObject` note API MIDI-file playback uses). The firing core is templated over the sink, so an external MIDI-out sink can plug into the same seam later.
- `play` / `stop` / `isPlaying`; `stop` releases everything sounding. Multiple clips run concurrently, each on its own clock.
- **`CLOCK::Manager::lookup()`** — control-thread name→`domainClock*` resolve so a transport binds once and reads the clock's published beat atomic every block. Bound clocks are caller-owned and must outlive the clip (same contract as MIDI-file → synth).
- **C ABI** `yse_clip_*` (`c_api/include/yse_c/yse_clip.h` + `yse_clip.cpp`) for the Dart/FFI consumer.
- Wired into `deviceManager::doOnCallback` (advance) and `global::close` (teardown, before the clocks).
- `PROJECT_OVERVIEW.md` §12c documents the subsystem.

## RT discipline

The audio-thread dispatch path allocates nothing, takes no lock, and frees nothing: event-list swaps use an atomic handoff + a control-thread-drained reclaim queue, the synth table is a fixed atomic array, and the sounding-note set is a bounded fixed array. Timing is decided block-accurately on the audio thread; the RT-safe target is the synth inbox (`try_push`). An external RtMidi-out sink is deliberately **not** wired here — sending to RtMidi can't happen on the audio callback, and doing it jitter-free needs a dedicated sender-thread decision that is out of scope for this issue; the templated sink seam leaves that a focused follow-up.

## Test plan

- [x] `clang-format --dry-run --Werror` clean on all new/changed files.
- [x] `clang-tidy` (`python yse.py analyze`) clean — no new findings on the changed files.
- [x] Unit + integration tests pass: **13 clip cases / 40 assertions**, plus the full `ctest` run (**32/32 processes, 100%**).
  - Timing-core unit tests against a recording sink: single-shot firing, half-open window, note-off scheduling, looping + loop-boundary wrap, no-loop mode, **note-off survival across a list swap**, per-note pitch bend, and `releaseAll` on stop.
  - Manager + real-clock integration case driving `CLOCK::Manager().update()` / `CLIP::Manager().update()` through bind → play → stop. This case caught (and the fix verified) an uninitialized-`std::atomic` synth-table crash under repeated runs.
  - Isolated in its own `yse_tests_clip` process and excluded from the monolithic run (like the clock suite) since it ticks the managers directly; no audio device needed, so it runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
