### PR TITLE
ci: skip the SonarQube scan on master pushes (#429)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,21 @@ jobs:
           echo "version=$VER" >> "$GITHUB_OUTPUT"
           echo "Resolved sonar.projectVersion=$VER"
       - name: SonarQube Scan
+        # Skipped on pushes to master. SonarCloud's main branch is `dev` (renamed
+        # from `master` — it captures the DevOps default branch once at project
+        # import and never revisits it, so it had drifted). On the free plan only
+        # the main branch can be analysed: non-main branches report "Not analyzed"
+        # behind an Upgrade badge. Submitting a master analysis would therefore
+        # burn the full scan to produce nothing. See #429.
+        #
+        # Everything above this step — build, both ctest runs, the coverage
+        # report — still runs on master, and the android/python/sanitizer jobs
+        # keep their release gate. Only the upload has nowhere to go.
+        #
+        # PR events need no guard here: the job-level `if` already skips PRs
+        # whose head is `dev` or `master`, covering both the dev -> master
+        # release PR and the master -> dev sync PR.
+        if: ${{ !(github.event_name == 'push' && github.ref_name == 'master') }}
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Closes #429. Part of epic #420.

Now that SonarCloud's main branch is `dev` (renamed from `master`), a scan submitted from a **push to master** targets a non-main branch — which the free plan cannot analyse ("Not analyzed", behind an Upgrade badge). It would burn the full ~10 min scan to produce nothing on every release promotion.

```yaml
if: ${{ !(github.event_name == 'push' && github.ref_name == 'master') }}
```

**Deliberately narrow.** `master` stays in `on.push.branches`: that trigger is shared by the whole workflow, and `build-android` / `build-python` / `build-sanitizers` are a documented release gate on master (`build.yml` describes the android job as running "on every push to master/dev (continuous coverage) and on PRs that target master (release gate)"). Dropping the trigger would silently remove that. The build, both ctest runs and the coverage report also still run on master — only the upload has nowhere to go.

PR events need no guard: the job-level `if` already skips PRs whose head is `dev` or `master`, covering both the `dev → master` release PR and the `master → dev` sync PR.

## Verification

Workflow re-parsed as YAML; condition and step ordering confirmed, `Resolve project version for Sonar` still present, `on.push.branches` still `[master, dev]`, and the other three jobs' conditions unchanged. Evaluated the expression across the cases that matter:

| event | ref_name | scan |
|---|---|---|
| push | dev | runs |
| push | master | **skipped** |
| pull_request | feature branch | runs |
| pull_request | dev | runs (already skipped at job level) |

`git diff --name-only` shows only `.github/workflows/build.yml`.