### PR TITLE
Release v2.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install Build Wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
       - name: Install dependencies
         run: |
           sudo apt-get update -y
@@ -81,7 +81,7 @@ jobs:
             build
           echo "=== coverage.xml preview ===" && head -20 coverage.xml
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -1,11 +1,11 @@
 <!-- META
-last_updated_commit: 8bc0dc3
-last_updated_at: 2026-07-15
+last_updated_commit: 0f1e731
+last_updated_at: 2026-07-16
 -->
 
 # YSE Sound Engine — Project Overview
 
-**Version:** 2.3.0 (single source of truth: [`YseEngine/system.hpp`](YseEngine/system.hpp))
+**Version:** 2.3.1 (single source of truth: [`YseEngine/system.hpp`](YseEngine/system.hpp))
 **Language:** C++17
 **Platforms:** Windows (MSYS2/Clang64, MSVC), Linux (gcc/clang), Android (NDK r27+, API 26+, arm64-v8a + x86_64)
 **Build:** CMake 3.20+ via `CMakePresets.json`; Android wraps the same CMake invocation through Gradle in `Tests/Android/`

--- a/Tests/channel/test_c_api_channel.cpp
+++ b/Tests/channel/test_c_api_channel.cpp
@@ -32,6 +32,7 @@
 #include "yse_c/yse_dsp.h"
 #include "yse_c/yse_dsp_modules.h"
 #include "yse_c/yse_enums.h"
+#include "yse_c/yse_patcher.h"
 #include "yse_c/yse_sound.h"
 #include "yse_c/yse_system.h"
 
@@ -365,6 +366,74 @@ TEST_SUITE("channelcapi") {
     CHECK(yse_dsp_object_get_bypass(m) == 1);
 
     yse_dsp_object_destroy(m);
+  }
+
+  // ─── patcher-as-insert (#167 module, #370 C API) ─────────────────────────────
+
+  TEST_CASE("c-api dsp: patcher insert wraps a graph and renders on a channel (#167/#370)") {
+    REQUIRE(ensureOffline());
+
+    // Build a passthrough patcher graph (~adc -> ~dac, stereo) entirely through
+    // the C ABI, then wrap it as a chainable insert. The graph is function-scoped
+    // so it outlives the insert that borrows it.
+    YsePatcher* graph = yse_patcher_create();
+    REQUIRE(graph != nullptr);
+    yse_patcher_init(graph, 2);
+    YsePHandle* adc = yse_patcher_create_object(graph, "~adc", nullptr);
+    YsePHandle* dac = yse_patcher_create_object(graph, "~dac", nullptr);
+    REQUIRE(adc != nullptr);
+    REQUIRE(dac != nullptr);
+    yse_patcher_connect(graph, adc, 0, dac, 0);
+    yse_patcher_connect(graph, adc, 1, dac, 1);
+
+    YseDspObject* insert = yse_dsp_patcher_insert_create(graph);
+    REQUIRE(insert != nullptr);
+
+    // The inherited dspObject surface reaches the same handle.
+    yse_dsp_object_set_bypass(insert, 1);
+    CHECK(yse_dsp_object_get_bypass(insert) == 1);
+    yse_dsp_object_set_bypass(insert, 0);
+
+    // Attach the insert to a channel; it round-trips through the C handle.
+    YseChannel* ch = yse_channel_create("capi_pi", yse_channel_master());
+    REQUIRE(ch != nullptr);
+    yse_channel_set_dsp(ch, insert);
+    CHECK(yse_channel_get_dsp(ch) == insert);
+
+    // Drive a real tone through the channel and render: the patcher insert now
+    // runs on the audio path and the whole graph must stay finite.
+    pump();
+    YseDspBuffer* tone = makeToneBuffer();
+    REQUIRE(tone != nullptr);
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_sound_load_buffer(snd, tone, ch, /*loop*/ 1, /*volume*/ 1.0f) == YSE_OK);
+    pump();
+    yse_sound_play(snd);
+    pump();
+    for (int i = 0; i < 8; ++i)
+      yse_system_render_offline(yse_system_get(), 16);
+
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(ch)));
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(yse_channel_master())));
+
+    // Tear down: detach the insert before the channel/sound fall away, then free
+    // the insert before the patcher it borrows, then the buffer.
+    yse_sound_stop(snd);
+    pump();
+    yse_channel_set_dsp(ch, nullptr);
+    yse_sound_destroy(snd);
+    yse_channel_destroy(ch);
+    pump();
+    yse_dsp_object_destroy(insert);
+    yse_patcher_destroy(graph);
+    yse_dsp_buffer_destroy(tone);
+  }
+
+  // A NULL patcher has no graph to wrap, so the creator reports failure rather
+  // than handing back an insert that can never render.
+  TEST_CASE("c-api dsp: patcher insert create rejects a NULL patcher (#370)") {
+    CHECK(yse_dsp_patcher_insert_create(nullptr) == nullptr);
   }
 
   // Module setters/getters are null-safe like the rest of the module surface.

--- a/Tests/channel/test_c_api_channel.cpp
+++ b/Tests/channel/test_c_api_channel.cpp
@@ -303,6 +303,70 @@ TEST_SUITE("channelcapi") {
     yse_dsp_object_destroy(c);
   }
 
+  TEST_CASE("c-api dsp: morphing reverb presets + morph round-trip (#326/#369)") {
+    YseDspObject* m = yse_dsp_morphing_reverb_create();
+    REQUIRE(m != nullptr);
+
+    // Defaults (per #326): A = GENERIC, B = HALL, morph = 0 (pure A).
+    CHECK(yse_dsp_morphing_reverb_get_morph(m) == doctest::Approx(0.0f));
+
+    // Named-preset endpoints resolve to the shared preset table.
+    yse_dsp_morphing_reverb_set_preset_a(m, YSE_REVERB_CAVE);
+    yse_dsp_morphing_reverb_set_preset_b(m, YSE_REVERB_OFF);
+    YseReverbPresetValues a{};
+    YseReverbPresetValues b{};
+    yse_dsp_morphing_reverb_get_preset_a(m, &a);
+    yse_dsp_morphing_reverb_get_preset_b(m, &b);
+    CHECK(a.roomsize == doctest::Approx(1.0f)); // CAVE
+    CHECK(a.wet == doctest::Approx(0.7f));
+    CHECK(a.dry == doctest::Approx(0.3f));
+    CHECK(a.early_time[0] == doctest::Approx(100.0f));
+    CHECK(a.early_gain[0] == doctest::Approx(0.8f));
+    CHECK(b.dry == doctest::Approx(1.0f)); // OFF: dry pass-through
+    CHECK(b.wet == doctest::Approx(0.0f));
+
+    // Custom endpoint values round-trip field-for-field through the mirror
+    // struct (send/return flavour: fully wet).
+    YseReverbPresetValues custom{};
+    custom.roomsize = 0.42f;
+    custom.damp = 0.3f;
+    custom.dry = 0.0f;
+    custom.wet = 1.0f;
+    custom.mod_frequency = 2.5f;
+    custom.mod_width = 8.0f;
+    for (int i = 0; i < 4; ++i) {
+      custom.early_time[i] = 100.0f * static_cast<float>(i + 1);
+      custom.early_gain[i] = 0.1f * static_cast<float>(i + 1);
+    }
+    yse_dsp_morphing_reverb_set_preset_b_values(m, &custom);
+    YseReverbPresetValues got{};
+    yse_dsp_morphing_reverb_get_preset_b(m, &got);
+    CHECK(got.roomsize == doctest::Approx(0.42f));
+    CHECK(got.damp == doctest::Approx(0.3f));
+    CHECK(got.dry == doctest::Approx(0.0f));
+    CHECK(got.wet == doctest::Approx(1.0f));
+    CHECK(got.mod_frequency == doctest::Approx(2.5f));
+    CHECK(got.mod_width == doctest::Approx(8.0f));
+    for (int i = 0; i < 4; ++i) {
+      CHECK(got.early_time[i] == doctest::Approx(100.0f * static_cast<float>(i + 1)));
+      CHECK(got.early_gain[i] == doctest::Approx(0.1f * static_cast<float>(i + 1)));
+    }
+
+    // Morph control input (per #326) is stored and clamped to [0, 1].
+    yse_dsp_morphing_reverb_set_morph(m, 0.25f);
+    CHECK(yse_dsp_morphing_reverb_get_morph(m) == doctest::Approx(0.25f));
+    yse_dsp_morphing_reverb_set_morph(m, 7.5f);
+    CHECK(yse_dsp_morphing_reverb_get_morph(m) == doctest::Approx(1.0f));
+    yse_dsp_morphing_reverb_set_morph(m, -2.0f);
+    CHECK(yse_dsp_morphing_reverb_get_morph(m) == doctest::Approx(0.0f));
+
+    // Inherited dspObject surface reaches the same handle.
+    yse_dsp_object_set_bypass(m, 1);
+    CHECK(yse_dsp_object_get_bypass(m) == 1);
+
+    yse_dsp_object_destroy(m);
+  }
+
   // Module setters/getters are null-safe like the rest of the module surface.
   TEST_CASE("c-api dsp: new module setters/getters are null-safe") {
     yse_dsp_feedback_delay_set_time(nullptr, 1.f);
@@ -315,6 +379,17 @@ TEST_SUITE("channelcapi") {
     CHECK(yse_dsp_plate_reverb_get_decay(nullptr) == doctest::Approx(0.f));
     CHECK(yse_dsp_eq_get_gain(nullptr, YSE_EQ_PEAK_1) == doctest::Approx(0.f));
     CHECK(yse_dsp_compressor_get_gain_reduction_db(nullptr) == doctest::Approx(0.f));
+
+    // morphing reverb (#326/#369)
+    yse_dsp_morphing_reverb_set_preset_a(nullptr, YSE_REVERB_HALL);
+    yse_dsp_morphing_reverb_set_preset_b_values(nullptr, nullptr);
+    yse_dsp_morphing_reverb_set_morph(nullptr, 0.5f);
+    CHECK(yse_dsp_morphing_reverb_get_morph(nullptr) == doctest::Approx(0.f));
+    YseReverbPresetValues z; // getter must zero-fill on a NULL handle
+    yse_dsp_morphing_reverb_get_preset_a(nullptr, &z);
+    CHECK(z.roomsize == doctest::Approx(0.f));
+    CHECK(z.wet == doctest::Approx(0.f));
+    yse_dsp_morphing_reverb_get_preset_a(nullptr, nullptr); // no crash
   }
 
 } // TEST_SUITE("channelcapi")

--- a/Tests/midi/test_midi_synth.cpp
+++ b/Tests/midi/test_midi_synth.cpp
@@ -18,6 +18,7 @@
 
 #include <doctest/doctest.h>
 #include <chrono>
+#include <cmath>
 #include <thread>
 #include <vector>
 
@@ -29,11 +30,16 @@
 #include "midi/midifile.hpp"
 #include "internal/time.h"
 
+// The MIDI file C API (yse_midi_file_*) is platform-agnostic — unlike MIDI
+// device I/O it is not RtMidi-gated — so its C headers are included
+// unconditionally for the #372 file->synth C-API case below.
+#include "yse_c/yse_midi.h"
+#include "yse_c/yse_synth.h"
+#include "yse_c/yse_sound.h"
+
 #if YSE_ENABLE_MIDI_DEVICE
 #include "midi/device.hpp"
 #include "support/midi_dispatch_tester.hpp"
-#include "yse_c/yse_midi.h"
-#include "yse_c/yse_synth.h"
 #endif
 
 using namespace std::chrono_literals;
@@ -51,6 +57,14 @@ namespace {
 
   void logNote(bool on, float* noteNumber, float* /*velocity*/) {
     g_noteLog.push_back({on, static_cast<int>(*noteNumber + 0.5f)});
+  }
+
+  // Same note log, reached through the flat C ABI note-rewrite hook
+  // (YseSynthNoteCallback: `int note_on` instead of the C++ `bool on`). Used by
+  // the #372 C-API case so it can observe note delivery without an engine synth
+  // handle. Captureless, as the hook contract requires.
+  void YSE_C_CALLBACK cLogNote(int on, float* noteNumber, float* /*velocity*/) {
+    g_noteLog.push_back({on != 0, static_cast<int>(std::lround(*noteNumber))});
   }
 
   // Bring a synth attached to a sound up to OBJECT_READY (voice cloning is
@@ -117,6 +131,83 @@ TEST_SUITE("midisynth") {
       } // sound destroyed first (§9 order)
       drain();
     } // synth destroyed after its sound
+    drain();
+    YSE::System().close();
+
+    REQUIRE(g_noteLog.size() == 2);
+    CHECK(g_noteLog[0].on == true);
+    CHECK(g_noteLog[0].note == 60);
+    CHECK(g_noteLog[1].on == false);
+    CHECK(g_noteLog[1].note == 60);
+  }
+
+  // ─── C API surface: yse_midi_file_connect_synth / disconnect_synth (#372) ───
+  //
+  // Drives the SAME MIDI file -> synth route as the engine-level case above, but
+  // wires it entirely through the flat C ABI (yse_midi_file_* + yse_synth_* +
+  // yse_sound_*), proving the new C wrappers bridge the opaque YseMidiFile /
+  // YseSynth handles into the engine's routing table and actually deliver notes.
+  // Unlike the device path in the #371 case, the MIDI file path needs no RtMidi
+  // port, so the full note-delivery semantics ARE reachable and asserted at the C
+  // layer. The note-rewrite hook (cLogNote) records what the synth received.
+  TEST_CASE("midisynth: C API routes MIDI file playback into a synth (#372)") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+    g_noteLog.clear();
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    // 8-voice omni pool, snappy envelope so the note-off tail resolves quickly.
+    REQUIRE(yse_synth_add_voices_sine(syn, 8, 0, 0, 127, 0.005f, 0.001f, 1.0f, 0.05f) == YSE_OK);
+    yse_synth_set_note_callback(syn, &cLogNote);
+
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_synth_attach_to_sound(syn, snd, nullptr, 0.8f) == YSE_OK);
+    yse_sound_play(snd);
+
+    // Setup pool clones the voices asynchronously; pump until the pool is ready.
+    {
+      const auto deadline = std::chrono::steady_clock::now() + 2s;
+      while (yse_synth_get_num_voices(syn) < 8 && std::chrono::steady_clock::now() < deadline) {
+        YSE::System().update();
+        YSE::System().renderOffline(1);
+        std::this_thread::sleep_for(5ms);
+      }
+      REQUIRE(yse_synth_get_num_voices(syn) == 8);
+    }
+
+    YseMidiFile* mf = yse_midi_file_create();
+    REQUIRE(mf != nullptr);
+    REQUIRE(yse_midi_file_load(
+                mf, (std::string(YSE_TEST_FIXTURES_DIR) + "/test_type0.mid").c_str()) == YSE_OK);
+    yse_midi_file_connect_synth(mf, syn);
+    yse_midi_file_connect_synth(mf, syn); // already connected -> no-op (idempotent)
+    yse_midi_file_play(mf);
+
+    // One update() drains the file into the MIDI manager's audio-thread list;
+    // then render blocks until both note events land (or a generous cap — the
+    // fixture's note-off is half a second in).
+    YSE::System().update();
+    for (int i = 0; i < 4000 && g_noteLog.size() < 2; ++i)
+      YSE::System().renderOffline(1);
+
+    yse_midi_file_disconnect_synth(mf, syn);
+    yse_midi_file_disconnect_synth(mf, syn); // disconnect when not connected: safe
+
+    // Null-safety matrix: any NULL handle / NULL synth combination is a no-op.
+    yse_midi_file_connect_synth(nullptr, syn);
+    yse_midi_file_connect_synth(mf, nullptr);
+    yse_midi_file_connect_synth(nullptr, nullptr);
+    yse_midi_file_disconnect_synth(nullptr, syn);
+    yse_midi_file_disconnect_synth(mf, nullptr);
+
+    yse_sound_stop(snd);
+    YSE::System().renderOffline(8);
+
+    yse_midi_file_destroy(mf);
+    yse_sound_destroy(snd); // sound must go before the synth it renders
+    yse_synth_destroy(syn);
     drain();
     YSE::System().close();
 

--- a/Tests/midi/test_midi_synth.cpp
+++ b/Tests/midi/test_midi_synth.cpp
@@ -32,6 +32,8 @@
 #if YSE_ENABLE_MIDI_DEVICE
 #include "midi/device.hpp"
 #include "support/midi_dispatch_tester.hpp"
+#include "yse_c/yse_midi.h"
+#include "yse_c/yse_synth.h"
 #endif
 
 using namespace std::chrono_literals;
@@ -219,6 +221,48 @@ TEST_SUITE("midisynth") {
       }
       drain();
     }
+    drain();
+    YSE::System().close();
+    CHECK(true);
+  }
+
+  // ─── C API surface: yse_midi_in_connect_synth / disconnect_synth (#371) ─────
+  //
+  // Mirrors the "device MIDI -> connected synth" wiring above, but drives the
+  // connect / disconnect through the flat C ABI (yse_midi_in_* + yse_synth_*),
+  // proving the C wrapper bridges the opaque YseSynth / YseMidiIn handles into
+  // the engine's routing table and is null-safe. The note-delivery semantics
+  // (channel offset, filter, normalization) are pinned by the engine-level
+  // cases above and by test_midi_synth_routing.cpp; they are not reachable at
+  // the C layer, because the opaque YseMidiIn hides the inner YSE::midiIn the
+  // dispatch tester needs and no RtMidi port is available in CI.
+  TEST_CASE("midisynth: C API routes a MIDI input device into a synth (#371)") {
+    YSE::System().close();
+    if (!YSE::System().initOffline()) return;
+
+    YseSynth* syn = yse_synth_create();
+    REQUIRE(syn != nullptr);
+    YseMidiIn* in = yse_midi_in_create();
+    REQUIRE(in != nullptr);
+
+    // Connect omni, then re-connect to exercise the engine's idempotent
+    // "already connected -> refresh channel filter" path, then disconnect.
+    yse_midi_in_connect_synth(in, syn, 0);
+    yse_midi_in_connect_synth(in, syn, 2); // update filter to MIDI channel 2
+    yse_midi_in_disconnect_synth(in, syn);
+    yse_midi_in_disconnect_synth(in, syn); // disconnect when not connected: safe
+
+    // Null-safety matrix: any NULL handle / NULL synth combination is a no-op.
+    yse_midi_in_connect_synth(nullptr, syn, 0);
+    yse_midi_in_connect_synth(in, nullptr, 0);
+    yse_midi_in_connect_synth(nullptr, nullptr, 5);
+    yse_midi_in_disconnect_synth(nullptr, syn);
+    yse_midi_in_disconnect_synth(in, nullptr);
+
+    // Destroy the port before the synth (the port holds the routing pointer).
+    yse_midi_in_destroy(in);
+    yse_synth_destroy(syn);
+
     drain();
     YSE::System().close();
     CHECK(true);

--- a/Tests/patcher/test_patcher_graphstate.cpp
+++ b/Tests/patcher/test_patcher_graphstate.cpp
@@ -341,4 +341,99 @@ TEST_SUITE("patcher") {
     CHECK_FALSE(p.output[0].isSilent());
   }
 
+  // ---- Free-list recycling of retired graph ids during churn (issue #364) ----
+
+  TEST_CASE("graphids: continuous create/delete churn recycles ids via the free-list") {
+    // #355's recompaction only fires when the patcher goes empty. A patcher that
+    // is continuously edited while at least one object always survives never
+    // empties, so the counters — and every snapshot's id-indexed tables — would
+    // climb with the lifetime create count. The free-list (issue #364) bounds
+    // that: the reclaimer returns a deleted object's ids once no snapshot can
+    // still index them, and AssignGraphIds pulls them before extending the
+    // counter, so the id space tracks the peak *simultaneous* object count.
+    patcherImplementation p(1, nullptr);
+    // A persistent noise->dac keeps one object live for the whole test, so the
+    // patcher never empties and compaction never runs — recycling is then the
+    // only mechanism that can keep the id space from growing. Toggling this edge
+    // also re-arms the background reclaimer each drain spin (a stalled epoch
+    // otherwise ends the reclaim chain until the next structural edit).
+    YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    REQUIRE(noise != nullptr);
+    REQUIRE(dac != nullptr);
+    p.Connect(noise, 0, dac, 0);
+    p.Calculate(YSE::T_DSP);
+
+    const std::size_t baseOut = p.OutletIdSpace();
+    const std::size_t baseIn = p.InletIdSpace();
+
+    // The first temp (a ~+ has two inlets and one outlet) finds an empty
+    // free-list, so it stamps fresh ids and lifts the high-water mark by exactly
+    // one temp's worth of pins. That peak is the bound every later temp must
+    // respect.
+    YSE::pHandle* first = p.CreateObject(YSE::OBJ::D_ADD, "");
+    REQUIRE(first != nullptr);
+    const std::size_t peakOut = p.OutletIdSpace();
+    const std::size_t peakIn = p.InletIdSpace();
+    REQUIRE(peakOut > baseOut); // the temp really consumed an outlet id
+    REQUIRE(peakIn > baseIn); // ... and inlet ids
+    p.DeleteObject(first);
+
+    for (int i = 0; i < 40; ++i) {
+      // Drain the reclaimer so the previous temp's ids are back on the free-list
+      // before the next create. Each spin toggles the persistent edge (re-arming
+      // the reclaimer) and renders blocks (advancing the audio epoch across the
+      // +2 grace); the background pool then frees the temp and recycles its ids
+      // (RecycleObjectIds pushes all of a temp's inlet + outlet ids under one
+      // reclaimMtx_ hold, so FreeIdCount jumps from 0 to the full count at once).
+      for (int spins = 0; spins < 3000 && p.FreeIdCount() == 0; ++spins) {
+        p.Disconnect(noise, 0, dac, 0);
+        p.Calculate(YSE::T_DSP);
+        p.Connect(noise, 0, dac, 0);
+        p.Calculate(YSE::T_DSP);
+        p.Calculate(YSE::T_DSP);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+      REQUIRE(p.FreeIdCount() > 0); // the deleted temp's ids are recyclable now
+
+      YSE::pHandle* temp = p.CreateObject(YSE::OBJ::D_ADD, "");
+      REQUIRE(temp != nullptr);
+      // The create must have pulled recycled ids instead of extending the
+      // counters: the high-water mark never climbs past the single-temp peak,
+      // no matter how many temps churned through. Before the free-list these
+      // grew by one temp's pins every iteration.
+      CHECK(p.OutletIdSpace() == peakOut);
+      CHECK(p.InletIdSpace() == peakIn);
+      p.DeleteObject(temp);
+    }
+  }
+
+  TEST_CASE("graphids: churning a source into a live sink stays correct with recycling") {
+    // Reusing an id must not corrupt what the audio thread renders: an outlet
+    // whose id was recycled from a deleted object must resolve *its own* targets
+    // in the pinned snapshot, never a stale entry. Repeatedly wire a fresh source
+    // into the surviving dac, render, then delete it. Each create-after-delete
+    // recycles the previous source's ids (the edits re-arm the reclaimer and the
+    // renders advance the epoch), so the recycled outlet is exercised in the
+    // signal path every iteration. An ASan/TSan build additionally trips on any
+    // dangling reuse.
+    patcherImplementation p(1, nullptr);
+    YSE::pHandle* dac = p.CreateObject(YSE::OBJ::D_DAC, "");
+    REQUIRE(dac != nullptr);
+
+    for (int i = 0; i < 30; ++i) {
+      YSE::pHandle* noise = p.CreateObject(YSE::OBJ::D_NOISE, "");
+      REQUIRE(noise != nullptr);
+      p.Connect(noise, 0, dac, 0);
+      p.Calculate(YSE::T_DSP);
+      CHECK_FALSE(p.output[0].isSilent()); // the (recycled) outlet resolves its target
+
+      p.Disconnect(noise, 0, dac, 0);
+      p.DeleteObject(noise);
+      p.Calculate(YSE::T_DSP);
+      p.Calculate(YSE::T_DSP);
+      CHECK(p.output[0].isSilent()); // source gone -> silence, no stale target
+    }
+  }
+
 } // TEST_SUITE("patcher")

--- a/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
@@ -25,6 +25,9 @@ extern "C" {
    subclass via the shared handle type. */
 typedef struct YseDspObject YseDspObject;
 
+/* Forward declaration — see yse_patcher.h for ownership. */
+typedef struct YsePatcher YsePatcher;
+
 /* ─── constructors ────────────────────────────────────────────────────── */
 
 YSE_C_API YseDspObject* yse_dsp_lowpass_create(void);
@@ -51,6 +54,19 @@ YSE_C_API YseDspObject* yse_dsp_plate_reverb_create(void); /* #162 */
 YSE_C_API YseDspObject* yse_dsp_eq_create(void); /* #163 */
 YSE_C_API YseDspObject* yse_dsp_compressor_create(void); /* #163 */
 YSE_C_API YseDspObject* yse_dsp_morphing_reverb_create(void); /* #326 module, #369 C API */
+
+/* Patcher-as-insert (#167 module, #370 C API). Wraps a YsePatcher graph as a
+   chainable insert effect (YSE::DSP::patcherInsert): a hand-patched network
+   (a filter-delay, a custom EQ, ...) drives a sound or channel insert slot,
+   feeding the host buffer to the graph's ~adc objects and copying the summed
+   ~dac output back over it. The patcher should contain at least one ~adc and
+   one ~dac, and it must outlive the insert — the insert BORROWS the patcher, it
+   never owns or destroys it. Returns NULL and sets yse_last_error() when patcher
+   is NULL (the insert needs a graph to wrap). The returned handle is owned:
+   release it with yse_dsp_object_destroy(), drive it with the inherited
+   yse_dsp_object_* surface (bypass, impact, ...), and attach it with
+   yse_sound_set_dsp() or yse_channel_set_dsp(). */
+YSE_C_API YseDspObject* yse_dsp_patcher_insert_create(YsePatcher* patcher);
 
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj);
 

--- a/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
@@ -50,6 +50,7 @@ YSE_C_API YseDspObject* yse_dsp_chorus_create(void); /* #161 */
 YSE_C_API YseDspObject* yse_dsp_plate_reverb_create(void); /* #162 */
 YSE_C_API YseDspObject* yse_dsp_eq_create(void); /* #163 */
 YSE_C_API YseDspObject* yse_dsp_compressor_create(void); /* #163 */
+YSE_C_API YseDspObject* yse_dsp_morphing_reverb_create(void); /* #326 module, #369 C API */
 
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj);
 
@@ -186,6 +187,50 @@ YSE_C_API float yse_dsp_compressor_get_release(YseDspObject* obj);
 YSE_C_API void yse_dsp_compressor_set_makeup(YseDspObject* obj, float db);
 YSE_C_API float yse_dsp_compressor_get_makeup(YseDspObject* obj);
 YSE_C_API float yse_dsp_compressor_get_gain_reduction_db(YseDspObject* obj);
+
+/* ─── morphing reverb (#326 module, #369 C API) ───────────────────────────
+ * The engine's zone/global reverb core packaged as a chainable insert whose
+ * preset blend is a *control input*. Two endpoints — slot A and slot B — are
+ * each a named YseReverbPreset or a custom YseReverbPresetValues; set_morph()
+ * linearly interpolates between them (0 = pure A, 1 = pure B, clamped to
+ * [0, 1]). morph is a control-rate signal: writes are allocation-free and
+ * click-free (the reverb core's faders smooth every move), so any control
+ * thread may call set_morph at control rate. Defaults: A = REVERB_GENERIC,
+ * B = REVERB_HALL, morph = 0. Its wet/dry balance rides the morphed presets
+ * (each carries dry/wet), so the inherited yse_dsp_object_set_impact() is NOT
+ * applied — for send/return use give both slots custom values with dry = 0,
+ * wet = 1. */
+
+/* Plain-old-data mirror of YSE::REVERB::presetValues (reverb/reverbPresets.hpp)
+ * — one complete reverb parameter set: the payload of a named preset and the
+ * custom endpoint type of the morphing reverb. Fields are copied one by one
+ * across the ABI; the layout is not assumed to match the engine struct. */
+typedef struct YseReverbPresetValues {
+  float roomsize; /* simulated room size, [0, 1] */
+  float damp; /* high-frequency damping, [0, 1] */
+  float dry; /* unprocessed level, [0, 1] */
+  float wet; /* reverberated level, [0, 1] */
+  float mod_frequency; /* tail modulation rate, Hz (0 = off) */
+  float mod_width; /* tail modulation depth (0 = off) */
+  float early_time[4]; /* early reflection delays, samples, [0, 2999] */
+  float early_gain[4]; /* early reflection gains, [0, 1] */
+} YseReverbPresetValues;
+
+/* Set an endpoint from a named preset. */
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_a(YseDspObject* obj, YseReverbPreset preset);
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_b(YseDspObject* obj, YseReverbPreset preset);
+/* Set an endpoint from a custom parameter set. NULL values is a no-op. */
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_a_values(YseDspObject* obj,
+                                                           const YseReverbPresetValues* values);
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_b_values(YseDspObject* obj,
+                                                           const YseReverbPresetValues* values);
+/* Read an endpoint's current parameter set into *out. NULL out is a no-op;
+   a NULL handle zero-fills *out. */
+YSE_C_API void yse_dsp_morphing_reverb_get_preset_a(YseDspObject* obj, YseReverbPresetValues* out);
+YSE_C_API void yse_dsp_morphing_reverb_get_preset_b(YseDspObject* obj, YseReverbPresetValues* out);
+/* The morph control input: 0 = pure A, 1 = pure B, clamped to [0, 1]. */
+YSE_C_API void yse_dsp_morphing_reverb_set_morph(YseDspObject* obj, float value);
+YSE_C_API float yse_dsp_morphing_reverb_get_morph(YseDspObject* obj);
 
 #ifdef __cplusplus
 }

--- a/YseEngine/c_api/include/yse_c/yse_midi.h
+++ b/YseEngine/c_api/include/yse_c/yse_midi.h
@@ -36,6 +36,9 @@ typedef struct YseMidiOut YseMidiOut;
 typedef struct YseMidiIn YseMidiIn;
 /* Owned — release with yse_midi_note_destroy. */
 typedef struct YseMidiNote YseMidiNote;
+/* Opaque synth handle (defined in yse_synth.h) — target of
+   yse_midi_in_connect_synth. */
+typedef struct YseSynth YseSynth;
 
 /* ─── standard MIDI file playback ─────────────────────────────────── */
 
@@ -99,6 +102,21 @@ YSE_C_API void yse_midi_in_set_parsed_callback(YseMidiIn* m, YseMidiInParsedCall
 
 /* Release a byte buffer previously delivered to a YseMidiInRawCallback. */
 YSE_C_API void yse_midi_in_free_message(unsigned char* bytes);
+
+/* Route incoming device MIDI into a synth (issue #155). Every channel-voice
+   message received on the open port is mapped to the synth's normalized note
+   API and pushed lock-free onto its inbox, on RtMidi's input thread.
+   `channel_filter` is a 1..16 MIDI channel to accept, or 0 for every channel.
+   May be called for several synths (up to a small fixed cap); calling it again
+   for an already-connected synth just updates its channel filter. The synth
+   must outlive the connection — disconnect it (or close/destroy this port)
+   before destroying the synth. This is a control-thread call; do not call it
+   from the input callbacks. On builds without MIDI device support it no-ops. */
+YSE_C_API void yse_midi_in_connect_synth(YseMidiIn* m, YseSynth* synth, int channel_filter);
+
+/* Stop routing incoming device MIDI into `synth` (issue #155). Safe to call for
+   a synth that was never connected. */
+YSE_C_API void yse_midi_in_disconnect_synth(YseMidiIn* m, YseSynth* synth);
 
 /* ─── midiNote convenience value ──────────────────────────────────── */
 

--- a/YseEngine/c_api/include/yse_c/yse_midi.h
+++ b/YseEngine/c_api/include/yse_c/yse_midi.h
@@ -37,7 +37,7 @@ typedef struct YseMidiIn YseMidiIn;
 /* Owned — release with yse_midi_note_destroy. */
 typedef struct YseMidiNote YseMidiNote;
 /* Opaque synth handle (defined in yse_synth.h) — target of
-   yse_midi_in_connect_synth. */
+   yse_midi_file_connect_synth / yse_midi_in_connect_synth. */
 typedef struct YseSynth YseSynth;
 
 /* ─── standard MIDI file playback ─────────────────────────────────── */
@@ -48,6 +48,23 @@ YSE_C_API YseStatus yse_midi_file_load(YseMidiFile* f, const char* filename);
 YSE_C_API void yse_midi_file_play(YseMidiFile* f);
 YSE_C_API void yse_midi_file_pause(YseMidiFile* f);
 YSE_C_API void yse_midi_file_stop(YseMidiFile* f);
+
+/* Route this file's playback into a synth (issue #372, mirrors
+   YSE::MIDI::file::connect). While the file plays, every note / controller /
+   pitch-bend event it contains is delivered to `synth` block-accurately on the
+   audio thread; may be called for several synths (up to a small fixed cap) to
+   drive them together. Calling it again for an already-connected synth is a
+   no-op. `synth` is the opaque handle from yse_synth_create; a NULL file or a
+   NULL / never-created synth is a no-op. connect only records the pointer in the
+   file's lock-free synth table, so no loaded file or active playback is required
+   here. The synth must outlive the connection — disconnect it (or destroy this
+   file) before destroying the synth. This is a control-thread call; do not call
+   it from the audio thread. */
+YSE_C_API void yse_midi_file_connect_synth(YseMidiFile* f, YseSynth* synth);
+
+/* Stop routing this file's playback into `synth` (issue #372). Safe to call for
+   a synth that was never connected. */
+YSE_C_API void yse_midi_file_disconnect_synth(YseMidiFile* f, YseSynth* synth);
 
 /* ─── MIDI device output ──────────────────────────────────────────── */
 

--- a/YseEngine/c_api/yse_dsp_modules.cpp
+++ b/YseEngine/c_api/yse_dsp_modules.cpp
@@ -19,6 +19,8 @@
 #include "../dsp/modules/plateReverb.hpp"
 #include "../dsp/modules/parametricEQ.hpp"
 #include "../dsp/modules/compressor.hpp"
+#include "../dsp/modules/morphingReverb.hpp"
+#include "../reverb/reverbPresets.hpp"
 
 #include <exception>
 
@@ -41,6 +43,39 @@ namespace {
       yse_c::set_last_error("dsp_module create: unknown C++ exception");
       return nullptr;
     }
+  }
+
+  // Field-by-field conversions between the C mirror struct and the engine's
+  // REVERB::presetValues. The ABI struct layout is never assumed to match the
+  // engine one, so every field is copied explicitly.
+  inline YSE::REVERB::presetValues to_cpp_preset(const YseReverbPresetValues& v) {
+    YSE::REVERB::presetValues p;
+    p.roomsize = v.roomsize;
+    p.damp = v.damp;
+    p.dry = v.dry;
+    p.wet = v.wet;
+    p.modFrequency = v.mod_frequency;
+    p.modWidth = v.mod_width;
+    for (int i = 0; i < 4; ++i) {
+      p.earlyTime[i] = v.early_time[i];
+      p.earlyGain[i] = v.early_gain[i];
+    }
+    return p;
+  }
+
+  inline YseReverbPresetValues to_c_preset(const YSE::REVERB::presetValues& p) {
+    YseReverbPresetValues v;
+    v.roomsize = p.roomsize;
+    v.damp = p.damp;
+    v.dry = p.dry;
+    v.wet = p.wet;
+    v.mod_frequency = p.modFrequency;
+    v.mod_width = p.modWidth;
+    for (int i = 0; i < 4; ++i) {
+      v.early_time[i] = p.earlyTime[i];
+      v.early_gain[i] = p.earlyGain[i];
+    }
+    return v;
   }
 } // namespace
 
@@ -117,6 +152,9 @@ YSE_C_API YseDspObject* yse_dsp_eq_create(void) {
 }
 YSE_C_API YseDspObject* yse_dsp_compressor_create(void) {
   return mk<YSE::DSP::MODULES::compressor>();
+}
+YSE_C_API YseDspObject* yse_dsp_morphing_reverb_create(void) {
+  return mk<YSE::DSP::MODULES::morphingReverb>();
 }
 
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj) {
@@ -514,6 +552,45 @@ YSE_C_API float yse_dsp_compressor_get_makeup(YseDspObject* o) {
 YSE_C_API float yse_dsp_compressor_get_gain_reduction_db(YseDspObject* o) {
   auto* c = as<YSE::DSP::MODULES::compressor>(o);
   return c ? c->gainReductionDb() : 0.0f;
+}
+
+// ─── morphing reverb (#326 module, #369 C API) ────────────────────────────
+
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_a(YseDspObject* o, YseReverbPreset preset) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r) r->presetA(static_cast<YSE::REVERB_PRESET>(preset));
+}
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_b(YseDspObject* o, YseReverbPreset preset) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r) r->presetB(static_cast<YSE::REVERB_PRESET>(preset));
+}
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_a_values(YseDspObject* o,
+                                                           const YseReverbPresetValues* values) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r && values) r->presetA(to_cpp_preset(*values));
+}
+YSE_C_API void yse_dsp_morphing_reverb_set_preset_b_values(YseDspObject* o,
+                                                           const YseReverbPresetValues* values) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r && values) r->presetB(to_cpp_preset(*values));
+}
+YSE_C_API void yse_dsp_morphing_reverb_get_preset_a(YseDspObject* o, YseReverbPresetValues* out) {
+  if (!out) return;
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  *out = r ? to_c_preset(r->presetA()) : YseReverbPresetValues{};
+}
+YSE_C_API void yse_dsp_morphing_reverb_get_preset_b(YseDspObject* o, YseReverbPresetValues* out) {
+  if (!out) return;
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  *out = r ? to_c_preset(r->presetB()) : YseReverbPresetValues{};
+}
+YSE_C_API void yse_dsp_morphing_reverb_set_morph(YseDspObject* o, float value) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  if (r) r->morph(value);
+}
+YSE_C_API float yse_dsp_morphing_reverb_get_morph(YseDspObject* o) {
+  auto* r = as<YSE::DSP::MODULES::morphingReverb>(o);
+  return r ? r->morph() : 0.0f;
 }
 
 } // extern "C"

--- a/YseEngine/c_api/yse_dsp_modules.cpp
+++ b/YseEngine/c_api/yse_dsp_modules.cpp
@@ -20,6 +20,8 @@
 #include "../dsp/modules/parametricEQ.hpp"
 #include "../dsp/modules/compressor.hpp"
 #include "../dsp/modules/morphingReverb.hpp"
+#include "../dsp/patcherInsert.hpp"
+#include "../patcher/patcher.hpp"
 #include "../reverb/reverbPresets.hpp"
 
 #include <exception>
@@ -155,6 +157,26 @@ YSE_C_API YseDspObject* yse_dsp_compressor_create(void) {
 }
 YSE_C_API YseDspObject* yse_dsp_morphing_reverb_create(void) {
   return mk<YSE::DSP::MODULES::morphingReverb>();
+}
+
+// Patcher-as-insert (#167 module, #370 C API). Unlike the no-arg module
+// creators, patcherInsert wraps a borrowed YSE::patcher, so a NULL patcher is
+// rejected rather than silently constructing an insert with nothing to render.
+YSE_C_API YseDspObject* yse_dsp_patcher_insert_create(YsePatcher* patcher) {
+  if (!patcher) {
+    yse_c::set_last_error("yse_dsp_patcher_insert_create: patcher is NULL");
+    return nullptr;
+  }
+  try {
+    auto* patch = reinterpret_cast<YSE::patcher*>(patcher);
+    return reinterpret_cast<YseDspObject*>(new YSE::DSP::patcherInsert(*patch));
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("patcher_insert_create: unknown C++ exception");
+    return nullptr;
+  }
 }
 
 YSE_C_API void yse_dsp_object_destroy(YseDspObject* obj) {

--- a/YseEngine/c_api/yse_midi.cpp
+++ b/YseEngine/c_api/yse_midi.cpp
@@ -118,6 +118,23 @@ YSE_C_API void yse_midi_file_stop(YseMidiFile* f) {
   if (f) to_cpp(f)->stop();
 }
 
+YSE_C_API void yse_midi_file_connect_synth(YseMidiFile* f, YseSynth* synth) {
+  if (!f) return;
+  // synth_from_handle (defined in yse_synth.cpp) yields the engine synth backing
+  // the opaque YseSynth; a NULL / never-created handle yields nullptr. connect()
+  // only records the pointer in the file's fixed-size, lock-free synth table, so
+  // no loaded file or active playback is required here. Mirrors the always-on
+  // midifile surface (unlike midi device I/O, this is not RtMidi-gated).
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_cpp(f)->connect(*s);
+}
+
+YSE_C_API void yse_midi_file_disconnect_synth(YseMidiFile* f, YseSynth* synth) {
+  if (!f) return;
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_cpp(f)->disconnect(*s);
+}
+
 // ─── midi out (Windows/Linux only) ─────────────────────────────────
 
 #if YSE_C_HAVE_MIDI_OUT

--- a/YseEngine/c_api/yse_midi.cpp
+++ b/YseEngine/c_api/yse_midi.cpp
@@ -251,6 +251,22 @@ YSE_C_API void yse_midi_in_free_message(unsigned char* bytes) {
   if (bytes) std::free(bytes);
 }
 
+YSE_C_API void yse_midi_in_connect_synth(YseMidiIn* m, YseSynth* synth, int channel_filter) {
+  if (!m) return;
+  // synth_from_handle (defined in yse_synth.cpp) yields the engine synth backing
+  // the opaque YseSynth; a NULL / never-created handle yields nullptr. connect()
+  // only records the pointer in the port's lock-free subscriber table, so no
+  // engine device or open port is required here.
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_impl(m)->cpp.connect(*s, channel_filter);
+}
+
+YSE_C_API void yse_midi_in_disconnect_synth(YseMidiIn* m, YseSynth* synth) {
+  if (!m) return;
+  YSE::synth* s = yse_c::synth_from_handle(synth);
+  if (s) to_impl(m)->cpp.disconnect(*s);
+}
+
 #else
 // Stub the midiOut surface on platforms without RtMidi so the C ABI is
 // uniform across builds. Each call sets last_error and returns / no-ops.
@@ -291,6 +307,8 @@ YSE_C_API void yse_midi_in_set_parsed_callback(YseMidiIn*, YseMidiInParsedCallba
 YSE_C_API void yse_midi_in_free_message(unsigned char* bytes) {
   if (bytes) std::free(bytes);
 }
+YSE_C_API void yse_midi_in_connect_synth(YseMidiIn*, YseSynth*, int) {}
+YSE_C_API void yse_midi_in_disconnect_synth(YseMidiIn*, YseSynth*) {}
 #endif
 
 // ─── midiNote ──────────────────────────────────────────────────────

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -303,6 +303,14 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
   // not free it yet — an in-flight audio block may still walk the retired
   // snapshot that references it. The free is deferred to the reclaimer.
   object->UnwireFromPeers();
+  // Capture the id generation this object's ids belong to *before* a possible
+  // recompaction below bumps it, so the reclaimer can tell whether they are
+  // still recyclable when it frees the object (issue #364).
+  std::uint64_t objGen;
+  {
+    std::scoped_lock rlk(reclaimMtx_);
+    objGen = idGeneration_;
+  }
   // If that was the patcher's last object, recompact the id space before the
   // next graph is built: an empty object set binds no live id (issue #355).
   CompactGraphIdsIfEmpty();
@@ -312,7 +320,7 @@ void patcherImplementation::DeleteObject(YSE::pHandle* handle) {
   // guarantees no retired graph outlives an object it points into.
   {
     std::scoped_lock rlk(reclaimMtx_);
-    retiredObjects_.emplace_back(object, audioBlock_.load(std::memory_order_acquire));
+    retiredObjects_.push_back({object, audioBlock_.load(std::memory_order_acquire), objGen});
   }
   ScheduleReclaim();
   // The handle is never referenced by a GraphState, so it can go immediately.
@@ -446,8 +454,11 @@ void patcherImplementation::ReplaceObjectUnlocked(YSE::pHandle* handle, const st
   handle->object = fresh;
   RebuildAndPublish();
   {
+    // No recompaction happens here (the patcher is never empty during a
+    // replace), so the current generation is the one the old object's ids belong
+    // to; the reclaimer recycles them when it frees the old object (issue #364).
     std::scoped_lock rlk(reclaimMtx_);
-    retiredObjects_.emplace_back(old, audioBlock_.load(std::memory_order_acquire));
+    retiredObjects_.push_back({old, audioBlock_.load(std::memory_order_acquire), idGeneration_});
   }
   ScheduleReclaim();
 }
@@ -466,6 +477,14 @@ void patcherImplementation::Clear() {
     delete it->first; // handle: not referenced by a GraphState
   }
   objects.clear();
+  // Capture the id generation the doomed objects' ids belong to before the
+  // recompaction below bumps it (issue #364): a Clear always empties the
+  // patcher, so their ids are a stale numbering the reclaimer must not recycle.
+  std::uint64_t objGen;
+  {
+    std::scoped_lock rlk(reclaimMtx_);
+    objGen = idGeneration_;
+  }
   // No live object remains, so the id space carries no stability constraint:
   // recompact it before the empty graph is built so later rebuilds restart from
   // a small id range instead of extending it every Clear (issue #355).
@@ -478,7 +497,7 @@ void patcherImplementation::Clear() {
     std::scoped_lock rlk(reclaimMtx_);
     const std::uint64_t at = audioBlock_.load(std::memory_order_acquire);
     for (pObject* obj : doomed)
-      retiredObjects_.emplace_back(obj, at);
+      retiredObjects_.push_back({obj, at, objGen});
   }
   ScheduleReclaim();
 }
@@ -593,6 +612,11 @@ std::size_t patcherImplementation::OutletIdSpace() {
 std::size_t patcherImplementation::InletIdSpace() {
   std::scoped_lock lk(mtx);
   return static_cast<std::size_t>(nextInletId_);
+}
+
+std::size_t patcherImplementation::FreeIdCount() {
+  std::scoped_lock lk(reclaimMtx_);
+  return freeInletIds_.size() + freeOutletIds_.size();
 }
 
 YSE::pHandle* patcherImplementation::GetHandleFromList(unsigned int obj) {
@@ -808,13 +832,50 @@ void patcherImplementation::SetHandler(YSE::oscHandler* handler) {
 }
 
 void patcherImplementation::AssignGraphIds(pObject* object) {
+  // Caller holds mtx. Recycled ids are produced by the background reclaimer
+  // under reclaimMtx_ (issue #364); pull from the free-list before extending the
+  // high-water mark so a continuously edited patcher reuses the id range of its
+  // deleted objects instead of growing it with the lifetime create count. A
+  // recycled id is always < the current counter, so it stays in bounds of every
+  // GraphState's id-indexed tables. mtx -> reclaimMtx_ is the established order;
+  // this never runs on the audio thread.
+  std::scoped_lock rlk(reclaimMtx_);
   for (int i = 0; i < object->NumInputs(); i++) {
     PATCHER::inlet* in = object->GetInlet(i);
-    if (in != nullptr && in->GraphId() < 0) in->SetGraphId(nextInletId_++);
+    if (in == nullptr || in->GraphId() >= 0) continue;
+    if (!freeInletIds_.empty()) {
+      in->SetGraphId(freeInletIds_.back());
+      freeInletIds_.pop_back();
+    } else {
+      in->SetGraphId(nextInletId_++);
+    }
   }
   for (int i = 0; i < object->NumOutputs(); i++) {
     PATCHER::outlet* out = object->GetOutlet(i);
-    if (out != nullptr && out->GraphId() < 0) out->SetGraphId(nextOutletId_++);
+    if (out == nullptr || out->GraphId() >= 0) continue;
+    if (!freeOutletIds_.empty()) {
+      out->SetGraphId(freeOutletIds_.back());
+      freeOutletIds_.pop_back();
+    } else {
+      out->SetGraphId(nextOutletId_++);
+    }
+  }
+}
+
+void patcherImplementation::RecycleObjectIds(pObject* object, std::uint64_t idGen) {
+  // Caller holds reclaimMtx_ (the background reclaimer, freeing this object now
+  // that no live or retired snapshot can still index its ids). Only return the
+  // ids to the free-list if they still belong to the current numbering: a
+  // CompactGraphIdsIfEmpty since retirement reset the counters, so these ids
+  // would collide with the fresh dense range if reused (issue #364).
+  if (idGen != idGeneration_) return;
+  for (int i = 0; i < object->NumInputs(); i++) {
+    PATCHER::inlet* in = object->GetInlet(i);
+    if (in != nullptr && in->GraphId() >= 0) freeInletIds_.push_back(in->GraphId());
+  }
+  for (int i = 0; i < object->NumOutputs(); i++) {
+    PATCHER::outlet* out = object->GetOutlet(i);
+    if (out != nullptr && out->GraphId() >= 0) freeOutletIds_.push_back(out->GraphId());
   }
 }
 
@@ -830,6 +891,14 @@ void patcherImplementation::CompactGraphIdsIfEmpty() {
   if (objects.empty()) {
     nextInletId_ = 0;
     nextOutletId_ = 0;
+    // The whole id space is reclaimed at once, so any recycled ids parked on the
+    // free-list belong to the pre-reset numbering and must be dropped; bumping
+    // the generation likewise marks the ids of still-pending retired objects as
+    // stale, so their deferred free won't push them into the reset space (#364).
+    std::scoped_lock rlk(reclaimMtx_);
+    freeInletIds_.clear();
+    freeOutletIds_.clear();
+    idGeneration_++;
   }
 }
 
@@ -903,8 +972,11 @@ bool patcherImplementation::ReclaimElapsed(std::uint64_t now) {
     }
   }
   for (std::size_t i = 0; i < retiredObjects_.size();) {
-    if (now >= retiredObjects_[i].second + 2) {
-      delete retiredObjects_[i].first;
+    if (now >= retiredObjects_[i].epoch + 2) {
+      // No live or retired snapshot can still index this object's ids now, so
+      // hand them back to the free-list for reuse before freeing it (issue #364).
+      RecycleObjectIds(retiredObjects_[i].object, retiredObjects_[i].idGen);
+      delete retiredObjects_[i].object;
       retiredObjects_.erase(retiredObjects_.begin() + i);
     } else {
       ++i;
@@ -941,7 +1013,7 @@ void patcherImplementation::FreeAllRetired() {
   const GraphState* g = active_.exchange(nullptr, std::memory_order_acq_rel);
   delete g;
   for (std::size_t i = 0; i < retiredObjects_.size(); i++) {
-    delete retiredObjects_[i].first;
+    delete retiredObjects_[i].object;
   }
   retiredObjects_.clear();
 }

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -88,6 +88,14 @@ namespace YSE {
       std::size_t OutletIdSpace();
       std::size_t InletIdSpace();
 
+      // Number of retired inlet + outlet graph ids currently parked on the
+      // free-list awaiting reuse (issue #364). A non-zero value after a
+      // create/delete churn (with the patcher never going empty) shows the
+      // reclaimer is returning ids for AssignGraphIds to recycle rather than
+      // letting the id space grow. Diagnostics / tests only: takes reclaimMtx_,
+      // so control-thread only.
+      std::size_t FreeIdCount();
+
       std::vector<YSE::DSP::buffer> output;
 
       aBool controlledBySound;
@@ -196,14 +204,23 @@ namespace YSE {
       // Control-thread only (allocates). See graphState.h.
       GraphState* BuildGraph();
       // Stamp lifetime-stable graph ids on a newly added object's inlets/outlets.
+      // Pulls a recycled id from the free-list before bumping the counter so a
+      // continuously edited patcher reuses the ids of its deleted objects (issue
+      // #364). Caller holds mtx; takes reclaimMtx_ for the free-list access.
       void AssignGraphIds(pObject* obj);
+      // Return a freed object's inlet/outlet graph ids to the free-list, but only
+      // if they belong to the current id generation — ids from a compacted-away
+      // numbering (issue #355) are dropped (issue #364). Caller holds reclaimMtx_.
+      void RecycleObjectIds(pObject* obj, std::uint64_t idGen);
       // Recompact the inlet/outlet id space when no live object remains. A
       // graph id is fixed for a live object's lifetime (the audio thread reads
       // it unsynchronised to index the pinned snapshot), so ids can only be
       // reclaimed when there is nothing live to re-stamp — an empty object set
       // is exactly that case. Restarting the counters at 0 then bounds each
       // GraphState's id-indexed tables by the peak simultaneous object count
-      // instead of the lifetime creation count (issue #355). Caller holds mtx.
+      // instead of the lifetime creation count (issue #355). Also bumps the id
+      // generation and drops the free-list, so ids from the old numbering are not
+      // recycled into the reset space (issue #364). Caller holds mtx.
       void CompactGraphIdsIfEmpty();
       // Build the next GraphState, publish it with one atomic swap, retire the
       // previous one, and schedule background reclamation.
@@ -265,6 +282,18 @@ namespace YSE {
       // tell when the audio thread has advanced past a retired snapshot.
       std::atomic<std::uint64_t> audioBlock_{0};
 
+      // A deleted object awaiting reclamation. `epoch` is the block count at
+      // retirement (the +2 grace is measured from it). `idGen` is the id-space
+      // generation the object's inlet/outlet graph ids belong to (issue #364):
+      // the reclaimer returns those ids to the free-list only when it still
+      // matches the current generation, so ids from a numbering that was
+      // compacted away (issue #355) are dropped rather than reused.
+      struct RetiredObject {
+        pObject* object;
+        std::uint64_t epoch;
+        std::uint64_t idGen;
+      };
+
       // Retired snapshots / deleted objects awaiting reclamation, tagged with
       // the block count at retirement. Produced by the control thread and drained
       // by the background pool, so guarded by reclaimMtx_ (never taken on the
@@ -272,7 +301,7 @@ namespace YSE {
       // may take it, but the background reclaimer takes only reclaimMtx_.
       std::mutex reclaimMtx_;
       std::vector<std::pair<const GraphState*, std::uint64_t>> retiredGraphs_;
-      std::vector<std::pair<pObject*, std::uint64_t>> retiredObjects_;
+      std::vector<RetiredObject> retiredObjects_;
       // Two-element ping-pong so a reclaim pass that still has work can re-arm
       // without re-enqueuing itself (see reclaimJob). Wired up in the ctor.
       reclaimJob reclaimJobs_[2];
@@ -292,6 +321,22 @@ namespace YSE {
       // lifetime creation count (issue #355).
       int nextInletId_ = 0;
       int nextOutletId_ = 0;
+
+      // Free-list of retired inlet / outlet graph ids (issue #364). The
+      // background reclaimer pushes a deleted object's ids here at the moment it
+      // frees the object — the point no live or retired snapshot can still index
+      // them — and AssignGraphIds pulls from here before bumping the counters. A
+      // continuously edited patcher that never goes empty (so #355's compaction
+      // never fires) thus reuses the id range of its deleted objects instead of
+      // growing it with the lifetime create count. Guarded by reclaimMtx_ and
+      // never touched on the audio thread; consumed under mtx -> reclaimMtx_.
+      std::vector<int> freeInletIds_;
+      std::vector<int> freeOutletIds_;
+      // Generation of the current id numbering. Bumped by CompactGraphIdsIfEmpty
+      // every time the counters reset, so ids stamped before a reset carry a
+      // stale generation and are dropped rather than recycled (see RetiredObject
+      // and RecycleObjectIds). Guarded by reclaimMtx_.
+      std::uint64_t idGeneration_ = 0;
 
       // Lock-free command queue for deferred value delivery (issue #225).
       // Producers: control/GUI threads (PassBang / PassData). Consumer: the


### PR DESCRIPTION
Patch release **v2.3.1** — ships the minor items missed in v2.3.0.

### What's included (since v2.3.0)
- **#369** — c-api: mirror `morphingReverb` insert module
- **#370** — c-api: mirror `patcherInsert` (patcher-as-insert surface)
- **#371** — c-api: route a MIDI input device into a synth (`midiIn` connect/disconnect)
- **#372** — c-api: route MIDI-file playback into a synth
- **#364** — patcher: recycle retired graph ids via a free-list during continuous churn (engine-internal)
- release-prep #383: PROJECT_OVERVIEW.md refreshed to 2.3.1

No C API drift (this release *is* the C API mirror work); release build green, enum mirror check passed.

The version bump to 2.3.1 lands in a follow-up PR after this promotion, per the release procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)