### PR TITLE
c-api: channel + note-range parameters on VA/FM/sampler voice builders

### DIFF
--- a/Tests/synth/test_c_api_instrument.cpp
+++ b/Tests/synth/test_c_api_instrument.cpp
@@ -158,9 +158,9 @@ TEST_SUITE("instrumentcapi") {
     yse_dx7_destroy(nullptr);
 
     // add-voices reject NULL / invalid arguments.
-    CHECK(yse_synth_add_voices_sampler(nullptr, nullptr, 4) == YSE_ERR_INVALID_HANDLE);
-    CHECK(yse_synth_add_voices_va(nullptr, 4) == YSE_ERR_INVALID_HANDLE);
-    CHECK(yse_synth_add_voices_fm(nullptr, 4) == YSE_ERR_INVALID_HANDLE);
+    CHECK(yse_synth_add_voices_sampler(nullptr, nullptr, 4, 0, 0, 127) == YSE_ERR_INVALID_HANDLE);
+    CHECK(yse_synth_add_voices_va(nullptr, 4, 0, 0, 127) == YSE_ERR_INVALID_HANDLE);
+    CHECK(yse_synth_add_voices_fm(nullptr, 4, 0, 0, 127) == YSE_ERR_INVALID_HANDLE);
     CHECK(yse_synth_fm_set_patch(nullptr, nullptr, 0) == YSE_ERR_INVALID_HANDLE);
 
     // Every VA + FM setter is a null-safe no-op on a NULL synth.
@@ -255,7 +255,7 @@ TEST_SUITE("instrumentcapi") {
 
     YseSynth* syn = yse_synth_create();
     REQUIRE(syn != nullptr);
-    CHECK(yse_synth_add_voices_sampler(syn, inst, 4) == YSE_ERR_INVALID_ARGUMENT);
+    CHECK(yse_synth_add_voices_sampler(syn, inst, 4, 0, 0, 127) == YSE_ERR_INVALID_ARGUMENT);
     yse_synth_destroy(syn);
   }
 
@@ -274,7 +274,7 @@ TEST_SUITE("instrumentcapi") {
 
     YseSynth* syn = yse_synth_create();
     REQUIRE(syn != nullptr);
-    REQUIRE(yse_synth_add_voices_sampler(syn, inst, 4) == YSE_OK);
+    REQUIRE(yse_synth_add_voices_sampler(syn, inst, 4, 0, 0, 127) == YSE_OK);
     // The voice group retains its own share — safe to drop the handle now.
     yse_sfz_destroy(inst);
 
@@ -311,7 +311,9 @@ TEST_SUITE("instrumentcapi") {
 
     YseSynth* syn = yse_synth_create();
     REQUIRE(syn != nullptr);
-    REQUIRE(yse_synth_add_voices_va(syn, 6) == YSE_OK);
+    // Channel 1 with the full key range — the notes below play on channel 1, so
+    // this also exercises the #390 channel window through a real render.
+    REQUIRE(yse_synth_add_voices_va(syn, 6, 1, 0, 127) == YSE_OK);
 
     // PARITY: exercise every vaParams field through its C setter. Setters are
     // glitch-free atomics, so this may run before or during play.
@@ -401,7 +403,7 @@ TEST_SUITE("instrumentcapi") {
 
     YseSynth* syn = yse_synth_create();
     REQUIRE(syn != nullptr);
-    REQUIRE(yse_synth_add_voices_fm(syn, 4) == YSE_OK);
+    REQUIRE(yse_synth_add_voices_fm(syn, 4, 0, 0, 127) == YSE_OK);
 
     // Select the imported patch — the way the full 155-parameter DX7 voice is
     // reached from C. Out-of-range / destroyed-bank guards return errors.

--- a/YseEngine/c_api/include/yse_c/yse_synth.h
+++ b/YseEngine/c_api/include/yse_c/yse_synth.h
@@ -132,13 +132,17 @@ YSE_C_API YseStatus yse_synth_add_voices_sine(YseSynth* h, int num_voices, int c
                                               int lowest_note, int highest_note, float attack,
                                               float decay, float sustain, float release);
 
-/* ─── instrument voice groups (issue #178) ────────────────────────────────
+/* ─── instrument voice groups (issues #178, #390) ─────────────────────────
    Each adds `num_voices` clones of the named built-in instrument voice,
-   responding omni (all channels) across the full key range — the SFZ regions /
-   patch decide how a note actually sounds. Like add_voices_sine, they must be
-   called BEFORE the synth is played; adding voices after the pool is built is
-   rejected. Return YseStatus; on failure yse_last_error() is set and no group
-   is added. */
+   responding to note numbers in [lowest_note, highest_note] on `channel`
+   (0 = omni), mirroring YSE::synth::addVoices 1:1 — C has no default
+   arguments, so pass 0, 0, 127 for the historical omni / full-key-range
+   behaviour. The channel + note-range window is the voice group's allocation
+   filter; within that window the SFZ regions / patch still decide how a note
+   actually sounds. Like add_voices_sine, they may be called several times to
+   build layered, split, or multitimbral pools, and must be called BEFORE the
+   synth is played; adding voices after the pool is built is rejected. Return
+   YseStatus; on failure yse_last_error() is set and no group is added. */
 
 /* Add a group of SFZ sampler voices rendering `instrument` (loaded via
    yse_sfz_load / yse_sfz_load_config). The instrument's region table and PCM
@@ -146,19 +150,22 @@ YSE_C_API YseStatus yse_synth_add_voices_sine(YseSynth* h, int num_voices, int c
    YseSfzInstrument handle may be destroyed right after this returns.
    YSE_ERR_INVALID_ARGUMENT if `instrument` is NULL or already destroyed. */
 YSE_C_API YseStatus yse_synth_add_voices_sampler(YseSynth* h, YseSfzInstrument* instrument,
-                                                 int num_voices);
+                                                 int num_voices, int channel, int lowest_note,
+                                                 int highest_note);
 
 /* Add a group of virtual-analog + wavetable voices with a fresh default patch.
    This establishes the synth's VA patch; the yse_synth_va_set_* setters below
    steer it. Call once per synth (a second call replaces which patch the setters
    target — layering multiple VA groups is out of scope for the C API). */
-YSE_C_API YseStatus yse_synth_add_voices_va(YseSynth* h, int num_voices);
+YSE_C_API YseStatus yse_synth_add_voices_va(YseSynth* h, int num_voices, int channel,
+                                            int lowest_note, int highest_note);
 
 /* Add a group of DX7-class 6-operator FM voices with the built-in sine test
    patch. This establishes the synth's FM patch; select a DX7 voice into it with
    yse_synth_fm_set_patch, or dial the headline params with yse_synth_fm_set_*.
    Call once per synth (see add_voices_va's note). */
-YSE_C_API YseStatus yse_synth_add_voices_fm(YseSynth* h, int num_voices);
+YSE_C_API YseStatus yse_synth_add_voices_fm(YseSynth* h, int num_voices, int channel,
+                                            int lowest_note, int highest_note);
 
 /* ─── VA patch parameters (issue #178) ─────────────────────────────────────
    Steer the synth's VA patch (established by yse_synth_add_voices_va). Every

--- a/YseEngine/c_api/yse_synth.cpp
+++ b/YseEngine/c_api/yse_synth.cpp
@@ -139,7 +139,8 @@ YSE_C_API YseStatus yse_synth_add_voices_sine(YseSynth* h, int num_voices, int c
 // ─── instrument voice groups (issue #178) ──────────────────────────────
 
 YSE_C_API YseStatus yse_synth_add_voices_sampler(YseSynth* h, YseSfzInstrument* instrument,
-                                                 int num_voices) {
+                                                 int num_voices, int channel, int lowest_note,
+                                                 int highest_note) {
   if (!h) return YSE_ERR_INVALID_HANDLE;
   if (num_voices <= 0) return YSE_ERR_INVALID_ARGUMENT;
   // Validated against the instrument-handle registry; a NULL / destroyed handle
@@ -155,7 +156,7 @@ YSE_C_API YseStatus yse_synth_add_voices_sampler(YseSynth* h, YseSfzInstrument* 
     proto->setInstrument(inst);
     YSE::SYNTH::dspVoice* raw = proto.get();
     impl->prototypes.push_back(std::move(proto));
-    impl->synth.addVoices(*raw, num_voices, 0, 0, 127);
+    impl->synth.addVoices(*raw, num_voices, channel, lowest_note, highest_note);
     return YSE_OK;
   } catch (const std::exception& e) {
     yse_c::set_last_error(e.what());
@@ -166,7 +167,8 @@ YSE_C_API YseStatus yse_synth_add_voices_sampler(YseSynth* h, YseSfzInstrument* 
   }
 }
 
-YSE_C_API YseStatus yse_synth_add_voices_va(YseSynth* h, int num_voices) {
+YSE_C_API YseStatus yse_synth_add_voices_va(YseSynth* h, int num_voices, int channel,
+                                            int lowest_note, int highest_note) {
   if (!h) return YSE_ERR_INVALID_HANDLE;
   if (num_voices <= 0) return YSE_ERR_INVALID_ARGUMENT;
   try {
@@ -177,7 +179,7 @@ YSE_C_API YseStatus yse_synth_add_voices_va(YseSynth* h, int num_voices) {
     impl->vaPatch = proto->patch();
     YSE::SYNTH::dspVoice* raw = proto.get();
     impl->prototypes.push_back(std::move(proto));
-    impl->synth.addVoices(*raw, num_voices, 0, 0, 127);
+    impl->synth.addVoices(*raw, num_voices, channel, lowest_note, highest_note);
     return YSE_OK;
   } catch (const std::exception& e) {
     yse_c::set_last_error(e.what());
@@ -188,7 +190,8 @@ YSE_C_API YseStatus yse_synth_add_voices_va(YseSynth* h, int num_voices) {
   }
 }
 
-YSE_C_API YseStatus yse_synth_add_voices_fm(YseSynth* h, int num_voices) {
+YSE_C_API YseStatus yse_synth_add_voices_fm(YseSynth* h, int num_voices, int channel,
+                                            int lowest_note, int highest_note) {
   if (!h) return YSE_ERR_INVALID_HANDLE;
   if (num_voices <= 0) return YSE_ERR_INVALID_ARGUMENT;
   try {
@@ -197,7 +200,7 @@ YSE_C_API YseStatus yse_synth_add_voices_fm(YseSynth* h, int num_voices) {
     impl->fmPatch = proto->patch();
     YSE::SYNTH::dspVoice* raw = proto.get();
     impl->prototypes.push_back(std::move(proto));
-    impl->synth.addVoices(*raw, num_voices, 0, 0, 127);
+    impl->synth.addVoices(*raw, num_voices, channel, lowest_note, highest_note);
     return YSE_OK;
   } catch (const std::exception& e) {
     yse_c::set_last_error(e.what());


### PR DESCRIPTION
## Summary

Mirrors the C++ `synth::addVoices` signature 1:1 on the three instrument voice builders. `yse_synth_add_voices_va` / `_fm` / `_sampler` each gain `int channel, int lowest_note, int highest_note` instead of hard-coding `0, 0, 127`, so VA/FM/sampler pools can be built with a MIDI-channel filter and key window — enabling multitimbral setups and key splits, restoring parity with `yse_synth_add_voices_sine`.

Pure C-API plumbing per the revised issue: the engine's `voiceGroup` already does per-channel / note-window allocation for every voice type — no engine change, no new filtering code. Breaking ABI change in place (no `_ex` variants), accepted per the issue's ABI note (in-house consumers only; dart-yse regenerates via ffigen and threads the new parameters in dart-yse #41).

## Linked issue

Closes #390

## Changes

- `YseEngine/c_api/include/yse_c/yse_synth.h` — the three declarations gain `channel, lowest_note, highest_note`; section doc block rewritten (the "responding omni (all channels) across the full key range" wording no longer holds; pass `0, 0, 127` for the historical behaviour; SFZ regions / patch still decide how a note sounds within the group's window).
- `YseEngine/c_api/yse_synth.cpp` — the three builders pass the parameters through to `synth::addVoices` instead of `0, 0, 127`.
- `Tests/synth/test_c_api_instrument.cpp` — all callers updated to the new signatures; the VA render test now builds its pool on channel 1 (notes play on channel 1) so the channel window is exercised through a real offline render.

## Test plan

- [x] `python yse.py format` — repo clean, only the three touched files changed
- [x] `python yse.py analyze` on `yse_synth.cpp` and `test_c_api_instrument.cpp` — no new findings (0 displayed warnings in both)
- [x] `python yse.py build` — debug preset green, no new warnings
- [x] `python yse.py test` — 34/34 CTest entries pass (100%), including the updated `instrumentcapi` suite
- Integration-level coverage: the `instrumentcapi` suite drives the change end-to-end through the flat C ABI against the real engine rendered offline (voice cloning, note-on, render, teardown); no separate e2e layer exists for this library beyond that suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)