### PR TITLE
c-api: route MIDI-file playback into a synth (midifile connect/disconnect) (#372)

### DIFF
--- a/Tests/midi/test_midi_synth.cpp
+++ b/Tests/midi/test_midi_synth.cpp
@@ -18,6 +18,7 @@
 
 #include <doctest/doctest.h>
 #include <chrono>
+#include <cmath>
 #include <thread>
 #include <vector>
 
@@ -29,11 +30,16 @@
 #include "midi/midifile.hpp"
 #include "internal/time.h"
 
+// The MIDI file C API (yse_midi_file_*) is platform-agnostic — unlike MIDI
+// device I/O it is not RtMidi-gated — so its C headers are included
+// unconditionally for the #372 file->synth C-API case below.
+#include "yse_c/yse_midi.h"
+#include "yse_c/yse_synth.h"
+#include "yse_c/yse_sound.h"
+
 #if YSE_ENABLE_MIDI_DEVICE
 #include "midi/device.hpp"
 #include "support/midi_dispatch_tester.hpp"
-#include "yse_c/yse_midi.h"
-#include "yse_c/yse_synth.h"
 #endif
 
 using namespace std::chrono_literals;
@@ -51,6 +57,14 @@ namespace {
 
   void logNote(bool on, float* noteNumber, float* /*velocity*/) {
     g_noteLog.push_back({on, static_cast<int>(*noteNumber + 0.5f)});
+  }
+
+  // Same note log, reached through the flat C ABI note-rewrite hook
+  // (YseSynthNoteCallback: `int note_on` instead of the C++ `bool on`). Used by
+  // the #372 C-API case so it can observe note delivery without an engine synth
+  // handle. Captureless, as the hook contract requires.
+  void YSE_C_CALLBACK cLogNote(int on, float* noteNumber, float* /*velocity*/) {
+    g_noteLog.push_back({on != 0, static_cast<int>(std::lround(*noteNumber))});
   }
 
   // Bring a synth attached to a sound up to OBJECT_READY (voice cloning is
@@ -117,6 +131,83 @@ TEST_SUITE("midisynth") {
       } // sound destroyed first (§9 order)
       drain();
     } // synth destroyed after its sound
+    drain();
+    YSE::System().close();
+
+    REQUIRE(g_noteLog.size() == 2);
+    CHECK(g_noteLog[0].on == true);
+    CHECK(g_noteLog[0].note == 60);
+    CHECK(g_noteLog[1].on == false);
+    CHECK(g_noteLog[1].note == 60);
+  }
+
+  // ─── C API surface: yse_midi_file_connect_synth / disconnect_synth (#372) ───
+  //
+  // Drives the SAME MIDI file -> synth route as the engine-level case above, but
+  // wires it entirely through the flat C ABI (yse_midi_file_* + yse_synth_* +
+  // yse_sound_*), proving the new C wrappers bridge the opaque YseMidiFile /
+  // YseSynth handles into the engine's routing table and actually deliver notes.
+  // Unlike the device path in the #371 case, the MIDI file path needs no RtMidi
+  // port, so the full note-delivery semantics ARE reachable and asserted at the C
+  // layer. The note-rewrite hook (cLogNote) records what the synth received.
+  TEST_CASE("midisynth: C API routes MIDI file playback into a synth (#372)") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+    g_noteLog.clear();
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    // 8-voice omni pool, snappy envelope so the note-off tail resolves quickly.
+    REQUIRE(yse_synth_add_voices_sine(syn, 8, 0, 0, 127, 0.005f, 0.001f, 1.0f, 0.05f) == YSE_OK);
+    yse_synth_set_note_callback(syn, &cLogNote);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    yse_sound_play(snd);
+
+    // Setup pool clones the voices asynchronously; pump until the pool is ready.
+    {
+      const auto deadline = std::chrono::steady_clock::now() + 2s;
+      while (yse_synth_get_num_voices(syn) < 8 && std::chrono::steady_clock::now() < deadline) {
+        YSE::System().update();
+        YSE::System().renderOffline(1);
+        std::this_thread::sleep_for(5ms);
+      }
+      REQUIRE(yse_synth_get_num_voices(syn) == 8);
+    }
+
+    YseMidiFile* mf = yse_midi_file_create();
+    REQUIRE(mf != nullptr);
+    REQUIRE(yse_midi_file_load(
+                mf, (std::string(YSE_TEST_FIXTURES_DIR) + "/test_type0.mid").c_str()) == YSE_OK);
+    yse_midi_file_connect_synth(mf, syn);
+    yse_midi_file_connect_synth(mf, syn); // already connected -> no-op (idempotent)
+    yse_midi_file_play(mf);
+
+    // One update() drains the file into the MIDI manager's audio-thread list;
+    // then render blocks until both note events land (or a generous cap — the
+    // fixture's note-off is half a second in).
+    YSE::System().update();
+    for (int i = 0; i < 4000 && g_noteLog.size() < 2; ++i)
+      YSE::System().renderOffline(1);
+
+    yse_midi_file_disconnect_synth(mf, syn);
+    yse_midi_file_disconnect_synth(mf, syn); // disconnect when not connected: safe
+
+    // Null-safety matrix: any NULL handle / NULL synth combination is a no-op.
+    yse_midi_file_connect_synth(nullptr, syn);
+    yse_midi_file_connect_synth(mf, nullptr);
+    yse_midi_file_connect_synth(nullptr, nullptr);
+    yse_midi_file_disconnect_synth(nullptr, syn);
+    yse_midi_file_disconnect_synth(mf, nullptr);
+
+    yse_sound_stop(snd);
+    YSE::System().renderOffline(8);
+
+    yse_midi_file_destroy(mf);
+    yse_sound_destroy(snd); // sound must go before the synth it renders
+    yse_synth_destroy(syn);
     drain();
     YSE::System().close();
 

--- a/YseEngine/c_api/include/yse_c/yse_midi.h
+++ b/YseEngine/c_api/include/yse_c/yse_midi.h
@@ -37,7 +37,7 @@ typedef struct YseMidiIn YseMidiIn;
 /* Owned — release with yse_midi_note_destroy. */
 typedef struct YseMidiNote YseMidiNote;
 /* Opaque synth handle (defined in yse_synth.h) — target of
-   yse_midi_in_connect_synth. */
+   yse_midi_file_connect_synth / yse_midi_in_connect_synth. */
 typedef struct YseSynth YseSynth;
 
 /* ─── standard MIDI file playback ─────────────────────────────────── */
@@ -48,6 +48,23 @@ YSE_C_API YseStatus yse_midi_file_load(YseMidiFile* f, const char* filename);
 YSE_C_API void yse_midi_file_play(YseMidiFile* f);
 YSE_C_API void yse_midi_file_pause(YseMidiFile* f);
 YSE_C_API void yse_midi_file_stop(YseMidiFile* f);
+
+/* Route this file's playback into a synth (issue #372, mirrors
+   YSE::MIDI::file::connect). While the file plays, every note / controller /
+   pitch-bend event it contains is delivered to `synth` block-accurately on the
+   audio thread; may be called for several synths (up to a small fixed cap) to
+   drive them together. Calling it again for an already-connected synth is a
+   no-op. `synth` is the opaque handle from yse_synth_create; a NULL file or a
+   NULL / never-created synth is a no-op. connect only records the pointer in the
+   file's lock-free synth table, so no loaded file or active playback is required
+   here. The synth must outlive the connection — disconnect it (or destroy this
+   file) before destroying the synth. This is a control-thread call; do not call
+   it from the audio thread. */
+YSE_C_API void yse_midi_file_connect_synth(YseMidiFile* f, YseSynth* synth);
+
+/* Stop routing this file's playback into `synth` (issue #372). Safe to call for
+   a synth that was never connected. */
+YSE_C_API void yse_midi_file_disconnect_synth(YseMidiFile* f, YseSynth* synth);
 
 /* ─── MIDI device output ──────────────────────────────────────────── */
 

--- a/YseEngine/c_api/yse_midi.cpp
+++ b/YseEngine/c_api/yse_midi.cpp
@@ -118,6 +118,23 @@ YSE_C_API void yse_midi_file_stop(YseMidiFile* f) {
   if (f) to_cpp(f)->stop();
 }
 
+YSE_C_API void yse_midi_file_connect_synth(YseMidiFile* f, YseSynth* synth) {
+  if (!f) return;
+  // synth_from_handle (defined in yse_synth.cpp) yields the engine synth backing
+  // the opaque YseSynth; a NULL / never-created handle yields nullptr. connect()
+  // only records the pointer in the file's fixed-size, lock-free synth table, so
+  // no loaded file or active playback is required here. Mirrors the always-on
+  // midifile surface (unlike midi device I/O, this is not RtMidi-gated).
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_cpp(f)->connect(*s);
+}
+
+YSE_C_API void yse_midi_file_disconnect_synth(YseMidiFile* f, YseSynth* synth) {
+  if (!f) return;
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_cpp(f)->disconnect(*s);
+}
+
 // ─── midi out (Windows/Linux only) ─────────────────────────────────
 
 #if YSE_C_HAVE_MIDI_OUT


### PR DESCRIPTION
## Summary

Adds the C ABI mirror of `YSE::MIDI::file::connect(YSE::synth&)` /
`disconnect(YSE::synth&)`, which the v2.3.0 release C-API drift audit found
missing. The analogous clip→synth (`yse_clip_connect_synth`) and
midiIn→synth (`yse_midi_in_connect_synth`, #371) routings were already
mirrored, so this closes the last gap in the synth-routing surface.

## Linked issue

Closes #372

## Changes

- `YseEngine/c_api/include/yse_c/yse_midi.h` — declare
  `yse_midi_file_connect_synth` / `yse_midi_file_disconnect_synth` in the
  MIDI-file section, with ownership/RT/lifetime docs matching the
  `yse_midi_in_*` siblings.
- `YseEngine/c_api/yse_midi.cpp` — implement both, forwarding through
  `yse_c::synth_from_handle`; null-safe on either handle. Placed in the
  **ungated** midifile section: the MIDI file surface is platform-agnostic
  (not RtMidi-gated), so unlike device input it ships on every build,
  including Android.
- `Tests/midi/test_midi_synth.cpp` — new `midisynth` C-API case (and moved
  the `yse_c/*` includes out of the `YSE_ENABLE_MIDI_DEVICE` guard since the
  file surface is always present).

## Design notes

- **RT-safety / ownership**: `connect`/`disconnect` are control-thread calls
  that store into the file impl's fixed-size atomic `synths[]` table
  (release/acquire) — no allocation, no lock. The synth must outlive the
  connection; documented in the header. ABI-stable additive declarations,
  no changes to existing symbols. Engine → C API → bindings layering intact
  (bindings consume the headers directly; nothing else references the
  siblings).

## Test plan

- [x] `clang-format` (22.1.4) clean on all changed files
- [x] `python yse.py analyze` clean on changed `.cpp` (only reported finding
  is a pre-existing `bugprone-incorrect-roundings` on the unmodified
  `logNote`; new `cLogNote` uses `std::lround`)
- [x] New C-API test drives the full MIDI file → synth route through the flat
  C ABI and asserts the delivered note on/off sequence (60 on / 60 off) via
  the note-rewrite hook, plus idempotent-connect and the NULL-handle matrix.
  A no-op wrapper would deliver zero notes → the `REQUIRE(size == 2)` is
  load-bearing.
- [x] `midisynth` suite: 5 cases / 34 assertions pass
- [x] Full `ctest --preset tests-debug`: 32/32 processes pass

Integration coverage: the new case is itself the end-to-end integration test
for this surface — it runs the real offline engine (voice cloning on the
setup pool, real block-accurate MIDI file playback, real synth note
allocation), driven entirely through the public C ABI.