### PR TITLE
sonar: derive projectVersion from system.hpp so New Code has a baseline (#408)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,12 +93,35 @@ jobs:
             --output coverage.xml \
             build
           echo "=== coverage.xml preview ===" && head -20 coverage.xml
+      - name: Resolve project version for Sonar
+        id: version
+        # The New Code period is set to "Previous version", which only advances
+        # when sonar.projectVersion changes between analyses. It used to be
+        # hardcoded in sonar-project.properties and was never bumped: it sat at
+        # 1.0.77 from the day SonarCloud was wired up while the project shipped
+        # through v2.4.0. With no version change there is no baseline, so every
+        # line ever written counted as "new code" -- which is why new_coverage
+        # tracked overall coverage to within 0.1 points and 2018-era findings
+        # gated the rating. See #408.
+        #
+        # YseEngine/system.hpp is the authoritative version source (the release
+        # skill bumps it; Sphinx conf.py already reads it the same way, per
+        # PR #89). Deriving it here means it can never drift again.
+        run: |
+          VER=$(sed -n 's/.*VERSION[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' YseEngine/system.hpp | head -1)
+          if [ -z "$VER" ]; then
+            echo "::error file=YseEngine/system.hpp::could not parse VERSION -- sonar.projectVersion would silently fall back and break the New Code baseline"
+            exit 1
+          fi
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo "Resolved sonar.projectVersion=$VER"
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
+            --define "sonar.projectVersion=${{ steps.version.outputs.version }}"
             --define "sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
 
   build-android:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,20 @@
 sonar.projectKey=yvanvds_yse-soundengine
 sonar.organization=yvanvds
 sonar.projectName=YSE Sound Engine
-sonar.projectVersion=1.0.77
+
+# sonar.projectVersion is deliberately NOT set here.
+#
+# It is supplied by the "Resolve project version for Sonar" step in
+# .github/workflows/build.yml, which reads the authoritative version from
+# YseEngine/system.hpp (the file the release skill bumps, and the same one
+# Sphinx conf.py reads -- PR #89).
+#
+# It used to be hardcoded on this line and was never updated: it stayed at
+# 1.0.77 from the initial SonarCloud commit while the project shipped through
+# v2.4.0. The New Code period is "Previous version", which only advances when
+# this value changes between analyses -- so it never advanced, no baseline was
+# ever set, and every line in the repository counted as "new code". Do not
+# reintroduce a literal here; a stale value silently disables New Code. See #408.
 
 # ── Source / test roots ───────────────────────────────────────────────────────
 sonar.sources=YseEngine


### PR DESCRIPTION
Closes #408. Part of epic #420.

## The bug

New Code is set to **"Previous version"** — the right setting. But it only
advances when `sonar.projectVersion` changes between analyses, and that value
was hardcoded in `sonar-project.properties` and **never bumped**:

```
sonar.projectVersion=1.0.77
```

`git log -L` on that line shows exactly one commit — `04bbb24`, "Add SonarCloud
configuration", the day the integration was added. Meanwhile the project shipped
v2.1.1, v2.2.0, v2.3.0, v2.3.1 and **v2.4.0**. The release skill has no mention
of Sonar, so nothing was ever going to update it.

With the version string frozen, SonarCloud never saw a version change, so it
never set a baseline — and **every line in the repository counted as "new
code"**.

That is the root cause of three things this epic had been treating as separate
mysteries:

- `new_coverage` (65.8%) sat within 0.1 points of overall `coverage` (65.9%)
- the single security hotspot, created 2026-05-17, counted as new
- `cpp:S8473` findings authored **2018-04-08** gated `new_reliability_rating`

## The fix

CI resolves the version from `YseEngine/system.hpp` and passes it to the
scanner:

```yaml
- name: Resolve project version for Sonar
  id: version
  run: |
    VER=$(sed -n 's/.*VERSION[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' YseEngine/system.hpp | head -1)
    if [ -z "$VER" ]; then
      echo "::error file=YseEngine/system.hpp::could not parse VERSION ..."
      exit 1
    fi
    echo "version=$VER" >> "$GITHUB_OUTPUT"
```

`system.hpp` is the authoritative source — it is what `python yse.py release`
bumps, and Sphinx's `conf.py` already reads it exactly this way (PR #89). So
this follows existing precedent and cannot drift again.

The literal is **removed** from `sonar-project.properties` rather than kept as a
fallback: a stale value there is precisely the failure being fixed, and silently
falling back to it would be worse than failing loudly. The resolve step exits 1
if it cannot parse the version.

## What this changes, stated honestly

This does **not** fix the 215 reliability findings, the 12 security findings, or
the coverage gap. It changes what the *gate* measures, to the clean-as-you-code
model SonarCloud is designed around. Every sub-issue in #420 remains worth doing
— they stop being gate blockers and become tracked backlog.

Expected effect, and deliberately not overstated: the first analysis carrying
`2.4.0` sets a baseline against the last `1.0.77` analysis (master,
**2026-07-21**). So New Code narrows from *all history* to *changes since
2026-07-21*, and narrows further at each subsequent release. It is not
guaranteed to turn the gate green on its own — that depends on what changed in
that window — but it makes the gate measure something meaningful for the first
time.

## Verification

- `build.yml` parses as YAML; the resolve step is confirmed ordered **before**
  the scan step, carries `id: version`, and the scan args reference
  `steps.version.outputs.version`.
- Extraction tested against the real file: resolves `2.4.0` from
  `YseEngine/system.hpp:22`.
- Negative test: a file with no `VERSION` line yields empty, so the step exits 1
  rather than silently shipping a bad baseline.
- `sonar-project.properties` re-parsed with `java.util.Properties` continuation
  semantics: `sonar.exclusions` still resolves to all 14 entries (msfa from
  #415 intact), `sonar.test.exclusions` to `Tests/Android/**` (#411), all other
  expected keys still parse, and `sonar.projectVersion` is confirmed absent.
- `git diff --name-only` shows only the two intended files.
