### PR TITLE
c-api: morphingReverb insert module surface (#369)

### DIFF
--- a/Tests/channel/test_c_api_channel.cpp
+++ b/Tests/channel/test_c_api_channel.cpp
@@ -303,6 +303,70 @@ TEST_SUITE("channelcapi") {
     yse_dsp_object_destroy(c);
   }
 
+  TEST_CASE("c-api dsp: morphing reverb presets + morph round-trip (#326/#369)") {
+    YseDspObject* m = yse_dsp_morphing_reverb_create();
+    REQUIRE(m != nullptr);
+
+    // Defaults (per #326): A = GENERIC, B = HALL, morph = 0 (pure A).
+    CHECK(yse_dsp_morphing_reverb_get_morph(m) == doctest::Approx(0.0f));
+
+    // Named-preset endpoints resolve to the shared preset table.
+    yse_dsp_morphing_reverb_set_preset_a(m, YSE_REVERB_CAVE);
+    yse_dsp_morphing_reverb_set_preset_b(m, YSE_REVERB_OFF);
+    YseReverbPresetValues a{};
+    YseReverbPresetValues b{};
+    yse_dsp_morphing_reverb_get_preset_a(m, &a);
+    yse_dsp_morphing_reverb_get_preset_b(m, &b);
+    CHECK(a.roomsize == doctest::Approx(1.0f)); // CAVE
+    CHECK(a.wet == doctest::Approx(0.7f));
+    CHECK(a.dry == doctest::Approx(0.3f));
+    CHECK(a.early_time[0] == doctest::Approx(100.0f));
+    CHECK(a.early_gain[0] == doctest::Approx(0.8f));
+    CHECK(b.dry == doctest::Approx(1.0f)); // OFF: dry pass-through
+    CHECK(b.wet == doctest::Approx(0.0f));
+
+    // Custom endpoint values round-trip field-for-field through the mirror
+    // struct (send/return flavour: fully wet).
+    YseReverbPresetValues custom{};
+    custom.roomsize = 0.42f;
+    custom.damp = 0.3f;
+    custom.dry = 0.0f;
+    custom.wet = 1.0f;
+    custom.mod_frequency = 2.5f;
+    custom.mod_width = 8.0f;
+    for (int i = 0; i < 4; ++i) {
+      custom.early_time[i] = 100.0f * static_cast<float>(i + 1);
+      custom.early_gain[i] = 0.1f * static_cast<float>(i + 1);
+    }
+    yse_dsp_morphing_reverb_set_preset_b_values(m, &custom);
+    YseReverbPresetValues got{};
+    yse_dsp_morphing_reverb_get_preset_b(m, &got);
+    CHECK(got.roomsize == doctest::Approx(0.42f));
+    CHECK(got.damp == doctest::Approx(0.3f));
+    CHECK(got.dry == doctest::Approx(0.0f));
+    CHECK(got.wet == doctest::Approx(1.0f));
+    CHECK(got.mod_frequency == doctest::Approx(2.5f));
+    CHECK(got.mod_width == doctest::Approx(8.0f));
+    for (int i = 0; i < 4; ++i) {
+      CHECK(got.early_time[i] == doctest::Approx(100.0f * static_cast<float>(i + 1)));
+      CHECK(got.early_gain[i] == doctest::Approx(0.1f * static_cast<float>(i + 1)));
+    }
+
+    // Morph control input (per #326) is stored and clamped to [0, 1].
+    yse_dsp_morphing_reverb_set_morph(m, 0.25f);
+    CHECK(yse_dsp_morphing_reverb_get_morph(m) == doctest::Approx(0.25f));
+    yse_dsp_morphing_reverb_set_morph(m, 7.5f);
+    CHECK(yse_dsp_morphing_reverb_get_morph(m) == doctest::Approx(1.0f));
+    yse_dsp_morphing_reverb_set_morph(m, -2.0f);
+    CHECK(yse_dsp_morphing_reverb_get_morph(m) == doctest::Approx(0.0f));
+
+    // Inherited dspObject surface reaches the same handle.
+    yse_dsp_object_set_bypass(m, 1);
+    CHECK(yse_dsp_object_get_bypass(m) == 1);
+
+    yse_dsp_object_destroy(m);
+  }
+
   // Module setters/getters are null-safe like the rest of the module surface.
   TEST_CASE("c-api dsp: new module setters/getters are null-safe") {
     yse_dsp_feedback_delay_set_time(nullptr, 1.f);
@@ -315,6 +379,17 @@ TEST_SUITE("channelcapi") {
     CHECK(yse_dsp_plate_reverb_get_decay(nullptr) == doctest::Approx(0.f));
     CHECK(yse_dsp_eq_get_gain(nullptr, YSE_EQ_PEAK_1) == doctest::Approx(0.f));
     CHECK(yse_dsp_compressor_get_gain_reduction_db(nullptr) == doctest::Approx(0.f));
+
+    // morphing reverb (#326/#369)
+    yse_dsp_morphing_reverb_set_preset_a(nullptr, YSE_REVERB_HALL);
+    yse_dsp_morphing_reverb_set_preset_b_values(nullptr, nullptr);
+    yse_dsp_morphing_reverb_set_morph(nullptr, 0.5f);
+    CHECK(yse_dsp_morphing_reverb_get_morph(nullptr) == doctest::Approx(0.f));
+    YseReverbPresetValues z; // getter must zero-fill on a NULL handle
+    yse_dsp_morphing_reverb_get_preset_a(nullptr, &z);
+    CHECK(z.roomsize == doctest::Approx(0.f));
+    CHECK(z.wet == doctest::Approx(0.f));
+    yse_dsp_morphing_reverb_get_preset_a(nullptr, nullptr); // no crash
   }
 
 } // TEST_SUITE("channelcapi")

--- a/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
@@ -50,6 +50,7 @@ YSE_C_API YseDspObject* yse_dsp_chorus_create(void); /* #161 */
 YSE_C_API YseDspObject* yse_dsp_plate_reverb_create(void); /* #162 */
 YSE_C_API YseDspObject* yse_dsp_eq_create(void); /* #163 */
 YSE_C_API YseDspObject* yse_dsp_compressor_create(void); /* #163 */
+YSE_C_API YseDspObject* yse_dsp_morphing_reverb_create(void); /* #326 module, #369 C API */
 
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj);
 
@@ -186,6 +187,50 @@ YSE_C_API float yse_dsp_compressor_get_release(YseDspObject* obj);
 YSE_C_API void yse_dsp_compressor_set_makeup(YseDspObject* obj, float db);
 YSE_C_API float yse_dsp_compressor_get_makeup(YseDspObject* obj);
 YSE_C_API float yse_dsp_compressor_get_gain_reduction_db(YseDspObject* obj);
+
+/* ─── morphing reverb (#326 module, #369 C API) ───────────────────────────
+ * The engine's zone/global reverb core packaged as a chainable insert whose
+ * preset blend is a *control input*. Two endpoints — slot A and slot B — are
+ * each a named YseReverbPreset or a custom YseReverbPresetValues; set_morph()
+ * linearly interpolates between them (0 = pure A, 1 = pure B, clamped to
+ * [0, 1]). morph is a control-rate signal: writes are allocation-free and
+ * click-free (the reverb core's faders smooth every move), so any control
+ * thread may call set_morph at control rate. Defaults: A = REVERB_GENERIC,
+ * B = REVERB_HALL, morph = 0. Its wet/dry balance rides the morphed presets
+ * (each carries dry/wet), so the inherited yse_dsp_object_set_impact() is NOT
+ * applied — for send/return use give both slots custom values with dry = 0,
+ * wet = 1. */
+
+/* Plain-old-data mirror of YSE::REVERB::presetValues (reverb/reverbPresets.hpp)
+ * — one complete reverb parameter set: the payload of a named preset and the
+ * custom endpoint type of the morphing reverb. Fields are copied one by one
+ * across the ABI; the layout is not assumed to match the engine struct. */
+typedef struct YseReverbPresetValues {
+  float roomsize; /* simulated room size, [0, 1] */
+  float damp; /* high-frequency damping, [0, 1] */
+  float dry; /* unprocessed level, [0, 1] */
+  float wet; /* reverberated level, [0, 1] */
+  float mod_frequency; /* tail modulation rate, Hz (0 = off) */
+  float mod_width; /* tail modulation depth (0 = off) */
+  float early_time[4]; /* early reflection delays, samples, [0, 2999] */
+  float early_gain[4]; /* early reflection gains, [0, 1] */
+} YseReverbPresetValues;
+
+/* Set an endpoint from a named preset. */
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_a(YseDspObject* obj, YseReverbPreset preset);
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_b(YseDspObject* obj, YseReverbPreset preset);
+/* Set an endpoint from a custom parameter set. NULL values is a no-op. */
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_a_values(YseDspObject* obj,
+                                                           const YseReverbPresetValues* values);
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_b_values(YseDspObject* obj,
+                                                           const YseReverbPresetValues* values);
+/* Read an endpoint's current parameter set into *out. NULL out is a no-op;
+   a NULL handle zero-fills *out. */
+YSE_C_API void yse_dsp_morphing_reverb_get_preset_a(YseDspObject* obj, YseReverbPresetValues* out);
+YSE_C_API void yse_dsp_morphing_reverb_get_preset_b(YseDspObject* obj, YseReverbPresetValues* out);
+/* The morph control input: 0 = pure A, 1 = pure B, clamped to [0, 1]. */
+YSE_C_API void yse_dsp_morphing_reverb_set_morph(YseDspObject* obj, float value);
+YSE_C_API float yse_dsp_morphing_reverb_get_morph(YseDspObject* obj);
 
 #ifdef __cplusplus
 }

--- a/YseEngine/c_api/yse_dsp_modules.cpp
+++ b/YseEngine/c_api/yse_dsp_modules.cpp
@@ -19,6 +19,8 @@
 #include "../dsp/modules/plateReverb.hpp"
 #include "../dsp/modules/parametricEQ.hpp"
 #include "../dsp/modules/compressor.hpp"
+#include "../dsp/modules/morphingReverb.hpp"
+#include "../reverb/reverbPresets.hpp"
 
 #include <exception>
 
@@ -41,6 +43,39 @@ namespace {
       yse_c::set_last_error("dsp_module create: unknown C++ exception");
       return nullptr;
     }
+  }
+
+  // Field-by-field conversions between the C mirror struct and the engine's
+  // REVERB::presetValues. The ABI struct layout is never assumed to match the
+  // engine one, so every field is copied explicitly.
+  inline YSE::REVERB::presetValues to_cpp_preset(const YseReverbPresetValues& v) {
+    YSE::REVERB::presetValues p;
+    p.roomsize = v.roomsize;
+    p.damp = v.damp;
+    p.dry = v.dry;
+    p.wet = v.wet;
+    p.modFrequency = v.mod_frequency;
+    p.modWidth = v.mod_width;
+    for (int i = 0; i < 4; ++i) {
+      p.earlyTime[i] = v.early_time[i];
+      p.earlyGain[i] = v.early_gain[i];
+    }
+    return p;
+  }
+
+  inline YseReverbPresetValues to_c_preset(const YSE::REVERB::presetValues& p) {
+    YseReverbPresetValues v;
+    v.roomsize = p.roomsize;
+    v.damp = p.damp;
+    v.dry = p.dry;
+    v.wet = p.wet;
+    v.mod_frequency = p.modFrequency;
+    v.mod_width = p.modWidth;
+    for (int i = 0; i < 4; ++i) {
+      v.early_time[i] = p.earlyTime[i];
+      v.early_gain[i] = p.earlyGain[i];
+    }
+    return v;
   }
 } // namespace
 
@@ -117,6 +152,9 @@ YSE_C_API YseDspObject* yse_dsp_eq_create(void) {
 }
 YSE_C_API YseDspObject* yse_dsp_compressor_create(void) {
   return mk<YSE::DSP::MODULES::compressor>();
+}
+YSE_C_API YseDspObject* yse_dsp_morphing_reverb_create(void) {
+  return mk<YSE::DSP::MODULES::morphingReverb>();
 }
 
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj) {
@@ -514,6 +552,45 @@ YSE_C_API float yse_dsp_compressor_get_makeup(YseDspObject* o) {
 YSE_C_API float yse_dsp_compressor_get_gain_reduction_db(YseDspObject* o) {
   auto* c = as<YSE::DSP::MODULES::compressor>(o);
   return c ? c->gainReductionDb() : 0.0f;
+}
+
+// ─── morphing reverb (#326 module, #369 C API) ────────────────────────────
+
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_a(YseDspObject* o, YseReverbPreset preset) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r) r->presetA(static_cast<YSE::REVERB_PRESET>(preset));
+}
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_b(YseDspObject* o, YseReverbPreset preset) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r) r->presetB(static_cast<YSE::REVERB_PRESET>(preset));
+}
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_a_values(YseDspObject* o,
+                                                           const YseReverbPresetValues* values) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r && values) r->presetA(to_cpp_preset(*values));
+}
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_b_values(YseDspObject* o,
+                                                           const YseReverbPresetValues* values) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r && values) r->presetB(to_cpp_preset(*values));
+}
+YSE_C_API void yse_dsp_morphing_reverb_get_preset_a(YseDspObject* o, YseReverbPresetValues* out) {
+  if (!out) return;
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  *out = r ? to_c_preset(r->presetA()) : YseReverbPresetValues{};
+}
+YSE_C_API void yse_dsp_morphing_reverb_get_preset_b(YseDspObject* o, YseReverbPresetValues* out) {
+  if (!out) return;
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  *out = r ? to_c_preset(r->presetB()) : YseReverbPresetValues{};
+}
+YSE_C_API void yse_dsp_morphing_reverb_set_morph(YseDspObject* o, float value) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r) r->morph(value);
+}
+YSE_C_API float yse_dsp_morphing_reverb_get_morph(YseDspObject* o) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  return r ? r->morph() : 0.0f;
 }
 
 } // extern "C"


### PR DESCRIPTION
## Summary

Adds the C ABI mirror for `YSE::DSP::MODULES::morphingReverb` (the #326 control-input morphing reverb). It was the one insert module with no C API surface — every sibling (chorus, compressor, feedbackDelay, parametricEQ, plateReverb) is already mirrored, and the token `morph` did not appear anywhere in the C API.

## Linked issue

Closes #369

## Changes

New in `yse_c/yse_dsp_modules.h` / `yse_dsp_modules.cpp`:

- `yse_dsp_morphing_reverb_create` — owned handle, released with the shared `yse_dsp_object_destroy`.
- `yse_dsp_morphing_reverb_set_preset_a` / `_set_preset_b` — set an endpoint from a named `YseReverbPreset` (already-mirrored enum).
- `yse_dsp_morphing_reverb_set_preset_a_values` / `_set_preset_b_values` + `_get_preset_a` / `_get_preset_b` — custom endpoints via a new `YseReverbPresetValues` POD struct that mirrors `YSE::REVERB::presetValues`, converted field-by-field across the ABI (no layout assumption).
- `yse_dsp_morphing_reverb_set_morph` / `_get_morph` — the control-rate morph input (0 = pure A, 1 = pure B, clamped to [0,1]), exposed as a plain setter per #326.

`YseReverbPreset` was already mirrored and drift-guarded, so no enum change was needed. All new surface follows the six c-api conventions: null-safe void no-ops, getters that return 0 / zero-fill `*out` on a null handle, exception-guarded `create`, no C++ types across the ABI. No new `.cpp` file, so no CMakeLists change. Engine → C API → bindings layering preserved (engine module untouched).

## Test plan

- [x] `python yse.py build` clean (300/300, exit 0)
- [x] `python yse.py analyze` on both changed `.cpp` files — no user-code findings (header covered transitively)
- [x] `python yse.py test` — 32/32 ctest entries pass (100%)
- [x] New C-only round-trip + null-safety coverage added to the `channelcapi` suite (`yse_tests_channelcapi`, passed); the new round-trip case alone is 27 assertions, all passing. Covers named + custom endpoints, `presetValues` field round-trip, morph clamping, and null-safe no-ops.

No integration test beyond the C-only suite is warranted: this is a flat ABI wrapper over an engine module that already has full behavioural coverage in `Tests/dsp/test_module_morphing_reverb.cpp`; the C surface only needs parameter-parity and null-safety, which the channelcapi test provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)