### PR TITLE
infra: exclude gcov throw/unreachable branches from coverage (#416)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,24 @@ jobs:
           YSE_TEST_FORCED_RATE: "48000"
         run: ctest --test-dir build --output-on-failure
       - name: Generate coverage report
+        # --exclude-throw-branches / --exclude-unreachable-branches drop the
+        # implicit exception-unwind and never-entered edges GCC emits around
+        # anything that can throw.  gcov records them as real conditions, so
+        # without these flags trivial headers report 4 conditions with 3
+        # uncovered and Sonar's blended coverage is dominated by branches no
+        # test can ever reach.  See #416.  Keep in sync with the gcovr call in
+        # yse.py (_cmd_coverage_linux) so local and CI numbers agree.
+        #
+        # --filter 'Tests/' stays: Tests is declared as sonar.tests, so Sonar
+        # discards those entries on import (verified — test files report
+        # 0 coverable lines in the analysis) and they cannot skew the totals.
         run: |
           gcovr \
             --root . \
             --filter 'YseEngine/' \
             --filter 'Tests/' \
+            --exclude-throw-branches \
+            --exclude-unreachable-branches \
             --gcov-ignore-parse-errors \
             --sonarqube \
             --output coverage.xml \

--- a/yse.py
+++ b/yse.py
@@ -170,11 +170,18 @@ def _cmd_coverage_linux():
         return
 
     report = ROOT / "coverage.xml"
+    # The --exclude-*-branches flags must match the gcovr invocation in
+    # .github/workflows/build.yml, otherwise local and CI coverage disagree.
+    # They drop gcov's implicit exception-unwind / never-entered edges, which
+    # are not reachable by any test and otherwise dominate the condition
+    # coverage figure.  See #416.
     run([
         "gcovr",
         "--root", str(ROOT),
         "--filter", "./YseEngine/",
         "--filter", "./Tests/",
+        "--exclude-throw-branches",
+        "--exclude-unreachable-branches",
         "--sonarqube",
         "--output", str(report),
     ])


### PR DESCRIPTION
## Summary

gcov records the implicit `__cxa_throw` / unwind edges GCC emits around anything
that can throw as ordinary conditions. No test can ever cover them, so they
inflate `conditions_to_cover` and drag down Sonar's blended `coverage` metric
without pointing at a single real testing gap. This adds gcovr's two standard
filters for exactly that problem, in CI and in the local path.

The distortion is visible per file in the current analysis:

| File | Coverable lines | Line cov | Conditions | Branch cov |
|---|---|---|---|---|
| `YseEngine/patcher/genericObjects/pLine.h` | 1 (0 uncovered) | 100% | 4, 3 uncovered | **25%** |

A dozen near-identical 2-line patcher headers report exactly 4 conditions with 3
uncovered. Two-line headers do not contain four real branches.

## Linked issue

Closes #416 — part of #420 (SonarCloud quality-gate epic).

## Changes

- `.github/workflows/build.yml` — add `--exclude-throw-branches` and
  `--exclude-unreachable-branches` to the "Generate coverage report" gcovr call.
- `yse.py` (`_cmd_coverage_linux`) — mirror both flags so `python yse.py coverage`
  and CI produce comparable numbers.
- Comments in both places record why the flags are there and that the two call
  sites must stay in sync.

No code, test, or build-configuration changes — this only affects how the
coverage report is generated.

## Decision on `--filter 'Tests/'` — kept

The issue asked whether the filter should be dropped, on the theory that test
coverage may be skewing the totals. **It is not, and the filter stays.**

Evidence from the current SonarCloud analysis (`master`, 2026-07-21):

| Component | Total lines | Coverable lines | Conditions |
|---|---|---|---|
| `Tests/channel/test_channel.cpp` | 208 | **0** | **0** |
| `Tests/test_sanity.cpp` | 9 | **0** | **0** |

`test_channel.cpp` is compiled with coverage instrumentation and executed on
every CI run, and it still shows zero coverable lines and zero conditions:
`Tests` is declared as `sonar.tests`, so Sonar discards coverage entries for
those files on import. The filter is therefore a proven no-op for the metric —
dropping it would gain nothing measurable while confounding the very
before/after comparison this PR exists to produce. Left in place, documented in
the workflow comment.

## Coverage figures

**Before** (SonarCloud `master`, analysis of 2026-07-21, read from the API):

| Metric | Value |
|---|---|
| `coverage` (blended) | **65.9%** |
| `line_coverage` | 78.5% (4,060 uncovered of 18,880) |
| `branch_coverage` | **51.7%** (8,140 uncovered of 16,858) |
| `ncloc` | 35,657 |

**After: not yet known, and deliberately not estimated here.** It has to be read
off the analysis this change triggers. `master` is the only long-lived branch
registered in SonarCloud, so the authoritative project-level figure appears on
the first `master` analysis after this lands; the PR analysis on this branch is
the first run that produces a report with the new flags. The revised gap to the
80% gate — and the re-scoping of #417 / #418 against it — should be recorded on
#416 from that measurement, not from a guess.

## Test plan

- [x] Both flags confirmed to exist in **gcovr 7.0** (the version `apt` installs
      on `ubuntu-latest`, which is what CI uses) and in gcovr 8.6, via
      `gcovr --help`. gcovr is not installed on the maintainer's Windows box, so
      this was verified in a throwaway venv.
- [x] The exact CI command line (`--root . --filter 'YseEngine/' --filter 'Tests/'
      --exclude-throw-branches --exclude-unreachable-branches
      --gcov-ignore-parse-errors --sonarqube --output …`) executed end-to-end
      under gcovr 7.0 against a path with no `.gcda`: exit 0, valid SonarQube-format
      XML. Confirms flag acceptance and ordering, not the resulting numbers.
- [x] `build.yml` parses as YAML and the regenerated `Generate coverage report`
      step body was inspected after the edit.
- [x] `python -m py_compile yse.py`, `python yse.py --help`, and
      `python yse.py coverage --help` all clean.
- [ ] **`python yse.py coverage` was not run.** On Windows that command takes the
      llvm-cov path (`_cmd_coverage_windows`), which does not touch the changed
      gcovr call at all, so running it would prove nothing about this change; the
      gcovr path is Linux-only. The real exercise of this code is the CI job on
      this PR.
- No unit or integration tests were added: this changes CI/tooling configuration
  only, with no engine, C API, or DSP behaviour to cover. The gcovr invocation is
  itself exercised by the `build` job on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
