### PR TITLE
Sync Release v2.4.0 bump back to dev

### DIFF
--- a/YseEngine/system.hpp
+++ b/YseEngine/system.hpp
@@ -19,7 +19,7 @@
 #include <string>
 
 namespace YSE {
-  const std::string VERSION = "2.3.1";
+  const std::string VERSION = "2.4.0";
 
   /** @brief Signature of a user-supplied sound-occlusion callback.
    *


### PR DESCRIPTION
Brings the version bump commit and tag back to dev so the two branches stay in sync. No CI wait — every commit already passed CI on the PR that put it on master, and the workflows skip master→dev sync PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)