### PR TITLE
INFRA: make content-pack SHA pins optional and repair stale source URLs (#367)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,21 @@ Generate.NET/YseEngine_wrap.cxx
 YSElog.txt
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
+
+#############
+## Content pack — fetched third-party sources (#179 / #367)
+#############
+# These DEST outputs are pulled on demand by -DYSE_FETCH_CONTENT_PACK=ON. They
+# stay on disk for a local build but are never committed / redistributed. The
+# committed CC0 seed (content/wavetables/ysewt_*.wav, content/sfz/yse_pulse.sfz,
+# content/sfz/samples/, content/fm/original/, content/fm/dx7-factory/README.md,
+# and the .gitkeep placeholders) lives outside these paths and stays tracked.
+/content/wavetables/akwf/
+/content/sfz/vsco2/
+/content/sfz/vcsl/
+/content/sfz/salamander/
+/content/sfz/freepats/
+# dx7-factory keeps its committed README.md + .gitkeep; only fetched banks/markers are ignored.
+/content/fm/dx7-factory/*.syx
+/content/fm/dx7-factory/*.SYX
+/content/fm/dx7-factory/.fetched

--- a/CONTENT-LICENSES.md
+++ b/CONTENT-LICENSES.md
@@ -15,8 +15,9 @@ required attribution. Two categories:
   deterministically by [`content/tools/generate_content.py`](content/tools/generate_content.py)
   and committed to the repo. Unambiguously CC0.
 - **Fetched (third-party)** — pulled on demand by the fetch path; **not**
-  committed. Each has a pinned SHA-256 in `pack-manifest.cmake` before it can be
-  fetched (an empty pin is a hard error — hashes are verified, never invented).
+  committed. Each may carry an optional SHA-256 pin in `pack-manifest.cmake`: a
+  pinned source is verified on fetch, an unpinned one downloads unverified with a
+  warning (hashes are verified, never invented).
 
 ## Committed CC0 seed (authored by YSE)
 
@@ -35,8 +36,8 @@ required attribution. Two categories:
 | VSCO 2 Community Edition (SFZ subset) | `sfz/vsco2/` | CC0-1.0 | https://github.com/sgossner/VSCO-2-CE | None (CC0) |
 | VCSL — Versilian Community Sample Library | `sfz/vcsl/` | CC0-1.0 | https://github.com/sgossner/VCSL | None (CC0) |
 | Salamander Grand Piano | `sfz/salamander/` | **CC-BY-3.0** | https://archive.org/details/SalamanderGrandPianoV3 | Required — see [`content/ATTRIBUTION-Salamander.txt`](content/ATTRIBUTION-Salamander.txt) |
-| FreePats selection (CC0 picks only) | `sfz/freepats/` | CC0-1.0 | https://freepats.zenvoid.org/ | None (CC0) |
-| DX7 factory-style `.syx` banks | `fm/dx7-factory/` | **tolerated-unclear** | https://github.com/asb2m10/dexed (Resources) | See risk note below |
+| FreePats selection (CC0 picks only) | `sfz/freepats/` | CC0-1.0 | _disabled (#367): no working CC0 source; FreePats GM is GPLv3_ | None (CC0) |
+| DX7 factory-style `.syx` banks | `fm/dx7-factory/` | **tolerated-unclear** | https://github.com/asb2m10/dexed (`assets/builtin_pgm.zip`) | See risk note below |
 
 ## The DX7 factory-bank decision (tolerated, not cleared)
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ factory banks are pulled only on demand by two opt-in CMake options (both
 
 | Option | Effect |
 |---|---|
-| `YSE_FETCH_CONTENT_PACK` | Download and SHA-256-verify the third-party pack sources into `content/` (an unpinned source is a hard error — hashes are verified, never invented) |
+| `YSE_FETCH_CONTENT_PACK` | Download the third-party pack sources into `content/`, verifying each against its SHA-256 pin when one is set (an unpinned source downloads unverified with a warning; pins are optional — never invented) |
 | `YSE_INSTALL_CONTENT_PACK` | Install the assembled pack to `<prefix>/share/yse/content` |
 
 Enable them through the Python workflow (no need to drop to raw `cmake`):

--- a/cmake/YseContentPack.cmake
+++ b/cmake/YseContentPack.cmake
@@ -29,7 +29,7 @@ endif()
 #   YSE_CONTENT_PACK_DIR     (content/) where the pack lives / is assembled
 
 option(YSE_FETCH_CONTENT_PACK
-  "Download and hash-verify the third-party content pack sources (opt-in; see content/pack-manifest.cmake)"
+  "Download the third-party content pack sources (opt-in; SHA-256 pins are optional — see content/pack-manifest.cmake)"
   OFF)
 option(YSE_INSTALL_CONTENT_PACK
   "Install the content pack under <prefix>/share/yse/content"
@@ -47,11 +47,16 @@ function(yse_content_source)
   if(NOT A_NAME OR NOT A_URL OR NOT A_DEST)
     message(FATAL_ERROR "yse_content_source: NAME, URL and DEST are required")
   endif()
+  # SHA-256 verification is OPTIONAL. A non-empty SHA256 is verified exactly (a
+  # mismatch fails the download); an empty SHA256 downloads the source UNVERIFIED
+  # after a warning, so a pin can be added to the manifest later.
+  set(_verify_sha TRUE)
   if(NOT DEFINED A_SHA256 OR A_SHA256 STREQUAL "")
-    message(FATAL_ERROR
-      "Content source '${A_NAME}' has no SHA256 pin. Download ${A_URL}, verify it "
-      "against upstream, and set its sha256 in content/pack-manifest.cmake before "
-      "enabling YSE_FETCH_CONTENT_PACK. (Never invent a hash.)")
+    set(_verify_sha FALSE)
+    message(WARNING
+      "Content source '${A_NAME}' has no SHA256 pin — downloading ${A_URL} "
+      "UNVERIFIED. To pin it, download the archive, verify it against upstream, "
+      "and set its sha256 in content/pack-manifest.cmake. (Never invent a hash.)")
   endif()
 
   set(_dest "${YSE_CONTENT_PACK_DIR}/${A_DEST}")
@@ -64,10 +69,16 @@ function(yse_content_source)
   get_filename_component(_ext "${A_URL}" LAST_EXT)
   set(_archive "${CMAKE_BINARY_DIR}/_content/${A_NAME}${_ext}")
   message(STATUS "Content pack: fetching '${A_NAME}' (${A_LICENSE}) → ${A_DEST}")
-  file(DOWNLOAD "${A_URL}" "${_archive}"
-    EXPECTED_HASH SHA256=${A_SHA256}
-    SHOW_PROGRESS
-    STATUS _dl_status)
+  if(_verify_sha)
+    file(DOWNLOAD "${A_URL}" "${_archive}"
+      EXPECTED_HASH SHA256=${A_SHA256}
+      SHOW_PROGRESS
+      STATUS _dl_status)
+  else()
+    file(DOWNLOAD "${A_URL}" "${_archive}"
+      SHOW_PROGRESS
+      STATUS _dl_status)
+  endif()
   list(GET _dl_status 0 _dl_code)
   if(NOT _dl_code EQUAL 0)
     list(GET _dl_status 1 _dl_msg)

--- a/content/pack-manifest.cmake
+++ b/content/pack-manifest.cmake
@@ -3,21 +3,22 @@
 # This file is read ONLY when a build opts in with -DYSE_FETCH_CONTENT_PACK=ON.
 # It never affects a default build. Each source is declared with yse_content_source()
 # (defined by cmake/YseContentPack.cmake before this file is included); the module
-# downloads the archive, verifies its SHA-256, and extracts it under
+# downloads the archive, optionally verifies its SHA-256, and extracts it under
 # ${YSE_CONTENT_PACK_DIR}/<DEST>.
 #
-# HASHES ARE DELIBERATELY LEFT EMPTY. Fetching a source with an empty SHA256 is a
-# hard error — the maintainer must download the pinned archive, verify it against
-# upstream, and paste the sha256 here (never invent a hash). This keeps the fetch
-# path auditable and reproducible while making the "opt in" a conscious act.
+# SHA-256 PINS ARE OPTIONAL. A source with an empty SHA256 downloads UNVERIFIED
+# (the fetch emits a warning); a non-empty SHA256 is verified exactly and a
+# mismatch fails the fetch. To pin a source, download the archive, verify it
+# against upstream, and paste the sha256 here — never invent a hash. This keeps
+# the "opt in" a conscious act while letting the pack be fetched before pins land.
 #
 # Every row below is mirrored, with its license, in the repo-root CONTENT-LICENSES.md.
 
 # ── Wavetables ────────────────────────────────────────────────────────────────
 yse_content_source(
   NAME    akwf
-  URL     "https://github.com/KristofferKarlAxelEkstrand/AKWF-FREE/archive/refs/heads/master.zip"
-  SHA256  ""                       # TODO: pin before enabling
+  URL     "https://github.com/KristofferKarlAxelEkstrand/AKWF-FREE/archive/refs/heads/main.zip"
+  SHA256  ""                       # optional: add a verified sha256 to pin
   DEST    "wavetables/akwf"
   LICENSE "CC0-1.0"
 )
@@ -26,39 +27,44 @@ yse_content_source(
 yse_content_source(
   NAME    vsco2-ce
   URL     "https://github.com/sgossner/VSCO-2-CE/archive/refs/heads/master.zip"
-  SHA256  ""                       # TODO: pin before enabling
+  SHA256  ""                       # optional: add a verified sha256 to pin
   DEST    "sfz/vsco2"
   LICENSE "CC0-1.0"
 )
 yse_content_source(
   NAME    vcsl
   URL     "https://github.com/sgossner/VCSL/archive/refs/heads/master.zip"
-  SHA256  ""                       # TODO: pin before enabling
+  SHA256  ""                       # optional: add a verified sha256 to pin
   DEST    "sfz/vcsl"
   LICENSE "CC0-1.0"
 )
 yse_content_source(
   NAME    salamander
-  URL     "https://archive.org/download/SalamanderGrandPianoV3/SalamanderGrandPianoV3.tar.bz2"
-  SHA256  ""                       # TODO: pin before enabling
+  URL     "https://archive.org/download/SalamanderGrandPianoV3/SalamanderGrandPianoV3_44.1khz16bit.tar.bz2"
+  SHA256  ""                       # optional: add a verified sha256 to pin
   DEST    "sfz/salamander"
   LICENSE "CC-BY-3.0"              # ATTRIBUTION-Salamander.txt ships with the pack
 )
-yse_content_source(
-  NAME    freepats-selection
-  URL     "https://freepats.zenvoid.org/sf2/freepats-general-midi.sf2"  # placeholder pick; CC0 subset only
-  SHA256  ""                       # TODO: pin before enabling
-  DEST    "sfz/freepats"
-  LICENSE "CC0-1.0"
-)
+# freepats-selection — DISABLED (#367): no working CC0 URL. The old placeholder
+# (https://freepats.zenvoid.org/sf2/freepats-general-midi.sf2) is 404, and the
+# current FreePats General MIDI set is licensed GPLv3 (not CC0) and shipped as a
+# .7z archive this fetch path cannot extract. Re-enable once a genuinely CC0
+# source with a supported archive format (zip/tar[.gz|.bz2|.xz]) is identified.
+# yse_content_source(
+#   NAME    freepats-selection
+#   URL     "https://freepats.zenvoid.org/..."   # TODO: real CC0 source, not the GPL GM set
+#   SHA256  ""                       # optional: add a verified sha256 to pin
+#   DEST    "sfz/freepats"
+#   LICENSE "CC0-1.0"
+# )
 
 # ── FM banks (TOLERATED, NOT LEGALLY CLEARED) ─────────────────────────────────
 # Isolated in fm/dx7-factory/ so the risk is reversible by deleting one folder.
 # See content/fm/dx7-factory/README.md.
 yse_content_source(
   NAME    dx7-factory
-  URL     "https://github.com/asb2m10/dexed/raw/master/Resources/DX7_0628.SYX"
-  SHA256  ""                       # TODO: pin before enabling
+  URL     "https://github.com/asb2m10/dexed/raw/master/assets/builtin_pgm.zip"  # dexed's built-in DX7 factory-style banks (Dexed_01 + SynprezFM_01..32 .syx)
+  SHA256  ""                       # optional: add a verified sha256 to pin
   DEST    "fm/dx7-factory"
   LICENSE "tolerated-unclear"
 )


### PR DESCRIPTION
## Summary

Makes the optional content-pack fetch (`YSE_FETCH_CONTENT_PACK`) actually usable. It was dead on arrival (pre-existing #179 state, exposed by #362): every source shipped with an empty `SHA256`, and `yse_content_source()` turned an empty hash into a `FATAL_ERROR`, so `python yse.py build --content-pack` stopped at the first source. Several source URLs were also stale (404 / wrong default branch).

Per the maintainer's decision, SHA-256 verification is now **optional**, and the four stale URLs are repaired (or surfaced where no working URL exists).

## Linked issue

Closes #367

## Changes

- **`cmake/YseContentPack.cmake`** — an empty `SHA256` now downloads **without** `EXPECTED_HASH` and emits a `message(WARNING …)` that the source is unverified. A non-empty `SHA256` still verifies exactly as before (mismatch fails the fetch). The `option()` and header comments no longer describe an empty hash as a hard error.
- **`content/pack-manifest.cmake`** — URL repairs (all candidates checked with a redirect-following HEAD, 200):
  - `akwf`: `…/AKWF-FREE/archive/refs/heads/master.zip` → **`main.zip`** (repo default branch is `main`).
  - `salamander`: `…/SalamanderGrandPianoV3.tar.bz2` (404) → **`SalamanderGrandPianoV3_44.1khz16bit.tar.bz2`** (200; the archive.org item only ships quality-suffixed files — picked the lighter 488 MB variant over the 1.45 GB one).
  - `dx7-factory`: `…/dexed/raw/master/Resources/DX7_0628.SYX` (404; that path is gone) → **`…/dexed/raw/master/assets/builtin_pgm.zip`** — dexed's built-in DX7 factory-style banks (`Dexed_01` + `SynprezFM_01..32` `.syx`). Downloaded + inspected out of band: real 88 KB zip, 33 `.syx` files. "Tolerated-not-cleared" labeling kept as-is per scope.
  - `freepats-selection`: **commented out** with a TODO. The old placeholder (`…/sf2/freepats-general-midi.sf2`) is 404, and the current FreePats General MIDI set is **GPLv3, not CC0**, and packaged as `.7z` (a format this fetch path can't extract). Surfaced rather than shipping a broken/mislabeled source.
  - `vsco2-ce` / `vcsl`: unchanged (`master`), confirmed 200.
  - `SHA256` fields deliberately left empty (maintainer decision — download without pinning; the cmake change is what makes that work).
- **Docs** — dropped the "empty hash is a hard error / hashes are mandatory" claim from the manifest header, the README content-pack table, and `CONTENT-LICENSES.md`; kept the "never invent a hash" guidance for the optional-pin case. (`yse.py`'s `--content-pack` help and `documentation/source/api/synth.rst` contain no mandatory-hash language, so nothing to correct there.)
- **`.gitignore`** — exclude the fetch DEST outputs and their `.fetched` markers so an opted-in local build keeps assets on disk without committing/redistributing hundreds of MB. Committed CC0 seed and `content/fm/dx7-factory/README.md`/`.gitkeep` stay tracked.

## Test plan

Verification was internet-limited (tested on a very slow/unstable connection), so this proves the **logic**, not a full multi-source fetch:

- [x] **Core fix proven end-to-end via the real build.** `python yse.py build --content-pack` on a clean tree: the empty-SHA path no longer `FATAL_ERROR`s — the configure log shows `CMake Warning … Content source 'akwf' has no SHA256 pin — downloading … UNVERIFIED` immediately followed by `Content pack: fetching 'akwf'`, i.e. it proceeds to `file(DOWNLOAD)` without `EXPECTED_HASH`. This is the exact wall #367 reported, now cleared.
- [x] **URLs resolve (200, HEAD following redirects):** akwf `main.zip`, vsco2 `master.zip`, vcsl `master.zip`, salamander `…_44.1khz16bit.tar.bz2` (Content-Length 488 MB). dx7 `builtin_pgm.zip` was fully downloaded + validated (real zip, 33 `.syx`). akwf `main.zip` fetched with valid `PK` zip magic (real archive, not an HTML error page).
- [ ] **Full download-to-real-files not completable on this connection.** The AKWF fetch started via the correct code path/URL but died on a transient `"Stream error in the HTTP/2 framing layer"` (network, not code/URL); the giant libraries (VSCO-2/VCSL/Salamander) were URL-checked only. So no source landed real content on disk here — this is honestly a logic-verified change, and a full fetch should be re-confirmed on a good connection.
- [x] `cmake --preset debug` reconfigures clean with the content options OFF; `git status` shows only the 5 intended files and **no** untracked content assets.
- n/a clang-tidy — only cmake/docs/gitignore changed (no C++).
