### PR TITLE
Release v2.3.1

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -19,7 +19,7 @@
 #include <string>
 
 namespace YSE {
-  const std::string VERSION = "2.3.0";
+  const std::string VERSION = "2.3.1";
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *


### PR DESCRIPTION
Version bump for the v2.3.1 release (`VERSION` 2.3.0 → 2.3.1 in `YseEngine/system.hpp`).

Routed through a PR because branch protection on master requires it (same path as release-v2.1.0 → PR #87). The tag `v2.3.1` will be placed on this PR's merge commit, matching how prior releases were tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)