### PR TITLE
Sync Release v2.3.1 bump back to dev

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -19,7 +19,7 @@
 #include <string>
 
 namespace YSE {
-  const std::string VERSION = "2.3.0";
+  const std::string VERSION = "2.3.1";
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *


### PR DESCRIPTION
Brings the version bump commit (`VERSION` → 2.3.1) and the release merge commits back to dev so the two branches stay in sync. No CI wait — every commit here already passed CI on the PR that put it on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)