### PR TITLE
ENGINE: document paused-queue accumulation on system::pause() (#289)

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -92,7 +92,27 @@ namespace YSE {
     /** @brief Shut down the engine and release the audio device. */
     void close();
 
-    /** @brief Pause audio output. The engine keeps running but the device is silent. */
+    /** @brief Pause audio output. The engine keeps running but the device is silent.
+     *
+     *  ``pause()`` closes the audio stream, so the audio tick stops draining the
+     *  lock-free control-to-audio inboxes (per-object message queues and the
+     *  managers' ``toLoadInbox``es). Interface setters and object creation called
+     *  while paused keep enqueuing onto those queues; the messages are held and
+     *  delivered in order on ``resume()``, not dropped. This is intentional — the
+     *  queues carry ordered discrete commands (play/stop, position, load-handoff
+     *  pointers), so silently dropping them would corrupt state, unlike the
+     *  latest-value-wins parameter queues (NamedBus, patcher) which do cap.
+     *
+     *  The consequence is unbounded memory growth if an app pushes a very large
+     *  number of setter/creation calls while paused: ``lfQueue`` allocates
+     *  doubling-size blocks on demand and never frees them, so the peak retained
+     *  capacity persists for the queue's lifetime even after the backlog drains.
+     *  All allocation happens producer-side on the control thread, so this never
+     *  violates audio-thread real-time discipline. Applications that drive a heavy
+     *  control-rate workload should keep the engine running (leave the device open)
+     *  rather than pausing, or simply avoid issuing large batches of setters while
+     *  paused. See issue #289.
+     */
     void pause();
 
     /** @brief Resume audio output after ``pause()``. */


### PR DESCRIPTION
## Summary

Resolves #289 as a documentation clarification of intended behavior — the issue's own cheapest, "probably fine" option.

`system::pause()` closes the audio stream, so the audio tick stops draining the lock-free control-to-audio inboxes (per-object `messages` queues and the managers' `toLoadInbox`es). Interface setters and object creation issued while paused keep enqueuing and are delivered in order on `resume()`. Because `lfQueue` allocates doubling-size blocks on demand and never frees them, a large batch of paused control calls grows the retained capacity without bound for the queue's lifetime. All allocation is producer-side on the control thread, so audio-thread RT discipline is unaffected.

### Why document, not cap

The alternative (switch setters to `try_push` + drop-with-log) is deliberately **not** applied: these queues carry ordered discrete commands (play/stop, position) and load-handoff pointers, where silently dropping a message would corrupt object state or orphan a load. That is unlike the latest-value-wins NamedBus / patcher parameter queues, where drop-on-overflow is correct because only the newest value matters. The 2026-07 round-2 audit already verified all ten allocating `push()` sites are control-thread producers, so this is purely a memory-growth footnote, not an RT hazard.

## Linked issue
Closes #289

## Changes
- `YseEngine/system.hpp` — expand the `pause()` doxygen comment to document the paused-queue accumulation, its bounded-by-usage memory implication, the RT-safety guarantee, and the mitigation (keep the device open under heavy control-rate workloads).

## Test plan
- [x] `python yse.py format` clean — only `system.hpp` changed (comment-only)
- [x] `python yse.py analyze YseEngine/system.cpp` (the TU including the header) clean — 0 new findings (166 warnings, all pre-existing/suppressed baseline)
- [x] No unit test added: comment-only documentation change with no runtime surface — the CLAUDE.md-sanctioned exception to the tests-where-sensible rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
