### PR TITLE
DSP: generalize the morphing reverb's morph input to a control signal (#326)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -463,7 +463,7 @@ sound.play()
                                                  └── device output (PortAudio / Oboe)
 ```
 
-Channel routing (epic [#146](https://github.com/yvanvds/yse-soundengine/issues/146)): each `YSE::channel` carries an optional pre-fader **insert** chain (`setDSP`, a linked `dspObject` list) and up to N **aux sends** to **return buses** (`makeReturn` / `send` / `setSendLevel`). Returns are ordinary channels flagged as returns — they keep their own inserts and may send onward to other returns (the send graph must stay acyclic). Mix-grade effect modules for these slots live in `dsp/modules/` (`parametricEQ`, `compressor`, `chorus`, `plateReverb`, `delay/feedbackDelay`).
+Channel routing (epic [#146](https://github.com/yvanvds/yse-soundengine/issues/146)): each `YSE::channel` carries an optional pre-fader **insert** chain (`setDSP`, a linked `dspObject` list) and up to N **aux sends** to **return buses** (`makeReturn` / `send` / `setSendLevel`). Returns are ordinary channels flagged as returns — they keep their own inserts and may send onward to other returns (the send graph must stay acyclic). Mix-grade effect modules for these slots live in `dsp/modules/` (`parametricEQ`, `compressor`, `chorus`, `plateReverb`, `morphingReverb`, `delay/feedbackDelay`).
 
 ---
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(YSE_TEST_SOURCES
   dsp/test_module_feedback_delay.cpp
   dsp/test_module_chorus.cpp
   dsp/test_module_plate_reverb.cpp
+  dsp/test_module_morphing_reverb.cpp
   dsp/test_module_parametric_eq.cpp
   dsp/test_module_compressor.cpp
   dsp/test_module_multichannel.cpp

--- a/Tests/dsp/test_module_morphing_reverb.cpp
+++ b/Tests/dsp/test_module_morphing_reverb.cpp
@@ -1,0 +1,303 @@
+// Behavioural tests for the morphing reverb MODULE (issue #326).
+//
+// morphingReverb packages the engine's reverb core (INTERNAL::reverbDSP) as a
+// chainable dspObject whose preset interpolation is a *control input*: two
+// endpoint parameter sets (slot A / slot B, named presets or custom
+// REVERB::presetValues) are linearly blended by morph(t) in [0, 1]. Writes are
+// atomic stores; the audio thread applies the blend through the core's ~1 s
+// faders, so morph moves are click-free.
+//
+// The acceptance criteria (issue #326) drive the cases below:
+//   - the shared preset table carries exactly the values reverb::setPreset
+//     has always applied (bit-compatibility of the extraction)
+//   - the morph control input actually drives the blend (t = 0 sounds like A,
+//     t = 1 sounds like B), is clamped, and survives sweeps without blowing up
+//   - steady-state process() allocates nothing; a channel-count change is
+//     tolerated (the one allocation-permitted path)
+//
+// No audio device required — SAMPLERATE is initialised by the
+// portaudioDeviceManager translation unit at static-initialisation time.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include "dsp/modules/morphingReverb.hpp"
+#include "reverb/reverbPresets.hpp"
+#include "headers/defines.hpp"
+#include "support/alloc_probe.hpp"
+#include "support/audio_helpers.hpp"
+
+namespace {
+
+  // The reverb core's faders ramp over 1000 ms = SAMPLERATE samples. With the
+  // default 128-sample test blocks that is ~345 blocks at 44.1 kHz and ~375 at
+  // 48 kHz; 500 blocks settles the faders at any supported rate.
+  constexpr int kSettleBlocks = 500;
+
+  // Process n silent blocks through the module (channels-count channels),
+  // discarding output. The input is re-zeroed every block because process()
+  // overwrites it with the reverb output.
+  void runSilence(YSE::DSP::MODULES::morphingReverb& rev, int n, unsigned channels = 1) {
+    MULTICHANNELBUFFER buf(channels);
+    for (int i = 0; i < n; ++i) {
+      for (unsigned ch = 0; ch < channels; ++ch)
+        buf[ch] = 0.0f;
+      rev.process(buf);
+    }
+  }
+
+  // Feed one impulse, then integrate the wet output energy over `blocks`
+  // silent blocks — a monotone proxy for how much reverb the module produces.
+  float impulseTailEnergy(YSE::DSP::MODULES::morphingReverb& rev, int blocks) {
+    MULTICHANNELBUFFER buf(1);
+    buf[0] = 0.0f;
+    buf[0].getPtr()[0] = 1.0f;
+    rev.process(buf);
+
+    float energy = 0.0f;
+    for (int i = 0; i < blocks; ++i) {
+      buf[0] = 0.0f;
+      rev.process(buf);
+      float rms = TestHelpers::measureRms(buf[0]);
+      energy += rms * rms;
+    }
+    return energy;
+  }
+
+  bool sameValues(const YSE::REVERB::presetValues& a, const YSE::REVERB::presetValues& b) {
+    bool same = a.roomsize == b.roomsize && a.damp == b.damp && a.dry == b.dry && a.wet == b.wet &&
+                a.modFrequency == b.modFrequency && a.modWidth == b.modWidth;
+    for (int i = 0; i < 4; ++i)
+      same = same && a.earlyTime[i] == b.earlyTime[i] && a.earlyGain[i] == b.earlyGain[i];
+    return same;
+  }
+
+} // anonymous namespace
+
+TEST_SUITE("dsp") {
+
+  // ─── the shared preset table (issue #326 extraction) ──────────────────────────
+
+  TEST_CASE("morphingReverb: preset table matches the historical setPreset values") {
+    // Spot-check the extracted table against the values reverb::setPreset has
+    // always applied (and that the interface tests in test_reverb_dsp.cpp
+    // still verify through the reverb interface).
+    const YSE::REVERB::presetValues& off = YSE::REVERB::getPresetValues(YSE::REVERB_OFF);
+    CHECK(off.roomsize == doctest::Approx(0.0f));
+    CHECK(off.damp == doctest::Approx(0.0f));
+    CHECK(off.dry == doctest::Approx(1.0f));
+    CHECK(off.wet == doctest::Approx(0.0f));
+
+    const YSE::REVERB::presetValues& generic = YSE::REVERB::getPresetValues(YSE::REVERB_GENERIC);
+    CHECK(generic.roomsize == doctest::Approx(0.5f));
+    CHECK(generic.damp == doctest::Approx(0.5f));
+    CHECK(generic.dry == doctest::Approx(0.6f));
+    CHECK(generic.wet == doctest::Approx(0.4f));
+
+    const YSE::REVERB::presetValues& hall = YSE::REVERB::getPresetValues(YSE::REVERB_HALL);
+    CHECK(hall.roomsize == doctest::Approx(0.7f));
+    CHECK(hall.damp == doctest::Approx(0.4f));
+    CHECK(hall.dry == doctest::Approx(0.5f));
+    CHECK(hall.wet == doctest::Approx(0.5f));
+
+    const YSE::REVERB::presetValues& cave = YSE::REVERB::getPresetValues(YSE::REVERB_CAVE);
+    CHECK(cave.roomsize == doctest::Approx(1.0f));
+    CHECK(cave.wet == doctest::Approx(0.7f));
+    CHECK(cave.dry == doctest::Approx(0.3f));
+    CHECK(cave.earlyTime[0] == doctest::Approx(100.0f));
+    CHECK(cave.earlyGain[0] == doctest::Approx(0.8f));
+
+    const YSE::REVERB::presetValues& pipe = YSE::REVERB::getPresetValues(YSE::REVERB_SEWERPIPE);
+    CHECK(pipe.modFrequency == doctest::Approx(3.5f));
+    CHECK(pipe.modWidth == doctest::Approx(20.0f));
+    CHECK(pipe.earlyTime[2] == doctest::Approx(1100.0f));
+    CHECK(pipe.earlyGain[2] == doctest::Approx(0.01f));
+  }
+
+  TEST_CASE("morphingReverb: preset lookup is range-safe") {
+    // Out-of-range enum values fall back to REVERB_OFF instead of reading
+    // past the table.
+    const YSE::REVERB::presetValues& bogus =
+        YSE::REVERB::getPresetValues(static_cast<YSE::REVERB_PRESET>(9999));
+    CHECK(sameValues(bogus, YSE::REVERB::getPresetValues(YSE::REVERB_OFF)));
+  }
+
+  // ─── the interpolation core ───────────────────────────────────────────────────
+
+  TEST_CASE("morphingReverb: morph(a, b, 0) returns a and morph(a, b, 1) returns b") {
+    const YSE::REVERB::presetValues& a = YSE::REVERB::getPresetValues(YSE::REVERB_CAVE);
+    const YSE::REVERB::presetValues& b = YSE::REVERB::getPresetValues(YSE::REVERB_PADDED);
+
+    CHECK(sameValues(YSE::REVERB::morph(a, b, 0.0f), a));
+    CHECK(sameValues(YSE::REVERB::morph(a, b, 1.0f), b));
+  }
+
+  TEST_CASE("morphingReverb: morph interpolates every field linearly") {
+    const YSE::REVERB::presetValues& a = YSE::REVERB::getPresetValues(YSE::REVERB_OFF);
+    const YSE::REVERB::presetValues& b = YSE::REVERB::getPresetValues(YSE::REVERB_CAVE);
+
+    YSE::REVERB::presetValues mid = YSE::REVERB::morph(a, b, 0.5f);
+    CHECK(mid.roomsize == doctest::Approx(0.5f)); // 0 → 1
+    CHECK(mid.dry == doctest::Approx(0.65f)); // 1 → 0.3
+    CHECK(mid.wet == doctest::Approx(0.35f)); // 0 → 0.7
+    CHECK(mid.earlyTime[3] == doctest::Approx(400.0f)); // 0 → 800
+    CHECK(mid.earlyGain[3] == doctest::Approx(0.25f)); // 0 → 0.5
+  }
+
+  TEST_CASE("morphingReverb: morph clamps t to [0, 1]") {
+    const YSE::REVERB::presetValues& a = YSE::REVERB::getPresetValues(YSE::REVERB_OFF);
+    const YSE::REVERB::presetValues& b = YSE::REVERB::getPresetValues(YSE::REVERB_CAVE);
+
+    CHECK(sameValues(YSE::REVERB::morph(a, b, -3.0f), a));
+    CHECK(sameValues(YSE::REVERB::morph(a, b, 42.0f), b));
+  }
+
+  // ─── module parameters ────────────────────────────────────────────────────────
+
+  TEST_CASE("morphingReverb: sensible defaults") {
+    YSE::DSP::MODULES::morphingReverb rev;
+    CHECK(rev.morph() == doctest::Approx(0.0f));
+    CHECK(sameValues(rev.presetA(), YSE::REVERB::getPresetValues(YSE::REVERB_GENERIC)));
+    CHECK(sameValues(rev.presetB(), YSE::REVERB::getPresetValues(YSE::REVERB_HALL)));
+  }
+
+  TEST_CASE("morphingReverb: preset slots round-trip (named and custom)") {
+    YSE::DSP::MODULES::morphingReverb rev;
+    rev.presetA(YSE::REVERB_CAVE).presetB(YSE::REVERB_OFF);
+    CHECK(sameValues(rev.presetA(), YSE::REVERB::getPresetValues(YSE::REVERB_CAVE)));
+    CHECK(sameValues(rev.presetB(), YSE::REVERB::getPresetValues(YSE::REVERB_OFF)));
+
+    YSE::REVERB::presetValues custom = YSE::REVERB::getPresetValues(YSE::REVERB_HALL);
+    custom.dry = 0.0f; // send/return flavour: fully wet
+    custom.wet = 1.0f;
+    rev.presetB(custom);
+    CHECK(sameValues(rev.presetB(), custom));
+  }
+
+  TEST_CASE("morphingReverb: morph control input is clamped") {
+    YSE::DSP::MODULES::morphingReverb rev;
+    rev.morph(7.5f);
+    CHECK(rev.morph() == doctest::Approx(1.0f));
+    rev.morph(-2.0f);
+    CHECK(rev.morph() == doctest::Approx(0.0f));
+    rev.morph(0.25f);
+    CHECK(rev.morph() == doctest::Approx(0.25f));
+  }
+
+  // ─── behaviour: the control input drives the blend ────────────────────────────
+
+  TEST_CASE("morphingReverb: morph position selects the audible space") {
+    // A = CAVE (long, wet), B = OFF (dry pass-through). At morph 0 an impulse
+    // must leave a reverb tail; at morph 1 it must not.
+    float wetTail = 0.0f;
+    {
+      YSE::DSP::MODULES::morphingReverb rev;
+      rev.presetA(YSE::REVERB_CAVE).presetB(YSE::REVERB_OFF).morph(0.0f);
+      runSilence(rev, kSettleBlocks);
+      wetTail = impulseTailEnergy(rev, 60);
+    }
+
+    float dryTail = 0.0f;
+    {
+      YSE::DSP::MODULES::morphingReverb rev;
+      rev.presetA(YSE::REVERB_CAVE).presetB(YSE::REVERB_OFF).morph(1.0f);
+      runSilence(rev, kSettleBlocks);
+      dryTail = impulseTailEnergy(rev, 60);
+    }
+
+    CHECK(wetTail > 0.0f);
+    CHECK(dryTail < wetTail * 0.01f);
+  }
+
+  TEST_CASE("morphingReverb: fully morphed to REVERB_OFF passes input through") {
+    YSE::DSP::MODULES::morphingReverb rev;
+    rev.presetA(YSE::REVERB_CAVE).presetB(YSE::REVERB_OFF).morph(1.0f);
+    runSilence(rev, kSettleBlocks); // settle faders on the OFF blend
+
+    MULTICHANNELBUFFER buf(1);
+    buf[0] = 0.5f;
+    rev.process(buf);
+
+    // OFF is dry = 1, wet = 0: the buffer must come back (essentially)
+    // unchanged.
+    float* ptr = buf[0].getPtr();
+    for (unsigned i = 0; i < buf[0].getLength(); ++i)
+      CHECK(ptr[i] == doctest::Approx(0.5f).epsilon(1e-3f));
+  }
+
+  TEST_CASE("morphingReverb: control-rate morph sweep stays bounded and finite") {
+    // Sweep the morph input over its full range while audio runs — the
+    // click-free contract at minimum means no instability: every sample stays
+    // finite and inside a sane amplitude bound.
+    YSE::DSP::MODULES::morphingReverb rev;
+    rev.presetA(YSE::REVERB_CAVE).presetB(YSE::REVERB_OFF);
+    runSilence(rev, kSettleBlocks);
+
+    MULTICHANNELBUFFER buf(1);
+    const int sweepBlocks = 200;
+    bool allFinite = true;
+    float maxAbs = 0.0f;
+    for (int i = 0; i < sweepBlocks; ++i) {
+      rev.morph(static_cast<Flt>(i) / static_cast<Flt>(sweepBlocks - 1));
+      buf[0] = 0.5f;
+      rev.process(buf);
+      float* ptr = buf[0].getPtr();
+      for (unsigned k = 0; k < buf[0].getLength(); ++k) {
+        if (!std::isfinite(ptr[k])) allFinite = false;
+        float a = std::fabs(ptr[k]);
+        if (a > maxAbs) maxAbs = a;
+      }
+    }
+
+    CHECK(allFinite);
+    CHECK(maxAbs < 4.0f);
+  }
+
+  // ─── RT discipline ────────────────────────────────────────────────────────────
+
+  TEST_CASE("morphingReverb: steady-state process allocates nothing") {
+    YSE::DSP::MODULES::morphingReverb rev;
+    rev.presetA(YSE::REVERB_GENERIC).presetB(YSE::REVERB_HALL).morph(0.3f);
+
+    // Warm up: first process sizes the per-channel state (the one permitted
+    // allocation) and the faders start ramping.
+    runSilence(rev, 40, 2);
+
+    MULTICHANNELBUFFER buf(2);
+    {
+      TestHelpers::ProbeScope probe;
+      for (int i = 0; i < 20; ++i) {
+        rev.morph(0.3f + 0.02f * static_cast<Flt>(i)); // live control writes
+        buf[0] = 0.25f;
+        buf[1] = 0.25f;
+        rev.process(buf);
+      }
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+  }
+
+  TEST_CASE("morphingReverb: tolerates a changing channel count between calls") {
+    YSE::DSP::MODULES::morphingReverb rev;
+    rev.presetA(YSE::REVERB_CAVE).presetB(YSE::REVERB_OFF).morph(0.0f);
+
+    MULTICHANNELBUFFER mono(1);
+    mono[0] = 0.5f;
+    rev.process(mono);
+
+    MULTICHANNELBUFFER stereo(2);
+    stereo[0] = 0.5f;
+    stereo[1] = 0.5f;
+    rev.process(stereo);
+
+    MULTICHANNELBUFFER backToMono(1);
+    backToMono[0] = 0.5f;
+    rev.process(backToMono);
+
+    // Survived the resizes and still produces finite output.
+    float* ptr = backToMono[0].getPtr();
+    bool finite = true;
+    for (unsigned i = 0; i < backToMono[0].getLength(); ++i)
+      if (!std::isfinite(ptr[i])) finite = false;
+    CHECK(finite);
+  }
+
+} // TEST_SUITE("dsp")

--- a/Tests/reverb/test_reverb_concurrency.cpp
+++ b/Tests/reverb/test_reverb_concurrency.cpp
@@ -16,10 +16,12 @@
 #include <doctest/doctest.h>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <thread>
 #include "yse.hpp"
 #include "reverb/reverbInterface.hpp"
 #include "reverb/reverbManager.h"
+#include "internal/reverbDSP.h"
 #include "internal/time.h"
 #include "support/null_device.hpp"
 
@@ -135,6 +137,52 @@ TEST_SUITE("reverb") {
 
     drainReverbs(40);
     CHECK(gr.getActive() == true);
+  }
+
+  // ─── reverbDSP instances process concurrently (issue #326) ───────────────────
+
+  TEST_CASE("reverb concurrency: independent reverbDSP instances process concurrently") {
+    // The morphing reverb module (issue #326) puts additional reverbDSP
+    // instances on channel inserts, which the fast-pool workers process
+    // concurrently with the manager's global instance. The DSP core's
+    // inner-loop state used to live in file-scope globals — a data race the
+    // moment two instances process at once. All state is per-instance now;
+    // under TSan the pre-fix code trips on the shared kernels, the fixed code
+    // is clean. No engine needed: the instances are self-contained.
+    constexpr int kThreads = 2;
+    constexpr int kBlocks = 200;
+
+    std::thread workers[kThreads];
+    std::atomic<bool> finite[kThreads];
+
+    for (int w = 0; w < kThreads; ++w) {
+      finite[w].store(true);
+      workers[w] = std::thread([w, &finite]() {
+        YSE::INTERNAL::reverbDSP verb;
+        verb.channels(2);
+        verb.bypass(false);
+
+        MULTICHANNELBUFFER buf(2);
+        for (int i = 0; i < kBlocks; ++i) {
+          buf[0] = 0.0f;
+          buf[1] = 0.0f;
+          buf[0].getPtr()[0] = 1.0f; // fresh impulse every block
+          buf[1].getPtr()[0] = 1.0f;
+          verb.process(buf);
+        }
+
+        float* ptr = buf[0].getPtr();
+        for (unsigned i = 0; i < buf[0].getLength(); ++i) {
+          if (!std::isfinite(ptr[i])) finite[w].store(false);
+        }
+      });
+    }
+
+    for (auto& worker : workers)
+      worker.join();
+
+    for (const auto& f : finite)
+      CHECK(f.load());
   }
 
 } // TEST_SUITE("reverb")

--- a/Tests/reverb/test_reverb_dsp.cpp
+++ b/Tests/reverb/test_reverb_dsp.cpp
@@ -11,8 +11,9 @@
 // fails (e.g. no PortAudio host APIs in CI), those cases return without asserting.
 //
 // reverbDSP tests drive the Freeverb DSP object directly (no engine init needed).
-// The DSP object uses static module-level globals for its inner loop; tests run
-// sequentially so there is no data-race concern.
+// Since issue #326 the DSP object keeps all working state in the instance
+// (the inner-loop globals are gone), so independent instances are genuinely
+// independent — see the instance-independence case below.
 
 #include <doctest/doctest.h>
 #include <cstring> // std::memset — dirties storage for the issue #263 regression test
@@ -398,6 +399,26 @@ TEST_SUITE("reverb") {
     YSE::INTERNAL::reverbDSP verb;
     verb.combFeedback(0.8f);
     CHECK(verb.combFeedback() == doctest::Approx(0.8f));
+  }
+
+  TEST_CASE("reverbDSP: instances hold independent state (issue #326)") {
+    // The comb/allpass feedback and damping coefficients used to be file-scope
+    // globals, shared by every reverbDSP in the process. With the morphing
+    // reverb module (issue #326) several instances can exist — the manager's
+    // global one plus channel inserts — so this state must be per-instance.
+    // Pre-fix, the second instance's setters overwrote the first's values.
+    YSE::INTERNAL::reverbDSP verbA;
+    YSE::INTERNAL::reverbDSP verbB;
+
+    verbA.combFeedback(0.9f);
+    verbB.combFeedback(0.1f);
+    CHECK(verbA.combFeedback() == doctest::Approx(0.9f));
+    CHECK(verbB.combFeedback() == doctest::Approx(0.1f));
+
+    verbA.allpassFeedback(0.7f);
+    verbB.allpassFeedback(0.2f);
+    CHECK(verbA.allpassFeedback() == doctest::Approx(0.7f));
+    CHECK(verbB.allpassFeedback() == doctest::Approx(0.2f));
   }
 
   TEST_CASE("reverbDSP: allpassFeedback getter/setter round-trip") {

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -49,6 +49,7 @@ set(YSE_SRCS
   dsp/modules/hilbert.cpp
   dsp/modules/chorus.cpp
   dsp/modules/compressor.cpp
+  dsp/modules/morphingReverb.cpp
   dsp/modules/parametricEQ.cpp
   dsp/modules/phaser.cpp
   dsp/modules/plateReverb.cpp
@@ -151,6 +152,7 @@ set(YSE_SRCS
   reverb/reverbImplementation.cpp
   reverb/reverbInterface.cpp
   reverb/reverbManager.cpp
+  reverb/reverbPresets.cpp
   sound/soundImplementation.cpp
   sound/soundInterface.cpp
   sound/soundManager.cpp

--- a/YseEngine/dsp/modules/morphingReverb.cpp
+++ b/YseEngine/dsp/modules/morphingReverb.cpp
@@ -1,0 +1,122 @@
+/*
+  ==============================================================================
+
+    morphingReverb.cpp
+    Morphing reverb module — preset interpolation as a control input
+    (issue #326).
+
+  ==============================================================================
+*/
+
+#include "morphingReverb.hpp"
+#include "../../utils/misc.hpp"
+
+// ─── slot ─────────────────────────────────────────────────────────────────────
+
+void YSE::DSP::MODULES::morphingReverb::slot::store(const YSE::REVERB::presetValues& v) {
+  roomsize.store(v.roomsize);
+  damp.store(v.damp);
+  dry.store(v.dry);
+  wet.store(v.wet);
+  modFrequency.store(v.modFrequency);
+  modWidth.store(v.modWidth);
+  for (Int i = 0; i < 4; i++) {
+    earlyTime[i].store(v.earlyTime[i]);
+    earlyGain[i].store(v.earlyGain[i]);
+  }
+}
+
+YSE::REVERB::presetValues YSE::DSP::MODULES::morphingReverb::slot::load() const {
+  YSE::REVERB::presetValues v;
+  v.roomsize = roomsize.load();
+  v.damp = damp.load();
+  v.dry = dry.load();
+  v.wet = wet.load();
+  v.modFrequency = modFrequency.load();
+  v.modWidth = modWidth.load();
+  for (Int i = 0; i < 4; i++) {
+    v.earlyTime[i] = earlyTime[i].load();
+    v.earlyGain[i] = earlyGain[i].load();
+  }
+  return v;
+}
+
+// ─── morphingReverb ───────────────────────────────────────────────────────────
+
+YSE::DSP::MODULES::morphingReverb::morphingReverb() : parmMorph(0.f) {
+  slotA.store(REVERB::getPresetValues(REVERB_GENERIC));
+  slotB.store(REVERB::getPresetValues(REVERB_HALL));
+}
+
+YSE::DSP::MODULES::morphingReverb& YSE::DSP::MODULES::morphingReverb::presetA(REVERB_PRESET value) {
+  slotA.store(REVERB::getPresetValues(value));
+  return *this;
+}
+
+YSE::DSP::MODULES::morphingReverb&
+YSE::DSP::MODULES::morphingReverb::presetA(const REVERB::presetValues& value) {
+  slotA.store(value);
+  return *this;
+}
+
+YSE::REVERB::presetValues YSE::DSP::MODULES::morphingReverb::presetA() const {
+  return slotA.load();
+}
+
+YSE::DSP::MODULES::morphingReverb& YSE::DSP::MODULES::morphingReverb::presetB(REVERB_PRESET value) {
+  slotB.store(REVERB::getPresetValues(value));
+  return *this;
+}
+
+YSE::DSP::MODULES::morphingReverb&
+YSE::DSP::MODULES::morphingReverb::presetB(const REVERB::presetValues& value) {
+  slotB.store(value);
+  return *this;
+}
+
+YSE::REVERB::presetValues YSE::DSP::MODULES::morphingReverb::presetB() const {
+  return slotB.load();
+}
+
+YSE::DSP::MODULES::morphingReverb& YSE::DSP::MODULES::morphingReverb::morph(Flt value) {
+  Clamp(value, 0.f, 1.f);
+  parmMorph.store(value);
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::morphingReverb::morph() const {
+  return parmMorph.load();
+}
+
+void YSE::DSP::MODULES::morphingReverb::create() {
+  // Nothing to size yet: the per-channel reverb state depends on the channel
+  // count, which is only known once process() sees a buffer. reverbDSP's
+  // channels() sizes it there (a no-op in steady state).
+}
+
+void YSE::DSP::MODULES::morphingReverb::process(MULTICHANNELBUFFER& buffer) {
+  createIfNeeded();
+
+  if (buffer.empty()) return;
+
+  // Size per-channel state to the buffer. This allocates only when the
+  // channel count actually changed — the device-restart path, the one place
+  // the dspObject contract permits allocation.
+  verb.channels(static_cast<Int>(buffer.size()));
+
+  // Blend the two endpoints at the current morph position and push the result
+  // through the core's faders: repeated control-rate writes ramp click-free.
+  REVERB::presetValues blended = REVERB::morph(slotA.load(), slotB.load(), parmMorph.load());
+
+  // Insert-grade gain mapping. The freeverb core's faders carry historical
+  // scale factors (scaledry = 2, and scalewet = 3 against a 0.5 width term)
+  // tuned for the global zone path, where dry = 1 means x2 makeup gain.
+  // Remap so this module's contract is what an insert user expects:
+  // dry = 1 is unity gain — morphing fully to REVERB_OFF is a true bypass —
+  // and wet = 1 is the reverb tank at its computed level.
+  blended.dry *= 0.5f;
+  blended.wet *= 2.0f / 3.0f;
+  verb.set(blended);
+
+  verb.process(buffer);
+}

--- a/YseEngine/dsp/modules/morphingReverb.hpp
+++ b/YseEngine/dsp/modules/morphingReverb.hpp
@@ -1,0 +1,153 @@
+/*
+  ==============================================================================
+
+    morphingReverb.hpp
+    Morphing reverb module — preset interpolation as a control input
+    (issue #326).
+
+  ==============================================================================
+*/
+
+#ifndef MORPHINGREVERB_HPP_INCLUDED
+#define MORPHINGREVERB_HPP_INCLUDED
+
+#include "../../headers/defines.hpp"
+#include "../../headers/types.hpp"
+#include "../../headers/enums.hpp"
+#include "../dspObject.hpp"
+#include "../../internal/reverbDSP.h"
+#include "../../reverb/reverbPresets.hpp"
+
+namespace YSE {
+  namespace DSP {
+    namespace MODULES {
+
+      /**
+       *  @brief A reverb whose preset interpolation is a *control input*.
+       *
+       *  This is the engine's zone/global reverb core (``INTERNAL::reverbDSP``)
+       *  packaged as an ordinary chainable ``dspObject``, with the parameter
+       *  blend generalized into a morph control (issue #326). Two endpoint
+       *  parameter sets — slot A and slot B, each a named ``REVERB_PRESET`` or
+       *  a custom ``REVERB::presetValues`` — are linearly interpolated by
+       *  ``morph(t)``: 0 is pure A ("cathedral"), 1 is pure B ("closet"),
+       *  anything in between is a genuine hybrid space.
+       *
+       *  ### Drivers
+       *
+       *  ``morph`` is deliberately driver-agnostic: a UI slider, a patcher
+       *  ramp, a live-coded expression, MIDI — anything running on a control
+       *  thread can call it at control rate. Writes are plain atomic stores
+       *  (allocation-free, wait-free); the audio thread picks the value up on
+       *  the next block and moves every underlying parameter through the
+       *  reverb core's faders (~1000-sample ramps), so sweeps and jumps are
+       *  click-free.
+       *
+       *  Listener-zone proximity — the classic game-audio driver — is *not*
+       *  wired into this module: it remains the default driver of the same
+       *  reverb core through the legacy ``REVERB::Manager`` path, computed
+       *  exactly as before. Same core, different drivers.
+       *
+       *  ### Placement
+       *
+       *  The module is a plain ``dspObject``: attach it with
+       *  ``YSE::channel::setDSP`` / ``YSE::sound::setDSP``, on any channel or
+       *  on a return bus (``r.makeReturn("verb").setDSP(&morphVerb)``) — it is
+       *  not welded to the global manager attach. The wet/dry balance rides
+       *  the morphed presets themselves (each preset carries ``dry``/``wet``),
+       *  so the inherited ``impact()`` is not applied; for send/return use,
+       *  give both slots custom ``presetValues`` with ``dry = 0, wet = 1``.
+       *  Unlike the legacy zone path (which applies historical makeup gain),
+       *  the module maps ``dry = 1`` to unity — morphing fully to
+       *  ``REVERB_OFF`` is a true bypass — and ``wet = 1`` to the reverb tank
+       *  at its computed level.
+       *
+       *  ### Trajectory note (design record, issue #326)
+       *
+       *  With zone-bound return buses
+       *  ([send_return_buses.md §12b](../../../docs/design/send_return_buses.md)),
+       *  a reverb *zone* can instead be a return bus tied to a region of
+       *  space, with proximity modulating the *send levels* into it — distinct
+       *  spaces crossfading as real wet signals. The two tools coexist:
+       *  **parameter morph** (this module) is one space transforming;
+       *  **zone returns** are spaces crossfading. This module is kept an
+       *  ordinary insert precisely so it can be dropped on such a return when
+       *  zone returns land; the in-place ``REVERB::Manager`` path stays
+       *  legacy-bound (bug fixes yes, new features no).
+       *
+       *  ### N-channel behaviour
+       *
+       *  Per-channel reverb state is sized to ``buffer.size()`` on the first
+       *  ``process`` call and re-sized only when the channel count changes
+       *  (the device-restart path — the only place the ``dspObject`` contract
+       *  allows allocation). Steady-state ``process`` allocates nothing.
+       */
+      class API morphingReverb : public dspObject {
+      public:
+        /** Slots default to A = ``REVERB_GENERIC``, B = ``REVERB_HALL``,
+         *  ``morph() == 0`` (pure A). */
+        morphingReverb();
+        virtual ~morphingReverb() {}
+
+        /** @brief Set morph endpoint A from a named preset. */
+        morphingReverb& presetA(REVERB_PRESET value);
+
+        /** @brief Set morph endpoint A from a custom parameter set. Fields are
+         *  stored individually-atomically; the faders smooth the (rare) block
+         *  that observes a partly-updated slot. */
+        morphingReverb& presetA(const REVERB::presetValues& value);
+
+        /** @brief Current endpoint A parameter set. */
+        REVERB::presetValues presetA() const;
+
+        /** @brief Set morph endpoint B from a named preset. */
+        morphingReverb& presetB(REVERB_PRESET value);
+
+        /** @brief Set morph endpoint B from a custom parameter set. */
+        morphingReverb& presetB(const REVERB::presetValues& value);
+
+        /** @brief Current endpoint B parameter set. */
+        REVERB::presetValues presetB() const;
+
+        /** @brief The morph control input: 0 = pure A, 1 = pure B, clamped to
+         *  [0, 1]. Callable from any control thread at control rate —
+         *  allocation-free, click-free (see class docs). */
+        morphingReverb& morph(Flt value);
+
+        /** @brief Current morph position. */
+        Flt morph() const;
+
+        /** @brief dspObject lifecycle hook. Per-channel state is sized in
+         *  ``process`` (the channel count is only known there). */
+        virtual void create();
+
+        /** @brief dspObject audio-thread entry point. */
+        virtual void process(MULTICHANNELBUFFER& buffer);
+
+      private:
+        // One morph endpoint. Control threads write, the audio thread reads;
+        // every field is individually atomic so writes are wait-free and
+        // reads never tear a float. A whole-slot update is not atomic as a
+        // set — the reverb faders smooth the one block that could observe a
+        // mix of old and new fields.
+        struct slot {
+          aFlt roomsize, damp, dry, wet, modFrequency, modWidth;
+          aFlt earlyTime[4];
+          aFlt earlyGain[4];
+
+          void store(const REVERB::presetValues& v);
+          REVERB::presetValues load() const;
+        };
+
+        slot slotA;
+        slot slotB;
+        aFlt parmMorph; // [0, 1]
+
+        INTERNAL::reverbDSP verb; // audio-thread-owned reverb core
+      };
+
+    } // namespace MODULES
+  } // namespace DSP
+} // namespace YSE
+
+#endif // MORPHINGREVERB_HPP_INCLUDED

--- a/YseEngine/internal/reverbDSP.cpp
+++ b/YseEngine/internal/reverbDSP.cpp
@@ -49,50 +49,41 @@ static const int allpasstuning[4] = {556, 441, 341, 225};
 // character stays consistent across device-negotiated sample rates.
 static constexpr float kReverbTuningReferenceRate = 44100.0f;
 
-// static inline functions and pointer for speed optimisation
-UInt ch;
-Int filterIndex;
-Int* curCombIndex;
-Int* curCombTuning;
-std::vector<std::vector<Flt>>* curBufComb;
-Flt* curFilterStore;
-std::vector<std::vector<Flt>>* curBufAll;
-Int* curAllIndex;
-Int* curAllTuning;
-Flt _allpassFeedback;
-Flt _combFeedback;
-Flt combDamp1;
-Flt combDamp2;
-Int bufferIndex;
+// The comb/allpass kernels and every loop-carried working value used to be
+// file-scope globals ("for speed optimisation", 2014). That made the whole
+// DSP core non-re-entrant: two reverbDSP instances processing concurrently
+// (the manager's global instance and a morphingReverb channel insert on
+// another fast-pool worker) raced on them. All state now lives in the
+// instance; the kernels below take their per-filter state by reference and
+// keep the exact arithmetic of the old globals-based versions (issue #326).
 
-static inline Flt combProcess(Flt input) {
-  Flt output;
-  output = (*curBufComb)[filterIndex][bufferIndex];
+inline Flt YSE::INTERNAL::reverbDSP::combProcess(Flt input, std::vector<Flt>& buf, Flt& filterStore,
+                                                 Int& index, Int tuning) {
+  Flt output = buf[index];
   Undenormal(output);
 
-  curFilterStore[filterIndex] = (output * combDamp2) + (curFilterStore[filterIndex] * combDamp1);
-  Undenormal(curFilterStore[filterIndex]);
+  filterStore = (output * _combDamp2) + (filterStore * _combDamp1);
+  Undenormal(filterStore);
 
-  (*curBufComb)[filterIndex][bufferIndex] = input + (curFilterStore[filterIndex] * _combFeedback);
-  if (++bufferIndex >= curCombTuning[filterIndex]) bufferIndex = 0;
+  buf[index] = input + (filterStore * _combFeedback);
+  if (++index >= tuning) index = 0;
   return output;
 }
 
-static inline void allpassProcess(Flt& input) {
-  Flt bufout;
-
-  bufout = (*curBufAll)[filterIndex][bufferIndex];
+inline void YSE::INTERNAL::reverbDSP::allpassProcess(Flt& value, std::vector<Flt>& buf, Int& index,
+                                                     Int tuning) {
+  Flt bufout = buf[index];
   Undenormal(bufout);
 
-  (*curBufAll)[filterIndex][bufferIndex] = input + (bufout * _allpassFeedback);
-  if (++bufferIndex >= curAllTuning[filterIndex]) bufferIndex = 0;
+  buf[index] = value + (bufout * _allpassFeedback);
+  if (++index >= tuning) index = 0;
 
-  input = -input + bufout;
+  value = -value + bufout;
 }
 
 void YSE::INTERNAL::reverbDSP::combDamp(Flt value) {
-  combDamp1 = value;
-  combDamp2 = 1 - value;
+  _combDamp1 = value;
+  _combDamp2 = 1 - value;
 }
 
 YSE::INTERNAL::reverbDSP& YSE::INTERNAL::reverbDSP::combFeedback(Flt value) {
@@ -144,72 +135,67 @@ void YSE::INTERNAL::reverbDSP::process(MULTICHANNELBUFFER& buffer) {
     cosPtr2 = cos2(modPtr);
   }
 
-  for (ch = 0; ch < channel.size(); ch++) {
+  for (UInt ch = 0; ch < channel.size(); ch++) {
+    reverbChannel& c = channel[ch];
     Flt* ptr = buffer[ch].getPtr();
-    channel[ch].out = 0;
-    Flt* out = channel[ch].out.getPtr();
+    c.out = 0;
+    Flt* out = c.out.getPtr();
     Int length = buffer[ch].getLength();
-    curCombIndex = channel[ch].combIndex;
-    curBufComb = &channel[ch].bufComb;
-    curFilterStore = channel[ch].filterStore;
-    curCombTuning = channel[ch].combTuning;
-    curBufAll = &channel[ch].bufAll;
-    curAllIndex = channel[ch].allIndex;
-    curAllTuning = channel[ch].allTuning;
 
     // update delay line
-    channel[ch].delayline.process(buffer[ch]);
+    c.delayline.process(buffer[ch]);
     for (Int i = 0; i < 4; i++) {
-      if (channel[ch].earlyVolume[i].getValue() > 0) {
-        channel[ch].delayline.read(channel[ch].early[i], channel[ch].earlyPtr[i]());
-        channel[ch].early[i] *= channel[ch].earlyVolume[i]();
-        buffer[ch] += channel[ch].early[i];
+      if (c.earlyVolume[i].getValue() > 0) {
+        c.delayline.read(c.early[i], c.earlyPtr[i]());
+        c.early[i] *= c.earlyVolume[i]();
+        buffer[ch] += c.early[i];
       }
     }
 
     for (; length > 7; length -= 8, ptr += 8, out += 8) {
-      // ptr[0] = ptr[1] = ptr[2] = ptr[3] = ptr[4] = ptr[5] = ptr[6] = ptr[7] = 0;
-      for (filterIndex = 0; filterIndex < COMBS; filterIndex++) {
-        bufferIndex = curCombIndex[filterIndex];
+      for (Int filterIndex = 0; filterIndex < COMBS; filterIndex++) {
+        std::vector<Flt>& buf = c.bufComb[filterIndex];
+        Flt& store = c.filterStore[filterIndex];
+        Int& index = c.combIndex[filterIndex];
+        const Int tuning = c.combTuning[filterIndex];
 
-        out[0] += combProcess(ptr[0] * _gain);
-        out[1] += combProcess(ptr[1] * _gain);
-        out[2] += combProcess(ptr[2] * _gain);
-        out[3] += combProcess(ptr[3] * _gain);
-        out[4] += combProcess(ptr[4] * _gain);
-        out[5] += combProcess(ptr[5] * _gain);
-        out[6] += combProcess(ptr[6] * _gain);
-        out[7] += combProcess(ptr[7] * _gain);
-        curCombIndex[filterIndex] = bufferIndex;
+        out[0] += combProcess(ptr[0] * _gain, buf, store, index, tuning);
+        out[1] += combProcess(ptr[1] * _gain, buf, store, index, tuning);
+        out[2] += combProcess(ptr[2] * _gain, buf, store, index, tuning);
+        out[3] += combProcess(ptr[3] * _gain, buf, store, index, tuning);
+        out[4] += combProcess(ptr[4] * _gain, buf, store, index, tuning);
+        out[5] += combProcess(ptr[5] * _gain, buf, store, index, tuning);
+        out[6] += combProcess(ptr[6] * _gain, buf, store, index, tuning);
+        out[7] += combProcess(ptr[7] * _gain, buf, store, index, tuning);
       }
 
-      for (filterIndex = 0; filterIndex < APASS; filterIndex++) {
-        bufferIndex = curAllIndex[filterIndex];
-        allpassProcess(out[0]);
-        allpassProcess(out[1]);
-        allpassProcess(out[2]);
-        allpassProcess(out[3]);
-        allpassProcess(out[4]);
-        allpassProcess(out[5]);
-        allpassProcess(out[6]);
-        allpassProcess(out[7]);
-        curAllIndex[filterIndex] = bufferIndex;
+      for (Int filterIndex = 0; filterIndex < APASS; filterIndex++) {
+        std::vector<Flt>& buf = c.bufAll[filterIndex];
+        Int& index = c.allIndex[filterIndex];
+        const Int tuning = c.allTuning[filterIndex];
+
+        allpassProcess(out[0], buf, index, tuning);
+        allpassProcess(out[1], buf, index, tuning);
+        allpassProcess(out[2], buf, index, tuning);
+        allpassProcess(out[3], buf, index, tuning);
+        allpassProcess(out[4], buf, index, tuning);
+        allpassProcess(out[5], buf, index, tuning);
+        allpassProcess(out[6], buf, index, tuning);
+        allpassProcess(out[7], buf, index, tuning);
       }
     }
 
     while (length--) {
       // accumulate comb filters in parallel
-      for (filterIndex = 0; filterIndex < COMBS; filterIndex++) {
-        bufferIndex = curCombIndex[filterIndex];
-        *out += combProcess(*ptr * _gain);
-        curCombIndex[filterIndex] = bufferIndex;
+      for (Int filterIndex = 0; filterIndex < COMBS; filterIndex++) {
+        *out += combProcess(*ptr * _gain, c.bufComb[filterIndex], c.filterStore[filterIndex],
+                            c.combIndex[filterIndex], c.combTuning[filterIndex]);
       }
 
       // feed through allpass in series
-      for (filterIndex = 0; filterIndex < APASS; filterIndex++) {
-        bufferIndex = curAllIndex[filterIndex];
-        allpassProcess(*out);
-        curAllIndex[filterIndex] = bufferIndex;
+      for (Int filterIndex = 0; filterIndex < APASS; filterIndex++) {
+        allpassProcess(*out, c.bufAll[filterIndex], c.allIndex[filterIndex],
+                       c.allTuning[filterIndex]);
       }
       ptr++;
       out++;
@@ -350,6 +336,46 @@ void YSE::INTERNAL::reverbDSP::set(YSE::reverb& params) {
   }
 }
 
+void YSE::INTERNAL::reverbDSP::set(const YSE::REVERB::presetValues& params) {
+  // Mirrors set(reverb&) but takes a plain parameter set, so a control input
+  // (DSP::MODULES::morphingReverb) can feed blended presets straight into the
+  // faders. set(reverb&) relies on the interface setters' clamping; a
+  // presetValues can come from user code, so clamp here instead. Runs on the
+  // audio thread: no allocation, faders ramp so repeated control-rate calls
+  // stay click-free.
+  bypass(false);
+
+  Flt value = params.roomsize;
+  Clamp(value, 0.f, 1.f);
+  roomSize(value);
+
+  value = params.damp;
+  Clamp(value, 0.f, 1.f);
+  damp(value);
+
+  value = params.wet;
+  Clamp(value, 0.f, 1.f);
+  wet(value);
+
+  value = params.dry;
+  Clamp(value, 0.f, 1.f);
+  dry(value);
+
+  width(0);
+  modulate(params.modFrequency, params.modWidth < 0.f ? 0.f : params.modWidth);
+
+  for (Int i = 0; i < 4; i++) {
+    Flt time = params.earlyTime[i];
+    Clamp(time, 0.f, 2999.f);
+    Flt gain = params.earlyGain[i];
+    Clamp(gain, 0.f, 1.f);
+    for (UInt ch = 0; ch < channel.size(); ch++) {
+      channel[ch].earlyPtr[i].setIfNew(time + channel[ch].earlyOffset, 1000);
+      channel[ch].earlyVolume[i].setIfNew(gain, 1000);
+    }
+  }
+}
+
 YSE::INTERNAL::reverbDSP::reverbDSP() {
   _freeze = false;
 
@@ -357,6 +383,9 @@ YSE::INTERNAL::reverbDSP::reverbDSP() {
   _modFrequency.set(0, 0);
   _modWidth.set(0, 0);
   _allpassFeedback = 0.5;
+  _combFeedback = 0;
+  _combDamp1 = 0;
+  _combDamp2 = 1;
   wet(initialwet);
   roomSize(initialroom);
   dry(initialdry);

--- a/YseEngine/internal/reverbDSP.h
+++ b/YseEngine/internal/reverbDSP.h
@@ -18,6 +18,7 @@
 #include "../dsp/ramp.hpp"
 #include "../dsp/dspObject.hpp"
 #include "../reverb/reverb.hpp"
+#include "../reverb/reverbPresets.hpp"
 
 #define COMBS 8
 #define APASS 4
@@ -53,6 +54,11 @@ namespace YSE {
       reverbChannel(const reverbChannel& source);
     };
 
+    // Every piece of working state — including the comb/allpass feedback and
+    // damping coefficients that used to be file-scope globals — is a member,
+    // so independent instances can process concurrently (e.g. the manager's
+    // global instance and DSP::MODULES::morphingReverb inserts on channels
+    // handled by different fast-pool workers, issue #326).
     class reverbDSP : DSP::dspObject {
     public:
       Flt _gain;
@@ -61,6 +67,10 @@ namespace YSE {
       Flt _wet, _wet1, _wet2;
       Bool _freeze;
       Bool _bypass;
+      Flt _combFeedback;
+      Flt _allpassFeedback;
+      Flt _combDamp1;
+      Flt _combDamp2;
 
       // faders for smooth value adjustment
       DSP::lint _roomsizeFader;
@@ -109,11 +119,24 @@ namespace YSE {
 
       void set(reverb& impl);
 
+      /** Apply a full parameter set (typically a blend produced by
+          REVERB::morph) through the faders, so successive control-rate calls
+          ramp click-free. Used by DSP::MODULES::morphingReverb (issue #326);
+          the manager path keeps using set(reverb&). Values are clamped to the
+          same ranges the interface setters enforce. */
+      void set(const REVERB::presetValues& params);
+
       virtual void create() {}
       virtual void process(MULTICHANNELBUFFER& buffer);
       void update();
       reverbDSP();
       ~reverbDSP();
+
+    private:
+      // Re-entrant comb/allpass kernels: all state is passed in or read from
+      // members, never from globals (issue #326).
+      Flt combProcess(Flt input, std::vector<Flt>& buf, Flt& filterStore, Int& index, Int tuning);
+      void allpassProcess(Flt& value, std::vector<Flt>& buf, Int& index, Int tuning);
     };
 
   } // namespace INTERNAL

--- a/YseEngine/reverb/reverbInterface.cpp
+++ b/YseEngine/reverb/reverbInterface.cpp
@@ -9,6 +9,7 @@
 */
 
 #include "../internalHeaders.h"
+#include "reverbPresets.hpp"
 
 YSE::reverb::reverb(bool global)
   : pimpl(nullptr),
@@ -241,70 +242,14 @@ Flt YSE::reverb::getReflectionGain(Int reflection) {
 }
 
 YSE::reverb& YSE::reverb::setPreset(REVERB_PRESET value) {
-  switch (value) {
-  case REVERB_OFF:
-    setRoomSize(0.f).setDamping(0.f).setDryWetBalance(1.f, 0.f).setModulation(0.f, 0.f);
-    setReflection(0, 0, 0.f).setReflection(1, 0, 0.f).setReflection(2, 0, 0.f).setReflection(3, 0,
-                                                                                             0.f);
-    break;
-  case REVERB_GENERIC:
-    setRoomSize(0.5f).setDamping(0.5f).setDryWetBalance(0.6f, 0.4f).setModulation(0.f, 0.f);
-    setReflection(0, 0, 0.f).setReflection(1, 0, 0.f).setReflection(2, 0, 0.f).setReflection(3, 0,
-                                                                                             0.f);
-    break;
-  case REVERB_PADDED:
-    setRoomSize(0.1f).setDamping(0.9f).setDryWetBalance(0.9f, 0.1f).setModulation(0.f, 0.f);
-    setReflection(0, 0, 0.f).setReflection(1, 0, 0.f).setReflection(2, 0, 0.f).setReflection(3, 0,
-                                                                                             0.f);
-    break;
-  case REVERB_ROOM:
-    setRoomSize(0.3f).setDamping(0.8f).setDryWetBalance(0.7f, 0.3f).setModulation(0.f, 0.f);
-    setReflection(0, 0, 0.f).setReflection(1, 0, 0.f).setReflection(2, 0, 0.f).setReflection(3, 0,
-                                                                                             0.f);
-    break;
-  case REVERB_BATHROOM:
-    setRoomSize(0.2f).setDamping(0.1f).setDryWetBalance(0.3f, 0.7f).setModulation(0.f, 0.f);
-    setReflection(0, 0, 1.f)
-        .setReflection(1, 20, 0.7f)
-        .setReflection(2, 50, 0.5f)
-        .setReflection(3, 85, 0.3f);
-    break;
-  case REVERB_STONEROOM:
-    setRoomSize(0.3f).setDamping(0.01f).setDryWetBalance(0.3f, 0.7f).setModulation(0.f, 0.f);
-    setReflection(0, 30, 0.8f)
-        .setReflection(1, 70, 0.3f)
-        .setReflection(2, 100, 0.5f)
-        .setReflection(3, 150, 0.3f);
-    break;
-  case REVERB_LARGEROOM:
-    setRoomSize(0.7f).setDamping(0.8f).setDryWetBalance(0.7f, 0.3f).setModulation(0.f, 0.f);
-    setReflection(0, 0, 0.f).setReflection(1, 0, 0.f).setReflection(2, 0, 0.f).setReflection(3, 0,
-                                                                                             0.f);
-    break;
-  case REVERB_HALL:
-    setRoomSize(0.7f).setDamping(0.4f).setDryWetBalance(0.5f, 0.5f).setModulation(0.f, 0.f);
-    setReflection(0, 0, 0.f).setReflection(1, 0, 0.f).setReflection(2, 0, 0.f).setReflection(3, 0,
-                                                                                             0.f);
-    break;
-  case REVERB_CAVE:
-    setRoomSize(1.0f).setDamping(0.3f).setDryWetBalance(0.3f, 0.7f).setModulation(0.f, 0.f);
-    setReflection(0, 100, 0.8f)
-        .setReflection(1, 250, 0.6f)
-        .setReflection(2, 400, 0.4f)
-        .setReflection(3, 800, 0.5f);
-    break;
-  case REVERB_SEWERPIPE:
-    setRoomSize(0.5f).setDamping(0.1f).setDryWetBalance(0.3f, 0.7f).setModulation(3.5f, 20.0f);
-    setReflection(0, 200, 0.05f)
-        .setReflection(1, 600, 0.04f)
-        .setReflection(2, 1100, 0.01f)
-        .setReflection(3, 0, 0.f);
-    break;
-  case REVERB_UNDERWATER:
-    setRoomSize(0.1f).setDamping(0.2f).setDryWetBalance(0.3f, 0.7f).setModulation(3.5f, 20.0f);
-    setReflection(0, 0, 0.f).setReflection(1, 0, 0.f).setReflection(2, 0, 0.f).setReflection(3, 0,
-                                                                                             0.f);
-    break;
+  // The preset values live in the shared table (reverbPresets.hpp, issue
+  // #326) so the morphing reverb module blends exactly the parameter sets
+  // this interface applies.
+  const REVERB::presetValues& p = REVERB::getPresetValues(value);
+  setRoomSize(p.roomsize).setDamping(p.damp).setDryWetBalance(p.dry, p.wet);
+  setModulation(p.modFrequency, p.modWidth);
+  for (Int i = 0; i < 4; i++) {
+    setReflection(i, static_cast<Int>(p.earlyTime[i]), p.earlyGain[i]);
   }
 
   return *this;

--- a/YseEngine/reverb/reverbManager.h
+++ b/YseEngine/reverb/reverbManager.h
@@ -25,6 +25,13 @@
 namespace YSE {
   namespace REVERB {
 
+    /** The global, listener-proximity-driven reverb path. This in-place blend
+        is legacy-bound (project vision / send_return_buses.md §12b): bug fixes
+        yes, new features no. Proximity here is the *default driver* of the
+        engine's reverb core; for a user-drivable morph between presets — as a
+        channel or return insert — use DSP::MODULES::morphingReverb, which
+        exposes the same preset interpolation as a control input (issue #326).
+    */
     class managerObject {
     public:
       using ImplementationType = implementationObject;

--- a/YseEngine/reverb/reverbPresets.cpp
+++ b/YseEngine/reverb/reverbPresets.cpp
@@ -1,0 +1,84 @@
+/*
+  ==============================================================================
+
+    reverbPresets.cpp
+    Shared reverb preset table + interpolation core (issue #326).
+
+  ==============================================================================
+*/
+
+#include "reverbPresets.hpp"
+#include "../utils/misc.hpp"
+
+namespace {
+
+  using YSE::REVERB::presetValues;
+
+  // Indexed by REVERB_PRESET. The values are copied verbatim from the
+  // historical YSE::reverb::setPreset switch so preset behaviour is
+  // bit-compatible with every release before the extraction (issue #326).
+  //
+  // Field order: roomsize, damp, dry, wet, modFrequency, modWidth,
+  //              earlyTime[4], earlyGain[4].
+  constexpr presetValues presetTable[] = {
+      // REVERB_OFF
+      {0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, {0.f, 0.f, 0.f, 0.f}, {0.f, 0.f, 0.f, 0.f}},
+      // REVERB_GENERIC
+      {0.5f, 0.5f, 0.6f, 0.4f, 0.0f, 0.0f, {0.f, 0.f, 0.f, 0.f}, {0.f, 0.f, 0.f, 0.f}},
+      // REVERB_PADDED
+      {0.1f, 0.9f, 0.9f, 0.1f, 0.0f, 0.0f, {0.f, 0.f, 0.f, 0.f}, {0.f, 0.f, 0.f, 0.f}},
+      // REVERB_ROOM
+      {0.3f, 0.8f, 0.7f, 0.3f, 0.0f, 0.0f, {0.f, 0.f, 0.f, 0.f}, {0.f, 0.f, 0.f, 0.f}},
+      // REVERB_BATHROOM
+      {0.2f, 0.1f, 0.3f, 0.7f, 0.0f, 0.0f, {0.f, 20.f, 50.f, 85.f}, {1.f, 0.7f, 0.5f, 0.3f}},
+      // REVERB_STONEROOM
+      {0.3f, 0.01f, 0.3f, 0.7f, 0.0f, 0.0f, {30.f, 70.f, 100.f, 150.f}, {0.8f, 0.3f, 0.5f, 0.3f}},
+      // REVERB_LARGEROOM
+      {0.7f, 0.8f, 0.7f, 0.3f, 0.0f, 0.0f, {0.f, 0.f, 0.f, 0.f}, {0.f, 0.f, 0.f, 0.f}},
+      // REVERB_HALL
+      {0.7f, 0.4f, 0.5f, 0.5f, 0.0f, 0.0f, {0.f, 0.f, 0.f, 0.f}, {0.f, 0.f, 0.f, 0.f}},
+      // REVERB_CAVE
+      {1.0f, 0.3f, 0.3f, 0.7f, 0.0f, 0.0f, {100.f, 250.f, 400.f, 800.f}, {0.8f, 0.6f, 0.4f, 0.5f}},
+      // REVERB_SEWERPIPE
+      {0.5f,
+       0.1f,
+       0.3f,
+       0.7f,
+       3.5f,
+       20.0f,
+       {200.f, 600.f, 1100.f, 0.f},
+       {0.05f, 0.04f, 0.01f, 0.f}},
+      // REVERB_UNDERWATER
+      {0.1f, 0.2f, 0.3f, 0.7f, 3.5f, 20.0f, {0.f, 0.f, 0.f, 0.f}, {0.f, 0.f, 0.f, 0.f}},
+  };
+
+  constexpr Int presetCount = static_cast<Int>(sizeof(presetTable) / sizeof(presetTable[0]));
+
+} // namespace
+
+const presetValues& YSE::REVERB::getPresetValues(REVERB_PRESET preset) {
+  Int index = static_cast<Int>(preset);
+  if (index < 0 || index >= presetCount) index = static_cast<Int>(REVERB_OFF);
+  return presetTable[index];
+}
+
+presetValues YSE::REVERB::morph(const presetValues& a, const presetValues& b, Flt t) {
+  Clamp(t, 0.f, 1.f);
+  // Weighted-sum form rather than x + (y - x) * t: this one is exact at both
+  // endpoints (t = 0 returns x bit-for-bit, t = 1 returns y bit-for-bit),
+  // which the module's "morph 1 == pure B" contract relies on.
+  const auto mix = [t](Flt x, Flt y) { return x * (1.0f - t) + y * t; };
+
+  presetValues result;
+  result.roomsize = mix(a.roomsize, b.roomsize);
+  result.damp = mix(a.damp, b.damp);
+  result.dry = mix(a.dry, b.dry);
+  result.wet = mix(a.wet, b.wet);
+  result.modFrequency = mix(a.modFrequency, b.modFrequency);
+  result.modWidth = mix(a.modWidth, b.modWidth);
+  for (Int i = 0; i < 4; i++) {
+    result.earlyTime[i] = mix(a.earlyTime[i], b.earlyTime[i]);
+    result.earlyGain[i] = mix(a.earlyGain[i], b.earlyGain[i]);
+  }
+  return result;
+}

--- a/YseEngine/reverb/reverbPresets.hpp
+++ b/YseEngine/reverb/reverbPresets.hpp
@@ -1,0 +1,64 @@
+/*
+  ==============================================================================
+
+    reverbPresets.hpp
+    Shared reverb preset table + interpolation core (issue #326).
+
+  ==============================================================================
+*/
+
+#ifndef REVERBPRESETS_HPP_INCLUDED
+#define REVERBPRESETS_HPP_INCLUDED
+
+#include "../headers/defines.hpp"
+#include "../headers/types.hpp"
+#include "../headers/enums.hpp"
+
+namespace YSE {
+  namespace REVERB {
+
+    /**
+     *  @brief One complete reverb parameter set — the payload of a named preset.
+     *
+     *  Historically the ``REVERB_PRESET`` values lived as a switch inside
+     *  ``YSE::reverb::setPreset``. They are extracted here (issue #326) so the
+     *  same parameter sets can feed both the zone/global reverb interface and
+     *  the morphing reverb module (``DSP::MODULES::morphingReverb``), which
+     *  blends two of them under a control input.
+     *
+     *  ``earlyTime`` is stored as float (the interface API uses whole samples)
+     *  so a morph between two presets moves the early reflections continuously
+     *  instead of stepping per sample.
+     */
+    struct API presetValues {
+      Flt roomsize; // simulated room size, [0, 1]
+      Flt damp; // high-frequency damping, [0, 1]
+      Flt dry; // unprocessed level, [0, 1]
+      Flt wet; // reverberated level, [0, 1]
+      Flt modFrequency; // tail modulation rate, Hz (0 = off)
+      Flt modWidth; // tail modulation depth (0 = off)
+      Flt earlyTime[4]; // early reflection delays, samples, [0, 2999]
+      Flt earlyGain[4]; // early reflection gains, [0, 1]
+    };
+
+    /**
+     *  @brief Parameter set of a named preset.
+     *
+     *  The returned values are identical to what ``YSE::reverb::setPreset``
+     *  has always applied — that function now reads from this table.
+     */
+    API const presetValues& getPresetValues(REVERB_PRESET preset);
+
+    /**
+     *  @brief The preset-interpolation core: linear blend of two parameter sets.
+     *
+     *  Every field is interpolated as ``a + (b - a) * t`` with ``t`` clamped to
+     *  [0, 1], so ``t == 0`` returns ``a`` and ``t == 1`` returns ``b``.
+     *  Allocation-free and safe to call on the audio thread.
+     */
+    API presetValues morph(const presetValues& a, const presetValues& b, Flt t);
+
+  } // namespace REVERB
+} // namespace YSE
+
+#endif // REVERBPRESETS_HPP_INCLUDED


### PR DESCRIPTION
## Summary

Implements step 1 of #326: the localized reverb's preset interpolation is extracted into a control input, delivered as a new `DSP::MODULES::morphingReverb` module, while the listener-proximity path stays exactly as it was — the default driver of the same core.

## Linked issue

Closes #326

## Changes

- **Shared preset core** (`YseEngine/reverb/reverbPresets.{hpp,cpp}`): the `REVERB_PRESET` table moves out of `reverb::setPreset` into `REVERB::getPresetValues`, alongside the interpolation core `REVERB::morph(a, b, t)` (endpoint-exact weighted blend, allocation-free). `reverb::setPreset` now reads the table — identical values, existing preset tests unchanged.
- **`INTERNAL::reverbDSP` made re-entrant** (`YseEngine/internal/reverbDSP.{h,cpp}`): the 2014 file-scope comb/allpass kernel globals (`curBufComb`, `_combFeedback`, `combDamp1/2`, loop registers, …) become instance state with the same arithmetic. Required for correctness: the manager's global instance and module inserts on other fast-pool workers can now process concurrently without racing. Also adds a `set(const REVERB::presetValues&)` overload (clamped, fader-ramped) for the module path.
- **New module** `DSP::MODULES::morphingReverb` (dspObject): two preset slots (named `REVERB_PRESET` or custom `presetValues`) blended by `morph(t)` in [0, 1]. Writes are atomic control-rate stores (allocation-free, wait-free); the audio thread applies the blend through the core's ~1 s faders, so sweeps are click-free. Usable as a channel/return insert via `setDSP` (e.g. `r.makeReturn("verb").setDSP(&morphVerb)`), not only via the global attach. `dry = 1` maps to unity gain, so morphing fully to `REVERB_OFF` is a true bypass (the legacy path's historical 2x dry makeup gain is not inherited).
- **Proximity stays the default driver**: `REVERB::Manager`'s blend at `reverbManager.cpp` is untouched (freeze rule — legacy-bound, no new features). Its header now records the status and points at the module.
- **Design note** (acceptance item 4): the zone-return trajectory (send_return_buses.md §12b — parameter morph = one space transforming; zone returns = spaces crossfading) is recorded in the module header doc.
- `PROJECT_OVERVIEW.md` module list updated.

## Test plan

- [x] `python yse.py format` run; diff limited to the touched files
- [x] `python yse.py analyze` on all touched engine/test files — zero new findings (all remaining warnings suppressed / non-user code)
- [x] `python yse.py test`: **32/32 ctest entries pass** (full suite, ~99 s), including the monolithic `yse_unit_tests`
- [x] New coverage: preset-table/interpolation checks, morph endpoint + clamping, audible A/B selection (impulse-tail energy), morph-to-OFF true bypass, full-range sweep bounded/finite, steady-state allocation probe (`ProbeScope`, 0 allocs), channel-count-change tolerance, `reverbDSP` instance-independence regression (fails on the pre-refactor globals), and a concurrent two-instance `reverbDSP` case that the TSan CI legs pick up via the `* concurrency: *` filter
- [x] Existing reverb tests stay green unchanged — the proximity path is bit-compatible (untouched code; the kernel refactor keeps the exact arithmetic)

Integration note: no end-to-end app flow exists for this library change beyond the doctest suite; behaviour is exercised through the module's real process path (the same entry point `channel::setDSP` inserts call), including the multi-instance concurrency case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)