### PR TITLE
PERF: float transcendentals + x*x in the synth-voice panner spread path (#341)

### DIFF
--- a/YseEngine/dsp/panner.cpp
+++ b/YseEngine/dsp/panner.cpp
@@ -238,7 +238,12 @@ namespace YSE {
       // out of the source-channel loop exactly like the sound path.
       Flt dist = distance - size;
       if (dist < 0) dist = 0;
-      Flt correctPower = 1 / ::pow(dist, (2 * INTERNAL::Settings().rolloffScale));
+      // std::pow with an Flt (float) exponent selects the single-precision
+      // overload; the bare ::pow would promote the args to double (#341, sibling
+      // of #214 which made the same change in the sound path). dist and
+      // rolloffScale are both Flt, so this is a genuine powf, computed once per
+      // gain recompute (this whole function only runs when gainDirty).
+      Flt correctPower = 1 / std::pow(dist, (2 * INTERNAL::Settings().rolloffScale));
       if (correctPower > 1) correctPower = 1;
 
       for (UInt x = 0; x < srcChannels; x++) {
@@ -249,13 +254,16 @@ namespace YSE {
 
         for (UInt i = 0; i < numOutputs; i++) {
           if (spkIsLFE[i]) continue; // LFE is not azimuth-panned
-          Flt initPan = (1 + horizFraction * ::cos(spkAngle[i] - (angle + spreadAdjust))) * 0.5f;
+          // std::cos on an Flt argument selects the float overload instead of
+          // promoting to double (#341) — same as the sound path since #214.
+          Flt initPan = (1 + horizFraction * std::cos(spkAngle[i] - (angle + spreadAdjust))) * 0.5f;
           initGainScratch[i] = initPan / spkEffective[i];
         }
         Flt power = 0;
         for (UInt i = 0; i < numOutputs; i++) {
           if (spkIsLFE[i]) continue;
-          power += static_cast<Flt>(::pow(initGainScratch[i], 2));
+          // Trivial squaring: g * g instead of a double ::pow(g, 2) (#341).
+          power += initGainScratch[i] * initGainScratch[i];
         }
 
         for (UInt j = 0; j < numOutputs; ++j) {


### PR DESCRIPTION
## Summary

Sibling of #214 (PR #342), which optimized the sound panner hot path. This applies the identical treatment to the synth-voice spread path `DSP::panner::computeFinalGains()` in `YseEngine/dsp/panner.cpp`:

- `std::pow` (float overload) for the rolloff attenuation — the bare `::pow` promoted `Flt` args to double
- `std::cos` (float overload) in the per-speaker azimuth pan term
- `initGainScratch[i] * initGainScratch[i]` instead of `::pow(g, 2)` in the power accumulation

The shared `computePanRatio` squaring was already handled by #214. Beyond dropping the double round-trips on this audio-thread path, the change restores bit-parity with the sound path's `computeFinalGains`, which switched to the float overloads in #214.

No fast-math flags, no approximation tables (per the issue's non-goals).

## Linked issue

Closes #341

## Changes

- `YseEngine/dsp/panner.cpp` — three call sites in `computeFinalGains()` switched to float-only math, with comments mirroring #214's

## Test plan

- [x] `clang-format --dry-run --Werror` clean on the touched file
- [x] `python yse.py analyze YseEngine/dsp/panner.cpp` — no new findings
- [x] `python yse.py test` — 32/32 ctest suites pass, including `yse_tests_panner` (bit-parity + spatializer invariants) and `yse_tests_synthpositioning` (per-instance panner pan/attenuation via offline engine)
- [x] No new integration test added: not a user-visible behavior change (perf-only, output must not change audibly per the issue); the existing offline-engine synth-positioning suite already drives the real spread path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)