### PR TITLE
TESTS: restore concurrency stress cases in the monolithic unit-test run (#304)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -201,17 +201,15 @@ add_test(
   # / yse_tests_synthlifecycle / yse_tests_synthcapi / yse_tests_midisynth /
   # yse_tests_playersynth / yse_tests_playercapi.
   #
-  # `* concurrency: *` (the cross-subsystem create/destroy + race stress cases:
-  # channel/sound/reverb/io/listener/midifile) is excluded here too and runs
-  # only in the dedicated, uncrowded yse_tests_concurrency process — the exact
-  # same filter that entry uses to *include* them. In this ~1100-case combined
-  # process the channel manager two-thread churn case hits a pre-existing,
-  # heap-layout-dependent cross-thread manager race (#41/#298 lineage): the wide
-  # race window makes it flake (hang or SIGSEGV) regardless of the code under
-  # test — a latent landmine that also flakes on dev. Isolating these mirrors the
-  # suite exclusions above and loses no coverage: yse_tests_concurrency plus the
-  # per-suite entries still run every case. Tracked in #304; the root fix is
-  # #41/#298 engine work.
+  # The `* concurrency: *` stress cases run here again (issue #304). They were
+  # temporarily excluded when the crowded ~1100-case process flaked (hang or
+  # SIGSEGV) in the channel two-thread churn case; the root cause turned out to
+  # be the channel impl ctor leaving `objectStatus` uninitialised, letting the
+  # slow-pool deleteJob free a node mid-construction (issue #336, fixed in
+  # PR #337). With that fixed, running the stress cases in this warm-heap,
+  # thread-churning process is deliberate coverage — it is exactly the
+  # environment that exposed #336 — on top of the dedicated
+  # yse_tests_concurrency entry and the per-suite entries.
   # `sendstress` is excluded too: like the lifecycle suites it drives
   # System::initOffline() (process-global engine state), so it must run in its
   # own process (yse_tests_sendstress) rather than in this shared one.
@@ -225,7 +223,7 @@ add_test(
   # `clip` (issue #250 clip transport) is excluded for the same reason as
   # `clock`: its cases drive CLOCK::Manager().update() / CLIP::Manager().update()
   # directly on the test thread. It runs isolated in yse_tests_clip.
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos,clock,clip "--test-case-exclude=* concurrency: *" --duration=true
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos,clock,clip --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)


### PR DESCRIPTION
## Summary

Lifts the #304 containment now that its root cause is fixed. The `* concurrency: *` stress cases were excluded from the monolithic `yse_unit_tests` ctest entry (bb0faf6) because the crowded ~1100-case process flaked (hang or SIGSEGV) in the channel two-thread create/destroy churn case. At the time the root cause was unknown and presumed to be deferred #41/#298 engine work.

It wasn't: the root cause was pinned and fixed in #336 / PR #337 — `CHANNEL::implementationObject`'s ctor left `objectStatus` (a C++17 `std::atomic`, default ctor leaves it indeterminate) uninitialised, so the slow-pool deleteJob could free a node mid-construction when the recycled heap slot happened to hold the `OBJECT_DELETE` bit pattern. With that fixed, the containment is obsolete, and the stale comment claiming "the root fix is #41/#298 engine work" is corrected.

Restoring the cases is deliberate coverage, not just cleanup: the warm-heap, thread-churning monolithic process is exactly the environment that exposed #336, so running the stress cases there again keeps that canary armed — on top of the dedicated `yse_tests_concurrency` entry and the per-suite entries, which never stopped running them.

## Linked issue

Closes #304

## Changes

- `Tests/CMakeLists.txt` — drop `"--test-case-exclude=* concurrency: *"` from the `yse_unit_tests` command; replace the containment comment with the actual root-cause history (#336/#337) and the rationale for keeping the stress cases in the crowded process.

## Test plan

- [x] Linux CI-faithful coverage container (`tools/ci-linux`, Ubuntu 24.04, gcc, `-DYSE_ENABLE_COVERAGE=ON` — the environment where #304 originally reproduced at iters 2 and 9 of 20): restored monolithic command looped **20/20 clean**, ~347,353 assertions per run.
- [x] Windows (MSYS2 Clang64) `python yse.py test`: full ctest **32/32 pass** with the restored entry.
- [x] Windows `ctest -R '^yse_unit_tests$' --repeat until-fail:10`: **10/10 pass** (~21 s each).
- [x] `yse.py analyze` — n/a: the diff touches only `Tests/CMakeLists.txt`, no C++ sources for clang-tidy.
- [x] Integration test: not applicable — test-infrastructure-only change with no user-visible engine behavior; the verification above *is* the end-to-end exercise of the changed ctest entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)