### PR TITLE
DOCS/INFRA: document FM/DX7 + SFZ synth and expose content-pack opt-in via yse.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ A flat `extern "C"` ABI (`yse_c/yse_*.h`) is folded into the same shared library
 so language bindings (Dart FFI, Python ctypes, …) can call it without C++ ABI
 compatibility — enabled by default via the `YSE_BUILD_C_API` option.
 
+Beyond sample playback, libYSE hosts a polyphonic **synth subsystem**: a
+virtual-analog / wavetable voice, a **DX7-class 6-operator FM voice** (with a
+DX7 SysEx bank importer), and an **SFZ sampler voice**. The instrument DSP is
+always compiled in — there is no feature switch to enable it. The *factory
+sounds* those voices load (SFZ instruments and samples, wavetables, DX7/FM
+`.SYX` banks) ship separately as an opt-in download — see
+[Content pack](#content-pack-optional-instrument-assets).
+
 **What is YSE trying to be?** Neither a game-audio engine nor a DAW: an
 authored signal graph played by spatial and physical controllers, built
 for experimental electronic music and live performance. The full
@@ -92,6 +100,8 @@ cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 | `YSE_BUILD_BENCHMARKS` | `OFF` | Build the `Bench/` google-benchmark suite (fetched on demand) |
 | `YSE_BUILD_C_API` | `ON` | Fold the `extern "C"` ABI bridge into `libyse` |
 | `YSE_ENABLE_MIDI_DEVICE` | `ON` (desktop) | RtMidi-backed MIDI device backend |
+| `YSE_FETCH_CONTENT_PACK` | `OFF` | Download the optional instrument [content pack](#content-pack-optional-instrument-assets) (SFZ instruments, wavetables, DX7/FM banks) |
+| `YSE_INSTALL_CONTENT_PACK` | `OFF` | Install the content pack under `<prefix>/share/yse/content` |
 
 ---
 
@@ -174,6 +184,7 @@ Flutter-style CLI for the common tasks.  On Windows run it via:
 python yse.py build              # configure + debug build (default)
 python yse.py build --release    # release build
 python yse.py build --python     # debug build with the embedded-Python live-coding feature (desktop only)
+python yse.py build --content-pack  # debug build + fetch the optional SFZ/DX7/FM content pack
 python yse.py test               # build tests-debug preset, run ctest
 python yse.py test --python      # tests-debug-python preset — also runs the embedded-interpreter suite
 python yse.py coverage           # coverage build + gcovr report (Linux only)
@@ -195,6 +206,49 @@ automatically without any extra setup.
 
 Direct `cmake -B build ...` invocations remain fully valid — the presets are
 additive and do not change how the build works when invoked directly.
+
+---
+
+## Content pack (optional instrument assets)
+
+libYSE's instrument voices — the virtual-analog / wavetable voice, the
+DX7-class 6-operator **FM voice** (plus its DX7 SysEx bank importer), and the
+**SFZ sampler voice** — are **always compiled** into `libyse`. There is no
+`YSE_ENABLE_FM` / `YSE_ENABLE_SFZ` compile switch; the instrument DSP is always
+present.
+
+What *is* optional is the **content pack**: the factory sounds those voices
+load at runtime — SFZ instruments and samples, single-cycle wavetables, and
+DX7/FM `.SYX` banks. None of it is baked into the binary (`libyse` links no
+asset); it is plain data read by the normal file loaders. A small CC0 seed is
+committed under `content/`; the larger third-party collections and the DX7
+factory banks are pulled only on demand by two opt-in CMake options (both
+`OFF` by default):
+
+| Option | Effect |
+|---|---|
+| `YSE_FETCH_CONTENT_PACK` | Download and SHA-256-verify the third-party pack sources into `content/` (an unpinned source is a hard error — hashes are verified, never invented) |
+| `YSE_INSTALL_CONTENT_PACK` | Install the assembled pack to `<prefix>/share/yse/content` |
+
+Enable them through the Python workflow (no need to drop to raw `cmake`):
+
+```sh
+python yse.py build --content-pack                        # debug build + fetch the pack
+python yse.py build --release --content-pack              # release build + fetch
+python yse.py build --content-pack --install-content-pack # also install it
+```
+
+`--install-content-pack` implies `--content-pack`. The equivalent direct
+invocation is `cmake -B build -G Ninja -DYSE_FETCH_CONTENT_PACK=ON`.
+
+**DX7 factory-bank licensing caveat.** The DX7 factory-style ROM voice banks
+are **tolerated, but not legally cleared** — Yamaha has never released these
+voice data sets under an open license. They are fetched only when
+`YSE_FETCH_CONTENT_PACK` is ON, land in `content/fm/dx7-factory/`, and every
+consumer treats that folder as optional (deleting it is a clean opt-out). For
+an unambiguously CC0 FM bank authored by this project, use
+`content/fm/original/yse_originals.syx`. Full provenance and licenses for every
+asset are in [CONTENT-LICENSES.md](CONTENT-LICENSES.md).
 
 ---
 

--- a/documentation/source/api/synth.rst
+++ b/documentation/source/api/synth.rst
@@ -15,6 +15,18 @@ See the tutorials for worked, compilable walk-throughs:
 :doc:`/tutorials/08_instruments`, and
 :doc:`/tutorials/10_per_note_3d`.
 
+.. note::
+
+   The instrument DSP below — the SFZ sampler voice and the DX7-class FM voice
+   — is **always compiled** into ``libyse``; there is no ``YSE_ENABLE_FM`` /
+   ``YSE_ENABLE_SFZ`` switch. The **factory sounds** these voices load (SFZ
+   instruments and samples, and the DX7/FM ``.SYX`` banks) are *not* part of
+   the library. They ship as an **opt-in content pack** fetched only when
+   libYSE is configured with ``-DYSE_FETCH_CONTENT_PACK=ON`` (or
+   ``python yse.py build --content-pack``). The DX7 factory-style banks are
+   *tolerated, not legally cleared* content — see the repository's
+   ``CONTENT-LICENSES.md`` and ``content/fm/dx7-factory/README.md``.
+
 The synth
 ---------
 

--- a/yse.py
+++ b/yse.py
@@ -81,7 +81,16 @@ def cmd_build(args):
     preset = "release" if args.release else "debug"
     if args.python:
         preset += "-python"
-    run(["cmake", "--preset", preset])
+    # The presets carry no -D for the optional content pack, so append the
+    # opt-in cache variables on top of the preset when requested. --install
+    # implies --fetch: installing an un-assembled pack would ship only the
+    # committed CC0 seed, which is never what a user asking to install wants.
+    configure = ["cmake", "--preset", preset]
+    if args.content_pack or args.install_content_pack:
+        configure.append("-DYSE_FETCH_CONTENT_PACK=ON")
+    if args.install_content_pack:
+        configure.append("-DYSE_INSTALL_CONTENT_PACK=ON")
+    run(configure)
     run(["cmake", "--build", "--preset", preset])
 
 
@@ -880,6 +889,7 @@ def build_parser():
   python yse.py build              configure + build (debug)
   python yse.py build --release    configure + build (release)
   python yse.py build --python     configure + build (debug) with embedded-Python live-coding (YSE_ENABLE_PYTHON=ON)
+  python yse.py build --content-pack   configure + build (debug) and fetch the optional SFZ/DX7/FM content pack (YSE_FETCH_CONTENT_PACK=ON)
   python yse.py test               build tests-debug preset, run ctest
   python yse.py test --integration same, plus the integration suite (needs real audio device)
   python yse.py test --python      build tests-debug-python preset so the embedded-interpreter suite runs
@@ -920,6 +930,19 @@ def build_parser():
         "--python", action="store_true",
         help="Enable the embedded-CPython live-coding feature (YSE_ENABLE_PYTHON=ON; "
              "uses the *-python preset; desktop only)",
+    )
+    p.add_argument(
+        "--content-pack", action="store_true",
+        help="Fetch the optional instrument content pack (SFZ instruments, "
+             "wavetables, and DX7/FM banks; YSE_FETCH_CONTENT_PACK=ON). The "
+             "instrument DSP is always compiled; this only pulls the factory "
+             "assets. Note the DX7 banks are tolerated-not-cleared content "
+             "(see CONTENT-LICENSES.md).",
+    )
+    p.add_argument(
+        "--install-content-pack", action="store_true",
+        help="Install the content pack under <prefix>/share/yse/content "
+             "(YSE_INSTALL_CONTENT_PACK=ON; implies --content-pack)",
     )
     p.set_defaults(func=cmd_build)
 


### PR DESCRIPTION
## Summary

libYSE's DX7-class FM voice, SFZ sampler voice, and the optional content
pack were undiscoverable from the front-door docs, and the opt-in
`YSE_FETCH_CONTENT_PACK` / `YSE_INSTALL_CONTENT_PACK` CMake options had no
path through the documented `yse.py` workflow (fixed presets, no `-D`
passthrough). This addresses all four "Done when" boxes of #362.

## Linked issue

Closes #362

## Changes

- **README.md**
  - Front-door paragraph introducing the polyphonic synth subsystem
    (virtual-analog/wavetable, DX7-class 6-op FM voice + SysEx importer,
    SFZ sampler voice).
  - New **Content pack (optional instrument assets)** section documenting
    `YSE_FETCH_CONTENT_PACK` / `YSE_INSTALL_CONTENT_PACK` (what they do,
    that they're opt-in), how to enable them via `yse.py`, and the DX7
    tolerated-not-cleared licensing caveat with a pointer to
    `CONTENT-LICENSES.md`.
  - Both options added to the optional-flags table; a `--content-pack`
    example added to the dev-workflow list.
  - States the engine-always-compiled vs. content-opt-in distinction so
    readers don't hunt for a nonexistent `YSE_ENABLE_FM` / `YSE_ENABLE_SFZ`
    compile switch.
- **yse.py** — `build --content-pack` and `build --install-content-pack`
  append the opt-in cache vars on top of the chosen preset. `--install`
  implies `--fetch` (installing an un-assembled pack would ship only the
  committed CC0 seed). Help text + epilog example updated.
- **documentation/source/api/synth.rst** — a `.. note::` recording that the
  SFZ instruments and DX7 factory banks are an opt-in content-pack download,
  with the DX7 licensing note and the no-compile-switch clarification.

Strictly docs/infra — no engine or C++ source touched.

## Test plan

`yse.py` has no pre-existing Python test harness (the only non-vendored
`.py` file is `yse.py` itself), so the behavior change was verified by
exercising the real code path rather than added as a new test suite:

- [x] **Flag handling** — drove `cmd_build` with `run` stubbed to capture
      commands across 7 flag combinations. Confirmed the configure line
      gains `-DYSE_FETCH_CONTENT_PACK=ON` for `--content-pack`, both
      `-D` vars for `--install-content-pack` (implies fetch), neither by
      default, correct preset selection (debug/release/`*-python`), that
      the build step carries no `-D`, and that exactly 2 `run()` calls
      (configure + build) are issued. All pass.
- [x] **End-to-end `-D` passthrough** — ran `python yse.py build
      --install-content-pack` against the real repo; CMake accepted the
      extra `-D` alongside `--preset` and drove the actual
      `YseContentPack.cmake` path (it stops at the manifest's deliberate
      unpinned-SHA guard, which is the repo's intended pre-existing state,
      not a regression). Restored `build-debug` to a clean OFF/OFF
      configure afterward.
- [x] `python yse.py build --help` renders the two new flags.
- No integration test: the change has no runtime/audio surface — it's
  documentation plus command-line assembly for the build wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
