### PR TITLE
c-api: patcherInsert (patcher-as-insert) surface (#370)

### DIFF
--- a/Tests/channel/test_c_api_channel.cpp
+++ b/Tests/channel/test_c_api_channel.cpp
@@ -32,6 +32,7 @@
 #include "yse_c/yse_dsp.h"
 #include "yse_c/yse_dsp_modules.h"
 #include "yse_c/yse_enums.h"
+#include "yse_c/yse_patcher.h"
 #include "yse_c/yse_sound.h"
 #include "yse_c/yse_system.h"
 
@@ -365,6 +366,74 @@ TEST_SUITE("channelcapi") {
     CHECK(yse_dsp_object_get_bypass(m) == 1);
 
     yse_dsp_object_destroy(m);
+  }
+
+  // ─── patcher-as-insert (#167 module, #370 C API) ─────────────────────────────
+
+  TEST_CASE("c-api dsp: patcher insert wraps a graph and renders on a channel (#167/#370)") {
+    REQUIRE(ensureOffline());
+
+    // Build a passthrough patcher graph (~adc -> ~dac, stereo) entirely through
+    // the C ABI, then wrap it as a chainable insert. The graph is function-scoped
+    // so it outlives the insert that borrows it.
+    YsePatcher* graph = yse_patcher_create();
+    REQUIRE(graph != nullptr);
+    yse_patcher_init(graph, 2);
+    YsePHandle* adc = yse_patcher_create_object(graph, "~adc", nullptr);
+    YsePHandle* dac = yse_patcher_create_object(graph, "~dac", nullptr);
+    REQUIRE(adc != nullptr);
+    REQUIRE(dac != nullptr);
+    yse_patcher_connect(graph, adc, 0, dac, 0);
+    yse_patcher_connect(graph, adc, 1, dac, 1);
+
+    YseDspObject* insert = yse_dsp_patcher_insert_create(graph);
+    REQUIRE(insert != nullptr);
+
+    // The inherited dspObject surface reaches the same handle.
+    yse_dsp_object_set_bypass(insert, 1);
+    CHECK(yse_dsp_object_get_bypass(insert) == 1);
+    yse_dsp_object_set_bypass(insert, 0);
+
+    // Attach the insert to a channel; it round-trips through the C handle.
+    YseChannel* ch = yse_channel_create("capi_pi", yse_channel_master());
+    REQUIRE(ch != nullptr);
+    yse_channel_set_dsp(ch, insert);
+    CHECK(yse_channel_get_dsp(ch) == insert);
+
+    // Drive a real tone through the channel and render: the patcher insert now
+    // runs on the audio path and the whole graph must stay finite.
+    pump();
+    YseDspBuffer* tone = makeToneBuffer();
+    REQUIRE(tone != nullptr);
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_sound_load_buffer(snd, tone, ch, /*loop*/ 1, /*volume*/ 1.0f) == YSE_OK);
+    pump();
+    yse_sound_play(snd);
+    pump();
+    for (int i = 0; i < 8; ++i)
+      yse_system_render_offline(yse_system_get(), 16);
+
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(ch)));
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(yse_channel_master())));
+
+    // Tear down: detach the insert before the channel/sound fall away, then free
+    // the insert before the patcher it borrows, then the buffer.
+    yse_sound_stop(snd);
+    pump();
+    yse_channel_set_dsp(ch, nullptr);
+    yse_sound_destroy(snd);
+    yse_channel_destroy(ch);
+    pump();
+    yse_dsp_object_destroy(insert);
+    yse_patcher_destroy(graph);
+    yse_dsp_buffer_destroy(tone);
+  }
+
+  // A NULL patcher has no graph to wrap, so the creator reports failure rather
+  // than handing back an insert that can never render.
+  TEST_CASE("c-api dsp: patcher insert create rejects a NULL patcher (#370)") {
+    CHECK(yse_dsp_patcher_insert_create(nullptr) == nullptr);
   }
 
   // Module setters/getters are null-safe like the rest of the module surface.

--- a/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
@@ -25,6 +25,9 @@ extern "C" {
    subclass via the shared handle type. */
 typedef struct YseDspObject YseDspObject;
 
+/* Forward declaration — see yse_patcher.h for ownership. */
+typedef struct YsePatcher YsePatcher;
+
 /* ─── constructors ────────────────────────────────────────────────────── */
 
 YSE_C_API YseDspObject* yse_dsp_lowpass_create(void);
@@ -51,6 +54,19 @@ YSE_C_API YseDspObject* yse_dsp_plate_reverb_create(void); /* #162 */
 YSE_C_API YseDspObject* yse_dsp_eq_create(void); /* #163 */
 YSE_C_API YseDspObject* yse_dsp_compressor_create(void); /* #163 */
 YSE_C_API YseDspObject* yse_dsp_morphing_reverb_create(void); /* #326 module, #369 C API */
+
+/* Patcher-as-insert (#167 module, #370 C API). Wraps a YsePatcher graph as a
+   chainable insert effect (YSE::DSP::patcherInsert): a hand-patched network
+   (a filter-delay, a custom EQ, ...) drives a sound or channel insert slot,
+   feeding the host buffer to the graph's ~adc objects and copying the summed
+   ~dac output back over it. The patcher should contain at least one ~adc and
+   one ~dac, and it must outlive the insert — the insert BORROWS the patcher, it
+   never owns or destroys it. Returns NULL and sets yse_last_error() when patcher
+   is NULL (the insert needs a graph to wrap). The returned handle is owned:
+   release it with yse_dsp_object_destroy(), drive it with the inherited
+   yse_dsp_object_* surface (bypass, impact, ...), and attach it with
+   yse_sound_set_dsp() or yse_channel_set_dsp(). */
+YSE_C_API YseDspObject* yse_dsp_patcher_insert_create(YsePatcher* patcher);
 
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj);
 

--- a/YseEngine/c_api/yse_dsp_modules.cpp
+++ b/YseEngine/c_api/yse_dsp_modules.cpp
@@ -20,6 +20,8 @@
 #include "../dsp/modules/parametricEQ.hpp"
 #include "../dsp/modules/compressor.hpp"
 #include "../dsp/modules/morphingReverb.hpp"
+#include "../dsp/patcherInsert.hpp"
+#include "../patcher/patcher.hpp"
 #include "../reverb/reverbPresets.hpp"
 
 #include <exception>
@@ -155,6 +157,26 @@ YSE_C_API YseDspObject* yse_dsp_compressor_create(void) {
 }
 YSE_C_API YseDspObject* yse_dsp_morphing_reverb_create(void) {
   return mk<YSE::DSP::MODULES::morphingReverb>();
+}
+
+// Patcher-as-insert (#167 module, #370 C API). Unlike the no-arg module
+// creators, patcherInsert wraps a borrowed YSE::patcher, so a NULL patcher is
+// rejected rather than silently constructing an insert with nothing to render.
+YSE_C_API YseDspObject* yse_dsp_patcher_insert_create(YsePatcher* patcher) {
+  if (!patcher) {
+    yse_c::set_last_error("yse_dsp_patcher_insert_create: patcher is NULL");
+    return nullptr;
+  }
+  try {
+    auto* patch = reinterpret_cast<YSE::patcher*>(patcher);
+    return reinterpret_cast<YseDspObject*>(new YSE::DSP::patcherInsert(*patch));
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("patcher_insert_create: unknown C++ exception");
+    return nullptr;
+  }
 }
 
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj) {


### PR DESCRIPTION
## Summary

Adds `yse_dsp_patcher_insert_create(YsePatcher*)`, the C ABI mirror of
`YSE::DSP::patcherInsert` (`YseEngine/dsp/patcherInsert.hpp`, added by #167).
It wraps a patcher graph as a chainable insert effect so a hand-patched
network (filter-delay, custom EQ, ...) can drive a sound or channel insert
slot. This is the **patcher-as-insert** path — distinct from the existing
`yse_sound_load_patcher` (patcher-as-source). The gap was flagged by the
v2.3.0 C API drift audit and shipped documented-as-missing in v2.3.0.

## Linked issue

Closes #370

## Changes

- `YseEngine/c_api/include/yse_c/yse_dsp_modules.h`: forward-declare
  `YsePatcher`; declare `yse_dsp_patcher_insert_create` with its
  ownership/usage contract.
- `YseEngine/c_api/yse_dsp_modules.cpp`: implement the creator (rejects a
  NULL patcher with `set_last_error`; exception-to-NULL translation like the
  other module creators).
- `Tests/channel/test_c_api_channel.cpp`: new `channelcapi` cases.

New public function (only one — the insert has no subclass-specific control
surface; everything else rides the shared `YseDspObject` handle):

- `YseDspObject* yse_dsp_patcher_insert_create(YsePatcher* patcher)`

### Ownership / RT notes

- The insert **borrows** the patcher: it must outlive the insert and is
  never destroyed by it. The returned handle is **owned** — release with
  `yse_dsp_object_destroy`, drive with the inherited `yse_dsp_object_*`
  surface, attach with `yse_sound_set_dsp` / `yse_channel_set_dsp`.
- No new audio-thread callback bridge, no allocation added on the audio
  path, no new enum/typedef requiring the drift guard.

## Test plan

- [x] `clang-format` (22.1.4, CI-pinned) clean on all changed files
- [x] `python yse.py analyze` clean on both changed `.cpp` files (no
      user-code findings)
- [x] `python yse.py test` — 32/32 CTest entries pass, including the
      monolithic `yse_unit_tests`, `yse_tests_patcher` (engine-level
      patcherInsert #167), and `yse_tests_channelcapi` (the new C-API cases)
- [x] New `channelcapi` cases run directly: 2 passed / 14 assertions —
      C-only `~adc->~dac` insert renders finite offline on a channel with a
      tone playing, `get_dsp` round-trip, inherited-bypass reach, and
      NULL-patcher rejection

Integration coverage is the offline end-to-end render (real engine, real
channel/sound graph, no audio hardware) — the norm for this suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)