### PR TITLE
utils: replace rand()/srand() with a thread-safe, RT-safe RNG (#410)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(YSE_TEST_SOURCES
   utils/test_mpmcqueue.cpp
   utils/test_interpolators.cpp
   utils/test_intrusive_list.cpp
+  utils/test_random.cpp
   internal/test_threadpool.cpp
   dsp/test_filters.cpp
   dsp/test_delay.cpp

--- a/Tests/reverb/test_reverb_dsp.cpp
+++ b/Tests/reverb/test_reverb_dsp.cpp
@@ -610,7 +610,7 @@ TEST_SUITE("reverb") {
     CHECK(leftEnergy > 0.0f);
     CHECK(rightEnergy > 0.0f);
     // L and R should differ because of independent Random() tuning offsets.
-    // Identical tuning has ~2% probability (rnd = rand()%50 same twice in a row).
+    // Identical tuning has ~2% probability (rnd = Random(50) same twice in a row).
     CHECK_MESSAGE(diffEnergy > 0.0f,
                   "L/R channels should differ due to independent Random(50) comb-tuning offsets; "
                   "identical offsets occur with ~2% probability");

--- a/Tests/utils/test_random.cpp
+++ b/Tests/utils/test_random.cpp
@@ -1,0 +1,298 @@
+// Tests for the pseudo-random helpers in YseEngine/utils/misc.hpp (issue #410).
+//
+// The helpers used to wrap C rand()/srand(); they now run a thread_local
+// xorshift128+ generator with a Lemire multiply-shift reduction. This suite
+// pins the contract that replacement has to keep:
+//
+//   - every helper stays inside its documented half-open range;
+//   - degenerate inputs (empty or inverted ranges) return deterministically
+//     instead of dividing by zero — `rand() % max` used to crash on max == 0,
+//     which the patcher's gRandom object can reach from the audio thread;
+//   - RandomF() carries more than the 15 bits RAND_MAX allowed on MSVC;
+//   - concurrent threads draw from independent state, stay in range, and the
+//     draw itself never allocates (audio-callback path, CLAUDE.md rule 3).
+
+#include <doctest/doctest.h>
+
+#include <cstddef>
+#include <limits>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include "support/alloc_probe.hpp"
+#include "utils/misc.hpp"
+
+TEST_SUITE("utils") {
+
+  // Enough draws to make a missed bound overwhelmingly likely to show up,
+  // cheap enough to stay in the fast unit suite.
+  static const int kDraws = 20000;
+
+  // --- Random(Int) ---
+
+  TEST_CASE("Random(Int): stays inside [0, max)") {
+    const Int bounds[] = {1, 2, 3, 50, 1000, 65537};
+    for (Int max : bounds) {
+      for (int i = 0; i < kDraws; ++i) {
+        const Int v = YSE::Random(max);
+        REQUIRE(v >= 0);
+        REQUIRE(v < max);
+      }
+    }
+  }
+
+  TEST_CASE("Random(Int): reaches every value in the range") {
+    std::set<Int> seen;
+    for (int i = 0; i < kDraws; ++i)
+      seen.insert(YSE::Random(8));
+    CHECK(seen.size() == 8);
+  }
+
+  TEST_CASE("Random(Int): degenerate bounds return 0 instead of dividing by zero") {
+    // max == 0 was the cpp:S3518 divide-by-zero in `rand() % max`.
+    CHECK(YSE::Random(0) == 0);
+    CHECK(YSE::Random(-1) == 0);
+    CHECK(YSE::Random(-1000) == 0);
+    CHECK(YSE::Random(std::numeric_limits<Int>::min()) == 0);
+    // max == 1 has exactly one legal answer.
+    for (int i = 0; i < 100; ++i)
+      REQUIRE(YSE::Random(1) == 0);
+  }
+
+  // --- Random(Int, Int) ---
+
+  TEST_CASE("Random(Int, Int): stays inside [min, max)") {
+    struct Range {
+      Int min;
+      Int max;
+    };
+    const Range ranges[] = {{0, 10}, {-10, 10}, {-100, -50}, {5, 6}, {1000, 100000}};
+    for (const Range& r : ranges) {
+      for (int i = 0; i < kDraws; ++i) {
+        const Int v = YSE::Random(r.min, r.max);
+        REQUIRE(v >= r.min);
+        REQUIRE(v < r.max);
+      }
+    }
+  }
+
+  TEST_CASE("Random(Int, Int): reaches every value in the range") {
+    std::set<Int> seen;
+    for (int i = 0; i < kDraws; ++i)
+      seen.insert(YSE::Random(-2, 3));
+    CHECK(seen.size() == 5);
+    CHECK(*seen.begin() == -2);
+    CHECK(*seen.rbegin() == 2);
+  }
+
+  TEST_CASE("Random(Int, Int): empty and inverted ranges return min") {
+    CHECK(YSE::Random(7, 7) == 7);
+    CHECK(YSE::Random(-5, -5) == -5);
+    CHECK(YSE::Random(10, 3) == 10);
+    CHECK(YSE::Random(0, -1) == 0);
+  }
+
+  TEST_CASE("Random(Int, Int): full-width span does not overflow") {
+    // max - min is 2^32 - 1 here, which overflows Int; the helper widens to 64
+    // bit before reducing.
+    const Int lo = std::numeric_limits<Int>::min();
+    const Int hi = std::numeric_limits<Int>::max();
+    for (int i = 0; i < 2000; ++i) {
+      const Int v = YSE::Random(lo, hi);
+      REQUIRE(v >= lo);
+      REQUIRE(v < hi);
+    }
+  }
+
+  // --- BigRandom ---
+
+  TEST_CASE("BigRandom: stays inside [0, max) and leans toward 0") {
+    const Int max = 10000;
+    double sum = 0.0;
+    for (int i = 0; i < kDraws; ++i) {
+      const Int v = YSE::BigRandom(max);
+      REQUIRE(v >= 0);
+      REQUIRE(v < max);
+      sum += static_cast<double>(v);
+    }
+    // Product of two uniform [0, 100) draws: mean ~2450, well under the 5000 a
+    // uniform draw over [0, max) would give.
+    CHECK(sum / kDraws < max / 3.0);
+  }
+
+  TEST_CASE("BigRandom: degenerate and tiny bounds return 0") {
+    // sqrt(max) was 0 for max == 0, so the old code divided by zero here too.
+    CHECK(YSE::BigRandom(0) == 0);
+    CHECK(YSE::BigRandom(-5) == 0);
+    CHECK(YSE::BigRandom(std::numeric_limits<Int>::min()) == 0);
+    // sqrt() floors to 1 for max in [1, 3], leaving a single legal answer.
+    for (int i = 0; i < 100; ++i) {
+      REQUIRE(YSE::BigRandom(1) == 0);
+      REQUIRE(YSE::BigRandom(2) == 0);
+      REQUIRE(YSE::BigRandom(3) == 0);
+    }
+  }
+
+  // --- RandomF ---
+
+  TEST_CASE("RandomF(): stays inside [0, 1) and spans it") {
+    Flt lo = 1.0f;
+    Flt hi = 0.0f;
+    for (int i = 0; i < kDraws; ++i) {
+      const Flt v = YSE::RandomF();
+      REQUIRE(v >= 0.0f);
+      REQUIRE(v < 1.0f);
+      if (v < lo) lo = v;
+      if (v > hi) hi = v;
+    }
+    CHECK(lo < 0.01f);
+    CHECK(hi > 0.99f);
+  }
+
+  TEST_CASE("RandomF(): resolution beats the 15-bit RAND_MAX of MSVC") {
+    // rand()/RAND_MAX could only ever produce 32768 distinct values on MSVC, so
+    // 100k draws could not exceed that count. The 24-bit replacement should
+    // come close to 100k distinct values.
+    std::set<Flt> seen;
+    for (int i = 0; i < 100000; ++i)
+      seen.insert(YSE::RandomF());
+    CHECK(seen.size() > 50000);
+  }
+
+  TEST_CASE("RandomF(Flt): stays inside [0, max)") {
+    for (int i = 0; i < kDraws; ++i) {
+      const Flt v = YSE::RandomF(4.5f);
+      REQUIRE(v >= 0.0f);
+      REQUIRE(v < 4.5f);
+    }
+    for (int i = 0; i < 100; ++i)
+      REQUIRE(YSE::RandomF(0.0f) == 0.0f);
+    // A negative bound mirrors the interval: (max, 0].
+    for (int i = 0; i < kDraws; ++i) {
+      const Flt v = YSE::RandomF(-2.0f);
+      REQUIRE(v <= 0.0f);
+      REQUIRE(v > -2.0f);
+    }
+  }
+
+  TEST_CASE("RandomF(Flt, Flt): stays inside [min, max)") {
+    for (int i = 0; i < kDraws; ++i) {
+      const Flt v = YSE::RandomF(-3.0f, 7.0f);
+      REQUIRE(v >= -3.0f);
+      REQUIRE(v < 7.0f);
+    }
+    for (int i = 0; i < 100; ++i)
+      REQUIRE(YSE::RandomF(2.5f, 2.5f) == 2.5f);
+    // An inverted range stays inside the closed hull rather than escaping it.
+    for (int i = 0; i < kDraws; ++i) {
+      const Flt v = YSE::RandomF(5.0f, 1.0f);
+      REQUIRE(v >= 1.0f);
+      REQUIRE(v <= 5.0f);
+    }
+  }
+
+  // --- Random(Flt*, Flt*) ---
+
+  TEST_CASE("Random(Flt*, Flt*): returns an in-range pointer on the Flt stride") {
+    Flt block[8] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
+    Flt* begin = block;
+    Flt* end = block + 8;
+
+    std::set<std::ptrdiff_t> seen;
+    for (int i = 0; i < kDraws; ++i) {
+      Flt* p = YSE::Random(begin, end);
+      REQUIRE(p >= begin);
+      REQUIRE(p < end);
+      const std::ptrdiff_t index = p - begin;
+      // Whole-element stride: dereferencing must land on a real slot.
+      REQUIRE(*p == doctest::Approx(static_cast<Flt>(index)));
+      seen.insert(index);
+    }
+    CHECK(seen.size() == 8);
+  }
+
+  TEST_CASE("Random(Flt*, Flt*): empty and inverted ranges return min") {
+    Flt block[8] = {};
+    CHECK(YSE::Random(block, block) == block);
+    CHECK(YSE::Random(block + 3, block + 3) == block + 3);
+    CHECK(YSE::Random(block + 5, block + 2) == block + 5);
+  }
+
+  // --- seeding ---
+
+  TEST_CASE("Randomize(): re-seeds without breaking the range contract") {
+    YSE::Randomize();
+    std::set<Int> seen;
+    for (int i = 0; i < kDraws; ++i) {
+      const Int v = YSE::Random(16);
+      REQUIRE(v >= 0);
+      REQUIRE(v < 16);
+      seen.insert(v);
+    }
+    CHECK(seen.size() == 16);
+  }
+
+  // --- threading / real-time properties ---
+
+  TEST_CASE("Random: concurrent threads stay in range and draw independent streams") {
+    const int kThreads = 4;
+    const int kPerThread = 5000;
+    std::vector<std::vector<Int>> sequences(kThreads);
+    std::vector<std::thread> workers;
+    workers.reserve(kThreads);
+
+    for (int t = 0; t < kThreads; ++t) {
+      sequences[t].reserve(kPerThread);
+      workers.emplace_back([&sequences, t, kPerThread]() {
+        for (int i = 0; i < kPerThread; ++i)
+          sequences[t].push_back(YSE::Random(1000000));
+      });
+    }
+    for (std::thread& w : workers)
+      w.join();
+
+    for (int t = 0; t < kThreads; ++t) {
+      CHECK(sequences[t].size() == static_cast<std::size_t>(kPerThread));
+      for (Int v : sequences[t]) {
+        REQUIRE(v >= 0);
+        REQUIRE(v < 1000000);
+      }
+    }
+
+    // Each thread seeds its own state from a distinct stream index, so no two
+    // threads may replay the same sequence.
+    for (int a = 0; a < kThreads; ++a)
+      for (int b = a + 1; b < kThreads; ++b)
+        CHECK(sequences[a] != sequences[b]);
+  }
+
+  TEST_CASE("Random: drawing never allocates") {
+    Flt block[8] = {};
+    // Warm the thread_local state up first: the one-time seed is lock- and
+    // allocation-free too, but keeping it outside the probe keeps the assertion
+    // about the steady-state draw.
+    YSE::Random(10);
+
+    volatile Int sinkI = 0;
+    volatile Flt sinkF = 0.0f;
+    volatile std::ptrdiff_t sinkP = 0;
+    {
+      TestHelpers::ProbeScope probe;
+      for (int i = 0; i < 1000; ++i) {
+        sinkI = YSE::Random(97);
+        sinkI = YSE::Random(-5, 5);
+        sinkI = YSE::BigRandom(400);
+        sinkF = YSE::RandomF();
+        sinkF = YSE::RandomF(3.0f);
+        sinkF = YSE::RandomF(-1.0f, 1.0f);
+        sinkP = YSE::Random(block, block + 8) - block;
+      }
+      CHECK(TestHelpers::g_alloc_count.load() == 0);
+    }
+    (void)sinkI;
+    (void)sinkF;
+    (void)sinkP;
+  }
+
+} // TEST_SUITE("utils")

--- a/YseEngine/utils/misc.hpp
+++ b/YseEngine/utils/misc.hpp
@@ -11,9 +11,10 @@
 #ifndef MISC_H_INCLUDED
 #define MISC_H_INCLUDED
 
-#include <cstdlib>
-#include <time.h>
+#include <atomic>
+#include <chrono>
 #include <cmath>
+#include <cstddef>
 #include "../headers/types.hpp"
 
 namespace YSE {
@@ -31,48 +32,187 @@ namespace YSE {
       x = max;
   }
 
-  /** @brief Seed the random generator from the current time. Call once at startup. */
+  /**
+   *  @brief Internals of the engine-wide pseudo-random generator.
+   *
+   *  The generator is **xorshift128+** over per-thread state, replacing the C
+   *  ``rand()`` / ``srand()`` pair. ``rand()`` keeps hidden *global* state, so
+   *  the concurrent calls this engine makes from the audio callback (the
+   *  ``gRandom`` patcher object, granulator jitter, the LFO's random shapes),
+   *  from the control thread and from the manager threads are a data race on
+   *  that state — and some libc implementations serialise inside ``rand()``,
+   *  which is exactly what must not happen on the callback path.
+   *
+   *  Everything here is real-time safe: no allocation, no locks, no I/O, no
+   *  division. The per-thread state is ``thread_local`` **and
+   *  constant-initialised**, so no lazy-init guard variable is checked on the
+   *  hot path. A thread seeds itself on its first draw, which costs one
+   *  well-predicted branch, one relaxed 32-bit ``fetch_add`` and two integer
+   *  mixing rounds — once per thread, ever.
+   */
+  namespace RANDOM {
+
+    /**
+     *  @brief Global seed base, published by ``Randomize()``.
+     *
+     *  Left at a fixed constant otherwise, so an application that never calls
+     *  ``Randomize()`` gets a reproducible sequence — the same contract an
+     *  unseeded ``rand()`` offered.
+     */
+    inline std::atomic<UInt> SeedBase{0x9E3779B9u};
+
+    /** @brief Hands every thread a distinct stream index on its first draw. */
+    inline std::atomic<UInt> StreamCounter{0};
+
+    /**
+     *  @brief Per-thread generator state; ``{0, 0}`` means "not seeded yet".
+     *
+     *  Constant-initialised on purpose: a dynamically initialised
+     *  ``thread_local`` would add a guard-variable check to every single draw.
+     */
+    inline thread_local U64 State[2] = {0, 0};
+
+    /** @brief SplitMix64 finalizer — turns a counter into well-distributed bits. */
+    inline U64 Mix(U64 z) {
+      z += 0x9E3779B97F4A7C15ull;
+      z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
+      z = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
+      return z ^ (z >> 31);
+    }
+
+    /**
+     *  @brief Give the calling thread a fresh, non-zero state.
+     *
+     *  Lock-free and allocation-free, so it is safe even when it happens to run
+     *  inside an audio callback — which is where the first draw on the audio
+     *  thread lands unless the host calls it earlier.
+     */
+    inline void SeedThread() {
+      const U64 base = static_cast<U64>(SeedBase.load(std::memory_order_relaxed));
+      const U64 stream = static_cast<U64>(StreamCounter.fetch_add(1, std::memory_order_relaxed));
+      State[0] = Mix((base << 32) ^ (stream + 1));
+      State[1] = Mix(State[0]) | 1ull; // the |1 keeps the pair from ever being all-zero
+    }
+
+    /** @brief xorshift128+ — 64 pseudo-random bits in a handful of instructions. */
+    inline U64 Next() {
+      if ((State[0] | State[1]) == 0) SeedThread();
+      U64 x = State[0];
+      const U64 y = State[1];
+      State[0] = y;
+      x ^= x << 23;
+      State[1] = x ^ y ^ (x >> 17) ^ (y >> 26);
+      return State[1] + y;
+    }
+
+    /**
+     *  @brief Uniform integer in [0, ``bound``) via Lemire's multiply-shift
+     *  reduction. Returns 0 when ``bound`` is 0, so there is no division and no
+     *  divide-by-zero to guard against.
+     *
+     *  The rejection step of Lemire's *exactly* unbiased variant is deliberately
+     *  left out: it makes the running time unbounded, which does not belong in
+     *  an audio callback. Without it the bias stays below ``bound / 2^32`` —
+     *  orders of magnitude under one least-significant bit for every bound this
+     *  engine uses (grain offsets, comb tunings, note pitches, patcher ranges).
+     */
+    inline UInt Bounded(UInt bound) {
+      const U64 product = static_cast<U64>(static_cast<UInt>(Next() >> 32)) * bound;
+      return static_cast<UInt>(product >> 32);
+    }
+
+    /**
+     *  @brief Uniform float in [0, 1).
+     *
+     *  Draws 24 bits — the full float mantissa — against the 15 bits
+     *  ``RAND_MAX`` allowed on MSVC.
+     */
+    inline Flt NextFloat() {
+      return static_cast<Flt>(Next() >> 40) * (1.0f / 16777216.0f);
+    }
+
+  } // namespace RANDOM
+
+  /**
+   *  @brief Seed the random generator from the current time. Call once at startup.
+   *
+   *  Optional — without it the engine still produces random-looking output, only
+   *  reproducibly so. This publishes a clock-derived seed base and re-seeds the
+   *  calling thread immediately; other threads pick the new base up on their
+   *  next draw.
+   *
+   *  Not real-time safe (it reads the system clock): call it from the control
+   *  thread at startup, never from an audio callback. Note that the generator
+   *  state is header-local, so a host that links the engine as a shared library
+   *  seeds its own copy, not the engine's.
+   */
   inline void Randomize() {
-    srand(static_cast<UInt>(::time(nullptr)));
+    const U64 now =
+        static_cast<U64>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    RANDOM::SeedBase.store(static_cast<UInt>(RANDOM::Mix(now) >> 32), std::memory_order_relaxed);
+    // Zeroing the state makes the calling thread re-seed from the new base on
+    // its next draw.
+    RANDOM::State[0] = 0;
+    RANDOM::State[1] = 0;
   }
 
-  /** @brief Random integer in [0, ``max``). */
+  /**
+   *  @brief Random integer in [0, ``max``). Returns 0 when ``max <= 0``.
+   *
+   *  The empty range has no other sensible answer, and saying so explicitly is
+   *  what retires the divide-by-zero that ``rand() % max`` carried: the patcher's
+   *  ``gRandom`` object lets a patch set its range to 0 from the audio thread.
+   */
   inline Int Random(Int max) {
-    return rand() % max;
-  } // NOSONAR S3518: caller-side precondition (max > 0) — same contract as
-    // std::uniform_int_distribution
+    if (max <= 0) return 0;
+    return static_cast<Int>(RANDOM::Bounded(static_cast<UInt>(max)));
+  }
 
-  /** @brief Random integer in [``min``, ``max``). */
+  /** @brief Random integer in [``min``, ``max``). Returns ``min`` when ``max <= min``. */
   inline Int Random(Int min, Int max) {
-    return min + (rand() % (max - min));
-  } // NOSONAR S3518: caller-side precondition (max > min)
+    if (max <= min) return min;
+    // Widened to 64 bit: a span such as [INT_MIN, INT_MAX) overflows Int.
+    const I64 span = static_cast<I64>(max) - static_cast<I64>(min);
+    const I64 offset = static_cast<I64>(RANDOM::Bounded(static_cast<UInt>(span)));
+    return static_cast<Int>(static_cast<I64>(min) + offset);
+  }
 
-  /** @brief Heavy-tailed random integer biased toward 0; produces fewer high values than
-   * ``Random``. */
+  /**
+   *  @brief Heavy-tailed random integer biased toward 0; produces fewer high values than
+   *  ``Random``. Returns 0 when ``max <= 0``.
+   */
   inline Int BigRandom(Int max) {
-    max = static_cast<Int>(sqrt(max));
-    return ((rand() % max) *
-            (rand() % max)); // NOSONAR S3518: caller-side precondition (max > 0 so sqrt(max) >= 1)
+    if (max <= 0) return 0;
+    const Int root = static_cast<Int>(std::sqrt(static_cast<Dbl>(max)));
+    return Random(root) * Random(root);
   }
 
-  /** @brief Random float in [0, 1]. */
+  /** @brief Random float in [0, 1). */
   inline Flt RandomF() {
-    return (float)rand() / (float)RAND_MAX;
+    return RANDOM::NextFloat();
   }
 
-  /** @brief Random float in [0, ``max``]. */
+  /** @brief Random float in [0, ``max``). */
   inline Flt RandomF(Flt max) {
-    return (float)rand() / (float)RAND_MAX * max;
+    return RANDOM::NextFloat() * max;
   }
 
-  /** @brief Random float in [``min``, ``max``]. */
+  /** @brief Random float in [``min``, ``max``). */
   inline Flt RandomF(Flt min, Flt max) {
-    return min + ((float)rand() / (float)RAND_MAX * (max - min));
+    return min + (RANDOM::NextFloat() * (max - min));
   }
 
-  /** @brief Random pointer in [``min``, ``max``), stride one ``Flt``. */
+  /**
+   *  @brief Random pointer in [``min``, ``max``), stride one ``Flt``.
+   *
+   *  Both pointers must address the same array. Returns ``min`` for an empty
+   *  range.
+   */
   inline Flt* Random(Flt* min, Flt* max) {
-    return min + (rand() % (max - min));
+    if (max <= min) return min;
+    U64 span = static_cast<U64>(max - min);
+    if (span > 0xFFFFFFFFull) span = 0xFFFFFFFFull; // the reduction takes a 32-bit bound
+    return min + static_cast<std::ptrdiff_t>(RANDOM::Bounded(static_cast<UInt>(span)));
   }
 
   const Flt Pi_6 = 0.52359878f; ///< PI/6 (30°).


### PR DESCRIPTION
## Summary

`YseEngine/utils/misc.hpp` built its entire random-number surface on C
`rand()` / `srand()`. This replaces it with a header-only **xorshift128+**
generator over `thread_local` state.

The security framing SonarCloud puts on `cpp:S2245` ("not cryptographically
secure") is beside the point — none of this feeds a security decision. The
two problems that *do* matter:

1. **`rand()` keeps hidden global state.** The engine calls these helpers
   from the audio callback (the `gRandom` patcher object, granulator jitter,
   the LFO's random shapes), from the control thread, and from the manager
   threads. That is a data race on libc's global state, and some
   implementations serialise inside `rand()` — precisely what must not
   happen on a callback path.
2. **Quality and range.** `rand() % max` is modulo-biased, and `RAND_MAX` is
   only 32767 on MSVC, giving `RandomF()` ~15 bits.

## Linked issue

Closes #410

Part of #420 (SonarCloud quality-gate epic).

## Changes

### `YseEngine/utils/misc.hpp`

New `YSE::RANDOM` namespace holding the generator, then the seven public
helpers rewritten on top of it. **Public signatures are unchanged.**

**Real-time discipline** (CLAUDE.md rule 3) — no allocation, no locks, no
I/O, and no division anywhere in the module:

- The per-thread state is `thread_local` **and constant-initialised**, so
  there is no lazy-init guard variable checked on the hot path (a
  `static thread_local std::mt19937` would have cost both a guard check per
  draw and ~2.5 KB of TLS).
- A thread seeds itself on its first draw. That costs one well-predicted
  branch, one relaxed **32-bit** `fetch_add` (32-bit so it stays lock-free on
  armeabi-v7a too) and two SplitMix64 rounds — once per thread, ever.
  Bounded, allocation-free and lock-free, so it is safe even when that first
  draw happens inside a callback.
- **Seeding was left lazy on purpose** rather than wired into engine
  startup. An explicit `System::init()` call would only have seeded the
  *control* thread — the audio thread's first draw still lands in a
  callback — so it would have added engine-behaviour scope without removing
  the case it was meant to remove. `RANDOM::SeedThread()` is public if a
  host ever wants to pre-seed a thread explicitly.
- Bounded integers use **Lemire's multiply-shift reduction**. The rejection
  step of the exactly-unbiased variant is deliberately omitted: it makes the
  running time unbounded, which does not belong in an audio callback. The
  residual bias is under `bound / 2^32` — orders of magnitude below one LSB
  for every bound this engine uses.
- `RandomF()` now draws 24 bits (the full float mantissa), up from ~15 on
  MSVC.
- The seed base stays a fixed constant unless `Randomize()` is called,
  preserving the reproducible-when-unseeded contract `rand()` had — so the
  test suite stays deterministic.

### `cpp:S3518` retired, not suppressed

The CRITICAL division-by-zero at the old line 41 is **gone**, not silenced:
the reduction never divides, and every helper handles a degenerate range
deterministically (`max <= 0` returns `0`, `max <= min` returns `min`).

This is a real fix rather than cosmetics — `gRandom`'s `SetIntRange` lets a
patch set the range to `0` from the audio thread, and `BigRandom(0)` was
reachable from `granulator.cpp:42` whenever `max == min`. Both used to divide
by zero.

The two `// NOSONAR S3518` comments were deleted with the rewrite. They sat
on closing braces, one line past the finding, and suppressed nothing.

### Findings cleared

Pulled the live list from SonarCloud for this file — it was larger than the
issue recorded:

| Rule | Severity | Count | Status |
|---|---|---|---|
| `cpp:S2245` | MAJOR | 7 | gone |
| `cpp:S5020` (`rand`/`srand` to `<random>`) | **BLOCKER** | 8 | gone |
| `cpp:S3518` (division by zero) | CRITICAL | 1 | gone |

The 8 `cpp:S5020` BLOCKERs were not listed in #410 and fall out for free.

`grep` is clean: no `rand(` / `srand(` / `RAND_MAX` left anywhere under
`YseEngine/` (only prose references in doc comments).

### Callers

Grepped the whole tree — `Tests/`, `Demo.Windows.Native/`, `YseEngine/c_api/`,
the pybind bindings and the docs — for `Randomize()`, `Random(`, `BigRandom(`
and `RandomF(`:

- **`Randomize()` has zero callers.** `srand()` was therefore *never* called,
  so the engine has been running off `rand()`'s default seed of 1 all along.
  Nothing depends on a globally-seeded `rand()`, so nothing breaks; the fixed
  default seed base preserves that behaviour exactly.
- `Random(Flt*, Flt*)` has no in-repo callers but is public API via
  `yse.hpp`, so it is kept and tested.
- All other call sites (`reverbDSP`, `granulator`, `lfo`,
  `playerImplementation`, `gRandom`, `interpolators`, Demo03, Demo17) compile
  unchanged.
- `DSP::noise` (which backs the `dNoise` patcher object) turned out to have
  its own private LCG in `oscillators.cpp` and never touched `rand()`.

**One behavioural change:** the float helpers are now half-open — `[0, 1)`
rather than `[0, 1]` — matching `uniform_real_distribution`. No caller depends
on hitting exactly `1.0`, and `Tests/utils/test_interpolators.cpp:84` already
documented the half-open assumption. Doc comments updated to match.

### `Tests/utils/test_random.cpp` (new, `utils` suite)

Registered in `Tests/CMakeLists.txt`, so it runs in both `yse_tests_utils` and
the monolithic `yse_unit_tests` entry. Covers, per helper:

- range and full-range coverage for `Random(Int)`, `Random(Int,Int)`,
  `BigRandom`, `RandomF()`, `RandomF(Flt)` and `RandomF(Flt,Flt)`;
- the degenerate inputs — `max == 0`, `max == 1`, `min == max`, inverted
  ranges, negative bounds, `INT_MIN`, and a full-width `[INT_MIN, INT_MAX)`
  span that would overflow a 32-bit subtraction;
- `Random(Flt*, Flt*)` pointer-stride behaviour (every returned pointer
  dereferences to its own slot) plus empty and inverted pointer ranges;
- a resolution check that would fail against a 15-bit `RAND_MAX`;
- a four-thread independence check — all draws in range, no two threads
  replaying the same sequence (no `std::thread::id` stringification, so it is
  portable to the libstdc++ CI leg);
- an `alloc_probe` assertion that drawing never allocates.

Also refreshed a now-stale `rand()%50` comment in
`Tests/reverb/test_reverb_dsp.cpp` that describes this code.

## Out of scope

- **Filed #426**: `.clang-tidy`'s `HeaderFilterRegex` requires headers to sit
  *directly* under `YseEngine/` or `Tests/`, so every header in a
  subdirectory is skipped. `python yse.py analyze` reported 0 findings on
  every TU including this header while the old code was live; re-running with
  a widened header filter reported 10 (`cert-msc50-cpp` x8,
  `bugprone-random-generator-seed` x1). The checks were enabled and working —
  the filter discarded the results. Out of scope here; it needs its own
  baseline re-measurement.
- `cpp:S995` (MINOR, "make `max` a pointer-to-const") on `Random(Flt*, Flt*)`
  is left as-is. It predates this work, is unrelated to the RNG, and its line
  is unchanged in the diff so it stays out of New Code. Changing a public
  signature for a MINOR is the opportunistic broadening CLAUDE.md rules out.
- Sibling #409 (misplaced NOSONAR markers elsewhere) does not touch this file,
  and PR #424 touches only `sonar-project.properties`. No overlap.

## Test plan

- [x] `python yse.py build` — clean (debug preset, MSYS2 Clang64). Dropping
      `<cstdlib>` / `<time.h>` from this widely-included header broke no
      transitive include; swept the tree for real `cstdlib` / `time.h`
      free-function uses and found none outside files that include them
      directly.
- [x] `python yse.py test` — **34/34 ctest entries pass**. Monolithic
      `yse_unit_tests`: **1365 test cases, 1,174,266 assertions, 0 failed**.
      Isolated `yse_tests_utils`: **103 cases, 838,217 assertions, 0 failed**.
- [x] `python yse.py analyze` on the consuming TUs — clean under the project
      baseline. A/B'd against `dev` with a widened header filter: **10
      findings before, 0 after**.
- [x] `python yse.py format` — stable, no re-formatting of the changed files
      (verified with `clang-format --dry-run -Werror`, version 22.1.4, the
      version the CI format gate is pinned to).
- [x] Linux-CI portability reviewed: no `std::thread::id` stringification,
      nothing Windows-specific, 32-bit atomics so the seed path stays
      lock-free on armeabi-v7a.

Integration/e2e: not applicable — this is a leaf utility header with no
user-visible surface of its own. Its behaviour is exercised end-to-end by the
existing reverb, granulator, LFO, player and patcher suites, all of which pass
unchanged.

The benchmark leg from the issue's acceptance list is not run here (the macro
bench runs with audio paused, so it would not measure the callback path
anyway); the replacement is strictly fewer instructions than `rand()` plus a
modulo, with no shared state to contend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
