### PR TITLE
sonar: exclude the vendored MSFA port from analysis (#415)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -24,8 +24,19 @@ sonar.tests=Tests
 # Keep the analysis focused on the core engine.  All vendored dependencies,
 # out-of-tree build directories, legacy platform projects, and Android projects
 # are excluded.
+#
+# The list also covers vendored / ported third-party sources that live *inside*
+# YseEngine/ rather than under dependencies/ (the MSFA FM port, the JSON
+# library, the atomic/queue helpers).  Those files are kept byte-identical to
+# upstream so they can be re-synced and diffed against it, which means analyzer
+# findings there cannot be fixed in place -- see CLAUDE.md rule 4, "Don't
+# modify vendored deps".
+#
+# Every line below except the last must end in a backslash continuation, with
+# no trailing whitespace after it, or the whole list is silently dropped.
 sonar.exclusions=\
   dependencies/**,\
+  YseEngine/dsp/fm/msfa/**,\
   YseEngine/json/**,\
   YseEngine/utils/json.hpp,\
   YseEngine/utils/atomicOps.hpp,\


### PR DESCRIPTION
## Summary

Two `cpp:S876` reliability findings sit in the vendored MSFA (Music Synthesizer
for Android) port. `S876` flags unary minus on an unsigned type; in both places
that is the standard bit-twiddling idiom, intentional and load-bearing:

| Location | Code | Purpose |
|---|---|---|
| `YseEngine/dsp/fm/msfa/aligned_buf.h:40` | `(... + alignment - 1) & -alignment` | round a pointer up to the alignment boundary |
| `YseEngine/dsp/fm/msfa/lfo.cc:69` | `x ^= -(phase_ >> 31)` | branch-free triangle-wave folding via a sign mask |

`YseEngine/dsp/fm/msfa/` is a port of
[google/music-synthesizer-for-android](https://github.com/google/music-synthesizer-for-android)
brought in for #176 and kept byte-identical to upstream so it can be re-synced
and diffed against it. Per CLAUDE.md rule 4 ("Don't modify vendored deps") the
fix is to exclude the tree from analysis, not to patch it.

## Linked issue

Closes #415 — part of #420 (SonarCloud quality-gate epic).

## Changes

- Add `YseEngine/dsp/fm/msfa/**` to `sonar.exclusions` in `sonar-project.properties`.
- Document the exclusion block: it covers vendored / ported third-party sources
  that live *inside* `YseEngine/` rather than under `dependencies/`, and the
  backslash continuations are load-bearing.

No file under `YseEngine/dsp/fm/msfa/` is modified — `git diff --name-only dev..HEAD`
returns `sonar-project.properties` and nothing else.

## Verifying the exclusion scope is correct

An over-broad glob here would hide real findings in engine-authored code, so
the boundary was checked rather than assumed:

- **All 21 tracked files** under `msfa/` carry the `Derived from
  music-synthesizer-for-android` provenance header. The subtree is wholly
  vendored — no engine-authored file lives inside it.
- YSE's own FM wrapper — the code that adapts msfa into the engine — sits one
  level up in `YseEngine/dsp/fm/` (`dx7Sysex.{cpp,hpp}`, `fmPatch.{cpp,hpp}`,
  `fmVoice.{cpp,hpp}`). The glob does not match it; those six files stay in
  analysis.
- Both target findings were confirmed live on SonarCloud at exactly the
  reported lines (`aligned_buf.h:40`, `lfo.cc:69`), both `OPEN`, both `cpp:S876`.

The full-subtree glob is therefore the right scope; no narrowing was needed.

## Blast radius

The msfa tree currently carries **108 open findings**, of which the 2 `cpp:S876`
are the ones this issue targets. The remaining 106 are the same class of
vendored-code noise (`S5945` C-style arrays, `S5028` macros, `S5812` nested
namespaces, `S5276` integer conversions, …) and drop out with them. All are in
code that cannot be fixed in place without breaking the byte-identical
re-sync property.

## Coverage side-effect — to be recorded, not guessed

Excluding files removes their lines from **both** the numerator and denominator
of coverage, so the project coverage number will shift. `sin.cc` sits at
**41.7%** per the issue, so the direction is *probably* a slight improvement —
but that is not asserted here.

Mechanically: `gcovr` still emits msfa entries into `coverage.xml` (its filter
is `YseEngine/`), and Sonar discards coverage for excluded files on import —
the same mechanism `build.yml` already documents for the `Tests/` filter.

**The actual delta must be read off the first analysis after merge and recorded
on #415**, per that issue's third acceptance box. No number is invented in this PR.

## Test plan

This change touches a single scanner-configuration file. No C++ changed, so
`yse.py analyze` (clang-tidy) and `yse.py format` (clang-format) have nothing in
scope, and no unit or integration test can exercise a `.properties` file — the
"not feasible to drive end-to-end" case. The real risk in this file is a
malformed line continuation, which fails *silently* by dropping the whole
exclusion list, so that is what was verified:

- [x] **Continuation backslashes checked byte-by-byte** via `cat -A`: every line
      of the list except the last ends in exactly `\$` — backslash immediately
      followed by end-of-line, no trailing whitespace. The final entry
      (`cmake/**`) correctly has no backslash.
- [x] **No trailing whitespace and no CR anywhere in the file**
      (`grep '[[:space:]]$'` and `grep $'\r'` both empty). `.gitattributes` has
      `* text=auto`, so the blob is stored LF.
- [x] **Parsed the file with java.util.Properties continuation semantics** (the
      scanner's own format): the list resolves to **14 entries**, up from 13,
      with `YseEngine/dsp/fm/msfa/**` present, no stray whitespace in any entry,
      no comment text leaking into a value, and all 8 other keys
      (`sonar.projectKey`, `sonar.sources`, `sonar.tests`,
      `sonar.cfamily.compile-commands`, `sonar.coverageReportPaths`,
      `sonar.sourceEncoding`, …) still parsing.
- [x] **Re-ran that parse against the committed blob** (`git show HEAD:...`), not
      just the working tree — same result.
- [x] Confirmed the scan reads this file: `build.yml` overrides only
      `sonar.cfamily.compile-commands` on the command line, so `sonar.exclusions`
      comes from `sonar-project.properties` as edited.

CI has not been observed for this PR; the exclusion takes effect on the next
analysis run.
