### PR TITLE
ENGINE: dedup MIDI file manager inUse to intrusive list (#266)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -88,6 +88,7 @@ set(YSE_TEST_SOURCES
   reverb/test_reverb_concurrency.cpp
   midi/test_midifile.cpp
   midi/test_midifile_concurrency.cpp
+  midi/test_midifile_alloc.cpp
   midi/test_devicemanager.cpp
   midi/test_midi_in.cpp
   midi/test_midi_synth_routing.cpp

--- a/Tests/midi/test_midifile_alloc.cpp
+++ b/Tests/midi/test_midifile_alloc.cpp
@@ -1,0 +1,79 @@
+// Engine-level RT-allocation test for the MIDI file manager bookkeeping
+// (issue #266).
+//
+// `MIDI::managerObject::update()` runs on the audio callback thread. Before
+// #266 it drained newly-created impls from its lock-free inbox into an
+// `std::forward_list<fileImpl*> inUse` with `emplace_front`, allocating a list
+// node on the heap for every MIDI file that started playing — the same per-tick
+// malloc churn #194 removed from the sound/channel/reverb managers. The fix
+// converts `inUse` to the intrusive `IntrusiveForwardList` (link embedded in
+// `fileImpl::_mgrNext`), so promoting an impl into the working list touches no
+// heap.
+//
+// This drives the *real* engine — real MIDI::file objects, the real lock-free
+// inbox and the real MIDI::Manager().update() — and probes the promote path for
+// allocations. Like the other engine allocation tests it drives update() from
+// the test thread with the audio stream paused (support/null_device.hpp), so it
+// runs where a default audio device is present and skips gracefully otherwise
+// (headless CI). Locally it fails on the pre-#266 code (per-promote emplace_front
+// allocation) and passes after the intrusive-list conversion.
+
+#include <doctest/doctest.h>
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "yse.hpp"
+#include "midi/midifile.hpp"
+#include "midi/midifileManager.h"
+#include "support/alloc_probe.hpp"
+#include "support/null_device.hpp"
+
+using namespace std::chrono_literals;
+
+TEST_SUITE("midi") {
+
+  TEST_CASE("midifile: promoting files into the audio-thread inUse list does not allocate (#266)") {
+    if (!TestHelpers::engineInit()) return;
+
+    // Construct a batch of MIDI files on the main thread. Each `file`'s
+    // constructor registers an impl and hands it to the manager over the
+    // lock-free inbox; we deliberately do NOT drive update() yet, so the impls
+    // sit queued and their (legitimate, main-thread) construction allocations
+    // all happen OUTSIDE the probe below.
+    constexpr int kFiles = 16;
+    std::vector<YSE::MIDI::file> files(kFiles);
+
+    {
+      TestHelpers::ProbeScope probe;
+      // The audio thread drains the inbox: every queued impl is push_front'ed
+      // into the `inUse` working list. Before #266 that allocated a
+      // std::forward_list node per file; after the intrusive-list conversion it
+      // is allocation free.
+      YSE::MIDI::Manager().update();
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+
+    {
+      // Steady state: with every impl already in `inUse` and still interfaced,
+      // repeated ticks walk the list and must not allocate either.
+      TestHelpers::ProbeScope probe;
+      for (int i = 0; i < 8; ++i)
+        YSE::MIDI::Manager().update();
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+
+    // Tear down: destroying the files orphans their impls; update() retires them
+    // from `inUse` and the slow-pool deleteJob reaps them. Functional check that
+    // the intrusive erase path leaves the lists intact (not an allocation one —
+    // reaping legitimately frees the canonical `implementations` nodes).
+    files.clear();
+    for (int i = 0; i < 16; ++i) {
+      YSE::MIDI::Manager().update();
+      std::this_thread::sleep_for(2ms);
+    }
+    CHECK(true);
+  }
+
+} // TEST_SUITE("midi")

--- a/YseEngine/midi/midifileImplementation.cpp
+++ b/YseEngine/midi/midifileImplementation.cpp
@@ -22,6 +22,9 @@
 #include <cstdint>
 #include <fstream>
 
+// The header now pulls only the public umbrella (issue #266); the definitions
+// this TU needs (INTERNAL::LogImpl) still come from internalHeaders.h.
+#include "../internalHeaders.h"
 #include "../synth/synthInterface.hpp"
 #include "midiSynthRouting.hpp"
 

--- a/YseEngine/midi/midifileImplementation.h
+++ b/YseEngine/midi/midifileImplementation.h
@@ -16,7 +16,13 @@
 #include <cstdint>
 #include <string>
 #include <vector>
-#include "../internalHeaders.h"
+// Public umbrella header only (enums, types, and the MIDI::file class). NOT
+// internalHeaders.h: the manager below now embeds an intrusive list keyed on a
+// pointer-to-member of this class, so it needs `fileImpl` complete — pulling in
+// the manager headers here would form an include cycle that leaves `fileImpl`
+// incomplete at the manager's declaration (issue #266). This mirrors how the
+// sound/reverb impl headers stay off internalHeaders.h.
+#include "../yse.hpp"
 #include "../synth/synth.hpp" // YSE::synth / SYNTH::interfaceObject forward decls
 
 namespace YSE {
@@ -96,6 +102,13 @@ namespace YSE {
       }
 
     private:
+      // Intrusive forward-list link (issue #266, mirrors #194). Threads this
+      // impl through the MIDI file manager's audio-thread `inUse` list. Touched
+      // only on the audio thread, replacing the std::forward_list<T*> node so
+      // MIDI-file start/stop no longer churns a heap node per tick. MIDI files
+      // skip the toLoad stage, so a single link suffices.
+      fileImpl* _mgrNext = nullptr;
+
       // Deliver one decoded event to every connected synth (audio thread).
       void dispatchEvent(const fileEvent& event);
       // Release every held note on every connected synth (pause / stop / EOT).
@@ -129,6 +142,9 @@ namespace YSE {
       // each event's status byte, so no per-connection channel filter is needed.
       static constexpr std::size_t kMaxSynths = 8;
       std::array<std::atomic<SYNTH::interfaceObject*>, kMaxSynths> synths;
+
+      // Grants the manager access to the intrusive `_mgrNext` link (issue #266).
+      friend class managerObject;
     };
 
   } // namespace MIDI

--- a/YseEngine/midi/midifileManager.cpp
+++ b/YseEngine/midi/midifileManager.cpp
@@ -58,7 +58,7 @@ void YSE::MIDI::managerObject::update() {
   {
     fileImpl* p;
     while (toLoadInbox.try_pop(p))
-      inUse.emplace_front(p);
+      inUse.push_front(p);
   }
 
   ///////////////////////////////////////////
@@ -76,17 +76,15 @@ void YSE::MIDI::managerObject::update() {
   // impl is flagged OBJECT_DELETE and left in `implementations` for the
   // slow-pool deleteJob to reap — it is never freed on the audio thread.
   ///////////////////////////////////////////
-  auto previous = inUse.before_begin();
-  for (auto i = inUse.begin(); i != inUse.end();) {
-    if (!(*i)->hasInterface()) {
-      fileImpl* ptr = *i;
-      i = inUse.erase_after(previous);
+  for (auto c = inUse.front(); c.valid();) {
+    fileImpl* ptr = c.get();
+    if (!ptr->hasInterface()) {
+      c.erase();
       ptr->setStatus(OBJECT_DELETE);
       runDelete = true;
-      continue;
+      continue; // c already refers to the successor after erase()
     }
-    previous = i;
-    ++i;
+    c.next();
   }
 }
 

--- a/YseEngine/midi/midifileManager.h
+++ b/YseEngine/midi/midifileManager.h
@@ -18,6 +18,7 @@
 #include "../internal/threadPool.h"
 #include "../internal/managerJobs.hpp"
 #include "../utils/lfQueue.hpp"
+#include "../utils/intrusiveForwardList.hpp"
 
 namespace YSE {
   namespace MIDI {
@@ -56,8 +57,9 @@ namespace YSE {
       lfQueue<fileImpl*> toLoadInbox;
 
       // Audio-thread-owned working list. update() iterates and erases from this
-      // list only; the impls it points at live in `implementations`.
-      std::forward_list<fileImpl*> inUse;
+      // list only; the impls it points at live in `implementations`. Intrusive
+      // (link embedded via `_mgrNext`) — allocation-free (issue #266).
+      IntrusiveForwardList<fileImpl, &fileImpl::_mgrNext> inUse;
 
       // Reaps impls flagged OBJECT_DELETE off the audio thread on the slow pool.
       INTERNAL::managerDeleteJob<managerObject> mgrDelete;


### PR DESCRIPTION
## Summary

`MIDI::managerObject::update()` runs on the audio callback thread. It drained newly-created impls from its lock-free inbox into an `std::forward_list<fileImpl*> inUse` with `emplace_front`, allocating a list node on the heap for every MIDI file that started playing (and freeing one per stop) — the same per-tick malloc/free churn #194 removed from the sound/channel/reverb managers.

This applies the #194 fix to the MIDI file manager: `fileImpl` gets an intrusive `_mgrNext` link and `inUse` becomes a `YSE::IntrusiveForwardList`. MIDI files skip the `toLoad` stage, so a single link suffices. `push_front` and cursor-based erase now touch no heap on the audio thread.

## Linked issue
Closes #266

## Changes
- `midifileImplementation.h`: add intrusive `fileImpl::_mgrNext` link + `friend managerObject`.
- `midifileManager.{h,cpp}`: convert `inUse` from `std::forward_list<fileImpl*>` to `IntrusiveForwardList<fileImpl, &fileImpl::_mgrNext>`; `emplace_front` -> `push_front`, `before_begin/erase_after` -> cursor `erase()`.
- **Include-cycle fix (required by the conversion):** the intrusive list keys on `&fileImpl::_mgrNext`, so the manager needs `fileImpl` *complete* at its declaration. `midifileImplementation.h` pulled `internalHeaders.h` (which re-includes the manager), forming a cycle that left `fileImpl` incomplete at `midifileManager.h`. Point the impl header at the public umbrella `yse.hpp` instead (mirroring the sound/reverb impl headers, which stay off `internalHeaders.h`) and include `internalHeaders.h` directly in the impl `.cpp` for `INTERNAL::LogImpl`. `internalHeaders.h` already includes `yse.hpp` first, so the full-engine build is unchanged.
- `Tests/midi/test_midifile_alloc.cpp`: new engine-level RT-allocation regression test.

## Test plan
- [x] `yse.py format` clean (no drift outside the changed files)
- [x] `yse.py analyze` on the changed engine `.cpp`s + new test — no new user-code findings (only the suppressed baseline)
- [x] Full suite green: `yse.py test` — 32/32 ctest targets pass; midi suite 85 cases / 165 assertions pass
- [x] New test is a real regression: temporarily reverting `inUse` to `std::forward_list` makes it **fail** (`16 == 0`, one alloc per file promoted); with the fix it passes (`0`)

Not user-visible (audio-engine internals with no rendered/UI surface), so no integration/e2e test — the engine-level allocation test drives the real `MIDI::file` + `MIDI::Manager().update()` path, which is the correct layer for this RT-safety change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)