### PR TITLE
c-api: route a MIDI input device into a synth (midiIn connect/disconnect) (#371)

### DIFF
--- a/Tests/midi/test_midi_synth.cpp
+++ b/Tests/midi/test_midi_synth.cpp
@@ -32,6 +32,8 @@
 #if YSE_ENABLE_MIDI_DEVICE
 #include "midi/device.hpp"
 #include "support/midi_dispatch_tester.hpp"
+#include "yse_c/yse_midi.h"
+#include "yse_c/yse_synth.h"
 #endif
 
 using namespace std::chrono_literals;
@@ -219,6 +221,48 @@ TEST_SUITE("midisynth") {
       }
       drain();
     }
+    drain();
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ─── C API surface: yse_midi_in_connect_synth / disconnect_synth (#371) ─────
+  //
+  // Mirrors the "device MIDI -> connected synth" wiring above, but drives the
+  // connect / disconnect through the flat C ABI (yse_midi_in_* + yse_synth_*),
+  // proving the C wrapper bridges the opaque YseSynth / YseMidiIn handles into
+  // the engine's routing table and is null-safe. The note-delivery semantics
+  // (channel offset, filter, normalization) are pinned by the engine-level
+  // cases above and by test_midi_synth_routing.cpp; they are not reachable at
+  // the C layer, because the opaque YseMidiIn hides the inner YSE::midiIn the
+  // dispatch tester needs and no RtMidi port is available in CI.
+  TEST_CASE("midisynth: C API routes a MIDI input device into a synth (#371)") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    YseMidiIn* in = yse_midi_in_create();
+    REQUIRE(in != nullptr);
+
+    // Connect omni, then re-connect to exercise the engine's idempotent
+    // "already connected -> refresh channel filter" path, then disconnect.
+    yse_midi_in_connect_synth(in, syn, 0);
+    yse_midi_in_connect_synth(in, syn, 2); // update filter to MIDI channel 2
+    yse_midi_in_disconnect_synth(in, syn);
+    yse_midi_in_disconnect_synth(in, syn); // disconnect when not connected: safe
+
+    // Null-safety matrix: any NULL handle / NULL synth combination is a no-op.
+    yse_midi_in_connect_synth(nullptr, syn, 0);
+    yse_midi_in_connect_synth(in, nullptr, 0);
+    yse_midi_in_connect_synth(nullptr, nullptr, 5);
+    yse_midi_in_disconnect_synth(nullptr, syn);
+    yse_midi_in_disconnect_synth(in, nullptr);
+
+    // Destroy the port before the synth (the port holds the routing pointer).
+    yse_midi_in_destroy(in);
+    yse_synth_destroy(syn);
+
     drain();
     YSE::System().close();
     CHECK(true);

--- a/YseEngine/c_api/include/yse_c/yse_midi.h
+++ b/YseEngine/c_api/include/yse_c/yse_midi.h
@@ -36,6 +36,9 @@ typedef struct YseMidiOut YseMidiOut;
 typedef struct YseMidiIn YseMidiIn;
 /* Owned — release with yse_midi_note_destroy. */
 typedef struct YseMidiNote YseMidiNote;
+/* Opaque synth handle (defined in yse_synth.h) — target of
+   yse_midi_in_connect_synth. */
+typedef struct YseSynth YseSynth;
 
 /* ─── standard MIDI file playback ─────────────────────────────────── */
 
@@ -99,6 +102,21 @@ YSE_C_API void yse_midi_in_set_parsed_callback(YseMidiIn* m, YseMidiInParsedCall
 
 /* Release a byte buffer previously delivered to a YseMidiInRawCallback. */
 YSE_C_API void yse_midi_in_free_message(unsigned char* bytes);
+
+/* Route incoming device MIDI into a synth (issue #155). Every channel-voice
+   message received on the open port is mapped to the synth's normalized note
+   API and pushed lock-free onto its inbox, on RtMidi's input thread.
+   `channel_filter` is a 1..16 MIDI channel to accept, or 0 for every channel.
+   May be called for several synths (up to a small fixed cap); calling it again
+   for an already-connected synth just updates its channel filter. The synth
+   must outlive the connection — disconnect it (or close/destroy this port)
+   before destroying the synth. This is a control-thread call; do not call it
+   from the input callbacks. On builds without MIDI device support it no-ops. */
+YSE_C_API void yse_midi_in_connect_synth(YseMidiIn* m, YseSynth* synth, int channel_filter);
+
+/* Stop routing incoming device MIDI into `synth` (issue #155). Safe to call for
+   a synth that was never connected. */
+YSE_C_API void yse_midi_in_disconnect_synth(YseMidiIn* m, YseSynth* synth);
 
 /* ─── midiNote convenience value ──────────────────────────────────── */
 

--- a/YseEngine/c_api/yse_midi.cpp
+++ b/YseEngine/c_api/yse_midi.cpp
@@ -251,6 +251,22 @@ YSE_C_API void yse_midi_in_free_message(unsigned char* bytes) {
   if (bytes) std::free(bytes);
 }
 
+YSE_C_API void yse_midi_in_connect_synth(YseMidiIn* m, YseSynth* synth, int channel_filter) {
+  if (!m) return;
+  // synth_from_handle (defined in yse_synth.cpp) yields the engine synth backing
+  // the opaque YseSynth; a NULL / never-created handle yields nullptr. connect()
+  // only records the pointer in the port's lock-free subscriber table, so no
+  // engine device or open port is required here.
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_impl(m)->cpp.connect(*s, channel_filter);
+}
+
+YSE_C_API void yse_midi_in_disconnect_synth(YseMidiIn* m, YseSynth* synth) {
+  if (!m) return;
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_impl(m)->cpp.disconnect(*s);
+}
+
 #else
 // Stub the midiOut surface on platforms without RtMidi so the C ABI is
 // uniform across builds. Each call sets last_error and returns / no-ops.
@@ -291,6 +307,8 @@ YSE_C_API void yse_midi_in_set_parsed_callback(YseMidiIn*, YseMidiInParsedCallba
 YSE_C_API void yse_midi_in_free_message(unsigned char* bytes) {
   if (bytes) std::free(bytes);
 }
+YSE_C_API void yse_midi_in_connect_synth(YseMidiIn*, YseSynth*, int) {}
+YSE_C_API void yse_midi_in_disconnect_synth(YseMidiIn*, YseSynth*) {}
 #endif
 
 // ─── midiNote ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Mirror `YSE::midiIn::connect(YSE::synth&, int channelFilter)` /
`disconnect(YSE::synth&)` (`YseEngine/midi/device.hpp`, added by #155) into the
C API. The v2.3.0 release drift audit flagged this gap: the analogous
clip→synth routing was already mirrored as `yse_clip_connect_synth`, while the
MIDI-device-input path had no C mirror.

Follows the additive 3-file c-api pattern established by the sibling PRs #369
(morphingReverb) and #370 (patcherInsert): header + cpp + test, no new enum,
callback, or `.cpp` file.

## Linked issue

Closes #371

## Changes

- `yse_c/yse_midi.h`: declare `yse_midi_in_connect_synth(m, synth, channel_filter)`
  and `yse_midi_in_disconnect_synth(m, synth)`; forward-declare the opaque
  `YseSynth` handle (points to `yse_synth.h` for ownership, per the
  forward-declaration convention).
- `yse_midi.cpp`: implement both, bridging the opaque handle via
  `yse_c::synth_from_handle` (the same accessor `yse_clip.cpp` uses) and
  forwarding to the C++ `midiIn`. `connect`/`disconnect` only record the pointer
  in the port's lock-free subscriber table — no allocation, no lock, no open
  port required. Both are null-safe no-ops per the header convention, and are
  stubbed to no-op on builds without MIDI device support.
- `Tests/midi/test_midi_synth.cpp`: a C-ABI wiring + null-safety case in the
  already-isolated `midisynth` suite (which inits offline / closes).

Note on test depth: the connect/disconnect **routing semantics** (channel
offset, filter, normalization) are already pinned by the engine-level
`midisynth` cases and `test_midi_synth_routing.cpp`. They are structurally not
reachable through the flat C ABI — the opaque `YseMidiIn` hides the inner
`YSE::midiIn` the dispatch tester needs, and no RtMidi port is available in CI —
so the C-layer test verifies the handle bridging and null-safety of the new
surface rather than re-asserting delivery.

## Test plan

- [x] `clang-format` 22.1.4 (CI-pinned) clean on all three changed files
- [x] `python yse.py analyze` clean on modified code (the one pre-existing
      `bugprone-incorrect-roundings` finding is in the untouched `logNote`
      helper — backlog, not introduced here)
- [x] `python yse.py build` — clean, no new warnings
- [x] `python yse.py test` — 32/32 ctest entries pass, incl. `yse_tests_midisynth`
      which carries the new case (1 case / 3 assertions)
- [x] No `std::mutex` / `std::lock_guard` introduced in `YseEngine/c_api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
