### PR TITLE
docs: C API reference coverage (clip, python, bus) + release-skill docs audit

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -76,6 +76,30 @@ this:
    it, document the gap in the release notes ("known to be missing from
    C API in this version").
 
+### 3b. API-reference coverage audit (docs drift)
+
+The Sphinx API reference enumerates C headers **explicitly** —
+`documentation/source/api/c_api.rst` carries one `doxygenfile` directive per
+`yse_c/*.h` header — so a brand-new header never appears on the docs site by
+itself. (This bit the v2.3.x cycle: `yse_clip.h`, `yse_python.h`, and
+`yse_bus.h` were all missing until the pre-v2.3.2 audit.) Check:
+
+```sh
+for h in YseEngine/c_api/include/yse_c/*.h; do
+  grep -q "$(basename "$h")" documentation/source/api/c_api.rst \
+    || echo "MISSING from c_api.rst: $(basename "$h")"
+done
+```
+
+Every hit is a doc gap: add a matching `doxygenfile` block (under a fitting
+section heading) in the release-prep PR (step 5).
+
+The C++ pages have the same failure mode at class granularity: for each new
+public class step 3 surfaced, confirm it renders somewhere under
+`documentation/source/api/*.rst` (a genuinely new subsystem needs a new page
+plus an `index.rst` toctree entry). There is no mechanical check for this
+side — use step 3's changed-header list as the worklist.
+
 ### 4. Build sanity + enum mirror check
 
 ```sh
@@ -102,8 +126,10 @@ Branch: `release/vX.Y.Z-prep` from `dev`.
   rewrite of a few sections.
 - Sphinx `conf.py` reads VERSION from `system.hpp` automatically (per
   PR #89) — **do not** edit `documentation/` for the version. Only
-  touch `documentation/source/` if a code change in this release also
-  changed user-facing behaviour that the intro/tutorials describe.
+  touch `documentation/source/` to close API-reference coverage gaps
+  found in step 3b (missing `doxygenfile` directives or pages), or if a
+  code change in this release also changed user-facing behaviour that
+  the intro/tutorials describe.
 
 Commit the prep PR with message:
 
@@ -245,6 +271,7 @@ About to release vX.Y.Z:
   Workflow: release.yml will publish Linux x64, Windows x64, Android multi-ABI archives
 
   C API drift check: <none | <list of headers worth reviewing>>
+  Docs coverage:     <complete | <headers missing from c_api.rst / classes without a page>>
 
   Steps that will run unattended after you confirm:
     1. release-prep PR on dev (skill housekeeping + README/PROJECT_OVERVIEW.md refresh)

--- a/documentation/source/api/c_api.rst
+++ b/documentation/source/api/c_api.rst
@@ -92,6 +92,29 @@ MIDI and music
 .. doxygenfile:: c_api/include/yse_c/yse_music.h
    :project: libYSE
 
+Clip transport
+--------------
+
+Beat-timed note clips dispatched from the audio thread against a domain
+clock, targeting internal synths or an external MIDI-out port.
+
+.. doxygenfile:: c_api/include/yse_c/yse_clip.h
+   :project: libYSE
+
+Live coding: scripting and bus tap
+----------------------------------
+
+The embedded-Python live-coding surface (``YSE_ENABLE_PYTHON`` builds; the
+symbols exist in every build) and the host bus tap, which subscribes the
+host to a bus-address prefix and delivers ``(address, value)`` frames on the
+thread that drives ``yse_system_update()``.
+
+.. doxygenfile:: c_api/include/yse_c/yse_python.h
+   :project: libYSE
+
+.. doxygenfile:: c_api/include/yse_c/yse_bus.h
+   :project: libYSE
+
 Logging and buffer I/O
 ----------------------
 


### PR DESCRIPTION
## What

- **`documentation/source/api/c_api.rst`** — the page lists each C header with an explicit `doxygenfile` directive, so new headers never appear on the docs site automatically. Three were missing: `yse_clip.h` and `yse_python.h` (omitted since they landed) and `yse_bus.h` (from the #388–#391 batch). All three are now wired in under new "Clip transport" and "Live coding: scripting and bus tap" sections.
- **`.claude/skills/release/SKILL.md`** — new step 3b "API-reference coverage audit": a mechanical check that every `yse_c/*.h` header appears in `c_api.rst` (plus a judgment pass for new C++ classes), with the fix routed through the release-prep PR. The confirmation gate now reports docs coverage alongside C-API drift, and step 5's documentation bullet references the audit.

## Why

The phi DAW is about to consume the bus-tap surface from the published API reference; without this it would be invisible on the docs site. The skill change makes the failure mode self-catching at every future release instead of relying on someone noticing.

Trivial doc/process fix — no issue, per the CLAUDE.md workflow exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)