### PR TITLE
DSP: re-express the underwater effect as a channel insert with a spatial default binding (#327)

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -268,7 +268,7 @@ One Freeverb-derived reverb processor; multiple `YSE::reverb` objects each repre
 **Reverb properties:** position, size, rollOff, roomSize, damping, dryWetBalance, modulation.
 **Built-in presets:** `REVERB_OFF, GENERIC, PADDED, ROOM, BATHROOM, STONEROOM, LARGEROOM, HALL, CAVE, SEWERPIPE, UNDERWATER`
 
-A separate `underWaterEffect` filter attaches per channel via `system::underWaterFX(channel)` + `setUnderWaterDepth(...)`.
+The underwater treatment is an ordinary insert module (`dsp/modules/underWater.hpp`, issue #327). `system::underWaterFX(channel)` binds the engine's default instance to a channel's insert slot through the normal `setDSP` path, and `setUnderWaterDepth(...)` drives it at control rate (listener depth below the water plane) alongside a matching `REVERB_UNDERWATER` zone; user code can instantiate and drive the module directly instead.
 
 ---
 
@@ -463,7 +463,7 @@ sound.play()
                                                  └── device output (PortAudio / Oboe)
 ```
 
-Channel routing (epic [#146](https://github.com/yvanvds/yse-soundengine/issues/146)): each `YSE::channel` carries an optional pre-fader **insert** chain (`setDSP`, a linked `dspObject` list) and up to N **aux sends** to **return buses** (`makeReturn` / `send` / `setSendLevel`). Returns are ordinary channels flagged as returns — they keep their own inserts and may send onward to other returns (the send graph must stay acyclic). Mix-grade effect modules for these slots live in `dsp/modules/` (`parametricEQ`, `compressor`, `chorus`, `plateReverb`, `morphingReverb`, `delay/feedbackDelay`).
+Channel routing (epic [#146](https://github.com/yvanvds/yse-soundengine/issues/146)): each `YSE::channel` carries an optional pre-fader **insert** chain (`setDSP`, a linked `dspObject` list) and up to N **aux sends** to **return buses** (`makeReturn` / `send` / `setSendLevel`). Returns are ordinary channels flagged as returns — they keep their own inserts and may send onward to other returns (the send graph must stay acyclic). Mix-grade effect modules for these slots live in `dsp/modules/` (`parametricEQ`, `compressor`, `chorus`, `plateReverb`, `morphingReverb`, `underWater`, `delay/feedbackDelay`).
 
 ---
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(YSE_TEST_SOURCES
   dsp/test_module_chorus.cpp
   dsp/test_module_plate_reverb.cpp
   dsp/test_module_morphing_reverb.cpp
+  dsp/test_module_underwater.cpp
   dsp/test_module_parametric_eq.cpp
   dsp/test_module_compressor.cpp
   dsp/test_module_multichannel.cpp
@@ -65,6 +66,7 @@ set(YSE_TEST_SOURCES
   channel/test_channel_layout.cpp
   channel/test_channel_dsp.cpp
   channel/test_channel_sends.cpp
+  channel/test_channel_underwater.cpp
   channel/test_c_api_channel.cpp
   sound/test_sound_state.cpp
   sound/test_sound_streaming.cpp

--- a/Tests/TEST_PLAN.md
+++ b/Tests/TEST_PLAN.md
@@ -412,7 +412,7 @@ Preliminary `Tests/support/null_device.hpp` (stub-out if needed for patcher): a 
 
 **Source files under test:**
 - `YseEngine/internal/reverbDSP.h` / `reverbDSP.cpp` — Freeverb algorithm
-- `YseEngine/internal/underWaterEffect.h` / `underWaterEffect.cpp` — underwater reverb preset
+- `YseEngine/internal/underWaterEffect.h` / `underWaterEffect.cpp` — driver binding the underwater insert module (`YseEngine/dsp/modules/underWater.*`) to its default spatial control
 - `YseEngine/reverb/reverbImplementation.h` / `reverbImplementation.cpp`
 - `YseEngine/reverb/reverbManager.h` / `reverbManager.cpp`
 - `YseEngine/reverb/reverbInterface.hpp` / `reverbInterface.cpp`
@@ -424,7 +424,7 @@ Preliminary `Tests/support/null_device.hpp` (stub-out if needed for patcher): a 
 - Impulse response: feeding an impulse into `reverbDSP` and observing that the tail decays to silence within a bounded number of samples (tests the reverb tail, not exact values).
 - Wet/dry mix: at 100% dry the output equals the input; at 100% wet the output diverges from the input.
 - Stereo output: left and right channels are non-identical after the reverb (decorrelation).
-- `underWaterEffect`: output power is lower than input at frequencies above the expected lowpass cutoff (qualitative energy check).
+- `DSP::MODULES::underWater` (issue #327): output power is lower than input at frequencies above the expected lowpass cutoff (qualitative energy check) — covered in `Tests/dsp/test_module_underwater.cpp`; the driver/attach path is covered in `Tests/channel/test_channel_underwater.cpp`.
 
 **Test areas — reverb zone management:**
 - `reverbMessage`: construction and field accessors.

--- a/Tests/channel/test_channel_underwater.cpp
+++ b/Tests/channel/test_channel_underwater.cpp
@@ -1,0 +1,114 @@
+// Driver / attach-path tests for the stock underwater effect (issue #327).
+//
+// The DSP itself is an ordinary insert module (DSP::MODULES::underWater,
+// covered in Tests/dsp/test_module_underwater.cpp). These cases verify the
+// engine-side default binding:
+//   - System().underWaterFX(channel) places the engine's module instance at
+//     the head of the channel's insert chain through the ordinary
+//     channel::setDSP / ATTACH_DSP message path — the hard-wired slot and
+//     bespoke attach path are gone from the channel implementation.
+//   - System().setUnderWaterDepth() drives the module's depth parameter as a
+//     control-rate write (the "listener depth below the water plane" default
+//     driver).
+//   - Re-attaching to a different channel severs the previous channel's
+//     insert link first, so one module instance is never processed by two
+//     channels concurrently.
+//
+// Engine-dependent cases guard on engineInit() like the rest of the channel
+// suite (skipped on CI hosts without an audio device).
+
+#include <doctest/doctest.h>
+#include <chrono>
+#include <thread>
+#include "yse.hpp"
+#include "channel/channelInterface.hpp"
+#include "channel/channelManager.h"
+#include "dsp/dspObject.hpp"
+#include "internal/underWaterEffect.h"
+#include "sound/soundManager.h"
+#include "internal/time.h"
+#include "support/null_device.hpp"
+
+namespace {
+
+  // Pump the (paused) engine so queued channel messages are applied on the
+  // manager update path — same helper as test_channel_dsp.cpp.
+  void drainChannels(int iterations = 8) {
+    for (int i = 0; i < iterations; ++i) {
+      YSE::INTERNAL::Time().update();
+      YSE::SOUND::Manager().update();
+      YSE::CHANNEL::Manager().update();
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("channel") {
+
+  TEST_CASE("channel underwater: underWaterFX attaches the module via the ordinary insert path") {
+    if (!TestHelpers::engineInit()) return;
+
+    YSE::channel ch;
+    ch.create("underwater_attach", YSE::ChannelMaster());
+    drainChannels();
+    CHECK(ch.getDSP() == nullptr);
+
+    YSE::System().underWaterFX(ch);
+    // The interface mirror reflects the ordinary setDSP path immediately...
+    CHECK(ch.getDSP() == &YSE::INTERNAL::UnderWaterEffect().module());
+
+    // ...and after the message pump the impl links the module back
+    // (calledfrom is the engine-managed back-pointer addDSP installs).
+    drainChannels();
+    CHECK(YSE::INTERNAL::UnderWaterEffect().module().calledfrom != nullptr);
+
+    // Detach so the shared singleton doesn't outlive this test's channel.
+    ch.setDSP(nullptr);
+    drainChannels();
+    CHECK(YSE::INTERNAL::UnderWaterEffect().module().calledfrom == nullptr);
+  }
+
+  TEST_CASE("channel underwater: setUnderWaterDepth drives the module's depth control") {
+    if (!TestHelpers::engineInit()) return;
+
+    YSE::System().setUnderWaterDepth(3.5f);
+    CHECK(YSE::INTERNAL::UnderWaterEffect().module().depth() == doctest::Approx(3.5f));
+
+    // Above the surface clamps to zero (effect fully released).
+    YSE::System().setUnderWaterDepth(-2.0f);
+    CHECK(YSE::INTERNAL::UnderWaterEffect().module().depth() == doctest::Approx(0.0f));
+
+    YSE::System().setUnderWaterDepth(0.0f);
+  }
+
+  TEST_CASE("channel underwater: moving the effect severs the previous channel's insert") {
+    if (!TestHelpers::engineInit()) return;
+
+    YSE::channel a;
+    YSE::channel b;
+    a.create("underwater_move_a", YSE::ChannelMaster());
+    b.create("underwater_move_b", YSE::ChannelMaster());
+    drainChannels();
+
+    YSE::System().underWaterFX(a);
+    drainChannels();
+    YSE::DSP::dspObject** slotA = YSE::INTERNAL::UnderWaterEffect().module().calledfrom;
+    REQUIRE(slotA != nullptr);
+
+    YSE::System().underWaterFX(b);
+    drainChannels();
+    YSE::DSP::dspObject** slotB = YSE::INTERNAL::UnderWaterEffect().module().calledfrom;
+
+    // Attached to b's impl now, and a's insert slot was cleared on the way —
+    // the module is never owned by two channels at once.
+    CHECK(slotB != nullptr);
+    CHECK(slotB != slotA);
+    CHECK(*slotA == nullptr);
+
+    b.setDSP(nullptr);
+    drainChannels();
+    CHECK(YSE::INTERNAL::UnderWaterEffect().module().calledfrom == nullptr);
+  }
+
+} // TEST_SUITE("channel")

--- a/Tests/dsp/test_module_underwater.cpp
+++ b/Tests/dsp/test_module_underwater.cpp
@@ -1,0 +1,269 @@
+// Behavioural tests for the underwater effect MODULE (issue #327).
+//
+// DSP::MODULES::underWater packages the legacy channel-path underwater
+// treatment as a chainable dspObject whose depth is a *control input*: all
+// channels are mixed down to a position-neutral average, darkened with a
+// depth-driven low-pass (cutoff = MidiToFreq(140 - 5 * depth), floored at
+// 200 Hz), and crossfaded against the positioned signal as the listener
+// sinks. Writes to depth() are atomic stores, callable from any control
+// thread at control rate.
+//
+// The acceptance criteria (issue #327) drive the cases below:
+//   - the module reproduces the legacy treatment: transparent at depth <= 1,
+//     a linear crossfade toward the low-passed neutral mix up to depth 5,
+//     fully position-neutral beyond
+//   - depth-driven parameter updates work as ordinary control-rate writes
+//     (manual driving from user code)
+//   - steady-state process() allocates nothing; a channel-count change is
+//     tolerated (the one allocation-permitted path)
+//
+// No audio device required — SAMPLERATE is initialised by the
+// portaudioDeviceManager translation unit at static-initialisation time.
+
+#include <doctest/doctest.h>
+#include <cmath>
+#include "dsp/modules/underWater.hpp"
+#include "headers/constants.hpp"
+#include "support/alloc_probe.hpp"
+#include "support/audio_helpers.hpp"
+
+namespace {
+
+  // Fill every channel of `buf` with a constant value.
+  void fill(MULTICHANNELBUFFER& buf, float value) {
+    for (auto& ch : buf)
+      ch = value;
+  }
+
+  // Write a sine of the given frequency into `ch`, continuing from `phase`
+  // (updated in place) so multi-block signals stay continuous.
+  void fillSine(YSE::DSP::buffer& ch, float freq, double& phase) {
+    float* ptr = ch.getPtr();
+    const double step = 2.0 * 3.14159265358979323846 * freq / YSE::SAMPLERATE;
+    for (unsigned i = 0; i < ch.getLength(); ++i) {
+      ptr[i] = static_cast<float>(std::sin(phase));
+      phase += step;
+    }
+  }
+
+  bool allFinite(MULTICHANNELBUFFER& buf) {
+    for (auto& ch : buf) {
+      float* ptr = ch.getPtr();
+      for (unsigned i = 0; i < ch.getLength(); ++i)
+        if (!std::isfinite(ptr[i])) return false;
+    }
+    return true;
+  }
+
+  // Run `blocks` blocks of constant per-channel input through the module so
+  // the one-pole filter settles, returning the buffer state after the last
+  // block. `values` supplies one constant per channel.
+  MULTICHANNELBUFFER settle(YSE::DSP::MODULES::underWater& fx, const std::vector<float>& values,
+                            int blocks = 30) {
+    MULTICHANNELBUFFER buf(values.size());
+    for (int i = 0; i < blocks; ++i) {
+      for (size_t ch = 0; ch < values.size(); ++ch)
+        buf[ch] = values[ch];
+      fx.process(buf);
+    }
+    return buf;
+  }
+
+} // anonymous namespace
+
+TEST_SUITE("dsp") {
+
+  // ─── the depth control input ──────────────────────────────────────────────
+
+  TEST_CASE("underWater: defaults to zero depth (transparent)") {
+    YSE::DSP::MODULES::underWater fx;
+    CHECK(fx.depth() == doctest::Approx(0.0f));
+  }
+
+  TEST_CASE("underWater: depth is clamped at the surface (no negative depth)") {
+    YSE::DSP::MODULES::underWater fx;
+    fx.depth(-4.0f);
+    CHECK(fx.depth() == doctest::Approx(0.0f));
+    fx.depth(2.5f);
+    CHECK(fx.depth() == doctest::Approx(2.5f));
+  }
+
+  // ─── transparency at / above the surface threshold ────────────────────────
+
+  TEST_CASE("underWater: depth <= 1 passes the buffer through untouched") {
+    YSE::DSP::MODULES::underWater fx;
+
+    MULTICHANNELBUFFER buf(2);
+    for (float depth : {0.0f, 0.5f, 1.0f}) {
+      fx.depth(depth);
+      buf[0] = 0.4f;
+      buf[1] = -0.2f;
+      fx.process(buf);
+
+      float* p0 = buf[0].getPtr();
+      float* p1 = buf[1].getPtr();
+      for (unsigned i = 0; i < buf[0].getLength(); ++i) {
+        CHECK(p0[i] == doctest::Approx(0.4f));
+        CHECK(p1[i] == doctest::Approx(-0.2f));
+      }
+    }
+  }
+
+  // ─── the crossfade toward the position-neutral mix ────────────────────────
+
+  TEST_CASE("underWater: intermediate depth blends toward the channel average") {
+    // ch0 = 0.8, ch1 = 0.2 -> neutral mix = 0.5. At depth 2.5 the blend is
+    // half positioned / half neutral: ch0 -> 0.65, ch1 -> 0.35. DC input, so
+    // once the one-pole low-pass settles the values are exact.
+    YSE::DSP::MODULES::underWater fx;
+    fx.depth(2.5f);
+
+    MULTICHANNELBUFFER buf = settle(fx, {0.8f, 0.2f});
+
+    float* p0 = buf[0].getPtr();
+    float* p1 = buf[1].getPtr();
+    const unsigned last = buf[0].getLength() - 1;
+    CHECK(p0[last] == doctest::Approx(0.65f).epsilon(1e-3));
+    CHECK(p1[last] == doctest::Approx(0.35f).epsilon(1e-3));
+  }
+
+  TEST_CASE("underWater: beyond depth 5 position information is discarded") {
+    // Fully submerged: every channel must carry the identical neutral mix
+    // (0.8 + 0.2) / 2 = 0.5.
+    YSE::DSP::MODULES::underWater fx;
+    fx.depth(6.0f);
+
+    MULTICHANNELBUFFER buf = settle(fx, {0.8f, 0.2f});
+
+    CHECK(TestHelpers::buffersNearlyEqual(buf[0], buf[1]));
+    const unsigned last = buf[0].getLength() - 1;
+    CHECK(buf[0].getPtr()[last] == doctest::Approx(0.5f).epsilon(1e-3));
+  }
+
+  // ─── the depth-driven low-pass (TEST_PLAN Phase 10 energy check) ──────────
+
+  TEST_CASE("underWater: high frequencies lose more power than low frequencies") {
+    // At depth 10 the cutoff is MidiToFreq(90) ~ 1.47 kHz. An 8 kHz sine must
+    // come out well below its input level; a 200 Hz sine mostly survives.
+    auto surviving = [](float freq) {
+      YSE::DSP::MODULES::underWater fx;
+      fx.depth(10.0f);
+      MULTICHANNELBUFFER buf(1);
+      double phase = 0.0;
+      float rms = 0.0f;
+      for (int i = 0; i < 40; ++i) { // let the filter reach steady state
+        fillSine(buf[0], freq, phase);
+        fx.process(buf);
+        rms = TestHelpers::measureRms(buf[0]);
+      }
+      return rms; // input sine RMS is 1/sqrt(2) ~ 0.707
+    };
+
+    const float high = surviving(8000.0f);
+    const float low = surviving(200.0f);
+
+    CHECK(high < 0.5f * 0.707f); // strongly attenuated above the cutoff
+    CHECK(low > 0.7f * 0.707f); // mostly preserved below it
+    CHECK(low > 2.0f * high);
+  }
+
+  TEST_CASE("underWater: extreme depth stays finite (cutoff floors at 200 Hz)") {
+    YSE::DSP::MODULES::underWater fx;
+    fx.depth(1000.0f);
+
+    MULTICHANNELBUFFER buf(2);
+    double phase = 0.0;
+    for (int i = 0; i < 50; ++i) {
+      fillSine(buf[0], 440.0f, phase);
+      buf[1] = 0.3f;
+      fx.process(buf);
+    }
+    CHECK(allFinite(buf));
+  }
+
+  TEST_CASE("underWater: mono input stays bounded over many blocks") {
+    // Regression guard: the legacy channel-path code accumulated the previous
+    // block's mixdown into the next one (divided by the channel count), which
+    // diverges on a single channel. The module zeroes its scratch per block,
+    // so a long constant mono feed must settle, not grow.
+    YSE::DSP::MODULES::underWater fx;
+    fx.depth(3.0f);
+
+    MULTICHANNELBUFFER buf(1);
+    float peak = 0.0f;
+    for (int i = 0; i < 400; ++i) {
+      buf[0] = 0.5f;
+      fx.process(buf);
+      peak = buf[0].maxValue();
+    }
+    CHECK(peak == doctest::Approx(0.5f).epsilon(1e-2));
+  }
+
+  // ─── control-rate driving ─────────────────────────────────────────────────
+
+  TEST_CASE("underWater: depth moves engage and release the effect between blocks") {
+    YSE::DSP::MODULES::underWater fx;
+    MULTICHANNELBUFFER buf(2);
+
+    // Engaged: distinct channels converge toward each other.
+    fx.depth(6.0f);
+    for (int i = 0; i < 30; ++i) {
+      buf[0] = 0.8f;
+      buf[1] = 0.2f;
+      fx.process(buf);
+    }
+    CHECK(TestHelpers::buffersNearlyEqual(buf[0], buf[1]));
+
+    // Released: the very next block passes through untouched.
+    fx.depth(0.0f);
+    buf[0] = 0.8f;
+    buf[1] = 0.2f;
+    fx.process(buf);
+    const unsigned last = buf[0].getLength() - 1;
+    CHECK(buf[0].getPtr()[last] == doctest::Approx(0.8f));
+    CHECK(buf[1].getPtr()[last] == doctest::Approx(0.2f));
+  }
+
+  // ─── RT discipline ────────────────────────────────────────────────────────
+
+  TEST_CASE("underWater: steady-state process allocates nothing") {
+    YSE::DSP::MODULES::underWater fx;
+    fx.depth(3.0f);
+
+    // Warm up: the first engaged process sizes the mixdown scratch (the one
+    // permitted allocation).
+    MULTICHANNELBUFFER buf(2);
+    fill(buf, 0.25f);
+    fx.process(buf);
+
+    {
+      TestHelpers::ProbeScope probe;
+      for (int i = 0; i < 20; ++i) {
+        fx.depth(2.0f + 0.1f * static_cast<float>(i)); // live control writes
+        fill(buf, 0.25f);
+        fx.process(buf);
+      }
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+  }
+
+  TEST_CASE("underWater: tolerates a changing channel count between calls") {
+    YSE::DSP::MODULES::underWater fx;
+    fx.depth(4.0f);
+
+    MULTICHANNELBUFFER mono(1);
+    mono[0] = 0.5f;
+    fx.process(mono);
+
+    MULTICHANNELBUFFER quad(4);
+    fill(quad, 0.5f);
+    fx.process(quad);
+
+    MULTICHANNELBUFFER stereo(2);
+    fill(stereo, 0.5f);
+    fx.process(stereo);
+
+    CHECK(allFinite(stereo));
+  }
+
+} // TEST_SUITE("dsp")

--- a/YseEngine/CMakeLists.txt
+++ b/YseEngine/CMakeLists.txt
@@ -55,6 +55,7 @@ set(YSE_SRCS
   dsp/modules/plateReverb.cpp
   dsp/modules/ringModulator.cpp
   dsp/modules/sineWave.cpp
+  dsp/modules/underWater.cpp
   dsp/fm/fmPatch.cpp
   dsp/fm/fmVoice.cpp
   dsp/fm/dx7Sysex.cpp

--- a/YseEngine/c_api/include/yse_c/yse_channel.h
+++ b/YseEngine/c_api/include/yse_c/yse_channel.h
@@ -108,7 +108,7 @@ YSE_C_API const char* yse_channel_get_name(YseChannel* ch);
 
 /* Output peak metering — see channelInterface.hpp for semantics.
  *
- * "Pre" reads the peak measured at the end of dsp() (after reverb/underwater FX,
+ * "Pre" reads the peak measured at the end of dsp() (after inserts and reverb,
  * before the channel volume is applied); "Post" reads the peak measured
  * immediately after adjustVolume() — what listeners hear. Per-output overloads
  * take an index in [0, yse_channel_get_num_outputs()); out-of-range indices

--- a/YseEngine/c_api/include/yse_c/yse_system.h
+++ b/YseEngine/c_api/include/yse_c/yse_system.h
@@ -120,8 +120,12 @@ YSE_C_API float yse_system_current_tempo(YseSystem* sys, const char* name);
    Returned pointer is borrowed; never destroy. */
 YSE_C_API YseReverb* yse_system_get_global_reverb(YseSystem* sys);
 
-/* Underwater effect: routes a channel through the built-in low-pass /
-   pitch-shift "underwater" filter. Depth is in [0.0, 1.0]. */
+/* Underwater effect: attaches the engine's underwater insert module to the
+   channel's insert slot (the same slot yse_channel_set_dsp uses; the two
+   replace each other). Depth is the listener's distance below the water
+   surface in world units: <= 0 disables the effect, the low-passed
+   position-neutral treatment fades in above 1 and saturates at 5. A positive
+   depth also enables the built-in underwater reverb zone. */
 YSE_C_API void yse_system_underwater_fx(YseSystem* sys, const YseChannel* target);
 YSE_C_API void yse_system_set_underwater_depth(YseSystem* sys, float depth);
 

--- a/YseEngine/channel/channelImplementation.cpp
+++ b/YseEngine/channel/channelImplementation.cpp
@@ -150,10 +150,6 @@ void YSE::CHANNEL::implementationObject::dsp() {
 
   REVERB::Manager().process(this);
 
-  if (INTERNAL::UnderWaterEffect().channel() == this) {
-    INTERNAL::UnderWaterEffect().apply(out);
-  }
-
   // Publish pre-volume peak for VU consumers. Sized in lock-step with `out`
   // in setup()/resize(); the std::min guards against a resize race.
   const UInt n = (UInt)std::min(out.size(), lastPeakLinearPre.size());
@@ -223,10 +219,6 @@ void YSE::CHANNEL::implementationObject::buffersToParent() {
     // parent size is not checked but should be ok because it's adjusted before calling this
     parent->out[i] += out[i];
   }
-}
-
-void YSE::CHANNEL::implementationObject::attachUnderWaterFX() {
-  INTERNAL::UnderWaterEffect().channel(this);
 }
 
 void YSE::CHANNEL::implementationObject::addDSP(DSP::dspObject* ptr) {
@@ -305,15 +297,11 @@ void YSE::CHANNEL::implementationObject::processReturnInsert() {
   // `out` already holds the accumulated sends (zeroed at block start by the
   // master, summed by the source tree and any earlier-generation returns). Run
   // the return's own DSP in place — its insert chain is the effect (e.g. a plate
-  // reverb on a send return), plus any attached global reverb / underwater FX —
-  // mirroring the tail of dsp(). Single-writer over this return's own `out`.
+  // reverb on a send return), plus any attached global reverb — mirroring the
+  // tail of dsp(). Single-writer over this return's own `out`.
   if (insert_dsp != nullptr) processInsertDSP();
 
   REVERB::Manager().process(this);
-
-  if (INTERNAL::UnderWaterEffect().channel() == this) {
-    INTERNAL::UnderWaterEffect().apply(out);
-  }
 
   // Publish pre-volume peak (mirrors dsp()).
   const UInt n = (UInt)std::min(out.size(), lastPeakLinearPre.size());

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -208,12 +208,6 @@ namespace YSE {
        */
       void adjustVolume();
 
-      /**
-        Attach the premade special effect for 'underwater' simulation to this channel
-      */
-
-      void attachUnderWaterFX();
-
       inline std::vector<DSP::buffer>& GetBuffers() {
         return out;
       }
@@ -252,7 +246,7 @@ namespace YSE {
 
       /**
         The fast-pool job body for a return bus: runs the return's own DSP
-        (insert chain + optional reverb / underwater FX) in place over the
+        (insert chain + optional reverb) in place over the
         already-accumulated `out`, then publishes the pre-fader peak. Mirrors the
         tail of dsp(); dispatched from CHANNEL::Manager::processReturns() exactly
         like a source channel's dsp(). Single-writer over this return's own `out`.

--- a/YseEngine/channel/channelInterface.hpp
+++ b/YseEngine/channel/channelInterface.hpp
@@ -223,7 +223,7 @@ namespace YSE {
     /// Lock-free getters returning the latest per-block peak of this channel's
     /// output buffers. Refresh granularity is one audio block (so polling
     /// faster than the audio block rate yields no new data). ``Pre`` reads
-    /// the peak measured at the end of ``dsp()`` (after reverb/underwater FX,
+    /// the peak measured at the end of ``dsp()`` (after inserts and reverb,
     /// before the channel volume is applied); ``Post`` reads the peak
     /// measured immediately after ``adjustVolume()`` — what listeners hear.
     /// Per-output overloads take an index in ``[0, getNumOutputs())``;

--- a/YseEngine/dsp/modules/underWater.cpp
+++ b/YseEngine/dsp/modules/underWater.cpp
@@ -1,0 +1,77 @@
+/*
+  ==============================================================================
+
+    underWater.cpp
+    Underwater effect module — the channel-path special case re-expressed as
+    an ordinary insert (issue #327).
+
+  ==============================================================================
+*/
+
+#include "underWater.hpp"
+#include "../math.hpp"
+
+YSE::DSP::MODULES::underWater::underWater() : parmDepth(0.f) {}
+
+YSE::DSP::MODULES::underWater& YSE::DSP::MODULES::underWater::depth(Flt value) {
+  if (value < 0.f) value = 0.f;
+  parmDepth.store(value);
+  return *this;
+}
+
+Flt YSE::DSP::MODULES::underWater::depth() const {
+  return parmDepth.load();
+}
+
+void YSE::DSP::MODULES::underWater::create() {
+  // Nothing to size yet: the mixdown scratch depends on the block length,
+  // which is only known once process() sees a buffer.
+}
+
+void YSE::DSP::MODULES::underWater::process(MULTICHANNELBUFFER& buffer) {
+  createIfNeeded();
+
+  // The effect only engages below one unit of depth — the same threshold the
+  // legacy channel-path implementation used. Above water (or barely under)
+  // the buffer passes through untouched.
+  const Flt d = parmDepth.load();
+  if (d <= 1.f || buffer.empty()) return;
+
+  // (Re)size the mixdown scratch to the block length. This allocates only
+  // when the length actually changed — the device-restart path, the one
+  // place the dspObject contract permits allocation.
+  const UInt length = buffer[0].getLength();
+  if (mono.getLength() != length) mono.resize(length);
+
+  // Sound underwater is more position neutral. Because the speed of sound is
+  // much higher, the ear cannot hear what direction it comes from: build a
+  // position-neutral average of all channels first.
+  mono = 0.f;
+  for (UInt i = 0; i < buffer.size(); ++i) {
+    mono += buffer[i];
+  }
+  mono /= static_cast<Flt>(buffer.size());
+
+  // The deeper the listener, the darker the mix: the cutoff falls with depth
+  // along the legacy curve, floored at 200 Hz.
+  Flt cutoff = MidiToFreq(140.f - d * 5.f);
+  if (cutoff < 200.f) cutoff = 200.f;
+  filter.setFrequency(cutoff);
+  // The one-pole returns its own output buffer (sized on the first call — the
+  // create path); scaling it below is fine, it is rewritten every block.
+  YSE::DSP::buffer& lp = filter(mono);
+
+  if (d > 5.f) {
+    // Fully submerged: discard position information entirely.
+    for (UInt i = 0; i < buffer.size(); ++i) {
+      buffer[i] = lp;
+    }
+  } else {
+    // Partly replace the positioned signal with the neutral version.
+    lp *= d / 5.f;
+    for (UInt i = 0; i < buffer.size(); ++i) {
+      buffer[i] *= (5.f - d) / 5.f;
+      buffer[i] += lp;
+    }
+  }
+}

--- a/YseEngine/dsp/modules/underWater.hpp
+++ b/YseEngine/dsp/modules/underWater.hpp
@@ -1,0 +1,122 @@
+/*
+  ==============================================================================
+
+    underWater.hpp
+    Underwater effect module — the channel-path special case re-expressed as
+    an ordinary insert (issue #327).
+
+  ==============================================================================
+*/
+
+#ifndef UNDERWATER_HPP_INCLUDED
+#define UNDERWATER_HPP_INCLUDED
+
+#include "../../headers/defines.hpp"
+#include "../../headers/types.hpp"
+#include "../dspObject.hpp"
+#include "../buffer.hpp"
+#include "../filters.hpp"
+
+namespace YSE {
+  namespace DSP {
+    namespace MODULES {
+
+      /**
+       *  @brief The underwater treatment as an ordinary chainable ``dspObject``.
+       *
+       *  This is the DSP half of the engine's classic underwater effect
+       *  (issue #327), extracted from the hard-wired slot it used to occupy in
+       *  the channel path. Sound underwater is more position neutral — the
+       *  speed of sound is much higher, so the ear cannot tell what direction
+       *  it comes from. The module therefore mixes all channels down to a
+       *  position-neutral average, darkens it with a depth-driven low-pass,
+       *  and crossfades the original image toward that neutral version as the
+       *  listener sinks.
+       *
+       *  ### The depth control
+       *
+       *  ``depth`` is the distance below the water surface, in world distance
+       *  units (meters):
+       *
+       *  - ``depth <= 1``: transparent — the buffer passes through untouched.
+       *  - ``1 < depth < 5``: the positioned signal is progressively replaced
+       *    by the low-passed neutral mix (linear crossfade over the range).
+       *  - ``depth >= 5``: position information is discarded entirely; every
+       *    channel carries the same low-passed mix.
+       *
+       *  The low-pass cutoff falls with depth as ``MidiToFreq(140 - 5 * depth)``
+       *  and is floored at 200 Hz — the same curve the legacy channel-path
+       *  effect has always applied.
+       *
+       *  ### Drivers
+       *
+       *  ``depth`` is deliberately driver-agnostic: writes are plain atomic
+       *  stores (allocation-free, wait-free), callable from any control thread
+       *  at control rate — a game tick, a patcher ramp, a live-coded
+       *  expression. The classic spatial binding — listener depth below the
+       *  water plane, plus the matching ``REVERB_UNDERWATER`` zone — remains
+       *  the *default* driver through ``System().underWaterFX()`` /
+       *  ``System().setUnderWaterDepth()``, which drive the engine's own
+       *  instance of this module (see ``INTERNAL::underWaterEffect``). Same
+       *  module, different drivers — the idiom established by
+       *  ``morphingReverb`` (issue #326).
+       *
+       *  ### Placement
+       *
+       *  Attach it with ``YSE::channel::setDSP`` / ``YSE::sound::setDSP``, on
+       *  any channel, return bus, or sound — it is no longer welded to the
+       *  channel implementation. Note one deliberate difference from the
+       *  legacy hard-wired slot: an insert runs *pre-fader, before* the global
+       *  manager reverb, whereas the old slot ran after it. When the module
+       *  and the (legacy-bound) global reverb sit on the same channel the
+       *  reverb tail is no longer low-passed; place the module after a reverb
+       *  insert (``dspObject::link``) or on a return to author that ordering
+       *  explicitly. The wet/dry balance is inherent in ``depth``, so the
+       *  inherited ``impact()`` slider is not applied.
+       *
+       *  ### RT discipline
+       *
+       *  Steady-state ``process`` allocates nothing. The mixdown scratch is
+       *  (re)sized only when the block length changes — the device-restart
+       *  path, the one place the ``dspObject`` contract permits allocation.
+       *  (The legacy implementation also carried the previous block's mixdown
+       *  into the next one at 1/N gain — an accumulate-without-clear that
+       *  diverges on mono buffers. This module zeroes the scratch every block
+       *  instead.)
+       */
+      class API underWater : public dspObject {
+      public:
+        /** Defaults to ``depth() == 0`` — fully transparent. */
+        underWater();
+        virtual ~underWater() {}
+
+        /** @brief The depth control input, in distance units below the water
+         *  surface. Negative values clamp to 0 (above water). Callable from
+         *  any control thread at control rate — allocation-free, wait-free
+         *  (see class docs for the response curve). */
+        underWater& depth(Flt value);
+
+        /** @brief Current depth. */
+        Flt depth() const;
+
+        /** @brief dspObject lifecycle hook. Nothing to allocate up front: the
+         *  mixdown scratch is sized in ``process`` (the block length is only
+         *  known there). */
+        virtual void create();
+
+        /** @brief dspObject audio-thread entry point. */
+        virtual void process(MULTICHANNELBUFFER& buffer);
+
+      private:
+        aFlt parmDepth; // control threads write, the audio thread reads
+
+        // Audio-thread-owned state.
+        buffer mono; // position-neutral mixdown scratch
+        lowPass filter;
+      };
+
+    } // namespace MODULES
+  } // namespace DSP
+} // namespace YSE
+
+#endif // UNDERWATER_HPP_INCLUDED

--- a/YseEngine/internal/underWaterEffect.cpp
+++ b/YseEngine/internal/underWaterEffect.cpp
@@ -5,6 +5,10 @@
     Created: 1 Feb 2014 10:02:28pm
     Author:  yvan
 
+    Re-expressed for issue #327: the DSP moved into the ordinary insert
+    module DSP::MODULES::underWater; this class is now only the engine-side
+    *driver* that binds the module to its default spatial control.
+
   ==============================================================================
 */
 
@@ -15,26 +19,40 @@ YSE::INTERNAL::underWaterEffect& YSE::INTERNAL::UnderWaterEffect() {
   return u;
 }
 
-YSE::INTERNAL::underWaterEffect::underWaterEffect() : activeChannel(nullptr) {
+YSE::INTERNAL::underWaterEffect::underWaterEffect() : lastTarget(nullptr) {
   verb.create();
   verb.setPreset(REVERB_UNDERWATER);
   verb.setSize(10);
   verb.setActive(false);
 }
 
-YSE::INTERNAL::underWaterEffect&
-YSE::INTERNAL::underWaterEffect::channel(CHANNEL::implementationObject* ch) {
-  activeChannel = ch;
+YSE::INTERNAL::underWaterEffect& YSE::INTERNAL::underWaterEffect::attach(const channel& target) {
+  // Re-pointing to another channel: sever the module from its current owner
+  // first so two channels can never run the same instance concurrently (the
+  // module's filter state is single-owner). calledfrom is the engine-managed
+  // back-pointer into the owning impl's insert_dsp slot; clearing through it
+  // is the same pointer-store discipline dspObject's destructor uses (#298).
+  // lastTarget is compared by identity only: if the previous interface has
+  // been destroyed, its impl teardown already cleared fx.calledfrom and this
+  // branch is a no-op. (The previous interface's getDSP() mirror goes stale
+  // here — the same staleness the destructor path has always had.)
+  if (lastTarget != &target && fx.calledfrom != nullptr) {
+    *fx.calledfrom = nullptr;
+    fx.calledfrom = nullptr;
+  }
+  lastTarget = &target;
+
+  // The ordinary insert path: setDSP posts ATTACH_DSP, applied by the
+  // channel's audio-thread sync(). setDSP is logically non-const on the
+  // channel (it occupies the insert slot); the const_cast keeps the
+  // historical system::underWaterFX(const channel&) signature intact.
+  const_cast<channel&>(target).setDSP(&fx);
   return *this;
 }
 
-YSE::CHANNEL::implementationObject* YSE::INTERNAL::underWaterEffect::channel() {
-  return activeChannel;
-}
-
 YSE::INTERNAL::underWaterEffect& YSE::INTERNAL::underWaterEffect::setDepth(Flt value) {
-  depth = value;
-  if (depth > 0) {
+  fx.depth(value);
+  if (value > 0) {
     verb.setActive(true);
     verb.setPosition(ListenerImpl().pos);
   } else {
@@ -43,37 +61,6 @@ YSE::INTERNAL::underWaterEffect& YSE::INTERNAL::underWaterEffect::setDepth(Flt v
   return *this;
 }
 
-YSE::INTERNAL::underWaterEffect&
-YSE::INTERNAL::underWaterEffect::apply(MULTICHANNELBUFFER& channelBuffer) {
-  if (depth > 1) {
-    // sound underwater is more position neutral. Because the speed of sound
-    // is much higher, the ear cannot hear from what direction it comes.
-
-    // first create a buffer that contains all sound with neutral positions
-    for (UInt i = 0; i < channelBuffer.size(); ++i) {
-      buffer += channelBuffer[i];
-    }
-    buffer /= static_cast<Flt>(CHANNEL::Manager().getNumberOfOutputs());
-
-    Flt factor = 140 - (depth * 5);
-    factor = DSP::MidiToFreq(factor);
-    if (factor < 200) factor = 200;
-    filter.setFrequency(factor);
-    lpBuffer = filter(buffer);
-
-    if (depth > 5.0f) {
-      // completely disregard position info
-      for (UInt i = 0; i < channelBuffer.size(); ++i) {
-        channelBuffer[i] = lpBuffer;
-      }
-    } else {
-      // partly replace with position-neutral version
-      lpBuffer *= (depth / 5.0f);
-      for (UInt i = 0; i < channelBuffer.size(); ++i) {
-        channelBuffer[i] *= (5 - depth) / 5.0f;
-        channelBuffer[i] += lpBuffer;
-      }
-    }
-  }
-  return *this;
+YSE::DSP::MODULES::underWater& YSE::INTERNAL::underWaterEffect::module() {
+  return fx;
 }

--- a/YseEngine/internal/underWaterEffect.h
+++ b/YseEngine/internal/underWaterEffect.h
@@ -5,40 +5,67 @@
     Created: 1 Feb 2014 10:02:28pm
     Author:  yvan
 
+    Re-expressed for issue #327: the DSP moved into the ordinary insert
+    module DSP::MODULES::underWater; this class is now only the engine-side
+    *driver* that binds the module to its default spatial control.
+
   ==============================================================================
 */
 
 #ifndef UNDERWATEREFFECT_H_INCLUDED
 #define UNDERWATEREFFECT_H_INCLUDED
 
-#include <atomic>
-#include <forward_list>
 #include "../classes.hpp"
-#include "../dsp/buffer.hpp"
-#include "../dsp/filters.hpp"
+#include "../dsp/modules/underWater.hpp"
 #include "../reverb/reverbInterface.hpp"
 
 namespace YSE {
+  class channel;
+
   namespace INTERNAL {
+
+    /**
+      The engine-side driver for the stock underwater effect (issue #327).
+
+      The DSP itself is an ordinary insert module (DSP::MODULES::underWater);
+      this class owns the engine's default instance plus the matching
+      REVERB_UNDERWATER zone, and binds both to the spatial control the public
+      API exposes: listener depth below the water plane.
+
+      - attach() places the module at the head of the target channel's insert
+        chain through the ordinary channel::setDSP message path — the channel
+        implementation carries no underwater knowledge any more.
+      - setDepth() is the control-rate default driver: it writes the module's
+        depth parameter (a wait-free atomic store the audio thread picks up on
+        the next block) and toggles/positions the underwater reverb zone,
+        exactly as the legacy hard-wired path did.
+
+      User code that wants a different binding (a slider, a patcher ramp, a
+      live-coded expression) instantiates its own DSP::MODULES::underWater and
+      drives depth() directly — same module, different drivers.
+    */
     class underWaterEffect {
     public:
       underWaterEffect();
-      underWaterEffect& channel(CHANNEL::implementationObject* ch);
-      CHANNEL::implementationObject* channel();
 
-      underWaterEffect&
-      setDepth(Flt value); // reverb has to be done before channel reverb processing
-      underWaterEffect& apply(MULTICHANNELBUFFER& channelBuffer); // lowpass has to be done AFTER
-                                                                  // channel reverb processing
+      /** Attach the engine's module instance to `target`'s insert slot via
+       *  the ordinary channel::setDSP path. Only one channel carries the
+       *  stock effect at a time: re-attaching to a different channel severs
+       *  the previous link first. */
+      underWaterEffect& attach(const channel& target);
+
+      /** The default spatial driver: listener depth below the water plane,
+       *  evaluated at control rate by the caller. Drives the module's depth
+       *  parameter and the underwater reverb zone. */
+      underWaterEffect& setDepth(Flt value);
+
+      /** The engine's default module instance (exposed for tests). */
+      DSP::MODULES::underWater& module();
 
     private:
-      Flt depth;
-      DSP::buffer buffer;
-      DSP::buffer lpBuffer;
-      DSP::lowPass filter;
+      DSP::MODULES::underWater fx;
       reverb verb;
-      std::atomic<CHANNEL::implementationObject*>
-          activeChannel; // only one channel can get the underwatereffect
+      const channel* lastTarget; // identity comparison only, never dereferenced
     };
 
     underWaterEffect& UnderWaterEffect();

--- a/YseEngine/system.cpp
+++ b/YseEngine/system.cpp
@@ -186,7 +186,14 @@ YSE::occlusionFunc YSE::system::occlusionCallback() {
 YSE::system::system() : occlusionPtr(nullptr) {}
 
 YSE::system& YSE::system::underWaterFX(const channel& target) {
-  INTERNAL::UnderWaterEffect().channel(target.pimpl);
+  // The stock underwater effect is an ordinary insert module since issue
+  // #327; the driver attaches it through the normal channel::setDSP path,
+  // which needs a live implementation to message.
+  if (target.pimpl == nullptr) {
+    INTERNAL::LogImpl().emit(E_ERROR, "underWaterFX: channel is not created; ignored");
+    return *this;
+  }
+  INTERNAL::UnderWaterEffect().attach(target);
   return *this;
 }
 

--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -228,13 +228,32 @@ namespace YSE {
     /** @brief Current occlusion callback, or ``nullptr`` if none installed. */
     occlusionFunc occlusionCallback();
 
-    /** @brief Route a channel through the under-water effect. */
+    /** @brief Route a channel through the built-in under-water effect.
+     *
+     *  Since issue #327 the underwater treatment is an ordinary insert module
+     *  (``DSP::MODULES::underWater``); this call places the engine's default
+     *  instance at the head of @p target's insert chain through the normal
+     *  ``channel::setDSP`` message path. It therefore occupies the channel's
+     *  insert slot: a later ``setDSP`` on the same channel replaces it, and
+     *  vice versa. Only one channel carries the stock effect at a time —
+     *  calling this again with a different channel moves it. To combine the
+     *  effect with other inserts, or to drive it from your own control logic,
+     *  instantiate your own ``DSP::MODULES::underWater`` instead.
+     */
     system& underWaterFX(const channel& target);
 
-    /** @brief Configure the depth (intensity) of the under-water effect.
+    /** @brief Set the listener's depth below the water surface.
      *
-     *  @param value Depth in the range [0.0, 1.0]. 0 is dry, 1 is the maximum
-     *               low-pass / pitch-shift the effect applies.
+     *  The default spatial driver of the underwater module: evaluate it at
+     *  control rate on your update thread and the value is delivered to the
+     *  audio thread as an ordinary wait-free parameter write.
+     *
+     *  @param value Depth below the surface in world distance units. Zero or
+     *               less disables the effect entirely; the low-passed,
+     *               position-neutral treatment fades in above 1 and is fully
+     *               position-neutral from 5 down. Any positive depth also
+     *               enables the built-in underwater reverb zone at the
+     *               listener's position.
      */
     system& setUnderWaterDepth(float value);
 


### PR DESCRIPTION
## Summary

Implements #327: the underwater effect — the last special-cased effect welded into the channel path — becomes an ordinary channel insert whose parameters carry a spatial default binding, following the same "module + spatial default binding" pattern morphingReverb established (#326, PR #357).

## Linked issue

Closes #327

## Changes

- **New module** `DSP::MODULES::underWater` (`YseEngine/dsp/modules/underWater.{hpp,cpp}`): the lowpass/damping treatment as a standard `dspObject`, usable in any insert chain — channel, return, or sound. `depth()` is the control input (wait-free atomic stores, callable at control rate from any control thread); the response reproduces the legacy curve exactly: transparent at depth ≤ 1, linear crossfade toward the low-passed position-neutral mix up to depth 5, fully position-neutral beyond, cutoff `MidiToFreq(140 − 5·depth)` floored at 200 Hz.
- **`INTERNAL::underWaterEffect` shrinks to the driver** (`YseEngine/internal/underWaterEffect.{h,cpp}`): owns the engine's default module instance plus the `REVERB_UNDERWATER` zone, and binds both to the "listener depth below the water plane" control, evaluated exactly where it was computed before. `attach()` goes through the ordinary `channel::setDSP` / `ATTACH_DSP` message path; re-attaching to a different channel severs the previous link via the engine-managed `calledfrom` back-pointer (same pointer-store discipline as the `dspObject` destructor, #298), so one instance is never processed by two channels concurrently.
- **Special case deleted from the channel implementation**: the underwater blocks in `dsp()` and `processReturnInsert()`, the bespoke `attachUnderWaterFX()` path, and the `activeChannel` atomic are gone. The channel code has zero underwater knowledge.
- **Public API behaviour preserved**: `system::underWaterFX()` / `setUnderWaterDepth()` (and the C API pair) keep their signatures; docs updated (the old `[0.0, 1.0]` depth doc was wrong — the effect has always engaged above 1 and saturated at 5). `underWaterFX` on a not-yet-created channel is now logged and ignored instead of silently storing a null impl.
- **RT discipline unchanged**: depth writes are wait-free stores; steady-state `process()` allocates nothing (verified by an allocation-probe test); the mixdown scratch resizes only when the block length changes (the device-restart path).
- Docs: `PROJECT_OVERVIEW.md`, `Tests/TEST_PLAN.md` (Phase 10 entries).

### Deliberate divergences (documented in the module header)

1. **Ordering vs the legacy manager reverb**: an insert runs pre-fader, *before* `REVERB::Manager().process()`, whereas the hard-wired slot ran after it — so when the module and the (legacy-bound) global reverb share a channel, the reverb tail is no longer low-passed. Authoring that ordering explicitly (reverb insert → underwater via `link()`, or on a return) is the vision-doc replacement.
2. **Per-block scratch clearing**: the legacy code accumulated the previous block's mixdown into the next at 1/N gain (unbounded on mono buffers). The module zeroes its scratch each block; a mono-boundedness regression test pins this.

There were no existing underwater tests, so acceptance item "existing tests stay green" is vacuous; the full suite confirms nothing else regressed.

## Test plan

- [x] `python yse.py format` run; diff limited to the touched files
- [x] `python yse.py analyze` on all touched engine + test files — zero new findings (all remaining warnings in non-user code / check-filtered)
- [x] `python yse.py test`: **32/32 ctest entries pass** (full suite, ~99 s), including the monolithic `yse_unit_tests`
- [x] New module coverage (`Tests/dsp/test_module_underwater.cpp`, 11 cases / 785 assertions): depth defaults + surface clamp, pass-through at depth ≤ 1, exact crossfade arithmetic at depth 2.5, position-neutral collapse beyond 5, high-vs-low frequency energy check (TEST_PLAN Phase 10), extreme-depth finiteness (200 Hz floor), mono boundedness regression, control-rate engage/release, steady-state allocation probe (0 allocs), channel-count-change tolerance
- [x] New driver coverage (`Tests/channel/test_channel_underwater.cpp`, live engine): `underWaterFX` attaches via the ordinary insert path (interface mirror + impl `calledfrom`), `setUnderWaterDepth` drives the module's control input, moving the effect severs the previous channel's insert slot

Integration note: no end-to-end app flow exists for this library change beyond the doctest suite; the driver cases run against a real initialised engine and exercise the same `ATTACH_DSP` message path the audio thread applies, and the module cases drive the real `process()` entry point channel inserts call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)