### PR TITLE
DOCS: link four documented DSP classes into API reference (#361)

### DIFF
--- a/documentation/source/api/dsp.rst
+++ b/documentation/source/api/dsp.rst
@@ -75,3 +75,12 @@ DSP base
 
 .. doxygenfile:: dsp/dspObject.hpp
    :project: libYSE
+
+Per-channel state helper
+------------------------
+
+A fan-out helper for module authors: hold one ``State`` struct per channel so
+a multichannel ``dspObject`` keeps each channel's history independent.
+
+.. doxygenfile:: dsp/perChannel.hpp
+   :project: libYSE

--- a/documentation/source/api/effects.rst
+++ b/documentation/source/api/effects.rst
@@ -50,3 +50,21 @@ A Dattorro-style plate reverb, well suited to a send/return bus.
 
 .. doxygenfile:: dsp/modules/plateReverb.hpp
    :project: libYSE
+
+Morphing reverb
+---------------
+
+The engine's zone/global reverb core as a chainable insert, with preset
+interpolation exposed as a ``morph`` control input.
+
+.. doxygenfile:: dsp/modules/morphingReverb.hpp
+   :project: libYSE
+
+Underwater
+----------
+
+The classic underwater treatment — a depth-driven low-pass blended toward a
+position-neutral mixdown — re-expressed as an ordinary insert.
+
+.. doxygenfile:: dsp/modules/underWater.hpp
+   :project: libYSE

--- a/documentation/source/api/patcher.rst
+++ b/documentation/source/api/patcher.rst
@@ -10,6 +10,15 @@ Patcher
 .. doxygenfile:: patcher/pObjectList.hpp
    :project: libYSE
 
+Running a patcher as an insert
+------------------------------
+
+Wrap a built patcher graph in a ``DSP::patcherInsert`` to attach it anywhere
+a ``DSP::dspObject`` chain goes — a channel or per-sound insert.
+
+.. doxygenfile:: dsp/patcherInsert.hpp
+   :project: libYSE
+
 .. toctree::
    :maxdepth: 1
    :caption: Object reference


### PR DESCRIPTION
## Summary

Four classes carried full Doxygen documentation but were referenced by no
`.rst` page under `documentation/source/api/`, so they never appeared in the
generated API reference. This wires each into the appropriate page with a
`.. doxygenfile::` directive and a section heading, mirroring the sibling
modules.

## Linked issue

Closes #361

## Changes

- `api/effects.rst` — add **Morphing reverb** (`morphingReverb`) and
  **Underwater** (`underWater`), alongside the existing plate reverb. Both are
  user-facing `dspObject` effect modules.
- `api/patcher.rst` — add **Running a patcher as an insert** (`patcherInsert`).
  Placed here (rather than `dsp.rst`) because it is the patcher→insert bridge,
  discoverable where patcher users look.
- `api/dsp.rst` — add **Per-channel state helper** (`perChannel`) next to the
  `dspObject` base it complements. It is a genuine public module-author helper,
  so it is documented rather than declared internal.

## Test plan

Documentation-only change; no runtime surface to unit- or integration-test, and
the existing `Tests/patcher/test_doc_coverage.cpp` covers only the patcher
registry. Verified by replicating the `documentation.yml` CI steps locally:

- [x] `doxygen Doxyfile` (from `documentation/`) — exit 0
- [x] `sphinx-build -b html source build/html` (from `documentation/`) — exit 0,
      **zero Sphinx warnings/errors**
- [x] All four classes render on their target pages (morphingReverb, underWater
      on `effects.html`; patcherInsert on `patcher.html`; perChannel on
      `dsp.html`)

## Note (out of scope, pre-existing)

Doxygen emits `morphingReverb.hpp:68: unable to resolve reference to
'.../send_return_buses.md' for \ref command` — a relative markdown link in the
source header that Doxygen misreads as a `\ref`. It exists on `dev` already
(Doxygen processes every header regardless of `.rst` linking) and is unaffected
by this change. Can be filed as a separate cleanup if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
