### PR TITLE
ENGINE: document control-thread contract for NamedBus identity (#290)

### DIFF
--- a/YseEngine/internal/namedBus.h
+++ b/YseEngine/internal/namedBus.h
@@ -136,6 +136,20 @@ namespace YSE {
       // happens-before every other thread that later publishes. A T_GUI
       // publish comparing unequal to this is off the control thread and must be
       // deferred rather than dispatched inline (issue #193).
+      //
+      // The identity is deliberately frozen at construction rather than derived
+      // from the first drainPending() call (issue #290). Construction is the
+      // earliest possible signal, and capturing it here lets a control-thread
+      // T_GUI publish dispatch inline immediately — before update() has ever
+      // run a drain tick (a behaviour the "control-thread T_GUI publish
+      // dispatches synchronously" test pins down). Deriving it lazily would
+      // force every such publish onto the deferred path until the first
+      // update(). The contract this rests on — System::init() and
+      // System::update() run on the same control thread — is the engine-wide
+      // single-control-thread assumption, documented on system::update(). An
+      // app that inits on one thread but updates on another still behaves
+      // correctly (all publishes take the deferred path) but loses the inline
+      // fast path.
       const std::thread::id controlThread_;
 
       // T_GUI publishes that arrived on a non-control thread (gMetro timer

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -54,6 +54,13 @@ namespace YSE {
     system();
 
     /** @brief Initialise the engine and open the default audio device.
+     *
+     *  @note **Threading.** This call runs on and *defines* the engine's
+     *        control thread. Call ``update()`` and ``close()`` from the same
+     *        thread. The control-thread identity is captured here and never
+     *        re-derived, so driving ``init()`` and ``update()`` from different
+     *        threads silently loses the named-bus inline fast path — see the
+     *        ``update()`` threading note (issue #290).
      *  @return ``true`` on success, ``false`` if no device could be opened.
      */
     bool init();
@@ -86,6 +93,20 @@ namespace YSE {
      *  Call once per frame from the main thread. Drives message delivery,
      *  sound state transitions, virtualisation decisions, and listener
      *  velocity calculations.
+     *
+     *  @note **Threading.** ``update()`` must be called from the same thread
+     *        that called ``init()`` — the engine's single control thread. That
+     *        identity is frozen when the engine initialises (not re-derived per
+     *        tick) and decides who may dispatch control-rate (``T_GUI``)
+     *        named-bus publishes inline; a publish from any other thread is
+     *        instead deferred to the next ``update()`` tick to keep the
+     *        per-object message queues single-producer (issue #193). Driving
+     *        ``init()`` and ``update()`` from *different* threads is
+     *        unsupported: it stays functionally correct — every publish simply
+     *        takes the deferred path and is dispatched on whichever thread runs
+     *        ``update()`` — but permanently forfeits the inline fast path,
+     *        because the control thread is captured at ``init()`` rather than
+     *        followed from ``update()`` (issue #290).
      */
     void update();
 


### PR DESCRIPTION
## Summary

Resolves #290. `NamedBus::controlThread_` is captured at construction
(`System::init`) and compared in `publish()` to decide between inline and
deferred `T_GUI` dispatch. An app that runs `init()` on one thread but drives
`update()` from another never matches the real update thread, so every
control-rate publish detours through the deferred inbox and the inline fast
path is silently lost.

The issue offered "document or derive from `drainPending()`". This takes the
**document** path, because deriving is not a free improvement:

- Capturing at construction is the *earliest possible* signal. It is what lets
  a control-thread `T_GUI` publish dispatch **inline immediately — before
  `update()` has ever run a drain tick**. The existing test
  `"named bus: control-thread T_GUI publish still dispatches synchronously"`
  (`Tests/system/test_named_bus.cpp`) pins that behaviour down.
- Deriving `controlThread_` lazily from the first `drainPending()` would force
  every pre-first-`update()` publish onto the deferred path, regressing that
  test.
- The real contract — `init()` and `update()` run on one control thread — is
  the engine-wide single-control-thread assumption, not a NamedBus quirk.

So the fix is to make that contract explicit rather than change behaviour.

## Linked issue

Closes #290

## Changes

- `YseEngine/system.hpp` — threading `@note` on `init()` and `update()`
  documenting the single-control-thread contract and that the identity is
  frozen at `init()` (off-thread `update()` stays correct but loses the inline
  fast path).
- `YseEngine/internal/namedBus.h` — record on the `controlThread_` member why
  the identity is frozen at construction rather than derived from
  `drainPending()`, cross-referencing the contract.

## Test plan

- [x] `python yse.py format` clean — only the two intended files changed, no
  formatting drift.
- [x] `python yse.py analyze YseEngine/internal/namedBus.cpp` and
  `... system.cpp` — 0 new findings (all suppressed baseline / non-user);
  clang-tidy parsed both changed headers, confirming they compile.
- [x] No new/changed tests — comment-only documentation change (CLAUDE.md tests
  exception). The behaviour documented is already covered by the existing
  `"control-thread T_GUI publish dispatches synchronously"` and
  off-control-thread deferral tests in `Tests/system/test_named_bus.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
