### PR TITLE
infra: bump actions/checkout v4.3.1 -> v5.1.0 off Node 20 (#404)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       # Mirrors build.yml's install line minus gcovr — the benchmark binary
       # links the same PortAudio / libsndfile / RtMidi as the engine.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install Build Wrapper
@@ -109,7 +109,7 @@ jobs:
       matrix:
         abi: [arm64-v8a, x86_64]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Install host build tools
         run: |
           sudo apt-get update -y
@@ -171,7 +171,7 @@ jobs:
       CC: clang
       CXX: clang++
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Install dependencies
         # python3-dev: the libpython we embed (find_package Python3 Development.Embed).
         # libclang-rt-dev: clang's compiler-rt, which ships libclang_rt.asan — not
@@ -224,7 +224,7 @@ jobs:
       matrix:
         san: [tsan, asan]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Install dependencies
         # libclang-rt-dev ships libclang_rt.{asan,tsan}; not pulled in by the base
         # clang package, so the sanitizer legs fail to link without it.

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Install system packages
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Install clang-format
         # Pin the exact version the tree was formatted with. The PyPI wheel
         # bundles the real LLVM clang-format binary, so CI matches a maintainer's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
@@ -104,7 +104,7 @@ jobs:
       matrix:
         abi: [arm64-v8a, x86_64]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
@@ -173,7 +173,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0


### PR DESCRIPTION
## Summary

`actions/checkout` was SHA-pinned to **v4.3.1** (`34e114876b0b11c390a56381ad16ebd13914f8d5`), whose action targets the deprecated **Node 20** runtime. GitHub currently force-runs it on Node 24, but that fallback is temporary — once removed, every checkout step fails hard. `actions/checkout` **v5** moved to Node 24.

This bumps all **12** occurrences across the five workflows to **v5.1.0**, keeping the repo's SHA-pin convention.

## Linked issue

Closes #404

## Changes

Replaced everywhere with:

```
actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
```

| Workflow | occurrences |
|----------|-------------|
| `build.yml` | 4 |
| `release.yml` | 5 |
| `benchmark.yml` | 1 |
| `documentation.yml` | 1 |
| `format.yml` | 1 |

## SHA-pin provenance

- Resolved authoritatively via `gh api repos/actions/checkout/commits/v5.1.0` → `fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09`. **v5.1.0** is the latest v5.x release (published 2026-07-20); its tag is lightweight and points directly at that commit (`git/ref/tags/v5.1.0` agrees, `type: commit`).
- `action.yml` at v5.1.0 declares `runs.using: node24` — the deprecation fix.
- Input contract preserved: our `with:` blocks use only `ref` and `fetch-depth`, both still present in v5.1.0's inputs. v5 adds no required inputs, so the bare-`uses` steps are also unaffected.

## Scope note

Kept to the checkout bump per the issue title. The three floating-tag-pinned actions mentioned as a secondary "maintainer's call" (`setup-python@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`) are intentionally left out of this PR.

## Test plan

CI-config change with no compilable code, so no local build/test applies. Validation performed:
- [x] All five workflow YAML files parse cleanly (PyYAML `safe_load`).
- [x] `grep` confirms **0** references to the old SHA `34e114876b0b11c390a56381ad16ebd13914f8d5` remain.
- [x] `grep` confirms **12** new pins, distributed exactly per the table above; no stray `actions/checkout@` on any other ref.
- [x] Real verification: the workflows themselves run on this PR.
