### PR TITLE
Host bus tap: C API to subscribe the host to a bus address prefix (#389)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -109,6 +109,7 @@ set(YSE_TEST_SOURCES
   io/test_bufferIO.cpp
   io/test_callback_counter.cpp
   system/test_named_bus.cpp
+  system/test_c_api_bus.cpp
   system/test_system_active_state.cpp
   system/test_lifecycle.cpp
   clock/test_domain_clocks.cpp
@@ -228,7 +229,11 @@ add_test(
   # `clip` (issue #250 clip transport) is excluded for the same reason as
   # `clock`: its cases drive CLOCK::Manager().update() / CLIP::Manager().update()
   # directly on the test thread. It runs isolated in yse_tests_clip.
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthbus,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos,clock,clip --duration=true
+  # `buscapi` (issue #389 host bus tap C API) is excluded like the other
+  # c-api lifecycle suites: it drives yse_system_init_offline()/close() —
+  # the tap-invalidation-at-close contract is part of the surface under
+  # test — so it runs in its own process (yse_tests_buscapi).
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthbus,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos,clock,clip,buscapi --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -399,6 +404,20 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_instrumentcapi PROPERTIES LABELS "synth;c-api;lifecycle")
+
+# C-API host bus tap surface (issue #389). Drives yse_bus_tap_create /
+# destroy through the flat C ABI under an offline engine, including the
+# yse_system_close() tap-invalidation contract. Isolated in its own process
+# for the same reason as yse_tests_synthcapi: System::close() tears down
+# process-global state (thread pools, named bus) the rest of the suite
+# assumes stays up (#298). initOffline() needs no audio hardware, so it runs
+# in CI.
+add_test(
+  NAME    yse_tests_buscapi
+  COMMAND yse_tests --test-suite=buscapi
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_buscapi PROPERTIES LABELS "system;c-api;lifecycle")
 
 add_test(
   NAME    yse_tests_midi

--- a/Tests/system/test_c_api_bus.cpp
+++ b/Tests/system/test_c_api_bus.cpp
@@ -1,0 +1,203 @@
+// C-API host bus tap tests (issue #389) — exercises YseEngine/c_api/yse_bus.*
+// through the flat C ABI: yse_bus_tap_create / yse_bus_tap_destroy plus the
+// yse_bus_tap_cb frame contract (five payload kinds incl. bang, engine-owned
+// buffers valid only for the call).
+//
+// Publishes are driven through INTERNAL::Bus() directly (the tests link
+// yse_objects with full symbol access) — there is no C publish surface, and
+// the tap's job is to observe engine-side publishes.
+//
+// The engine runs offline (yse_system_init_offline), so no audio hardware is
+// needed and the suite runs in CI. Because it calls yse_system_close() — the
+// tap-invalidation contract is part of the surface under test — it lives in
+// its own TEST_SUITE("buscapi") and its own ctest process (see
+// Tests/CMakeLists.txt), like the other lifecycle-driving c-api suites
+// (#298/#304 isolation).
+
+#include <doctest/doctest.h>
+
+#include <string>
+#include <vector>
+
+#include "yse_c/yse_bus.h"
+#include "yse_c/yse_system.h"
+
+#include "yse.hpp"
+#include "internal/namedBus.h"
+
+namespace {
+
+  // One decoded callback frame, with the engine-owned buffers copied during
+  // the call — exactly what the header tells a real host to do.
+  struct Frame {
+    std::string address;
+    YseBusValueKind kind{YSE_BUS_BANG};
+    int i = 0;
+    float f = 0.0f;
+    std::string str;
+    std::vector<float> list;
+    bool strWasNull = true;
+    bool listWasNull = true;
+  };
+
+  struct Sink {
+    std::vector<Frame> frames;
+  };
+
+  void YSE_C_CALLBACK captureCb(const char* address, YseBusValueKind kind, int i, float f,
+                                const char* str, const float* list, size_t list_len,
+                                void* user_data) {
+    auto* sink = static_cast<Sink*>(user_data);
+    Frame frame;
+    frame.address = address != nullptr ? address : "";
+    frame.kind = kind;
+    frame.i = i;
+    frame.f = f;
+    frame.strWasNull = str == nullptr;
+    if (str != nullptr) frame.str = str;
+    frame.listWasNull = list == nullptr;
+    if (list != nullptr) frame.list.assign(list, list + list_len);
+    sink->frames.push_back(frame);
+  }
+
+  void publish(const char* name, YSE::INTERNAL::BusValue value) {
+    // The test thread ran init_offline, so it is the control thread: a T_GUI
+    // publish dispatches synchronously and the tap fires before this returns.
+    YSE::INTERNAL::Bus().publish(name, value, YSE::T_GUI);
+  }
+
+} // namespace
+
+TEST_SUITE("buscapi") {
+
+  // Runs first (doctest keeps file order): no engine session exists yet.
+  TEST_CASE("c-api bus: create fails cleanly before init and on NULL args") {
+    yse_clear_last_error();
+    CHECK(yse_bus_tap_create("phi.ctl.", &captureCb, nullptr) == nullptr);
+    CHECK(std::string(yse_last_error()).find("not initialised") != std::string::npos);
+
+    CHECK(yse_bus_tap_create(nullptr, &captureCb, nullptr) == nullptr);
+    CHECK(yse_bus_tap_create("phi.ctl.", nullptr, nullptr) == nullptr);
+
+    yse_bus_tap_destroy(nullptr); // null-safe no-op, engine down or not
+  }
+
+  TEST_CASE("c-api bus: tap delivers all five value kinds with call-time copies") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(yse_system_init_offline(sys) == YSE_OK);
+
+    Sink sink;
+    YseBusTap* tap = yse_bus_tap_create("cap.k.", &captureCb, &sink);
+    REQUIRE(tap != nullptr);
+
+    publish("cap.k.bang", YSE::INTERNAL::BusValue{});
+    publish("cap.k.int", YSE::INTERNAL::BusValue{42});
+    publish("cap.k.float", YSE::INTERNAL::BusValue{1.5f});
+    publish("cap.k.str", YSE::INTERNAL::BusValue{std::string("hello")});
+    publish("cap.k.list", YSE::INTERNAL::BusValue{std::vector<float>{3.0f, 4.0f, 5.0f}});
+
+    REQUIRE(sink.frames.size() == 5);
+
+    CHECK(sink.frames[0].address == "cap.k.bang");
+    CHECK(sink.frames[0].kind == YSE_BUS_BANG);
+    CHECK(sink.frames[0].strWasNull);
+    CHECK(sink.frames[0].listWasNull);
+
+    CHECK(sink.frames[1].address == "cap.k.int");
+    CHECK(sink.frames[1].kind == YSE_BUS_INT);
+    CHECK(sink.frames[1].i == 42);
+
+    CHECK(sink.frames[2].address == "cap.k.float");
+    CHECK(sink.frames[2].kind == YSE_BUS_FLOAT);
+    CHECK(sink.frames[2].f == doctest::Approx(1.5f));
+
+    CHECK(sink.frames[3].address == "cap.k.str");
+    CHECK(sink.frames[3].kind == YSE_BUS_STRING);
+    CHECK_FALSE(sink.frames[3].strWasNull);
+    CHECK(sink.frames[3].str == "hello");
+
+    CHECK(sink.frames[4].address == "cap.k.list");
+    CHECK(sink.frames[4].kind == YSE_BUS_LIST);
+    REQUIRE(sink.frames[4].list.size() == 3);
+    CHECK(sink.frames[4].list[0] == doctest::Approx(3.0f));
+    CHECK(sink.frames[4].list[2] == doctest::Approx(5.0f));
+
+    yse_bus_tap_destroy(tap);
+  }
+
+  TEST_CASE("c-api bus: multiple taps filter by their own prefix and user_data") {
+    Sink ctl, all;
+    YseBusTap* tapCtl = yse_bus_tap_create("cap.ctl.", &captureCb, &ctl);
+    YseBusTap* tapAll = yse_bus_tap_create("", &captureCb, &all); // matches everything
+    REQUIRE(tapCtl != nullptr);
+    REQUIRE(tapAll != nullptr);
+
+    publish("cap.ctl.play", YSE::INTERNAL::BusValue{1});
+    publish("cap.other", YSE::INTERNAL::BusValue{2});
+
+    REQUIRE(ctl.frames.size() == 1);
+    CHECK(ctl.frames[0].address == "cap.ctl.play");
+    CHECK(all.frames.size() == 2);
+
+    yse_bus_tap_destroy(tapCtl);
+    publish("cap.ctl.stop", YSE::INTERNAL::BusValue{3});
+    CHECK(ctl.frames.size() == 1); // destroyed — no further delivery
+    CHECK(all.frames.size() == 3);
+
+    yse_bus_tap_destroy(tapAll);
+  }
+
+  TEST_CASE("c-api bus: audio-thread publishes arrive on the next yse_system_update") {
+    YseSystem* sys = yse_system_get();
+
+    Sink sink;
+    YseBusTap* tap = yse_bus_tap_create("cap.dsp.", &captureCb, &sink);
+    REQUIRE(tap != nullptr);
+
+    YSE::INTERNAL::Bus().publish("cap.dsp.meter", YSE::INTERNAL::BusValue{0.25f}, YSE::T_DSP);
+    CHECK(sink.frames.empty()); // queued, not delivered inline
+
+    yse_system_update(sys); // drainPending() runs on this (control) thread
+    REQUIRE(sink.frames.size() == 1);
+    CHECK(sink.frames[0].address == "cap.dsp.meter");
+    CHECK(sink.frames[0].kind == YSE_BUS_FLOAT);
+    CHECK(sink.frames[0].f == doctest::Approx(0.25f));
+
+    yse_bus_tap_destroy(tap);
+  }
+
+  TEST_CASE("c-api bus: yse_system_close invalidates taps; hosts re-create after re-init") {
+    YseSystem* sys = yse_system_get();
+
+    Sink stale;
+    YseBusTap* staleTap = yse_bus_tap_create("cap.life.", &captureCb, &stale);
+    REQUIRE(staleTap != nullptr);
+
+    yse_system_close(sys);
+
+    // Engine down: create must fail, destroy of the stale tap must be safe.
+    CHECK(yse_bus_tap_create("cap.life.", &captureCb, &stale) == nullptr);
+
+    REQUIRE(yse_system_init_offline(sys) == YSE_OK);
+
+    // The stale tap did not survive the restart: a matching publish on the
+    // new session's bus reaches only a freshly created tap.
+    Sink fresh;
+    YseBusTap* freshTap = yse_bus_tap_create("cap.life.", &captureCb, &fresh);
+    REQUIRE(freshTap != nullptr);
+
+    publish("cap.life.tick", YSE::INTERNAL::BusValue{1});
+    CHECK(stale.frames.empty());
+    CHECK(fresh.frames.size() == 1);
+
+    // Destroying the stale handle now (engine active again) must not disturb
+    // the new registration — tap handles are process-unique across sessions.
+    yse_bus_tap_destroy(staleTap);
+    publish("cap.life.tock", YSE::INTERNAL::BusValue{2});
+    CHECK(fresh.frames.size() == 2);
+
+    yse_bus_tap_destroy(freshTap);
+    yse_system_close(sys);
+  }
+
+} // TEST_SUITE("buscapi")

--- a/Tests/system/test_named_bus.cpp
+++ b/Tests/system/test_named_bus.cpp
@@ -303,6 +303,125 @@ TEST_SUITE("system") {
     bus.unsubscribe(h);
   }
 
+  TEST_CASE("named bus: prefix tap receives every matching publish with its full name") {
+    // Host prefix taps (issue #389): a tap registered on "tap.a." must see
+    // every publish whose name starts with that prefix — including names that
+    // have no exact-match subscriber at all (dispatch used to early-return on
+    // an unknown name; taps must still be scanned).
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    std::vector<std::string> names;
+    int ints = 0;
+    auto t =
+        bus.subscribeTap("tap.a.", [&](const std::string& name, const YSE::INTERNAL::BusValue& v) {
+          names.push_back(name);
+          if (std::get_if<int>(&v)) ++ints;
+        });
+
+    bus.publish("tap.a.play", YSE::INTERNAL::BusValue{1}, YSE::T_GUI);
+    bus.publish("tap.a.stop", YSE::INTERNAL::BusValue{2}, YSE::T_GUI);
+    bus.publish("tap.b.play", YSE::INTERNAL::BusValue{3}, YSE::T_GUI); // no match
+    bus.publish("tap.a", YSE::INTERNAL::BusValue{4}, YSE::T_GUI); // shorter than prefix
+
+    REQUIRE(names.size() == 2);
+    CHECK(names[0] == "tap.a.play");
+    CHECK(names[1] == "tap.a.stop");
+    CHECK(ints == 2);
+
+    bus.unsubscribeTap(t);
+  }
+
+  TEST_CASE("named bus: prefix tap delivers all five payload kinds incl. bang") {
+    // The bus carries bang (monostate) besides int/float/string/list — gSend's
+    // bang outlet publishes it. A tap must deliver every kind.
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    int bangs = 0, is = 0, fs = 0, ss = 0, ls = 0;
+    auto t =
+        bus.subscribeTap("tap.kinds.", [&](const std::string&, const YSE::INTERNAL::BusValue& v) {
+          if (std::holds_alternative<std::monostate>(v))
+            ++bangs;
+          else if (std::holds_alternative<int>(v))
+            ++is;
+          else if (std::holds_alternative<float>(v))
+            ++fs;
+          else if (std::holds_alternative<std::string>(v))
+            ++ss;
+          else if (std::holds_alternative<std::vector<float>>(v))
+            ++ls;
+        });
+
+    bus.publish("tap.kinds.bang", YSE::INTERNAL::BusValue{}, YSE::T_GUI);
+    bus.publish("tap.kinds.int", YSE::INTERNAL::BusValue{7}, YSE::T_GUI);
+    bus.publish("tap.kinds.float", YSE::INTERNAL::BusValue{0.5f}, YSE::T_GUI);
+    bus.publish("tap.kinds.str", YSE::INTERNAL::BusValue{std::string("s")}, YSE::T_GUI);
+    bus.publish("tap.kinds.list", YSE::INTERNAL::BusValue{std::vector<float>{1.0f}}, YSE::T_GUI);
+
+    CHECK(bangs == 1);
+    CHECK(is == 1);
+    CHECK(fs == 1);
+    CHECK(ss == 1);
+    CHECK(ls == 1);
+
+    bus.unsubscribeTap(t);
+  }
+
+  TEST_CASE("named bus: taps coexist with exact subscribers and unsubscribe cleanly") {
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    int exact = 0, tapAll = 0, tapNarrow = 0;
+    auto h = bus.subscribe("tap.co.x", [&](const YSE::INTERNAL::BusValue&) { ++exact; });
+    auto tAll =
+        bus.subscribeTap("", // empty prefix matches every address
+                         [&](const std::string&, const YSE::INTERNAL::BusValue&) { ++tapAll; });
+    auto tNarrow = bus.subscribeTap(
+        "tap.co.", [&](const std::string&, const YSE::INTERNAL::BusValue&) { ++tapNarrow; });
+
+    bus.publish("tap.co.x", YSE::INTERNAL::BusValue{1}, YSE::T_GUI);
+    CHECK(exact == 1);
+    CHECK(tapAll == 1);
+    CHECK(tapNarrow == 1);
+
+    bus.publish("elsewhere", YSE::INTERNAL::BusValue{2}, YSE::T_GUI);
+    CHECK(tapAll == 2);
+    CHECK(tapNarrow == 1);
+
+    bus.unsubscribeTap(tNarrow);
+    bus.publish("tap.co.x", YSE::INTERNAL::BusValue{3}, YSE::T_GUI);
+    CHECK(exact == 2);
+    CHECK(tapAll == 3);
+    CHECK(tapNarrow == 1); // unsubscribed — no further delivery
+
+    bus.unsubscribeTap(tAll);
+    bus.unsubscribe(h);
+  }
+
+  TEST_CASE("named bus: T_DSP and deferred T_GUI publishes reach taps on drainPending") {
+    // Audio-thread and off-control-thread publishes are already funnelled into
+    // dispatch() via drainPending(); the tap rides that path with zero extra
+    // audio-thread machinery.
+    REQUIRE(TestHelpers::engineInit());
+    auto& bus = YSE::INTERNAL::Bus();
+
+    int hits = 0;
+    auto t = bus.subscribeTap("tap.drain.",
+                              [&](const std::string&, const YSE::INTERNAL::BusValue&) { ++hits; });
+
+    bus.publish("tap.drain.dsp", YSE::INTERNAL::BusValue{1}, YSE::T_DSP);
+    std::thread worker(
+        [&] { bus.publish("tap.drain.gui", YSE::INTERNAL::BusValue{2}, YSE::T_GUI); });
+    worker.join();
+    CHECK(hits == 0); // nothing delivered before the drain
+
+    bus.drainPending();
+    CHECK(hits == 2);
+
+    bus.unsubscribeTap(t);
+  }
+
   TEST_CASE("named bus: duplicate subscriptions on a name each get called") {
     REQUIRE(TestHelpers::engineInit());
     auto& bus = YSE::INTERNAL::Bus();

--- a/YseEngine/c_api/CMakeLists.txt
+++ b/YseEngine/c_api/CMakeLists.txt
@@ -32,6 +32,7 @@ set(YSE_C_API_SRCS
   yse_log.cpp
   yse_buffer_io.cpp
   yse_python.cpp
+  yse_bus.cpp
   yse_enums_check.cpp
 )
 list(TRANSFORM YSE_C_API_SRCS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")

--- a/YseEngine/c_api/include/yse_c/yse_all.h
+++ b/YseEngine/c_api/include/yse_c/yse_all.h
@@ -25,5 +25,6 @@
 #include "yse_log.h"
 #include "yse_buffer_io.h"
 #include "yse_python.h"
+#include "yse_bus.h"
 
 #endif

--- a/YseEngine/c_api/include/yse_c/yse_bus.h
+++ b/YseEngine/c_api/include/yse_c/yse_bus.h
@@ -1,0 +1,90 @@
+/*
+  yse_bus.h — host tap onto the global named bus (issue #389).
+
+  Lets a host (Phi via dart-yse, Python ctypes, …) subscribe to a bus address
+  *prefix* and receive an (address, value) frame for every publish whose
+  address starts with that prefix — e.g. a "phi.ctl." tap sees every
+  live-coding control verb a script publishes. Multiple taps may be live at
+  once, each with its own callback + user_data.
+
+  This is host-only surface: the script-facing subscribe (`yse.on()`) stays
+  exact-match with no wildcards, per the DSL spec (docs/design/
+  live_coding_dsl.md §"Address grammar"). Prefix matching happens inside the
+  engine's control-thread dispatch, so a tap adds zero audio-thread cost.
+
+  Delivery: the callback fires on the thread that drives yse_system_update()
+  (the control thread). Publishes made on the control thread itself are
+  delivered synchronously inside the publish; publishes from any other thread
+  (audio callback, script thread, timer thread) are queued and delivered
+  during the next yse_system_update() tick.
+
+  Convention (see yse_c_internal.hpp): void functions taking a handle are
+  null-safe no-ops on a NULL handle.
+
+  Self-contained C header: depends only on yse_common.h.
+*/
+
+#ifndef YSE_C_BUS_H_INCLUDED
+#define YSE_C_BUS_H_INCLUDED
+
+#include "yse_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Owned — release with yse_bus_tap_destroy. */
+typedef struct YseBusTap YseBusTap;
+
+/* Payload kind of a bus value. The bus carries five kinds: bang (a valueless
+   trigger, published e.g. by a patcher gSend bang outlet), int, float, string,
+   and float list. Bus int/float are 32-bit. */
+typedef enum YseBusValueKind {
+  YSE_BUS_BANG = 0,
+  YSE_BUS_INT = 1,
+  YSE_BUS_FLOAT = 2,
+  YSE_BUS_STRING = 3,
+  YSE_BUS_LIST = 4
+} YseBusValueKind;
+
+/* Receives one (address, value) frame per matching publish. Exactly one of
+   the payload parameters is meaningful, selected by `kind`:
+
+     YSE_BUS_BANG   — no payload (i, f, str, list are all zero/NULL)
+     YSE_BUS_INT    — `i`
+     YSE_BUS_FLOAT  — `f`
+     YSE_BUS_STRING — `str` (NUL-terminated UTF-8)
+     YSE_BUS_LIST   — `list` + `list_len` (list may be NULL when list_len
+                      is 0)
+
+   `address`, `str` and `list` are owned by the engine and valid ONLY for the
+   duration of the call — copy anything you need to retain before returning.
+   There is no free function (same contract as yse_script_error_cb). */
+typedef void(YSE_C_CALLBACK* yse_bus_tap_cb)(const char* address, YseBusValueKind kind, int i,
+                                             float f, const char* str, const float* list,
+                                             size_t list_len, void* user_data);
+
+/* Subscribe `cb` to every bus publish whose address starts with `prefix`
+   (plain byte-wise prefix match; an empty string matches every address).
+   Returns NULL — with the reason in yse_last_error() — if `prefix` or `cb`
+   is NULL, or if the engine is not initialised: create taps after
+   yse_system_init / yse_system_init_offline.
+
+   Lifecycle: yse_system_close() invalidates every live tap — the engine-side
+   subscription dies with the bus, and no callback fires after close returns.
+   The YseBusTap handle itself stays safe to destroy (before or after a
+   re-init), but it does not reattach: re-create taps after the next init.
+
+   Threading: call create and destroy on the control thread (the one driving
+   yse_system_update()). That guarantees no callback fires after destroy
+   returns. */
+YSE_C_API YseBusTap* yse_bus_tap_create(const char* prefix, yse_bus_tap_cb cb, void* user_data);
+
+/* Unsubscribe and release the tap. Null-safe no-op. */
+YSE_C_API void yse_bus_tap_destroy(YseBusTap* tap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* YSE_C_BUS_H_INCLUDED */

--- a/YseEngine/c_api/yse_bus.cpp
+++ b/YseEngine/c_api/yse_bus.cpp
@@ -1,0 +1,123 @@
+/*
+  yse_bus.cpp — host tap onto the global named bus (issue #389).
+
+  Each tap is an engine-side prefix subscription (INTERNAL::NamedBus::
+  subscribeTap) whose closure captures the host callback + user_data BY VALUE.
+  Nothing is mutable after create — there is no swap API, so the atomic-swap
+  install discipline from yse_c_internal.hpp's callback-bridge rules does not
+  apply here; it governs mutable global callback slots (yse_python.cpp). The
+  closure never dereferences the YseBusTap handle either, so a copied-out
+  dispatch cannot use-after-free a destroyed tap.
+
+  Taps fire from NamedBus::dispatch(), which only ever runs on the control
+  thread (the thread driving yse_system_update(), or a control-thread publish
+  dispatching inline). The audio-thread publish path is untouched, so the
+  no-allocation rule for audio-callback-reachable bridges does not bind —
+  the variant unpacking below may touch heap-backed strings freely.
+
+  Lifecycle: NamedBus dies at System::close(), taking every engine-side tap
+  registration with it. yse_bus_tap_destroy therefore only touches the bus
+  while a session is active; tap handles are process-unique across sessions
+  (namedBus.cpp), so a stale destroy after a re-init is a guaranteed no-op on
+  the new bus.
+*/
+
+#include "yse_c/yse_bus.h"
+
+#include "yse_c_internal.hpp"
+
+#include "../internal/global.h"
+#include "../internal/namedBus.h"
+
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+namespace {
+
+  // Drift guard: YseBusValueKind mirrors the alternative order of the
+  // engine's BusValue variant. There is no engine enum to YSE_ASSERT_ENUM
+  // against, so pin the indices here — reordering the variant (or the C enum)
+  // breaks the build loudly instead of silently mislabeling payloads.
+  using YSE::INTERNAL::BusValue;
+  static_assert(std::variant_size_v<BusValue> == 5,
+                "BusValue gained/lost an alternative — update YseBusValueKind and this bridge");
+  static_assert(std::is_same_v<std::variant_alternative_t<YSE_BUS_BANG, BusValue>, std::monostate>,
+                "YSE_BUS_BANG must index BusValue's monostate alternative");
+  static_assert(std::is_same_v<std::variant_alternative_t<YSE_BUS_INT, BusValue>, int>,
+                "YSE_BUS_INT must index BusValue's int alternative");
+  static_assert(std::is_same_v<std::variant_alternative_t<YSE_BUS_FLOAT, BusValue>, float>,
+                "YSE_BUS_FLOAT must index BusValue's float alternative");
+  static_assert(std::is_same_v<std::variant_alternative_t<YSE_BUS_STRING, BusValue>, std::string>,
+                "YSE_BUS_STRING must index BusValue's string alternative");
+  static_assert(
+      std::is_same_v<std::variant_alternative_t<YSE_BUS_LIST, BusValue>, std::vector<float>>,
+      "YSE_BUS_LIST must index BusValue's list alternative");
+
+  struct YseBusTapImpl {
+    YSE::INTERNAL::TapHandle handle = 0;
+  };
+
+  inline YseBusTapImpl* to_impl(YseBusTap* h) {
+    return reinterpret_cast<YseBusTapImpl*>(h);
+  }
+
+} // namespace
+
+extern "C" {
+
+YSE_C_API YseBusTap* yse_bus_tap_create(const char* prefix, yse_bus_tap_cb cb, void* user_data) {
+  if (prefix == nullptr || cb == nullptr) {
+    yse_c::set_last_error("yse_bus_tap_create: prefix and cb must be non-NULL");
+    return nullptr;
+  }
+  if (!YSE::INTERNAL::Global().isActive()) {
+    yse_c::set_last_error("yse_bus_tap_create: engine not initialised — create taps after "
+                          "yse_system_init / yse_system_init_offline");
+    return nullptr;
+  }
+  try {
+    auto* impl = new YseBusTapImpl;
+    impl->handle = YSE::INTERNAL::Bus().subscribeTap(
+        prefix, [cb, user_data](const std::string& name, const BusValue& value) {
+          // Everything handed to the host is engine-owned and valid only for
+          // this call — the header tells the host to copy before returning.
+          if (const int* ip = std::get_if<int>(&value)) {
+            cb(name.c_str(), YSE_BUS_INT, *ip, 0.0f, nullptr, nullptr, 0, user_data);
+          } else if (const float* fp = std::get_if<float>(&value)) {
+            cb(name.c_str(), YSE_BUS_FLOAT, 0, *fp, nullptr, nullptr, 0, user_data);
+          } else if (const std::string* sp = std::get_if<std::string>(&value)) {
+            cb(name.c_str(), YSE_BUS_STRING, 0, 0.0f, sp->c_str(), nullptr, 0, user_data);
+          } else if (const std::vector<float>* lp = std::get_if<std::vector<float>>(&value)) {
+            cb(name.c_str(), YSE_BUS_LIST, 0, 0.0f, nullptr, lp->data(), lp->size(), user_data);
+          } else {
+            // monostate — a bang (e.g. patcher gSend bang outlet).
+            cb(name.c_str(), YSE_BUS_BANG, 0, 0.0f, nullptr, nullptr, 0, user_data);
+          }
+        });
+    return reinterpret_cast<YseBusTap*>(impl);
+  } catch (const std::exception& e) {
+    yse_c::set_last_error(e.what());
+    return nullptr;
+  } catch (...) {
+    yse_c::set_last_error("yse_bus_tap_create: unknown C++ exception");
+    return nullptr;
+  }
+}
+
+YSE_C_API void yse_bus_tap_destroy(YseBusTap* tap) {
+  if (tap == nullptr) return;
+  YseBusTapImpl* impl = to_impl(tap);
+  // Only touch the bus while a session is active: yse_system_close() already
+  // tore the engine-side registration down with the bus. Handles are
+  // process-unique, so after a close + re-init this unsubscribe of a stale
+  // handle is a safe no-op on the new bus.
+  if (YSE::INTERNAL::Global().isActive()) {
+    YSE::INTERNAL::Bus().unsubscribeTap(impl->handle);
+  }
+  delete impl;
+}
+
+} // extern "C"

--- a/YseEngine/internal/namedBus.cpp
+++ b/YseEngine/internal/namedBus.cpp
@@ -25,6 +25,15 @@ namespace YSE {
       // producerQueue().
       std::atomic<std::uint64_t> g_busGeneration{0};
 
+      // Tap handles (issue #389) draw from a process-global counter rather
+      // than a per-bus one: a host-held tap handle can outlive the bus it was
+      // registered on (engine close/re-init), and per-bus numbering would let
+      // the next session's bus hand out the same value again — a stale
+      // unsubscribeTap() would then silently drop somebody else's live tap.
+      // Process-global numbering makes a stale handle permanently unknown, so
+      // unsubscribeTap() on it is a guaranteed no-op.
+      std::atomic<std::uint64_t> g_tapHandleCounter{0};
+
       // Per-thread slot into the current bus's queue pool. `generation` marks
       // which bus instance `index` was claimed against; a mismatch means this
       // thread has not yet claimed a slot on the live bus.
@@ -158,6 +167,20 @@ namespace YSE {
       handleIndex_.erase(idxIt);
     }
 
+    TapHandle NamedBus::subscribeTap(const std::string& prefix, TapSubscriber callback) {
+      const TapHandle handle = g_tapHandleCounter.fetch_add(1, std::memory_order_relaxed) + 1;
+      std::unique_lock lock(subsMutex_);
+      taps_.push_back(TapSubscription{handle, prefix, std::move(callback)});
+      return handle;
+    }
+
+    void NamedBus::unsubscribeTap(TapHandle handle) {
+      std::unique_lock lock(subsMutex_);
+      taps_.erase(std::remove_if(taps_.begin(), taps_.end(),
+                                 [handle](const TapSubscription& t) { return t.handle == handle; }),
+                  taps_.end());
+    }
+
     void NamedBus::drainPending() {
       // Drain every producer queue. Each is single-consumer (only this call
       // pops), so touching them all from the update thread is race-free. Empty
@@ -197,19 +220,36 @@ namespace YSE {
     void NamedBus::dispatch(const std::string& name, const BusValue& value) {
       // Copy out the matching callbacks under the shared lock, then invoke
       // them with the lock released. This lets a subscriber call back into
-      // subscribe()/unsubscribe() without self-deadlock.
+      // subscribe()/unsubscribe() without self-deadlock. When nothing matches
+      // (the common case for an unsubscribed name with no taps registered)
+      // neither vector allocates — the no-subscriber publish path stays
+      // allocation-free (pinned by the alloc-probe test).
       std::vector<Subscriber> callbacks;
+      std::vector<TapSubscriber> tapCallbacks;
       {
         std::shared_lock lock(subsMutex_);
         auto it = subs_.find(name);
-        if (it == subs_.end()) return;
-        callbacks.reserve(it->second.size());
-        for (const auto& sub : it->second) {
-          callbacks.push_back(sub.callback);
+        if (it != subs_.end()) {
+          callbacks.reserve(it->second.size());
+          for (const auto& sub : it->second) {
+            callbacks.push_back(sub.callback);
+          }
+        }
+        // Prefix taps (issue #389). Linear scan — the tap count is a handful
+        // of host-registered prefixes. dispatch() only ever runs on the
+        // control thread, so this costs the audio path nothing.
+        for (const auto& tap : taps_) {
+          if (name.size() >= tap.prefix.size() &&
+              name.compare(0, tap.prefix.size(), tap.prefix) == 0) {
+            tapCallbacks.push_back(tap.callback);
+          }
         }
       }
       for (auto& cb : callbacks) {
         cb(value);
+      }
+      for (auto& cb : tapCallbacks) {
+        cb(name, value);
       }
     }
 

--- a/YseEngine/internal/namedBus.h
+++ b/YseEngine/internal/namedBus.h
@@ -40,6 +40,8 @@ namespace YSE {
     using BusValue = std::variant<std::monostate, int, float, std::string, std::vector<float>>;
     using SubHandle = std::uint64_t;
     using Subscriber = std::function<void(const BusValue&)>;
+    using TapHandle = std::uint64_t;
+    using TapSubscriber = std::function<void(const std::string& name, const BusValue&)>;
 
     class NamedBus {
     public:
@@ -87,6 +89,24 @@ namespace YSE {
       // unknown (e.g. already unsubscribed, or never issued).
       void unsubscribe(SubHandle handle);
 
+      // Register a prefix tap (issue #389): `callback` receives every dispatch
+      // whose name starts with `prefix` (plain byte-wise prefix — an empty
+      // prefix matches everything), together with the full name. Taps run on
+      // the control thread only, from dispatch(), after the exact-match
+      // subscribers for the name — the T_DSP publish path is untouched, so a
+      // tap adds zero audio-thread cost. Matching is a linear scan over the
+      // registered taps; callers register a handful of prefixes, not
+      // thousands. Tap handles are unique across every bus instance in the
+      // process (the counter is process-global), so a handle that outlives an
+      // engine restart can never alias a registration on the next session's
+      // bus — unsubscribeTap() on such a stale handle is a safe no-op. This
+      // backs the C API contract that host taps are invalidated by
+      // System::close() (c_api/yse_bus.cpp).
+      TapHandle subscribeTap(const std::string& prefix, TapSubscriber callback);
+
+      // Drop the tap that owns `handle`. No-op if the handle is unknown.
+      void unsubscribeTap(TapHandle handle);
+
       // Drain the audio-thread queue and dispatch each message. Must run on
       // the same thread that registers subscribers (main / update thread).
       // Called once per `system::update()` tick.
@@ -109,6 +129,12 @@ namespace YSE {
       struct Subscription {
         SubHandle handle;
         Subscriber callback;
+      };
+
+      struct TapSubscription {
+        TapHandle handle;
+        std::string prefix;
+        TapSubscriber callback;
       };
 
       void dispatch(const std::string& name, const BusValue& value);
@@ -165,6 +191,11 @@ namespace YSE {
       mutable std::shared_mutex subsMutex_;
       std::unordered_map<std::string, std::vector<Subscription>> subs_;
       std::unordered_map<SubHandle, std::string> handleIndex_;
+      // Prefix taps (issue #389), guarded by subsMutex_ like subs_. Kept in a
+      // flat vector: dispatch() scans it linearly, and the registered-tap
+      // count is expected to stay tiny (a host subscribes a handful of
+      // prefixes).
+      std::vector<TapSubscription> taps_;
       std::atomic<SubHandle> nextHandle_{1};
     };
 

--- a/docs/design/live_coding_dsl.md
+++ b/docs/design/live_coding_dsl.md
@@ -107,6 +107,15 @@ for these addresses.
 by that object. All are matched exact-string — case-sensitive, no
 globbing, no wildcards.
 
+> **Host tap.** The exact-match rule governs the *script-facing*
+> subscribe surface (`yse.on()`). The **host** additionally has a C API
+> tap — `yse_bus_tap_create` in `c_api/include/yse_c/yse_bus.h`
+> ([#389][gh-389]) — that subscribes to a bus address *prefix* and
+> receives every publish whose address starts with it (e.g. a
+> `phi.ctl.` tap for the live-coding control plane). That is host-only
+> plumbing, matched on the control thread; it does not add globbing or
+> wildcards to the DSL.
+
 The set of valid `<prop>`, `<slot>` and `<event>` names is fixed by
 the engine (see [#123][gh-123] for the initial sound/channel
 properties: `volume`, `speed`, `position`; see [#122][gh-122] for
@@ -837,3 +846,4 @@ sections wrong, update this document in the same PR.
 [gh-126]: https://github.com/yvanvds/yse-soundengine/issues/126
 [gh-127]: https://github.com/yvanvds/yse-soundengine/issues/127
 [gh-388]: https://github.com/yvanvds/yse-soundengine/issues/388
+[gh-389]: https://github.com/yvanvds/yse-soundengine/issues/389


### PR DESCRIPTION
## Summary

Adds the one blocking engine dependency for the Phi live-coding epic: a C API
that lets the host subscribe to a bus address *prefix* and receive
`(address, value)` frames for every matching publish.

New public C surface (`c_api/include/yse_c/yse_bus.h`):

- `YseBusTap` — opaque owned handle (`yse_bus_tap_create` / `yse_bus_tap_destroy`)
- `YseBusValueKind` — five kinds incl. `YSE_BUS_BANG` (monostate, e.g. patcher `gSend` bang), pinned to the `BusValue` variant order by static_asserts
- `yse_bus_tap_cb` — `YSE_C_CALLBACK` typedef; `address` / `str` / `list` are engine-owned and valid only for the duration of the call (no free function, same contract as `yse_script_error_cb`)

Engine side: `INTERNAL::NamedBus::subscribeTap()` / `unsubscribeTap()`, matched
as a linear prefix scan inside `dispatch()` **on the control thread** — the
`T_DSP` publish path is untouched, so taps add zero audio-thread cost, and the
no-subscriber publish path stays allocation-free (pinned by the existing
alloc-probe test). Delivery falls out of the existing design: callbacks fire on
the thread driving `yse_system_update()`; control-thread publishes dispatch
synchronously.

Lifecycle contract (documented in the header): taps are invalidated by
`yse_system_close()`; the host re-creates them after the next init. Tap handles
are process-unique across sessions, so a stale destroy after a re-init is a
guaranteed no-op on the new bus.

The DSL spec gains a short "host tap" note so the script-facing exact-match
rule (`yse.on()`, no globbing/wildcards) isn't conflated with this host-only
surface.

## Linked issue

Closes #389

## Changes

- `YseEngine/internal/namedBus.{h,cpp}` — prefix taps: `TapHandle` / `TapSubscriber` / `subscribeTap` / `unsubscribeTap`, tap scan in `dispatch()`, process-global tap-handle counter
- `YseEngine/c_api/include/yse_c/yse_bus.h` + `yse_bus.cpp` — new module (ownership comment, null-safe semantics, variant-order drift guards), registered in `c_api/CMakeLists.txt` and `yse_all.h`
- `Tests/system/test_named_bus.cpp` — 4 engine-level tap cases (prefix matching incl. no-exact-subscriber names, all five payload kinds, coexistence with exact subs + empty-prefix tap, T_DSP/deferred delivery via `drainPending()`)
- `Tests/system/test_c_api_bus.cpp` — new `buscapi` suite: 5 cases through the flat C ABI (pre-init/NULL failure paths, five kinds with call-time copies, multi-tap prefix filtering, delivery via `yse_system_update()`, close-invalidation + re-init)
- `Tests/CMakeLists.txt` — `yse_tests_buscapi` isolated ctest entry (drives `yse_system_close()`, #298-style isolation), excluded from the monolithic run
- `docs/design/live_coding_dsl.md` — "host tap" note in §Address grammar

## Test plan

- [x] `python yse.py format` — clang-format 22.1.4, no drift beyond this branch's files
- [x] `python yse.py analyze` on all four touched TUs (`namedBus.cpp`, `yse_bus.cpp`, both test TUs) — zero new user-code findings
- [x] `python yse.py build` — debug preset clean, no new warnings
- [x] `python yse.py test` — 34/34 CTest entries pass, incl. the new `yse_tests_buscapi` (5 cases / 46 assertions) and the extended system suite (4 new tap cases / 23 assertions)
- No integration/e2e beyond the above: the change is not user-visible in an app flow — it is host-FFI surface, and the `buscapi` suite already exercises it end-to-end through the flat C ABI against a live offline engine incl. the close/re-init lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)