### PR TITLE
sonar: move NOSONAR markers onto the lines findings anchor to (#409)

### DIFF
--- a/YseEngine/dsp/oscillators.cpp
+++ b/YseEngine/dsp/oscillators.cpp
@@ -153,9 +153,8 @@ namespace YSE {
         tf.d = dphase;
         f1 = addr[0];
         f2 = addr[1];
-        addr = tab + (tf.i[HIOFFSET] &
-                      (COSTABSIZE - 1)); // NOSONAR S6232: intentional UNITBIT32 fast-phase pun —
-                                         // see union tablePhase declaration above
+        // S6232: intentional UNITBIT32 fast-phase pun — see union tablePhase above.
+        addr = tab + (tf.i[HIOFFSET] & (COSTABSIZE - 1)); // NOSONAR
         *outPtr++ = f1 + frac * (f2 - f1);
         tf.i[HIOFFSET] = normhipart; // NOSONAR S6232: intentional UNITBIT32 fast-phase pun — see
                                      // union tablePhase declaration above
@@ -233,9 +232,8 @@ namespace YSE {
           dphase += frequency * conv;
         else
           dphase += *inPtr++ * conv;
-        addr = tab + (tf.i[HIOFFSET] &
-                      (COSTABSIZE - 1)); // NOSONAR S6232: intentional UNITBIT32 fast-phase pun —
-                                         // see union tablePhase declaration above
+        // S6232: intentional UNITBIT32 fast-phase pun — see union tablePhase above.
+        addr = tab + (tf.i[HIOFFSET] & (COSTABSIZE - 1)); // NOSONAR
         tf.i[HIOFFSET] = normhipart; // NOSONAR S6232: intentional UNITBIT32 fast-phase pun — see
                                      // union tablePhase declaration above
         *outPtr++ = f1 + frac * (f2 - f1);

--- a/YseEngine/internal/abstractSoundFile.cpp
+++ b/YseEngine/internal/abstractSoundFile.cpp
@@ -500,10 +500,13 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
   // set cursor to the output buffer start
   FOREACH(filebuffer) filebuffer[i].cursor = filebuffer[i].getPtr();
 
-  for (UInt x = 0;
-       x < length;) { // x is updated within loop, when increasing cursor // NOSONAR S1751: loop
-                      // body iterates via internal cursor advance; goto-based state machine — see
-                      // function-level S3776 justification
+  // x is updated inside the body as the cursor advances. The goto-based state
+  // machine re-enters at `startAgain` rather than falling through to the loop
+  // header, so control never reaches the end of the body — which is why S1751
+  // ("loop body executes at most once") fires here. Termination is guaranteed
+  // by the explicit `x >= length` break below. See the function-level S3776
+  // justification.
+  for (UInt x = 0; x < length;) { // NOSONAR
 
     // set position in filebuffer, according to nr of channels
     // UInt channelPos = ((UInt)pos) * file->_channels;
@@ -545,10 +548,8 @@ Bool YSE::INTERNAL::abstractSoundFile::readInterleaved(
         pos += speed;
         x++;
 
-        if (pos < 0 ||
-            pos >= (file->_streaming ? streamEnd
-                                     : len)) { // NOSONAR S134: nesting follows the state-machine
-                                               // structure documented at function level
+        // S134: nesting follows the state-machine structure documented at function level.
+        if (pos < 0 || pos >= (file->_streaming ? streamEnd : len)) { // NOSONAR
           goto calibrate;
         }
       }


### PR DESCRIPTION
Closes #409. Part of epic #420.

Comments only — no behaviour change.

## The problem

`NOSONAR` suppresses issues raised on **its own line**. Three deliberate
suppressions sat one line below the statement SonarCloud anchors the finding
to, because `clang-format` had wrapped them there. They suppressed nothing and
the findings stayed open:

| Rule | Was at | Marker was on |
|---|---|---|
| `cpp:S6232` | `dsp/oscillators.cpp:156` | 157 (wrapped continuation) |
| `cpp:S6232` | `dsp/oscillators.cpp:236` | wrapped continuation |
| `cpp:S1751` | `internal/abstractSoundFile.cpp:503` | 504 (wrapped continuation) |

## Scope note

The issue lists a **fourth** finding, `cpp:S3518` at `utils/misc.hpp:41`. That
is already resolved — #410 (PR #427) rewrote that file to drop `rand()`
entirely, so it no longer divides and the finding is gone along with its dead
markers. `misc.hpp` is untouched here.

## The fix

Short bare `// NOSONAR` on the anchor line; rationale moved to a normal comment
above:

```cpp
// S6232: intentional UNITBIT32 fast-phase pun — see union tablePhase above.
addr = tab + (tf.i[HIOFFSET] & (COSTABSIZE - 1)); // NOSONAR
```

The marker **must** stay short. `.clang-format` sets `ColumnLimit: 100` and
counts a trailing comment toward it, so a long marker pushes the statement past
the limit and clang-format breaks the *statement* — relocating the marker all
over again. `ReflowComments: false` was tested against the repo's own config
and produces **byte-identical** output: it governs comment reflowing, not
statement wrapping. Only `ColumnLimit: 0` would change this, and that would
reformat the whole codebase, so `.clang-format` is deliberately left alone.

Also fixed: a **fourth** marker stranded the same way — `cpp:S134` in
`abstractSoundFile.cpp` — surfaced by the repo-wide sweep this issue asks for.

## Verification

**Format stability** (the check this issue exists for): ran `python yse.py
format` after editing. Both files came back **byte-identical** — `diff -q`
reports no change — so the markers survive the formatter.

**Final marker positions** (line numbers shifted because the rationale comments
add lines above):

```
YseEngine/dsp/oscillators.cpp:157         addr = tab + (...); // NOSONAR
YseEngine/dsp/oscillators.cpp:236         addr = tab + (...); // NOSONAR
YseEngine/internal/abstractSoundFile.cpp:509   for (UInt x = 0; x < length;) { // NOSONAR
YseEngine/internal/abstractSoundFile.cpp:552   if (pos < 0 || ...) { // NOSONAR   (the S134 extra)
```

**Repo-wide sweep** — every `NOSONAR` under `YseEngine/` (excluding vendored
`msfa/` and `json/`) classified by whether it sits on a statement-terminating
line: **38 correctly anchored, 0 stranded.** The single flagged hit is a false
positive — `oscillators.cpp:26` is prose in the file header that merely
mentions the word.

Note the pre-existing long-form markers such as
`tf.i[HIOFFSET] = normhipart; // NOSONAR S6232: ...` are fine and untouched:
the `// NOSONAR` token is on the statement line, and only the trailing comment
*text* wraps. That distinction is what made the original bug easy to miss —
and it is directly observable in the old analysis, where line 160 (same-line
marker) was never reported while line 156 (wrapped) was.

**Build/test:** `python yse.py build` clean; `python yse.py test` passes — 39
ctest entries, 107s, exit 0.

## On whether these should be suppressed at all

Per the issue, this PR does not re-litigate the justifications, which are
already written in the source. Reading them: both `S6232` sites are the
UNITBIT32 fast-phase union pun (a deliberate, documented DSP idiom), and the
`S1751` site is a `goto`-based state machine whose body re-enters at
`startAgain` rather than falling through the loop header — which is exactly why
"loop body executes at most once" fires, and termination is guaranteed by the
explicit `x >= length` break. Neither looks like a masked real bug.

Since `NOSONAR` is not rule-scoped and silences everything on its line, the
markers are kept on the narrowest possible line.
