### PR TITLE
BENCH: bound patcher structural-edit benches so the CI bench lane survives (#315)

### DIFF
--- a/Bench/patcher/bench_patcher.cpp
+++ b/Bench/patcher/bench_patcher.cpp
@@ -12,6 +12,33 @@
 // and PassData every frame for any patcher-driven parameter. A regression
 // in any of them maps directly to frame budget consumed by the audio
 // system.
+//
+// ── Why these benches recycle the patcher in batches (issue #315) ─────────
+//
+// Since the GraphState rework (issue #226), every structural edit
+// (CreateObject / Connect / Disconnect / Clear / ParseJSON) compiles and
+// publishes a fresh immutable snapshot and retires the previous one. Two
+// consequences for a benchmark loop, neither of which production code hits:
+//
+//  1. Retired snapshots/objects are reclaimed only after the patcher's
+//     audio-thread block counter advances past their retirement epoch
+//     (issue #227). These benches run with no audio thread at all
+//     (offline init, nothing renders the patcher), so the epoch never
+//     advances and *every* retired snapshot is held until the patcher
+//     itself is destroyed.
+//
+//  2. Graph ids are stamped once per inlet/outlet and never reused within
+//     a patcherImplementation, and every GraphState allocates id-indexed
+//     tables. A loop that keeps creating objects therefore makes each
+//     successive snapshot bigger, so cost and retained memory grow
+//     quadratically with iteration count.
+//
+// At the previous 100k-iteration cap this added up to a multi-GB,
+// effectively never-finishing run that took down the CI bench lane on
+// every dev push (issue #315). Recycling the patcher every kEditBatch
+// iterations — outside the timed region; its destructor frees all retired
+// state and resets the id counters — bounds both effects while keeping
+// the measured per-iteration operation identical.
 
 #include "yse.hpp"
 #include "patcher/patcher.hpp"
@@ -21,9 +48,32 @@
 
 #include <benchmark/benchmark.h>
 
+#include <memory>
 #include <string>
 
 namespace {
+
+// Iterations between patcher recycles. Keeps the per-batch id count (and
+// with it the size of every snapshot built in the batch) small and bounds
+// un-reclaimed retired state to a couple of MB. Also deliberately below
+// the patcher's 256-slot value-queue capacity so BM_Patcher_PassFloat
+// always measures the real enqueue path, never the queue-full drop+log
+// path (with no audio thread the queue is never drained).
+constexpr int kEditBatch = 64;
+
+// Iteration cap for the structural-edit benches. They cannot use
+// google-benchmark's default min-time autoscaling for the reasons above,
+// and BenchHelpers::kLeakyBenchIterations (100k) is far more than needed
+// for a stable aggregate on µs-scale ops: 8192 keeps each repetition in
+// the tens-of-milliseconds range while the 3-repetition aggregates stay
+// well inside the bench lane's 110% alert threshold.
+constexpr int kEditIterations = 8192;
+
+std::unique_ptr<YSE::patcher> makePatcher() {
+    auto p = std::make_unique<YSE::patcher>();
+    p->create(2);
+    return p;
+}
 
 // Build a representative 5-object signal-flow graph:
 //   sine → biquad → delay → DAC, with a receive object for external control.
@@ -52,15 +102,22 @@ static void BM_Patcher_BuildSmallGraph(benchmark::State& state) {
         state.SkipWithError("YSE::System().init() failed");
         return;
     }
-    YSE::patcher p;
-    p.create(2);
+    auto p = makePatcher();
 
+    int inBatch = 0;
     for (auto _ : state) {
-        buildSmallGraph(p);
-        benchmark::DoNotOptimize(&p);
+        if (inBatch == kEditBatch) {
+            state.PauseTiming();
+            p = makePatcher();  // frees all retired state, resets graph ids
+            inBatch = 0;
+            state.ResumeTiming();
+        }
+        ++inBatch;
+        buildSmallGraph(*p);
+        benchmark::DoNotOptimize(p.get());
     }
 }
-BENCHMARK(BM_Patcher_BuildSmallGraph)->Iterations(BenchHelpers::kLeakyBenchIterations);
+BENCHMARK(BM_Patcher_BuildSmallGraph)->Iterations(kEditIterations);
 
 // ── CreateObject only — isolates per-object construction cost ────────────
 
@@ -69,19 +126,26 @@ static void BM_Patcher_CreateObject(benchmark::State& state) {
         state.SkipWithError("YSE::System().init() failed");
         return;
     }
-    YSE::patcher p;
-    p.create(2);
+    auto p = makePatcher();
 
+    int inBatch = 0;
     for (auto _ : state) {
-        auto* h = p.CreateObject(YSE::OBJ::D_SINE, "440");
+        if (inBatch == kEditBatch) {
+            state.PauseTiming();
+            p = makePatcher();
+            inBatch = 0;
+            state.ResumeTiming();
+        }
+        ++inBatch;
+        auto* h = p->CreateObject(YSE::OBJ::D_SINE, "440");
         benchmark::DoNotOptimize(h);
         // Keep the patcher from growing without bound — if we let it,
         // later iterations would see a larger object list and the
         // per-create cost would creep up across the run.
-        p.Clear();
+        p->Clear();
     }
 }
-BENCHMARK(BM_Patcher_CreateObject)->Iterations(BenchHelpers::kLeakyBenchIterations);
+BENCHMARK(BM_Patcher_CreateObject)->Iterations(kEditIterations);
 
 // ── Connect — pure edge-insertion cost ───────────────────────────────────
 
@@ -90,21 +154,31 @@ static void BM_Patcher_Connect(benchmark::State& state) {
         state.SkipWithError("YSE::System().init() failed");
         return;
     }
-    YSE::patcher p;
-    p.create(2);
+    auto p = makePatcher();
+    auto* a = p->CreateObject(YSE::OBJ::D_SINE,    "440");
+    auto* b = p->CreateObject(YSE::OBJ::D_LOWPASS, "2000");
 
-    auto* a = p.CreateObject(YSE::OBJ::D_SINE,    "440");
-    auto* b = p.CreateObject(YSE::OBJ::D_LOWPASS, "2000");
-
+    // The two objects live for the whole batch, so ids stay constant here;
+    // the recycle only bounds the retired snapshots the edits produce.
+    int inBatch = 0;
     for (auto _ : state) {
-        p.Connect(a, 0, b, 0);
+        if (inBatch == kEditBatch) {
+            state.PauseTiming();
+            p = makePatcher();
+            a = p->CreateObject(YSE::OBJ::D_SINE,    "440");
+            b = p->CreateObject(YSE::OBJ::D_LOWPASS, "2000");
+            inBatch = 0;
+            state.ResumeTiming();
+        }
+        ++inBatch;
+        p->Connect(a, 0, b, 0);
         // Disconnect immediately so the next iteration sees the same
         // starting state (no degenerate "edge already exists" fast path).
-        p.Disconnect(a, 0, b, 0);
-        benchmark::DoNotOptimize(&p);
+        p->Disconnect(a, 0, b, 0);
+        benchmark::DoNotOptimize(p.get());
     }
 }
-BENCHMARK(BM_Patcher_Connect)->Iterations(BenchHelpers::kLeakyBenchIterations);
+BENCHMARK(BM_Patcher_Connect)->Iterations(kEditIterations);
 
 // ── JSON serialise ───────────────────────────────────────────────────────
 
@@ -113,6 +187,8 @@ static void BM_Patcher_DumpJSON(benchmark::State& state) {
         state.SkipWithError("YSE::System().init() failed");
         return;
     }
+    // DumpJSON does no structural edits, so no recycling is needed: nothing
+    // is retired and the default min-time iteration count is safe.
     YSE::patcher p;
     p.create(2);
     buildSmallGraph(p);
@@ -136,15 +212,22 @@ static void BM_Patcher_ParseJSON(benchmark::State& state) {
     buildSmallGraph(source);
     const std::string json = source.DumpJSON();
 
-    YSE::patcher target;
-    target.create(2);
+    auto target = makePatcher();
 
+    int inBatch = 0;
     for (auto _ : state) {
-        target.ParseJSON(json);
-        benchmark::DoNotOptimize(&target);
+        if (inBatch == kEditBatch) {
+            state.PauseTiming();
+            target = makePatcher();
+            inBatch = 0;
+            state.ResumeTiming();
+        }
+        ++inBatch;
+        target->ParseJSON(json);
+        benchmark::DoNotOptimize(target.get());
     }
 }
-BENCHMARK(BM_Patcher_ParseJSON)->Iterations(BenchHelpers::kLeakyBenchIterations);
+BENCHMARK(BM_Patcher_ParseJSON)->Iterations(kEditIterations);
 
 // ── External message dispatch ────────────────────────────────────────────
 
@@ -153,16 +236,28 @@ static void BM_Patcher_PassFloat(benchmark::State& state) {
         state.SkipWithError("YSE::System().init() failed");
         return;
     }
-    YSE::patcher p;
-    p.create(2);
-    buildSmallGraph(p);  // has a `.r freq` receive object
+    auto p = makePatcher();
+    buildSmallGraph(*p);  // has a `.r freq` receive object
 
+    // PassData enqueues on a fixed 256-slot queue that only the (absent)
+    // audio thread drains. Recycling every kEditBatch (< 256) iterations
+    // keeps the queue from filling, so every iteration measures the real
+    // enqueue path rather than the drop-and-log backpressure path.
+    int inBatch = 0;
     float v = 0.0f;
     for (auto _ : state) {
+        if (inBatch == kEditBatch) {
+            state.PauseTiming();
+            p = makePatcher();
+            buildSmallGraph(*p);
+            inBatch = 0;
+            state.ResumeTiming();
+        }
+        ++inBatch;
         v += 1.0f;
         if (v > 2000.0f) v = 100.0f;
-        bool ok = p.PassData(v, "freq");
+        bool ok = p->PassData(v, "freq");
         benchmark::DoNotOptimize(ok);
     }
 }
-BENCHMARK(BM_Patcher_PassFloat)->Iterations(BenchHelpers::kLeakyBenchIterations);
+BENCHMARK(BM_Patcher_PassFloat)->Iterations(kEditIterations);


### PR DESCRIPTION
## Summary

The Benchmarks workflow has been red on every dev push since PR #230 (last green run: the #224 merge, 2026-07-03 12:30 UTC; first red: the #230 merge, 14:11 UTC). The suspicion in the issue was right — it is the patcher benchmarks — but the mechanism is not a deadlock: since the GraphState rework (#226), every structural edit (`CreateObject` / `Connect` / `Disconnect` / `Clear` / `ParseJSON`) compiles and publishes a fresh immutable snapshot and retires the previous one. The bench binary runs with **no audio thread at all** (offline init, nothing renders the patcher), so:

1. the reclaim epoch (#227) never advances past retirement, and every retired snapshot/object is held until the patcher is destroyed, and
2. graph ids are never reused within a `patcherImplementation`, and every `GraphState` allocates id-indexed tables — so a loop that keeps creating objects makes each successive snapshot bigger.

At `Iterations(100000)` × 3 repetitions the edit benches became quadratic in both time and memory: `BM_Patcher_BuildSmallGraph` alone no longer finishes in CI timeframes (locally it burns >30 s and hundreds of MB without completing one repetition, where pre-#226 in-place edits finished in well under a second). CI dies ~17 s into that churn with SIGTERM/143 — the GHA runner killing the busy job — well before the 25-minute step timeout, which is why the log shows silence after `BM_MpmcQueue_8P8C` and then exit 143.

## Linked issue

Closes #315

## Changes

- `Bench/patcher/bench_patcher.cpp`: the structural-edit benches (`BuildSmallGraph`, `CreateObject`, `Connect`, `ParseJSON`, `PassFloat`) now recycle the patcher every 64 iterations, **outside the timed region** (`PauseTiming`/`ResumeTiming`) — the patcher destructor frees all retired state and resets the id counters, bounding both growth mechanisms while the measured per-iteration op stays identical.
- Edit benches drop from the 100k leaky-queue iteration cap to 8192 fixed iterations (µs-scale ops; per-repetition runtime is tens of ms, well within the lane's 110% fail-soft alert budget).
- The 64-iteration recycle batch is deliberately below the patcher's 256-slot value-queue capacity, so `BM_Patcher_PassFloat` now always measures the real enqueue path — previously (post-#225) the queue filled after 256 sends and the remaining ~99.7k iterations timed the drop-and-log backpressure path while spamming the engine log.
- `BM_Patcher_DumpJSON` is untouched (no structural edits, nothing retired).

No engine code is touched; nothing on the audio-thread path changes. The engine-side id-growth observation (long-lived live-edited patchers pay O(total-ids-ever) per edit) is filed separately as #355 — out of scope for this branch.

## Test plan

- [x] Formatter: CI's format gate scopes `YseEngine/ Tests/` (Bench/ excluded); `python yse.py format` leaves the tree clean.
- [x] `python yse.py analyze` equivalent on the changed file (`clang-tidy -p build-bench`): 6 findings, all pre-existing `clang-analyzer-deadcode.DeadStores` on the mandatory `for (auto _ : state)` google-benchmark idiom — identical count on the unmodified file, no new findings.
- [x] **Linux CI repro** (tools/ci-linux `yse-ci` image, 7 GB memory cap, exact benchmark.yml flags — `--benchmark_repetitions=3 --benchmark_report_aggregates_only=true --benchmark_out=json`): full suite completes end-to-end (through the integration/synth benches registered after patcher) in **3m42s, exit 0**, valid JSON produced. Before the fix the run never gets past the first patcher bench.
- [x] Windows (MSYS2 Clang64, `build-bench`): patcher benches complete in 4.3 s with 15 MB peak private memory (previously: unbounded growth, no completion); full suite completes in 4.9 min, exit 0, 133 MB peak.
- [x] Repro confirmed before fixing: the pre-fix binary's `BM_Patcher_BuildSmallGraph` shows monotonic memory growth and does not finish a single 100k-iteration repetition in 30 s.
- No unit-test changes: this diff touches only `Bench/` (no runtime engine surface). Integration coverage *is* the benchmark suite run above, executed in the same container/flags CI uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
