### PR TITLE
release-prep v2.3.0: refresh README and overview

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,11 +1,11 @@
 <!-- META
-last_updated_commit: ce0fe64
-last_updated_at: 2026-07-14
+last_updated_commit: 8bc0dc3
+last_updated_at: 2026-07-15
 -->
 
 # YSE Sound Engine — Project Overview
 
-**Version:** 2.2.0 (single source of truth: [`YseEngine/system.hpp`](YseEngine/system.hpp))
+**Version:** 2.3.0 (single source of truth: [`YseEngine/system.hpp`](YseEngine/system.hpp))
 **Language:** C++17
 **Platforms:** Windows (MSYS2/Clang64, MSVC), Linux (gcc/clang), Android (NDK r27+, API 26+, arm64-v8a + x86_64)
 **Build:** CMake 3.20+ via `CMakePresets.json`; Android wraps the same CMake invocation through Gradle in `Tests/Android/`
@@ -80,6 +80,7 @@ The old .NET/Xamarin wrappers, the WPF demo, the UWP build, and the JUCE backend
 python yse.py build                # cmake --preset debug + build
 python yse.py build --release      # release variant
 python yse.py build --python       # debug variant with embedded-Python live-coding (YSE_ENABLE_PYTHON=ON, desktop only)
+python yse.py build --content-pack  # also fetch the optional SFZ/DX7/FM instrument content pack (YSE_FETCH_CONTENT_PACK=ON)
 python yse.py test                 # tests-debug preset + ctest
 python yse.py test --integration   # also run the integration suite (needs a real audio device)
 python yse.py test --python        # tests-debug-python preset — also runs the embedded-interpreter suite

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="logo/yse-logo.svg" alt="libYSE" width="520">
 </p>
 
-# libYSE 2.2
+# libYSE 2.3
 
 libYSE is a cross-platform sound engine written in C++. PortAudio handles audio
 I/O on desktop, Oboe (AAudio + OpenSL ES fallback) on Android, and libsndfile


### PR DESCRIPTION
Release-prep housekeeping ahead of cutting **v2.3.0** (minor).

## Changes
- **README.md** — `# libYSE 2.2` → `# libYSE 2.3` (minor bump touches the header).
- **PROJECT_OVERVIEW.md** — `**Version:** 2.2.0` → `2.3.0`, meta header refreshed to the current `dev` tip (`8bc0dc3`, 2026-07-15), and the `yse.py build --content-pack` opt-in (#362 / #367) added to the command reference.

The overview's architecture sections were already kept current through the newest feature commits (#249 domain clocks, #250 clip transport, #326 morph control input, #327 underwater insert module, #350 clip MIDI-out sink); the commits after those are internal fixes, perf, docs, tests, and content-pack infra, so no architectural rewrite is needed for this release.

Sphinx `conf.py` reads `VERSION` from `system.hpp` automatically (#89), so `documentation/` needs no version edit.

## C API drift note
The pre-release C API drift audit surfaced 4 features that landed in the engine this cycle without a C API mirror — filed as follow-ups to close in a later patch: #369 (morphingReverb insert), #370 (patcherInsert), #371 (midiIn→synth routing), #372 (midifile→synth routing). All additive/non-breaking; v2.3.0 ships with them documented-as-missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
