### PR TITLE
release-prep v2.3.1: refresh overview

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,11 +1,11 @@
 <!-- META
-last_updated_commit: 8bc0dc3
-last_updated_at: 2026-07-15
+last_updated_commit: 0f1e731
+last_updated_at: 2026-07-16
 -->
 
 # YSE Sound Engine — Project Overview
 
-**Version:** 2.3.0 (single source of truth: [`YseEngine/system.hpp`](YseEngine/system.hpp))
+**Version:** 2.3.1 (single source of truth: [`YseEngine/system.hpp`](YseEngine/system.hpp))
 **Language:** C++17
 **Platforms:** Windows (MSYS2/Clang64, MSVC), Linux (gcc/clang), Android (NDK r27+, API 26+, arm64-v8a + x86_64)
 **Build:** CMake 3.20+ via `CMakePresets.json`; Android wraps the same CMake invocation through Gradle in `Tests/Android/`


### PR DESCRIPTION
Release-prep housekeeping for **v2.3.1** (patch).

- Bump `PROJECT_OVERVIEW.md` version to 2.3.1, advance meta header to dev tip `0f1e731`.
- README header untouched (patch release stays at "libYSE 2.3").
- `conf.py` reads VERSION from `system.hpp` automatically — no docs edit.

This patch ships the C API mirror additions that landed after v2.3.0:
- #369 — c-api: mirror `morphingReverb` insert module
- #370 — c-api: mirror `patcherInsert` (patcher-as-insert)
- #371 — c-api: route a MIDI input device into a synth
- #372 — c-api: route MIDI-file playback into a synth
- #364 — patcher: recycle retired graph ids (engine-internal)

No C API drift; release build green, enum mirror check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)