### PR TITLE
tests: add Demo22_MissedCallbacks idle-drift harness

### DIFF
--- a/Demo.Windows.Native/CMakeLists.txt
+++ b/Demo.Windows.Native/CMakeLists.txt
@@ -98,6 +98,11 @@ add_yse_demo(Demo19 Demo19_SfzPiano   DemoSfzPiano)
 add_yse_demo(Demo20 Demo20_Swarm      DemoSwarm)
 add_yse_demo(Demo21 Demo21_Mixer      DemoMixer)
 
+# Minimal engine-only harness to reproduce idle missed-callback drift (issue
+# #406). Opens the device, idles, and latches a cumulative missed-callback
+# total; a sine source and a sample can each be toggled.
+add_yse_demo(Demo22 Demo22_MissedCallbacks DemoMissedCallbacks)
+
 # ── Combined Demo executable (all pages via menu) ─────────────────────────────
 add_executable(Demo
   demo_main.cpp
@@ -128,6 +133,7 @@ add_executable(Demo
   Demo19_SfzPiano.cpp
   Demo20_Swarm.cpp
   Demo21_Mixer.cpp
+  Demo22_MissedCallbacks.cpp
   Test01_Pitch.cpp
 )
 target_compile_features(Demo PRIVATE cxx_std_17)

--- a/Demo.Windows.Native/Demo22_MissedCallbacks.cpp
+++ b/Demo.Windows.Native/Demo22_MissedCallbacks.cpp
@@ -1,0 +1,78 @@
+
+#include "stdafx.h"
+
+#include "Demo22_MissedCallbacks.h"
+
+#include <iostream>
+
+DemoMissedCallbacks::DemoMissedCallbacks() {
+  SetTitle("Missed Callbacks (idle drift harness)");
+
+  AddAction('1', "Toggle sine wave", std::bind(&DemoMissedCallbacks::ToggleSine, this));
+  AddAction('2', "Toggle sample", std::bind(&DemoMissedCallbacks::ToggleSample, this));
+
+  // Prepare a sine source and a looping sample, but start both silent: the
+  // point of the demo is to watch the device at idle first.
+  sine_.frequency(220.f);
+  sineSound_.create(sine_);
+
+  sampleSound_.create(YSE_TEST_RESOURCES_DIR "/drone.ogg", nullptr, true);
+  sampleValid_ = sampleSound_.isValid();
+  if (!sampleValid_) {
+    std::cout << "sample 'drone.ogg' not found - sample toggle disabled" << std::endl;
+  }
+}
+
+DemoMissedCallbacks::~DemoMissedCallbacks() {
+  // Stop both sounds and let the engine's slow-pool delete tick fire before the
+  // sine source (sine_) destructs, so the audio thread stops calling into it
+  // (see the lifetime contract on sound::create(dspSourceObject&)).
+  sineSound_.stop();
+  if (sampleValid_) sampleSound_.stop();
+  for (int i = 0; i < 5; i++) {
+    YSE::System().update();
+    YSE::System().sleep(20);
+  }
+  std::cout << std::endl;
+}
+
+void DemoMissedCallbacks::ExplainDemo() {
+  std::cout << "Opens the audio device and idles. The line below refreshes about once a"
+            << std::endl;
+  std::cout << "second with the instantaneous missedCallbacks() value plus a cumulative"
+            << std::endl;
+  std::cout << "count of every 0 -> non-zero transition over the session (the engine getter"
+            << std::endl;
+  std::cout << "resets itself, so the running total is latched here). Toggle a sine wave (1)"
+            << std::endl;
+  std::cout << "and/or a sample (2) to see whether drops track audio activity." << std::endl;
+}
+
+void DemoMissedCallbacks::ShowStatus() {
+  // Sample every tick (~100 ms) so no 0 -> non-zero transition is missed: the
+  // engine clears the counter on the next control tick that sees callbacks.
+  int now = YSE::System().missedCallbacks();
+  if (previousMissed_ == 0 && now > 0) cumulativeMissed_++;
+  if (now > peakMissed_) peakMissed_ = now;
+  previousMissed_ = now;
+
+  // Redraw roughly once a second (10 ticks * ~100 ms).
+  if (++refreshCounter_ < 10) return;
+  refreshCounter_ = 0;
+  seconds_++;
+
+  std::cout << "\r[" << seconds_ << "s] missedCallbacks(now)=" << now
+            << "  cumulative=" << cumulativeMissed_ << "  peak=" << peakMissed_
+            << "  sine=" << (sineSound_.isPlaying() ? "on " : "off")
+            << "  sample=" << (sampleSound_.isPlaying() ? "on " : "off") << "        "
+            << std::flush;
+}
+
+void DemoMissedCallbacks::ToggleSine() {
+  sineSound_.toggle();
+}
+
+void DemoMissedCallbacks::ToggleSample() {
+  if (!sampleValid_) return;
+  sampleSound_.toggle();
+}

--- a/Demo.Windows.Native/Demo22_MissedCallbacks.h
+++ b/Demo.Windows.Native/Demo22_MissedCallbacks.h
@@ -1,0 +1,45 @@
+
+#pragma once
+
+#include "basePage.h"
+#include "../YseEngine/yse.hpp"
+
+// Minimal engine-only harness for issue #406. On start it just opens the audio
+// device and idles; it then reports the missed-callback count on a steady
+// interval. A sine wave and a sample can each be toggled independently so we
+// can tell whether the reported drops are tied to any audio activity or happen
+// even with a completely idle device.
+class DemoMissedCallbacks : public basePage {
+public:
+  DemoMissedCallbacks();
+  ~DemoMissedCallbacks();
+
+  virtual void ExplainDemo();
+  virtual void ShowStatus();
+
+  void ToggleSine();
+  void ToggleSample();
+
+private:
+  // A single built-in sine source (cf. shepard in Demo07_DspSource). Declared
+  // before the sound so it outlives it: members destruct in reverse order.
+  YSE::DSP::sineWave sine_;
+  YSE::sound sineSound_;
+  YSE::sound sampleSound_;
+  bool sampleValid_ = false;
+
+  // Cumulative latch. system::update() resets missedCallbacks() to 0 as soon as
+  // a control tick sees callbacks again (system.cpp:112-121, :167), so the
+  // getter is a consecutive-missed-ticks gauge, not a running total. We bump
+  // cumulativeMissed_ on every 0 -> non-zero transition so intermittent drops
+  // stay visible over the session, and track the largest run in peakMissed_.
+  int previousMissed_ = 0;
+  unsigned long long cumulativeMissed_ = 0;
+  int peakMissed_ = 0;
+
+  // Throttle the on-screen refresh to ~once per second. basePage::Run() calls
+  // ShowStatus() every ~100 ms tick (it sleeps 100 ms), so latch every tick but
+  // only redraw every tenth.
+  int refreshCounter_ = 0;
+  int seconds_ = 0;
+};

--- a/Demo.Windows.Native/MenuOther.cpp
+++ b/Demo.Windows.Native/MenuOther.cpp
@@ -8,6 +8,7 @@
 #include "Demo15_RestartAudio.h"
 #include "Demo16_Midi.h"
 #include "Demo17_MidiPatcher.h"
+#include "Demo22_MissedCallbacks.h"
 #include "Test01_Pitch.h"
 
 OtherMenu::OtherMenu()
@@ -20,6 +21,7 @@ OtherMenu::OtherMenu()
 	AddAction('5', "MIDI", std::bind(&OtherMenu::MidiDemo, this));
 	AddAction('6', "MIDI PAtcher", std::bind(&OtherMenu::MidiPatcherDemo, this));
 	AddAction('7', "Test Pitch", std::bind(&OtherMenu::PitchTest, this));
+	AddAction('8', "Missed Callbacks", std::bind(&OtherMenu::MissedCallbacksDemo, this));
 }
 
 void OtherMenu::DevicesDemo()
@@ -68,6 +70,12 @@ void OtherMenu::MidiPatcherDemo() {
 
 void OtherMenu::PitchTest() {
 	Test01_Pitch demo;
+	demo.Run();
+	ShowMenu();
+}
+
+void OtherMenu::MissedCallbacksDemo() {
+	DemoMissedCallbacks demo;
 	demo.Run();
 	ShowMenu();
 }

--- a/Demo.Windows.Native/MenuOther.h
+++ b/Demo.Windows.Native/MenuOther.h
@@ -15,5 +15,6 @@ public:
 	void MidiDemo();
 	void MidiPatcherDemo();
 	void PitchTest();
+	void MissedCallbacksDemo();
 };
 


### PR DESCRIPTION
## Summary

Adds `Demo22_MissedCallbacks`, a minimal engine-only native demo to reproduce
the ~1 missed-callback-per-second reports seen at idle (issue #406). On start it
just opens the audio device and idles; it then reports the missed-callback
figure on a steady ~1 s interval.

`system::missedCallbacks()` is a *consecutive-missed-ticks* gauge: `system::update()`
resets it to 0 as soon as a control tick sees callbacks again
(`YseEngine/system.cpp:112-121`, `:167`). The instantaneous value alone therefore
hides intermittent drops, so the demo latches its **own cumulative total**,
incrementing on every 0 → non-zero transition. It samples every ~100 ms control
tick (so no transition is missed) and redraws once per second, showing the
instantaneous value, the cumulative count, and the largest run seen.

A built-in `YSE::DSP::sineWave` source (toggle `1`) and a looping sample
(toggle `2`, `drone.ogg` from `TestResources/`) can each be switched on/off
independently, giving the four states (silent / sine / sample / both) to see
whether reported drops track audio activity or occur at a completely idle device.

## Linked issue
Closes #406

## Changes
- `Demo.Windows.Native/Demo22_MissedCallbacks.{h,cpp}` — new demo (uses the
  built-in `YSE::DSP::sineWave` source; `sound.create(...ogg...)` / `toggle()`
  for the sample; a small teardown drain protects the sine source's lifetime).
- `Demo.Windows.Native/MenuOther.{cpp,h}` — registered as entry `8`
  ("Missed Callbacks"), mirroring how Demo15_RestartAudio is wired.
- `Demo.Windows.Native/CMakeLists.txt` — added the standalone `Demo22` target
  and `Demo22_MissedCallbacks.cpp` to the combined `Demo` executable source list.

## Test plan
- [x] `python yse.py build` (debug preset) — clean; `Demo22.exe` and combined
      `Demo.exe` both link. The 111 warnings in the log are all pre-existing
      engine warnings (`inconsistent-missing-override` in `lsfSoundfile.h`,
      `cast-function-type-mismatch`); **none** reference the changed files.
- [x] `python yse.py analyze Demo22_MissedCallbacks.cpp` and `MenuOther.cpp` —
      clang-tidy reports **zero** findings in user code (all suppressed warnings
      are in non-user headers).
- [x] Format gate N/A — `.github/workflows/format.yml` only checks `YseEngine/`
      and `Tests/`; the demo files match the surrounding `Demo.Windows.Native/`
      style.
- No unit tests: per the project test policy demos don't get tests, and this is
  a diagnostic harness (opens a real audio device; the drift it probes only
  surfaces on live hardware). Manual verification against the DAW's ~1/sec
  report is the follow-up noted in the issue.
