### PR TITLE
ENGINE: defer pre-setup synth messages instead of dropping them (#352)

### DIFF
--- a/Tests/synth/test_synth_handlers.cpp
+++ b/Tests/synth/test_synth_handlers.cpp
@@ -59,6 +59,22 @@ namespace {
     return std::sqrt(static_cast<double>(p.x) * p.x + static_cast<double>(p.z) * p.z);
   }
 
+  // A sineVoice whose clone() sleeps on the setup pool. Cloning N of these
+  // holds the synth in OBJECT_SETTING_UP for a deterministic, machine-speed-
+  // independent window while the owning sound is already rendering — exactly
+  // the state in which a pre-#352 renderBlock() destroyed queued messages.
+  class SlowCloneVoice : public YSE::SYNTH::sineVoice {
+  public:
+    SlowCloneVoice() = default;
+    YSE::SYNTH::dspVoice* clone() override {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      return new SlowCloneVoice(*this);
+    }
+
+  private:
+    SlowCloneVoice(const SlowCloneVoice&) = default;
+  };
+
   // A handler that echoes voiceContext fields straight into a position, so a
   // test can assert exactly which live value reached the handler. It is also the
   // minimal "write your own handler" example (steers position only, RT-safe).
@@ -440,6 +456,53 @@ TEST_SUITE("synthhandlers") {
       YSE::Pos p = syn.getVoicePosition(1, 60);
       CHECK(p.x == doctest::Approx(7.f));
       CHECK(p.z == doctest::Approx(-3.f));
+
+      snd.stop();
+      pump(4);
+    }
+    pump(4);
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ── Messages sent before setup completes are deferred, not dropped (#352):
+  //    a note queued while the voices are still cloning on the setup pool must
+  //    survive and arm once the synth is ready. SlowCloneVoice pins the synth
+  //    in OBJECT_SETTING_UP while the owning sound already renders, so the
+  //    offline pump exercises the not-ready inbox path deterministically. ──
+  TEST_CASE("synthhandlers: notes sent before setup are deferred until ready") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    SlowCloneVoice voiceProto;
+    voiceProto.attack(0.005f).sustain(0.8f).release(0.05f);
+    YSE::SYNTH::orbitHandler proto;
+    proto.radius(2.f).velocityRadius(0.f).rate(1.f);
+    {
+      YSE::synth syn;
+      syn.create().addVoices(voiceProto, 4).positionHandler(proto); // ~200 ms setup
+      YSE::sound snd;
+      snd.create(syn);
+      snd.play();
+      // Queue the note NOW — the setup job has not even been scheduled yet.
+      syn.noteOn(1, 60, 0.8f);
+
+      // Render for ~100 ms of wall time. The single setup worker is asleep in
+      // SlowCloneVoice::clone(), so the sound comes up and renders many blocks
+      // while the synth is still OBJECT_SETTING_UP — the exact window in which
+      // the queued note used to be popped and discarded.
+      const auto until = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+      while (std::chrono::steady_clock::now() < until) {
+        YSE::System().update();
+        YSE::System().renderOffline(1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+      }
+
+      // Once the voices exist the deferred note must arm on the next blocks
+      // and sit on the handler's radius-2 ring — not silently vanish.
+      REQUIRE(bringToReady(syn, 4));
+      pump(2);
+      CHECK(planarRadius(syn.getVoicePosition(1, 60)) == doctest::Approx(2.0).epsilon(0.05));
 
       snd.stop();
       pump(4);

--- a/YseEngine/synth/synthImplementation.cpp
+++ b/YseEngine/synth/synthImplementation.cpp
@@ -90,7 +90,10 @@ namespace YSE {
     }
 
     int implementationObject::getNumVoices() const {
-      return numVoicesTotal.load(std::memory_order_relaxed);
+      // Acquire pairs with the release store at the end of setup(): a caller
+      // that observes the final voice count also observes OBJECT_SETUP — the
+      // synth accepts (and no longer defers) messages from that point on (#352).
+      return numVoicesTotal.load(std::memory_order_acquire);
     }
 
     Flt implementationObject::getChannelPitchWheel(int channel) const {
@@ -172,7 +175,6 @@ namespace YSE {
       int total = 0;
       for (auto& g : groups)
         total += static_cast<int>(g.voices.size());
-      numVoicesTotal.store(total, std::memory_order_relaxed);
 
       stealFadeSamples = std::max(1, static_cast<int>(SAMPLERATE * kStealFadeSec));
 
@@ -186,6 +188,12 @@ namespace YSE {
       // window where an addVoiceGroup() could append a request this setup will
       // never build (it is serialised on buildMutex and now sees OBJECT_SETUP).
       objectStatus.store(OBJECT_SETUP, std::memory_order_release);
+
+      // The voice count is published strictly after OBJECT_SETUP: observing
+      // getNumVoices() == N must imply the synth is message-ready, because the
+      // count is the public readiness signal hosts and tests poll before
+      // sending notes (#352). Release pairs with the acquire in getNumVoices().
+      numVoicesTotal.store(total, std::memory_order_release);
     }
 
     bool implementationObject::readyCheck() {
@@ -254,19 +262,23 @@ namespace YSE {
       const OBJECT_IMPLEMENTATION_STATE st = objectStatus.load(std::memory_order_acquire);
       const bool ready = (st == OBJECT_SETUP || st == OBJECT_READY);
 
-      // 1. Drain the inbox so every note event for this block takes effect
-      //    before any audio is produced. Events arriving before the synth is
-      //    ready are discarded (they have no group to target yet).
-      messageObject m;
-      while (messages.try_pop(m)) {
-        if (ready) parseMessage(m);
-      }
-
       if (!ready) {
-        // 2. Clear whatever aggregate buffers exist (may be unsized pre-setup).
+        // Not set up yet: leave the inbox untouched so the render path never
+        // destroys queued events — messages arriving while the voices are
+        // still cloning stay in the SPSC inbox and take effect on the first
+        // ready block (#352; the only drop is sendMessage()'s logged overflow).
+        // Just clear whatever aggregate buffers exist (may be unsized
+        // pre-setup).
         for (auto& b : output.samples)
           b = 0.f;
         return;
+      }
+
+      // 1. Drain the inbox so every note event for this block takes effect
+      //    before any audio is produced.
+      messageObject m;
+      while (messages.try_pop(m)) {
+        parseMessage(m);
       }
 
       // Size the device-width bed + voice panners to the current output width.


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring `yse_tests_synthhandlers` CI flake (all-zero
voice-position reads). Two changes in `YseEngine/synth/synthImplementation.cpp`:

1. **Defer, don't drop.** `renderBlock()` no longer pops the SPSC inbox while
   the impl is not ready. Previously it popped and *discarded* every message
   when `objectStatus ∉ {OBJECT_SETUP, OBJECT_READY}` — so a noteOn sent while
   voices were still cloning on the (single, FIFO) setup worker was destroyed
   forever: the voice never armed, `getVoicePosition()` read `Pos(0)` for the
   rest of the test case, and a later `notePosition()` no-oped. Messages now
   stay queued and take effect on the first ready block. The not-ready branch
   does strictly less work than before (no pops) — the audio-callback path only
   gets cheaper. On live devices this also fixes real note loss: MIDI sent
   while a synth is loading used to vanish silently.

2. **Publish readiness in the right order.** `setup()` stored `numVoicesTotal`
   *before* `ensureDeviceWidth()` and the `OBJECT_SETUP` release-store, and
   `getNumVoices()` used a relaxed load. Tests/hosts poll `getNumVoices()` as
   the readiness gate before sending notes (`bringToReady()` in the synth
   suites), so the gate could open mid-setup — under a gcov-instrumented Debug
   build on a loaded 2-vCPU runner, the worker gets preempted between the two
   stores and the first notes land in the discard window from (1). The count
   is now release-stored strictly after `OBJECT_SETUP`, and `getNumVoices()`
   acquire-loads it: observing the final voice count implies message-ready.

## Linked issues

Closes #352
Closes #343
Closes #351

## Why the as-filed fixes were moot

- **#343 (widen `pump(2)`):** the drop happens at the *first rendered block*
  after the noteOn, while the synth is still `OBJECT_SETTING_UP`. Widening the
  pump before the *read* cannot un-drop a message that was already destroyed,
  and "pump until the position is observed" would simply time out.
- **#351 (isolate the suite from the monolithic run):** already the case. Its
  own evidence cites failures in "test #15 `yse_tests_synthhandlers`" — the
  dedicated per-suite ctest process. `synthhandlers` has been excluded from the
  monolithic `yse_unit_tests` entry since the suite was born (aa8441d, #170;
  see `Tests/CMakeLists.txt`). The failures were load/instrumentation-dependent
  (coverage build widens the preemption window), not cross-suite teardown, so
  further isolation cannot help.

The pre-existing exclusion list is untouched: the lifecycle-suite isolations
guard `System::close()` process-global teardown and #304's channel-churn race —
different roots, out of scope here.

## Semantics change (called out)

Messages sent to a created-but-still-loading synth are now **deferred and
applied once setup completes** (previously: silently dropped). A >1024 backlog
still drops at the producer via `sendMessage()`'s non-allocating `try_push`,
with the existing debug log — no worse than today, and no allocation added
anywhere.

## Regression test

`synthhandlers: notes sent before setup are deferred until ready`
(`Tests/synth/test_synth_handlers.cpp`): a `SlowCloneVoice` whose `clone()`
sleeps 50 ms on the setup pool pins the synth in `OBJECT_SETTING_UP` for
~200 ms while the owning sound is already rendering — the exact window —
machine-speed independent. **Verified to fail on the unfixed engine** with the
exact CI signature before the fix was applied:

```
test_synth_handlers.cpp:505: CHECK( planarRadius(...) == Approx(2.0) ) -> CHECK( 0 == Approx( 2 ) )
```

## Test plan

- [x] Regression test fails pre-fix (`0 == Approx(2)`, first run), passes post-fix
- [x] `python yse.py test`: 32/32 ctest entries pass (incl. monolithic `yse_unit_tests`)
- [x] `yse_tests --test-suite=synthhandlers` 60× loop on Windows: 0 failures
- [x] Same suite at `YSE_TEST_FORCED_RATE=48000`: pass
- [x] 60× loop in the CI-faithful coverage container (`tools/ci-linux`, gcc Debug + `YSE_ENABLE_COVERAGE=ON`): 0 failures / 60 runs
- [x] `python yse.py analyze` on both touched files: no new findings (one pre-existing `performance-inefficient-vector-operation` in an untouched test loop, present on dev)
- [x] `python yse.py format`: no reformatting needed (clang-format 22.1.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
