### PR TITLE
dsp: support detaching a chain edge — unlink() / link NULL (#391)

### DIFF
--- a/Tests/channel/test_c_api_channel.cpp
+++ b/Tests/channel/test_c_api_channel.cpp
@@ -436,6 +436,80 @@ TEST_SUITE("channelcapi") {
     CHECK(yse_dsp_patcher_insert_create(nullptr) == nullptr);
   }
 
+  // ─── forward-edge detach + live restructure pattern (#391) ───────────────────
+
+  // yse_dsp_object_link(head, NULL) detaches the forward edge (it used to be a
+  // silent no-op). This drives the exact restructure sequence the header
+  // documents — detach the chain from its owner, unlink, re-link in the new
+  // order, re-attach — entirely through the flat C ABI against a live offline
+  // render. If the NULL call regressed to a no-op, the stale forward edges
+  // would survive the rebuild and close a cycle in the chain walk, so the
+  // render below would never return (caught by the suite's ctest timeout).
+  // The precise pointer semantics are asserted engine-side in
+  // test_channel_dsp.cpp.
+  TEST_CASE("c-api dsp: link NULL detaches; live chain restructure stays safe (#391)") {
+    REQUIRE(ensureOffline());
+
+    YseChannel* ch = yse_channel_create("capi_unlink", yse_channel_master());
+    REQUIRE(ch != nullptr);
+
+    // A three-module insert chain: eq1 -> eq2 -> eq3.
+    YseDspObject* eq1 = yse_dsp_eq_create();
+    YseDspObject* eq2 = yse_dsp_eq_create();
+    YseDspObject* eq3 = yse_dsp_eq_create();
+    REQUIRE(eq1 != nullptr);
+    REQUIRE(eq2 != nullptr);
+    REQUIRE(eq3 != nullptr);
+    yse_dsp_object_link(eq1, eq2);
+    yse_dsp_object_link(eq2, eq3);
+    yse_channel_set_dsp(ch, eq1);
+    CHECK(yse_channel_get_dsp(ch) == eq1);
+
+    // Render a real tone through the chain.
+    pump();
+    YseDspBuffer* tone = makeToneBuffer();
+    REQUIRE(tone != nullptr);
+    YseSound* snd = yse_sound_create();
+    REQUIRE(snd != nullptr);
+    REQUIRE(yse_sound_load_buffer(snd, tone, ch, /*loop*/ 1, /*volume*/ 1.0f) == YSE_OK);
+    pump();
+    yse_sound_play(snd);
+    pump();
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(ch)));
+
+    // Documented RT-safe restructure: detach from the owner (pointer swap on
+    // the audio thread), clear the stale forward edges, rebuild as
+    // eq1 -> eq3 -> eq2, then re-attach the head.
+    yse_channel_set_dsp(ch, nullptr);
+    pump();
+    yse_dsp_object_link(eq1, nullptr); // detach eq1 -> eq2
+    yse_dsp_object_link(eq2, nullptr); // detach eq2 -> eq3
+    yse_dsp_object_link(eq1, eq3);
+    yse_dsp_object_link(eq3, eq2); // new order: eq1 -> eq3 -> eq2
+    yse_channel_set_dsp(ch, eq1);
+    CHECK(yse_channel_get_dsp(ch) == eq1);
+
+    // The rebuilt chain renders block after block: a stale-edge cycle would
+    // never return from the walk.
+    pump();
+    for (int i = 0; i < 8; ++i)
+      yse_system_render_offline(yse_system_get(), 16);
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(ch)));
+    CHECK(std::isfinite(yse_channel_get_peak_linear_post(yse_channel_master())));
+
+    // Tear down in the usual order.
+    yse_sound_stop(snd);
+    pump();
+    yse_channel_set_dsp(ch, nullptr);
+    yse_sound_destroy(snd);
+    yse_channel_destroy(ch);
+    pump();
+    yse_dsp_object_destroy(eq3);
+    yse_dsp_object_destroy(eq2);
+    yse_dsp_object_destroy(eq1);
+    yse_dsp_buffer_destroy(tone);
+  }
+
   // Module setters/getters are null-safe like the rest of the module surface.
   TEST_CASE("c-api dsp: new module setters/getters are null-safe") {
     yse_dsp_feedback_delay_set_time(nullptr, 1.f);

--- a/Tests/channel/test_channel_dsp.cpp
+++ b/Tests/channel/test_channel_dsp.cpp
@@ -10,6 +10,10 @@
 //     (#298): replacing clears the old plugin's back-reference, detaching with
 //     nullptr severs it, and a plugin destroyed before the channel nulls the
 //     impl's insert_dsp instead of leaving it dangling.
+//   - dspObject::unlink() (#391) detaches the forward edge: clears `next` and
+//     the detached neighbour's `previous`, leaves `calledfrom` alone, enables
+//     in-place chain reorder without stale-edge cycles, and the C ABI's
+//     yse_dsp_object_link(head, NULL) dispatches to it instead of no-oping.
 //   - Interface-level setDSP()/getDSP() round-trip on a live channel.
 //
 // The behavioural cases drive CHANNEL::implementationObject directly (the same
@@ -30,6 +34,7 @@
 #include "sound/soundManager.h"
 #include "internal/time.h"
 #include "support/null_device.hpp"
+#include "yse_c/yse_dsp_modules.h"
 
 namespace {
   // A minimal N-channel-aware insert module: multiplies every sample of every
@@ -238,6 +243,119 @@ TEST_SUITE("channel") {
     fill(bufs, 0.5f);
     impl.processInsertDSP();
     CHECK(allEqual(bufs, 0.5f));
+  }
+
+  // ─── Forward-edge detach: dspObject::unlink (#391) ─────────────────────────
+
+  TEST_CASE("channel dsp: unlink detaches the forward edge and is a no-op when unlinked") {
+    if (!TestHelpers::engineInit()) return;
+    GainDsp a(2.0f);
+    GainDsp b(3.0f);
+    a.link(b);
+    REQUIRE(a.link() == &b);
+
+    a.unlink();
+    CHECK(a.link() == nullptr);
+
+    a.unlink(); // nothing linked -> safe no-op
+    CHECK(a.link() == nullptr);
+  }
+
+  TEST_CASE("channel dsp: unlink clears the detached neighbour's previous back-pointer") {
+    if (!TestHelpers::engineInit()) return;
+    GainDsp a(2.0f);
+    GainDsp c(4.0f);
+    {
+      GainDsp b(3.0f);
+      a.link(b);
+      a.unlink(); // must clear b.previous, not just a.next
+      a.link(c); // a -> c
+    } // ~b with a stale previous would run previous->next = b.next, severing a -> c
+    CHECK(a.link() == &c);
+  }
+
+  TEST_CASE("channel dsp: unlink leaves calledfrom untouched") {
+    if (!TestHelpers::engineInit()) return;
+    GainDsp a(2.0f);
+    GainDsp b(3.0f);
+    YSE::DSP::dspObject* slot = &a; // stand-in for an owner's insert_dsp slot
+    a.calledfrom = &slot;
+    a.link(b);
+
+    a.unlink();
+    CHECK(a.calledfrom == &slot); // attachment back-reference is not unlink's job
+    CHECK(slot == &a);
+
+    a.calledfrom = nullptr; // detach before ~a so the stack slot isn't written
+  }
+
+  TEST_CASE("channel dsp: unlink enables in-place reorder without a stale-edge cycle") {
+    if (!TestHelpers::engineInit()) return;
+    GainDsp a(2.0f);
+    GainDsp b(3.0f);
+    GainDsp c(4.0f);
+    a.link(b);
+    b.link(c); // a -> b -> c
+    REQUIRE(a.link() == &b);
+    REQUIRE(b.link() == &c);
+
+    // A naive a.link(c) here would splice to a -> c -> b but leave b.next
+    // aimed at c, closing the walk cycle a -> c -> b -> c -> ... (#391).
+    // Clear the stale forward edges first, then rebuild the new order.
+    a.unlink();
+    b.unlink();
+    a.link(c);
+    c.link(b); // a -> c -> b
+    CHECK(a.link() == &c);
+    CHECK(c.link() == &b);
+    CHECK(b.link() == nullptr); // the tail terminates -> no cycle
+  }
+
+  TEST_CASE("channel dsp: unlink shortens an attached insert chain") {
+    if (!TestHelpers::engineInit()) return;
+    YSE::CHANNEL::implementationObject impl(nullptr);
+    primeImpl(impl);
+    auto& bufs = impl.GetBuffers();
+    REQUIRE(bufs.size() > 0);
+
+    GainDsp a(2.0f);
+    GainDsp b(3.0f);
+    a.link(b); // chain: a -> b
+    attach(impl, &a);
+    fill(bufs, 0.1f);
+    impl.processInsertDSP();
+    CHECK(allEqual(bufs, 0.6f)); // 0.1 * 2 * 3: both ran
+
+    a.unlink(); // drop b; a stays attached to the channel
+    fill(bufs, 0.1f);
+    impl.processInsertDSP();
+    CHECK(allEqual(bufs, 0.2f)); // 0.1 * 2: only a runs now
+  }
+
+  TEST_CASE("channel dsp: C ABI yse_dsp_object_link(head, NULL) detaches, not no-ops") {
+    if (!TestHelpers::engineInit()) return;
+    // The flat C ABI has no chain getter, so observe through the engine
+    // object — the same reinterpret_cast the C API implementation uses.
+    YseDspObject* a = yse_dsp_lowpass_create();
+    YseDspObject* b = yse_dsp_highpass_create();
+    REQUIRE(a != nullptr);
+    REQUIRE(b != nullptr);
+    auto* aCpp = reinterpret_cast<YSE::DSP::dspObject*>(a);
+    auto* bCpp = reinterpret_cast<YSE::DSP::dspObject*>(b);
+
+    yse_dsp_object_link(a, b);
+    REQUIRE(aCpp->link() == bCpp);
+
+    yse_dsp_object_link(a, nullptr); // detach the forward edge (#391)
+    CHECK(aCpp->link() == nullptr);
+
+    // A NULL head stays a null-safe no-op, with or without a next.
+    yse_dsp_object_link(nullptr, b);
+    yse_dsp_object_link(nullptr, nullptr);
+    CHECK(aCpp->link() == nullptr);
+
+    yse_dsp_object_destroy(b);
+    yse_dsp_object_destroy(a);
   }
 
   // ─── Interface-level API round-trip ────────────────────────────────────────

--- a/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
+++ b/YseEngine/c_api/include/yse_c/yse_dsp_modules.h
@@ -80,6 +80,21 @@ YSE_C_API void yse_dsp_object_set_lfo_type(YseDspObject* obj, YseLfoType type);
 YSE_C_API YseLfoType yse_dsp_object_get_lfo_type(YseDspObject* obj);
 YSE_C_API void yse_dsp_object_set_lfo_frequency(YseDspObject* obj, float value);
 YSE_C_API float yse_dsp_object_get_lfo_frequency(YseDspObject* obj);
+
+/* Insert `next` after `head` in a processing chain (dspObject::link): with
+   head->X already linked, the result is head->next->X. Pass NULL as `next` to
+   detach the forward edge instead (dspObject::unlink, #391): head's next
+   pointer is cleared and the detached neighbour's back-pointer severed, so the
+   neighbour becomes a standalone chain again. Detaching never touches head's
+   own attachment to a sound/channel (that is yse_sound_set_dsp /
+   yse_channel_set_dsp territory).
+   RT-safety: the audio thread walks these links lock-free every block. To
+   restructure a chain attached to a live sound or channel, detach the chain
+   from its owner first (yse_channel_set_dsp(ch, NULL) / yse_sound_set_dsp(s,
+   NULL) — a pointer swap applied on the audio thread), re-link the objects
+   into the new order, then re-attach the new head. That keeps the audio
+   thread from ever observing a half-rewired chain; effect DSP state survives
+   because the objects themselves are untouched. */
 YSE_C_API void yse_dsp_object_link(YseDspObject* head, YseDspObject* next);
 
 /* ─── filter modules ─────────────────────────────────────────────────── */

--- a/YseEngine/c_api/yse_dsp_modules.cpp
+++ b/YseEngine/c_api/yse_dsp_modules.cpp
@@ -213,7 +213,12 @@ YSE_C_API float yse_dsp_object_get_lfo_frequency(YseDspObject* o) {
 }
 
 YSE_C_API void yse_dsp_object_link(YseDspObject* head, YseDspObject* next) {
-  if (!head || !next) return;
+  if (!head) return;
+  if (!next) {
+    // NULL next detaches the forward edge (#391) instead of no-oping.
+    to_cpp(head)->unlink();
+    return;
+  }
   to_cpp(head)->link(*to_cpp(next));
 }
 

--- a/YseEngine/dsp/dspObject.cpp
+++ b/YseEngine/dsp/dspObject.cpp
@@ -25,6 +25,17 @@ YSE::DSP::dspObject* YSE::DSP::dspObject::link() {
   return this->next;
 }
 
+void YSE::DSP::dspObject::unlink() {
+  // Detach the forward edge only (#391): clear our next pointer and the
+  // detached neighbour's previous back-pointer. calledfrom is deliberately
+  // untouched — that is the sound/channel attachment back-reference, owned by
+  // setDSP / engine teardown.
+  if (next != nullptr) {
+    next->previous = nullptr;
+    next = nullptr;
+  }
+}
+
 YSE::DSP::dspObject::dspObject()
   : calledfrom(nullptr),
     next(nullptr),

--- a/YseEngine/dsp/dspObject.hpp
+++ b/YseEngine/dsp/dspObject.hpp
@@ -99,6 +99,26 @@ namespace YSE {
       /** @brief Next object in the processing chain, or ``nullptr`` if this is the tail. */
       dspObject* link();
 
+      /** @brief Detach the forward edge of the chain at this object.
+       *
+       *  Clears this object's ``next`` pointer and the detached neighbour's
+       *  ``previous`` back-pointer, so the neighbour becomes a standalone
+       *  (potential) chain head. A no-op when nothing is linked. It does NOT
+       *  touch ``calledfrom`` — the sound/channel attachment back-reference is
+       *  owned by ``setDSP`` / engine teardown and only meaningful on a chain
+       *  head.
+       *
+       *  RT-safety: the audio thread walks ``next`` pointers lock-free every
+       *  block. To restructure a chain that is attached to a live sound or
+       *  channel, detach the chain from its owner first (``setDSP(nullptr)``
+       *  — a pointer swap applied on the audio thread), ``unlink()`` and
+       *  re-``link()`` the objects into the new order, then re-attach the new
+       *  head. That keeps the audio thread from ever observing a half-rewired
+       *  chain; effect DSP state survives because the objects themselves are
+       *  untouched.
+       */
+      void unlink();
+
       /** @brief Bypass this effect when ``true``. Bypassed effects still run but pass input through
        * unchanged. */
       dspObject& bypass(Bool value) {


### PR DESCRIPTION
## Summary

Adds the missing detach capability for `dspObject` insert chains. `link()` is an insert/splice, and no API could clear a stale forward `next` edge, so a chain could not be reordered or shortened in place — a former non-tail element kept a stale `next`, closing a cycle when the engine walks the chain.

## Linked issue

Closes #391

## Changes

- **C++** — `void dspObject::unlink()` detaches the forward edge: clears `next` and the detached neighbour's `previous`. It does **not** touch `calledfrom` (the channel/sound attachment back-reference, owned by `addDSP` / impl teardown). Doc comment carries the RT-safe live-restructure pattern (detach chain from owner via `setDSP(nullptr)` → unlink/re-link → re-attach the new head).
- **C ABI** — `yse_dsp_object_link(head, NULL)` now calls `head->unlink()` instead of silently no-oping (`NULL` head remains a null-safe no-op). The declaration in `yse_dsp_modules.h` documents "pass NULL to detach the forward edge" plus the same RT-safety usage note.
- **Tests** — engine-side semantics in `Tests/channel/test_channel_dsp.cpp` (detach + no-op-when-unlinked, neighbour `previous` cleared, `calledfrom` untouched, the issue's cycle-free in-place reorder, live insert-chain shortening through `processInsertDSP()`, and the C-ABI NULL dispatch observed through the engine object). A pure-C end-to-end case in `Tests/channel/test_c_api_channel.cpp` drives the documented restructure sequence against a live offline render — a regression to the no-op would leave a stale-edge cycle and trip the suite's ctest timeout.

No new C-API surface, enums, or files; no allocation/locking added to any audio-thread path (`unlink()` is two pointer stores, same class as `link()`).

## Test plan

- [x] `python yse.py format` — no changes needed (diff untouched by the formatter)
- [x] `python yse.py analyze` on all four touched .cpp files — zero user-code findings
- [x] `python yse.py build` (debug preset) — clean
- [x] `python yse.py test` — 34/34 CTest entries pass (incl. the isolated `yse_tests_channelcapi` process); new cases verified individually with doctest filters
- [x] Downstream note: unblocks dart-yse #42 (`link(DspObject? next)`) and lets Phi #207 drop its permanent bypassed terminator tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)