### PR TITLE
PATCHER: recompact graph ids when the patcher goes empty (#355)

### DIFF
--- a/Tests/patcher/test_patcher_graphstate.cpp
+++ b/Tests/patcher/test_patcher_graphstate.cpp
@@ -271,4 +271,74 @@ TEST_SUITE("patcher") {
     CHECK_FALSE(p.output[0].isSilent());
   }
 
+  // ---- Graph-id recompaction on an empty patcher (issue #355) ----
+
+  TEST_CASE("graphids: repeated Clear + rebuild reuses the id space") {
+    // graphId is a per-patcher monotonic counter that sizes every new
+    // GraphState's id-indexed tables (outletTargets / inletHasDsp). Without
+    // recompaction the counters — and thus each snapshot's tables and per-edit
+    // rebuild cost — grow with the *total* objects ever created, unbounded over a
+    // long live-coding / preset-reload session. Recompacting when the patcher
+    // goes empty restarts the ids, so a fresh noise->dac always lands in the same
+    // small id range no matter how many Clear cycles preceded it.
+    patcherImplementation p(1, nullptr);
+    std::size_t baseOut = 0;
+    std::size_t baseIn = 0;
+    for (int i = 0; i < 50; ++i) {
+      YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+      YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+      REQUIRE(noise != nullptr);
+      REQUIRE(dac != nullptr);
+      p.Connect(noise, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      CHECK_FALSE(p.output[0].isSilent());
+
+      if (i == 0) {
+        baseOut = p.OutletIdSpace();
+        baseIn = p.InletIdSpace();
+      }
+      // The id high-water mark must not grow with the iteration count: every
+      // rebuild starts from a compacted id space. Before the fix these climbed
+      // linearly and this would fail within a few iterations.
+      CHECK(p.OutletIdSpace() == baseOut);
+      CHECK(p.InletIdSpace() == baseIn);
+
+      p.Clear();
+      p.Calculate(YSE::T_DSP);
+      CHECK(p.output[0].isSilent());
+      // Clear empties the patcher, so the id counters reset to 0.
+      CHECK(p.OutletIdSpace() == 0);
+      CHECK(p.InletIdSpace() == 0);
+    }
+    // Sanity: the graph really did consume outlet ids, so the invariant above is
+    // meaningful (not vacuously satisfied by an all-zero id space).
+    CHECK(baseOut > 0);
+  }
+
+  TEST_CASE("graphids: deleting every object recompacts the id space") {
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    p.Connect(noise, 0, dac, 0);
+    const std::size_t firstOut = p.OutletIdSpace();
+    const std::size_t firstIn = p.InletIdSpace();
+    REQUIRE(firstOut > 0);
+
+    // Deleting objects one by one down to empty must recompact just like Clear.
+    p.DeleteObject(noise);
+    p.DeleteObject(dac);
+    p.Calculate(YSE::T_DSP);
+    CHECK(p.OutletIdSpace() == 0);
+    CHECK(p.InletIdSpace() == 0);
+
+    // Rebuilding the same graph reuses the same id range instead of extending it.
+    YSE::pHandle* noise2 = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac2 = p.CreateObject(YSE::OBJ::D_DAC, "");
+    p.Connect(noise2, 0, dac2, 0);
+    CHECK(p.OutletIdSpace() == firstOut);
+    CHECK(p.InletIdSpace() == firstIn);
+    p.Calculate(YSE::T_DSP);
+    CHECK_FALSE(p.output[0].isSilent());
+  }
+
 } // TEST_SUITE("patcher")

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -303,6 +303,9 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
   // not free it yet — an in-flight audio block may still walk the retired
   // snapshot that references it. The free is deferred to the reclaimer.
   object->UnwireFromPeers();
+  // If that was the patcher's last object, recompact the id space before the
+  // next graph is built: an empty object set binds no live id (issue #355).
+  CompactGraphIdsIfEmpty();
   RebuildAndPublish();
   // Tag the object only after RebuildAndPublish has retired the graph that last
   // referenced it, so its epoch is >= that graph's — the graphs-first drain then
@@ -463,6 +466,10 @@ void patcherImplementation::Clear() {
     delete it->first; // handle: not referenced by a GraphState
   }
   objects.clear();
+  // No live object remains, so the id space carries no stability constraint:
+  // recompact it before the empty graph is built so later rebuilds restart from
+  // a small id range instead of extending it every Clear (issue #355).
+  CompactGraphIdsIfEmpty();
   RebuildAndPublish();
   // Tag the removed objects only after their covering graph has been retired by
   // RebuildAndPublish, so each object's epoch is >= that graph's (see the
@@ -576,6 +583,16 @@ unsigned int patcherImplementation::Objects() {
 std::size_t patcherImplementation::PendingRetired() {
   std::scoped_lock lk(reclaimMtx_);
   return retiredGraphs_.size() + retiredObjects_.size();
+}
+
+std::size_t patcherImplementation::OutletIdSpace() {
+  std::scoped_lock lk(mtx);
+  return static_cast<std::size_t>(nextOutletId_);
+}
+
+std::size_t patcherImplementation::InletIdSpace() {
+  std::scoped_lock lk(mtx);
+  return static_cast<std::size_t>(nextInletId_);
 }
 
 YSE::pHandle* patcherImplementation::GetHandleFromList(unsigned int obj) {
@@ -798,6 +815,21 @@ void patcherImplementation::AssignGraphIds(pObject* object) {
   for (int i = 0; i < object->NumOutputs(); i++) {
     PATCHER::outlet* out = object->GetOutlet(i);
     if (out != nullptr && out->GraphId() < 0) out->SetGraphId(nextOutletId_++);
+  }
+}
+
+void patcherImplementation::CompactGraphIdsIfEmpty() {
+  // Only safe with no live object: a graph id must stay fixed for a live
+  // object's lifetime (the audio thread indexes the pinned snapshot by it with
+  // no synchronisation), so the counters may restart only when there is nothing
+  // live to re-stamp. Retired snapshots and objects keep their old ids and their
+  // own already-sized tables — they are never re-indexed — so this is safe even
+  // while their reclamation is still pending. Restarting at 0 bounds every later
+  // GraphState's id-indexed tables by the peak simultaneous object count instead
+  // of the lifetime creation count (issue #355).
+  if (objects.empty()) {
+    nextInletId_ = 0;
+    nextOutletId_ = 0;
   }
 }
 

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -79,6 +79,15 @@ namespace YSE {
       // up until teardown.
       std::size_t PendingRetired();
 
+      // Current outlet / inlet graph-id high-water marks — exactly the sizes
+      // BuildGraph gives every new GraphState's id-indexed tables (outletTargets
+      // / inletHasDsp). Recompacted to 0 whenever the patcher goes empty, so
+      // across Clear()/delete-all cycles they track the peak simultaneous object
+      // count rather than the lifetime creation count (issue #355). Diagnostics /
+      // tests only: takes mtx, so control-thread only.
+      std::size_t OutletIdSpace();
+      std::size_t InletIdSpace();
+
       std::vector<YSE::DSP::buffer> output;
 
       aBool controlledBySound;
@@ -188,6 +197,14 @@ namespace YSE {
       GraphState* BuildGraph();
       // Stamp lifetime-stable graph ids on a newly added object's inlets/outlets.
       void AssignGraphIds(pObject* obj);
+      // Recompact the inlet/outlet id space when no live object remains. A
+      // graph id is fixed for a live object's lifetime (the audio thread reads
+      // it unsynchronised to index the pinned snapshot), so ids can only be
+      // reclaimed when there is nothing live to re-stamp — an empty object set
+      // is exactly that case. Restarting the counters at 0 then bounds each
+      // GraphState's id-indexed tables by the peak simultaneous object count
+      // instead of the lifetime creation count (issue #355). Caller holds mtx.
+      void CompactGraphIdsIfEmpty();
       // Build the next GraphState, publish it with one atomic swap, retire the
       // previous one, and schedule background reclamation.
       void RebuildAndPublish();
@@ -266,8 +283,13 @@ namespace YSE {
       // Set once at teardown to stop scheduling and re-arming reclaim passes so
       // the destructor's joins terminate. Read on the background pool.
       std::atomic<bool> shuttingDown_{false};
-      // Per-patcher dense id counters for inlets / outlets. Never reused, so
-      // ids stay stable across edits.
+      // Per-patcher dense id counters for inlets / outlets. An id is fixed for a
+      // live object's lifetime (the audio thread reads it unsynchronised to
+      // index the pinned snapshot), so ids are never re-stamped while an object
+      // is live. The counters are recompacted to 0 only when the patcher holds
+      // no live object (Clear / delete-all), which bounds each GraphState's
+      // id-indexed tables by the peak simultaneous object count rather than the
+      // lifetime creation count (issue #355).
       int nextInletId_ = 0;
       int nextOutletId_ = 0;
 


### PR DESCRIPTION
## Summary

`patcherImplementation` stamps every inlet/outlet with a dense, lifetime-stable
`graphId` from the per-patcher `nextInletId_` / `nextOutletId_` counters, and
`BuildGraph()` sizes each new `GraphState`'s id-indexed tables (`outletTargets`,
`inletHasDsp`) by those counters. Because the counters were never reused, a
patcher that keeps creating objects (live-coding, repeated `Clear()`+rebuild,
repeated `ParseJSON` preset loads) made **every successive snapshot larger** and
every edit's rebuild cost creep up with the *total* number of objects ever
created — unbounded over a long session.

This recompacts the id space to 0 whenever the patcher holds **no live object**
(`Clear()` or delete-all). With an empty object set no live inlet/outlet carries
a `graphId`, so the stability contract binds nothing and the counters can safely
restart — bounding each `GraphState`'s tables by the patcher's *peak simultaneous*
object count instead of its lifetime creation count.

Why the empty-set case (issue's "cheap special case") and not the free-list:
the reset runs **synchronously on the control thread**, so it also fixes the
audio-paused `Clear`/rebuild scenario (the #315 bench harness that surfaced this)
where reclamation-driven id recycling would never fire. The continuous
create/delete churn that never empties needs the epoch-coordinated free-list and
is filed as a follow-up (#364).

## Real-time safety

The audio thread is untouched. No live object's `graphId` is ever re-stamped
(the reset only restarts the counters for *future* objects), so the audio
thread — which reads `graphId` unsynchronised to index the pinned snapshot —
never sees a torn id. Retired snapshots/objects keep their old ids and their own
already-sized tables and are never re-indexed, so the reset is safe even while
their reclamation is still pending. No allocation, lock, or blocking is added to
any audio-thread path; the compaction runs under the existing control-thread
`mtx`.

## Linked issue

Closes #355

## Changes

- `CompactGraphIdsIfEmpty()` — resets `nextInletId_` / `nextOutletId_` to 0 when
  `objects` is empty; called from `Clear()` and `DeleteObject()` before the
  next graph is built.
- `OutletIdSpace()` / `InletIdSpace()` — control-thread diagnostics exposing the
  id high-water marks (exactly the `GraphState` table sizes).
- Two regression tests in `test_patcher_graphstate.cpp` (repeated Clear+rebuild,
  delete-all+rebuild) asserting the id space stays bounded / reuses its range.

## Test plan

- [x] `clang-format` 22.1.4 (pinned CI version) clean on all changed files.
- [x] `clang-tidy` (`python yse.py analyze`) clean on both changed `.cpp` files —
  no new findings.
- [x] New tests pass with the fix and **fail without it** (verified by
  neutralizing `CompactGraphIdsIfEmpty` and rebuilding: id space grows `2 == 1`).
- [x] Full patcher suite passes (232 cases / 4860 assertions).
- [x] `ctest --preset tests-debug`: 100% (32/32).
- [x] No integration test added: the change is control-plane bookkeeping with no
  new user-visible flow — the id space is not observable through the public API
  (the two new unit tests drive `Calculate` directly and assert audio continuity
  across the compaction). The 3 monolithic-run failures in
  `test_system_active_state.cpp` are a pre-existing audio-device ordering
  artifact (they pass in isolation; unrelated to patcher code, untouched here).
