### PR TITLE
Release v2.4.0

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -19,7 +19,7 @@
 #include <string>
 
 namespace YSE {
-  const std::string VERSION = "2.3.1";
+  const std::string VERSION = "2.4.0";
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *


### PR DESCRIPTION
Version bump for the v2.4.0 release. Routed through a PR because branch protection on master requires it (same path as release-v2.1.0 → PR #87).

Bumps `YseEngine/system.hpp` VERSION 2.3.1 → 2.4.0. The tag is applied to this PR's merge commit on master after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)