### PR TITLE
Release v2.3.0

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -19,7 +19,7 @@
 #include <string>
 
 namespace YSE {
-  const std::string VERSION = "2.2.0";
+  const std::string VERSION = "2.3.0";
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *


### PR DESCRIPTION
Version bump for the v2.3.0 release: `VERSION` `2.2.0` → `2.3.0` in `YseEngine/system.hpp`.

Routed through a PR because branch protection on `master` requires it (same path as release-v2.1.0 → PR #87). After this merges, the `v2.3.0` tag is placed on the **merge commit** and `release.yml` publishes the Linux x64 / Windows x64 / Android multi-ABI archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
