### PR TITLE
PATCHER: recycle retired graph ids during continuous create/delete churn (#364)

### DIFF
--- a/Tests/patcher/test_patcher_graphstate.cpp
+++ b/Tests/patcher/test_patcher_graphstate.cpp
@@ -341,4 +341,99 @@ TEST_SUITE("patcher") {
     CHECK_FALSE(p.output[0].isSilent());
   }
 
+  // ---- Free-list recycling of retired graph ids during churn (issue #364) ----
+
+  TEST_CASE("graphids: continuous create/delete churn recycles ids via the free-list") {
+    // #355's recompaction only fires when the patcher goes empty. A patcher that
+    // is continuously edited while at least one object always survives never
+    // empties, so the counters — and every snapshot's id-indexed tables — would
+    // climb with the lifetime create count. The free-list (issue #364) bounds
+    // that: the reclaimer returns a deleted object's ids once no snapshot can
+    // still index them, and AssignGraphIds pulls them before extending the
+    // counter, so the id space tracks the peak *simultaneous* object count.
+    patcherImplementation p(1, nullptr);
+    // A persistent noise->dac keeps one object live for the whole test, so the
+    // patcher never empties and compaction never runs — recycling is then the
+    // only mechanism that can keep the id space from growing. Toggling this edge
+    // also re-arms the background reclaimer each drain spin (a stalled epoch
+    // otherwise ends the reclaim chain until the next structural edit).
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    REQUIRE(noise != nullptr);
+    REQUIRE(dac != nullptr);
+    p.Connect(noise, 0, dac, 0);
+    p.Calculate(YSE::T_DSP);
+
+    const std::size_t baseOut = p.OutletIdSpace();
+    const std::size_t baseIn = p.InletIdSpace();
+
+    // The first temp (a ~+ has two inlets and one outlet) finds an empty
+    // free-list, so it stamps fresh ids and lifts the high-water mark by exactly
+    // one temp's worth of pins. That peak is the bound every later temp must
+    // respect.
+    YSE::pHandle* first = p.CreateObject(YSE::OBJ::D_ADD, "");
+    REQUIRE(first != nullptr);
+    const std::size_t peakOut = p.OutletIdSpace();
+    const std::size_t peakIn = p.InletIdSpace();
+    REQUIRE(peakOut > baseOut); // the temp really consumed an outlet id
+    REQUIRE(peakIn > baseIn); // ... and inlet ids
+    p.DeleteObject(first);
+
+    for (int i = 0; i < 40; ++i) {
+      // Drain the reclaimer so the previous temp's ids are back on the free-list
+      // before the next create. Each spin toggles the persistent edge (re-arming
+      // the reclaimer) and renders blocks (advancing the audio epoch across the
+      // +2 grace); the background pool then frees the temp and recycles its ids
+      // (RecycleObjectIds pushes all of a temp's inlet + outlet ids under one
+      // reclaimMtx_ hold, so FreeIdCount jumps from 0 to the full count at once).
+      for (int spins = 0; spins < 3000 && p.FreeIdCount() == 0; ++spins) {
+        p.Disconnect(noise, 0, dac, 0);
+        p.Calculate(YSE::T_DSP);
+        p.Connect(noise, 0, dac, 0);
+        p.Calculate(YSE::T_DSP);
+        p.Calculate(YSE::T_DSP);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+      REQUIRE(p.FreeIdCount() > 0); // the deleted temp's ids are recyclable now
+
+      YSE::pHandle* temp = p.CreateObject(YSE::OBJ::D_ADD, "");
+      REQUIRE(temp != nullptr);
+      // The create must have pulled recycled ids instead of extending the
+      // counters: the high-water mark never climbs past the single-temp peak,
+      // no matter how many temps churned through. Before the free-list these
+      // grew by one temp's pins every iteration.
+      CHECK(p.OutletIdSpace() == peakOut);
+      CHECK(p.InletIdSpace() == peakIn);
+      p.DeleteObject(temp);
+    }
+  }
+
+  TEST_CASE("graphids: churning a source into a live sink stays correct with recycling") {
+    // Reusing an id must not corrupt what the audio thread renders: an outlet
+    // whose id was recycled from a deleted object must resolve *its own* targets
+    // in the pinned snapshot, never a stale entry. Repeatedly wire a fresh source
+    // into the surviving dac, render, then delete it. Each create-after-delete
+    // recycles the previous source's ids (the edits re-arm the reclaimer and the
+    // renders advance the epoch), so the recycled outlet is exercised in the
+    // signal path every iteration. An ASan/TSan build additionally trips on any
+    // dangling reuse.
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    REQUIRE(dac != nullptr);
+
+    for (int i = 0; i < 30; ++i) {
+      YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+      REQUIRE(noise != nullptr);
+      p.Connect(noise, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      CHECK_FALSE(p.output[0].isSilent()); // the (recycled) outlet resolves its target
+
+      p.Disconnect(noise, 0, dac, 0);
+      p.DeleteObject(noise);
+      p.Calculate(YSE::T_DSP);
+      p.Calculate(YSE::T_DSP);
+      CHECK(p.output[0].isSilent()); // source gone -> silence, no stale target
+    }
+  }
+
 } // TEST_SUITE("patcher")

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -303,6 +303,14 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
   // not free it yet — an in-flight audio block may still walk the retired
   // snapshot that references it. The free is deferred to the reclaimer.
   object->UnwireFromPeers();
+  // Capture the id generation this object's ids belong to *before* a possible
+  // recompaction below bumps it, so the reclaimer can tell whether they are
+  // still recyclable when it frees the object (issue #364).
+  std::uint64_t objGen;
+  {
+    std::scoped_lock rlk(reclaimMtx_);
+    objGen = idGeneration_;
+  }
   // If that was the patcher's last object, recompact the id space before the
   // next graph is built: an empty object set binds no live id (issue #355).
   CompactGraphIdsIfEmpty();
@@ -312,7 +320,7 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
   // guarantees no retired graph outlives an object it points into.
   {
     std::scoped_lock rlk(reclaimMtx_);
-    retiredObjects_.emplace_back(object, audioBlock_.load(std::memory_order_acquire));
+    retiredObjects_.push_back({object, audioBlock_.load(std::memory_order_acquire), objGen});
   }
   ScheduleReclaim();
   // The handle is never referenced by a GraphState, so it can go immediately.
@@ -446,8 +454,11 @@ void patcherImplementation::ReplaceObjectUnlocked(YSE::pHandle* handle, const st
   handle->object = fresh;
   RebuildAndPublish();
   {
+    // No recompaction happens here (the patcher is never empty during a
+    // replace), so the current generation is the one the old object's ids belong
+    // to; the reclaimer recycles them when it frees the old object (issue #364).
     std::scoped_lock rlk(reclaimMtx_);
-    retiredObjects_.emplace_back(old, audioBlock_.load(std::memory_order_acquire));
+    retiredObjects_.push_back({old, audioBlock_.load(std::memory_order_acquire), idGeneration_});
   }
   ScheduleReclaim();
 }
@@ -466,6 +477,14 @@ void patcherImplementation::Clear() {
     delete it->first; // handle: not referenced by a GraphState
   }
   objects.clear();
+  // Capture the id generation the doomed objects' ids belong to before the
+  // recompaction below bumps it (issue #364): a Clear always empties the
+  // patcher, so their ids are a stale numbering the reclaimer must not recycle.
+  std::uint64_t objGen;
+  {
+    std::scoped_lock rlk(reclaimMtx_);
+    objGen = idGeneration_;
+  }
   // No live object remains, so the id space carries no stability constraint:
   // recompact it before the empty graph is built so later rebuilds restart from
   // a small id range instead of extending it every Clear (issue #355).
@@ -478,7 +497,7 @@ void patcherImplementation::Clear() {
     std::scoped_lock rlk(reclaimMtx_);
     const std::uint64_t at = audioBlock_.load(std::memory_order_acquire);
     for (pObject* obj : doomed)
-      retiredObjects_.emplace_back(obj, at);
+      retiredObjects_.push_back({obj, at, objGen});
   }
   ScheduleReclaim();
 }
@@ -593,6 +612,11 @@ std::size_t patcherImplementation::OutletIdSpace() {
 std::size_t patcherImplementation::InletIdSpace() {
   std::scoped_lock lk(mtx);
   return static_cast<std::size_t>(nextInletId_);
+}
+
+std::size_t patcherImplementation::FreeIdCount() {
+  std::scoped_lock lk(reclaimMtx_);
+  return freeInletIds_.size() + freeOutletIds_.size();
 }
 
 YSE::pHandle* patcherImplementation::GetHandleFromList(unsigned int obj) {
@@ -808,13 +832,50 @@ void patcherImplementation::SetHandler(YSE::oscHandler* handler) {
 }
 
 void patcherImplementation::AssignGraphIds(pObject* object) {
+  // Caller holds mtx. Recycled ids are produced by the background reclaimer
+  // under reclaimMtx_ (issue #364); pull from the free-list before extending the
+  // high-water mark so a continuously edited patcher reuses the id range of its
+  // deleted objects instead of growing it with the lifetime create count. A
+  // recycled id is always < the current counter, so it stays in bounds of every
+  // GraphState's id-indexed tables. mtx -> reclaimMtx_ is the established order;
+  // this never runs on the audio thread.
+  std::scoped_lock rlk(reclaimMtx_);
   for (int i = 0; i < object->NumInputs(); i++) {
     PATCHER::inlet* in = object->GetInlet(i);
-    if (in != nullptr && in->GraphId() < 0) in->SetGraphId(nextInletId_++);
+    if (in == nullptr || in->GraphId() >= 0) continue;
+    if (!freeInletIds_.empty()) {
+      in->SetGraphId(freeInletIds_.back());
+      freeInletIds_.pop_back();
+    } else {
+      in->SetGraphId(nextInletId_++);
+    }
   }
   for (int i = 0; i < object->NumOutputs(); i++) {
     PATCHER::outlet* out = object->GetOutlet(i);
-    if (out != nullptr && out->GraphId() < 0) out->SetGraphId(nextOutletId_++);
+    if (out == nullptr || out->GraphId() >= 0) continue;
+    if (!freeOutletIds_.empty()) {
+      out->SetGraphId(freeOutletIds_.back());
+      freeOutletIds_.pop_back();
+    } else {
+      out->SetGraphId(nextOutletId_++);
+    }
+  }
+}
+
+void patcherImplementation::RecycleObjectIds(pObject* object, std::uint64_t idGen) {
+  // Caller holds reclaimMtx_ (the background reclaimer, freeing this object now
+  // that no live or retired snapshot can still index its ids). Only return the
+  // ids to the free-list if they still belong to the current numbering: a
+  // CompactGraphIdsIfEmpty since retirement reset the counters, so these ids
+  // would collide with the fresh dense range if reused (issue #364).
+  if (idGen != idGeneration_) return;
+  for (int i = 0; i < object->NumInputs(); i++) {
+    PATCHER::inlet* in = object->GetInlet(i);
+    if (in != nullptr && in->GraphId() >= 0) freeInletIds_.push_back(in->GraphId());
+  }
+  for (int i = 0; i < object->NumOutputs(); i++) {
+    PATCHER::outlet* out = object->GetOutlet(i);
+    if (out != nullptr && out->GraphId() >= 0) freeOutletIds_.push_back(out->GraphId());
   }
 }
 
@@ -830,6 +891,14 @@ void patcherImplementation::CompactGraphIdsIfEmpty() {
   if (objects.empty()) {
     nextInletId_ = 0;
     nextOutletId_ = 0;
+    // The whole id space is reclaimed at once, so any recycled ids parked on the
+    // free-list belong to the pre-reset numbering and must be dropped; bumping
+    // the generation likewise marks the ids of still-pending retired objects as
+    // stale, so their deferred free won't push them into the reset space (#364).
+    std::scoped_lock rlk(reclaimMtx_);
+    freeInletIds_.clear();
+    freeOutletIds_.clear();
+    idGeneration_++;
   }
 }
 
@@ -903,8 +972,11 @@ bool patcherImplementation::ReclaimElapsed(std::uint64_t now) {
     }
   }
   for (std::size_t i = 0; i < retiredObjects_.size();) {
-    if (now >= retiredObjects_[i].second + 2) {
-      delete retiredObjects_[i].first;
+    if (now >= retiredObjects_[i].epoch + 2) {
+      // No live or retired snapshot can still index this object's ids now, so
+      // hand them back to the free-list for reuse before freeing it (issue #364).
+      RecycleObjectIds(retiredObjects_[i].object, retiredObjects_[i].idGen);
+      delete retiredObjects_[i].object;
       retiredObjects_.erase(retiredObjects_.begin() + i);
     } else {
       ++i;
@@ -941,7 +1013,7 @@ void patcherImplementation::FreeAllRetired() {
   const GraphState* g = active_.exchange(nullptr, std::memory_order_acq_rel);
   delete g;
   for (std::size_t i = 0; i < retiredObjects_.size(); i++) {
-    delete retiredObjects_[i].first;
+    delete retiredObjects_[i].object;
   }
   retiredObjects_.clear();
 }

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -88,6 +88,14 @@ namespace YSE {
       std::size_t OutletIdSpace();
       std::size_t InletIdSpace();
 
+      // Number of retired inlet + outlet graph ids currently parked on the
+      // free-list awaiting reuse (issue #364). A non-zero value after a
+      // create/delete churn (with the patcher never going empty) shows the
+      // reclaimer is returning ids for AssignGraphIds to recycle rather than
+      // letting the id space grow. Diagnostics / tests only: takes reclaimMtx_,
+      // so control-thread only.
+      std::size_t FreeIdCount();
+
       std::vector<YSE::DSP::buffer> output;
 
       aBool controlledBySound;
@@ -196,14 +204,23 @@ namespace YSE {
       // Control-thread only (allocates). See graphState.h.
       GraphState* BuildGraph();
       // Stamp lifetime-stable graph ids on a newly added object's inlets/outlets.
+      // Pulls a recycled id from the free-list before bumping the counter so a
+      // continuously edited patcher reuses the ids of its deleted objects (issue
+      // #364). Caller holds mtx; takes reclaimMtx_ for the free-list access.
       void AssignGraphIds(pObject* obj);
+      // Return a freed object's inlet/outlet graph ids to the free-list, but only
+      // if they belong to the current id generation — ids from a compacted-away
+      // numbering (issue #355) are dropped (issue #364). Caller holds reclaimMtx_.
+      void RecycleObjectIds(pObject* obj, std::uint64_t idGen);
       // Recompact the inlet/outlet id space when no live object remains. A
       // graph id is fixed for a live object's lifetime (the audio thread reads
       // it unsynchronised to index the pinned snapshot), so ids can only be
       // reclaimed when there is nothing live to re-stamp — an empty object set
       // is exactly that case. Restarting the counters at 0 then bounds each
       // GraphState's id-indexed tables by the peak simultaneous object count
-      // instead of the lifetime creation count (issue #355). Caller holds mtx.
+      // instead of the lifetime creation count (issue #355). Also bumps the id
+      // generation and drops the free-list, so ids from the old numbering are not
+      // recycled into the reset space (issue #364). Caller holds mtx.
       void CompactGraphIdsIfEmpty();
       // Build the next GraphState, publish it with one atomic swap, retire the
       // previous one, and schedule background reclamation.
@@ -265,6 +282,18 @@ namespace YSE {
       // tell when the audio thread has advanced past a retired snapshot.
       std::atomic<std::uint64_t> audioBlock_{0};
 
+      // A deleted object awaiting reclamation. `epoch` is the block count at
+      // retirement (the +2 grace is measured from it). `idGen` is the id-space
+      // generation the object's inlet/outlet graph ids belong to (issue #364):
+      // the reclaimer returns those ids to the free-list only when it still
+      // matches the current generation, so ids from a numbering that was
+      // compacted away (issue #355) are dropped rather than reused.
+      struct RetiredObject {
+        pObject* object;
+        std::uint64_t epoch;
+        std::uint64_t idGen;
+      };
+
       // Retired snapshots / deleted objects awaiting reclamation, tagged with
       // the block count at retirement. Produced by the control thread and drained
       // by the background pool, so guarded by reclaimMtx_ (never taken on the
@@ -272,7 +301,7 @@ namespace YSE {
       // may take it, but the background reclaimer takes only reclaimMtx_.
       std::mutex reclaimMtx_;
       std::vector<std::pair<const GraphState*, std::uint64_t>> retiredGraphs_;
-      std::vector<std::pair<pObject*, std::uint64_t>> retiredObjects_;
+      std::vector<RetiredObject> retiredObjects_;
       // Two-element ping-pong so a reclaim pass that still has work can re-arm
       // without re-enqueuing itself (see reclaimJob). Wired up in the ctor.
       reclaimJob reclaimJobs_[2];
@@ -292,6 +321,22 @@ namespace YSE {
       // lifetime creation count (issue #355).
       int nextInletId_ = 0;
       int nextOutletId_ = 0;
+
+      // Free-list of retired inlet / outlet graph ids (issue #364). The
+      // background reclaimer pushes a deleted object's ids here at the moment it
+      // frees the object — the point no live or retired snapshot can still index
+      // them — and AssignGraphIds pulls from here before bumping the counters. A
+      // continuously edited patcher that never goes empty (so #355's compaction
+      // never fires) thus reuses the id range of its deleted objects instead of
+      // growing it with the lifetime create count. Guarded by reclaimMtx_ and
+      // never touched on the audio thread; consumed under mtx -> reclaimMtx_.
+      std::vector<int> freeInletIds_;
+      std::vector<int> freeOutletIds_;
+      // Generation of the current id numbering. Bumped by CompactGraphIdsIfEmpty
+      // every time the counters reset, so ids stamped before a reset carry a
+      // stale generation and are dropped rather than recycled (see RetiredObject
+      // and RecycleObjectIds). Guarded by reclaimMtx_.
+      std::uint64_t idGeneration_ = 0;
 
       // Lock-free command queue for deferred value delivery (issue #225).
       // Producers: control/GUI threads (PassBang / PassData). Consumer: the


### PR DESCRIPTION
## Summary

Free-list follow-up to #355. #355's empty-set recompaction bounds graph-id
growth only when the patcher goes **empty**. A long-lived patcher that is
continuously edited while at least one object always survives (a live-coding
session that grows and prunes a graph in place) never empties, so the
per-patcher `nextInletId_` / `nextOutletId_` counters — and thus every
`GraphState`'s id-indexed tables (`outletTargets` / `inletHasDsp`) and the
per-edit rebuild cost — kept climbing with the patcher's lifetime create count.

This adds the free-list option from #355: the background epoch reclaimer (#227)
returns a deleted object's inlet/outlet ids to a per-patcher free-list at the
moment it frees the object (the point no live or retired snapshot can still
index them), and `AssignGraphIds` pulls from the free-list before bumping the
counter. So a never-empty churn loop reuses the id range of its deleted objects
and the id space tracks the **peak simultaneous** object count.

## Linked issue

Closes #364

## Changes

- `patcherImplementation`: add `freeInletIds_` / `freeOutletIds_` (guarded by
  `reclaimMtx_`, consumed under `mtx -> reclaimMtx_`; never touched on the audio
  thread). `AssignGraphIds` pulls a recycled id before extending the high-water
  mark; a recycled id is always `< counter`, so it stays in bounds of every
  snapshot's tables.
- `RecycleObjectIds` (background pool, in `ReclaimElapsed`): return a freed
  object's ids to the free-list.
- Correctness across the #355 recompaction: bump an `idGeneration_` every time
  `CompactGraphIdsIfEmpty` resets the counters and clear the free-list. Retired
  objects carry the generation their ids belong to; the reclaimer recycles them
  only when the generation still matches, so ids from a compacted-away numbering
  are dropped rather than collided into the reset dense range.
- Add a `FreeIdCount()` diagnostic (tests only) and two regression tests.

## Real-time discipline

Control-thread + background-pool cost only. The audio thread (`Calculate`) is
untouched — it never allocates, locks, or recycles these ids. `AssignGraphIds`
/ `RecycleObjectIds` / `CompactGraphIdsIfEmpty` run only on the control thread
or the background reclaimer, all under the established `mtx -> reclaimMtx_`
lock order.

## Test plan

- [x] clang-format clean (`clang-format 22.1.4 --dry-run --Werror` on all three files)
- [x] clang-tidy clean (`python yse.py analyze` on both changed `.cpp` files — 0 displayed findings, only pre-existing baseline/non-user-code suppressions)
- [x] patcher suite green: `yse_tests --test-suite=patcher` → 234 cases / 5116 assertions pass (incl. the 4 `graphids:` cases: 2 new + 2 existing #355)
- [x] DSP suite green: `yse_tests --test-suite=dsp` → 399 cases pass
- [x] New tests: `graphids: continuous create/delete churn recycles ids via the free-list` (fails without the free-list — id space would grow every iteration) and `graphids: churning a source into a live sink stays correct with recycling`
- [ ] Integration/e2e: not applicable — this is control-plane engine logic with no user-visible rendered output beyond what the unit tests drive (`Calculate` is exercised directly). The full monolithic run shows 3 pre-existing failures in `test_system_active_state.cpp` (audio-device sample-rate asserts, `getActiveSampleRate()==0` headless); the `system` suite passes 25/25 in isolation — documented cross-suite teardown flake (#298/#304), unrelated to this change.

_Note:_ per the issue's caveat, recycling only fires while the audio epoch advances; the #355 empty-set reset remains the mechanism for an audio-paused churn loop. The TSan/ASan stress gate (#229 lineage) covers the added control/background-pool id coupling.