### PR TITLE
sonar: balance the locks/unlocks in patcher TimerThread (#412)

### DIFF
--- a/YseEngine/patcher/time/TimerThread.cpp
+++ b/YseEngine/patcher/time/TimerThread.cpp
@@ -62,11 +62,19 @@ void timerThread::timerThreadWorker() {
 timerThread::timerThread() : nextId(noTimer + 1), queue(), done(false) {}
 
 timerThread::~timerThread() {
-  ScopedLock lock(sync);
+  // The locked region gets its own scope so RAII releases the mutex on every
+  // path, rather than an explicit unlock() inside the branch that leaves this
+  // function's lock/unlock counts unbalanced (cpp:S8473). Ordering is
+  // unchanged: `done` is set under the lock, the mutex is released, and only
+  // then is the worker woken — so it never wakes onto a mutex we still hold.
+  bool needJoin;
+  {
+    ScopedLock lock(sync);
+    needJoin = worker.joinable();
+    if (needJoin) done = true;
+  }
 
-  if (worker.joinable()) {
-    done = true;
-    lock.unlock();
+  if (needJoin) {
     wakeUp.notify_all();
     worker.join();
   }
@@ -81,23 +89,31 @@ timerThread::timerID timerThread::setTimeout(timerFunc func, millisec timeout) {
 }
 
 timerThread::timerID timerThread::Add(millisec msDelay, millisec msPeriod, timerFunc func) {
-  ScopedLock lock(sync);
+  timerID id;
+  bool needNotify;
 
-  // start timer if not running
-  if (!worker.joinable()) {
-    worker = std::thread(&timerThread::timerThreadWorker, this);
+  // Scoped so RAII releases the mutex on every path, rather than an explicit
+  // unlock() that leaves this function's lock/unlock counts unbalanced
+  // (cpp:S8473). Ordering is unchanged: the mutex is released at the closing
+  // brace, before the notify below, so the worker never wakes onto a mutex we
+  // still hold.
+  {
+    ScopedLock lock(sync);
+
+    // start timer if not running
+    if (!worker.joinable()) {
+      worker = std::thread(&timerThread::timerThreadWorker, this);
+    }
+
+    id = nextId++;
+    auto iter = active.emplace(
+        id, Timer(id, Clock::now() + Duration(msDelay), Duration(msPeriod), std::move(func)));
+
+    Queue::iterator place = queue.emplace(iter.first->second);
+
+    // notify if in front of queue
+    needNotify = (place == queue.begin());
   }
-
-  auto id = nextId++;
-  auto iter = active.emplace(
-      id, Timer(id, Clock::now() + Duration(msDelay), Duration(msPeriod), std::move(func)));
-
-  Queue::iterator place = queue.emplace(iter.first->second);
-
-  // notify if in front of queue
-  bool needNotify = (place == queue.begin());
-
-  lock.unlock();
 
   if (needNotify) wakeUp.notify_all();
 
@@ -154,7 +170,13 @@ bool timerThread::destroyImpl(ScopedLock& lock, timerThread::TimerMap::iterator 
     active.erase(i);
 
     if (notify) {
-      lock.unlock();
+      // S8473: the unlock is deliberately unbalanced here and cannot be scoped
+      // away as in Add()/~timerThread(). The lock belongs to the caller (it
+      // arrives by reference) and the wait() above needs it, so this function
+      // documents that it "returns with lock unlocked" when notify is set. The
+      // mutex must be released *before* notify_all() so the worker does not
+      // wake straight onto a mutex we still hold.
+      lock.unlock(); // NOSONAR
       wakeUp.notify_all();
     }
   }


### PR DESCRIPTION
## Summary

`cpp:S8473` fired three times in `YseEngine/patcher/time/TimerThread.cpp` (lines
69, 100, 157). Each finding carries **both** RELIABILITY and SECURITY impact, so
the three of them hold back two failing quality-gate conditions at once. Part of
the #420 SonarCloud quality-gate epic.

**None of the three were bugs.** All three are the same correct idiom: release the
mutex *before* signalling the condition variable, so the woken thread does not
immediately block on a mutex the notifier still holds. `ScopedLock` is a
`std::unique_lock`, so every path already released the mutex — the rule objects to
the shape of the control flow, not to a leaked lock. They are deliberately **not**
"balanced" by moving the unlock after `notify_all()`; that would reintroduce the
wake-then-immediately-block stall this code avoids.

## Linked issue

Closes #412

## Changes

Confirmed against SonarCloud that all three findings anchor to the
`lock.unlock();` statement line, so each is addressed at exactly that line.

**`~timerThread()` (line 69) — restructured.** The locked region gets its own
scope; RAII performs the unlock on every path and the explicit `lock.unlock()`
disappears. `done = true` is still set under the lock, the mutex is still released
before `wakeUp.notify_all()`, and `worker.join()` still runs unlocked.

**`Add()` (line 100) — restructured.** Same shape. `id` and `needNotify` are hoisted
above the scope; every mutation (`worker` start, `nextId++`, `active.emplace`,
`queue.emplace`) still happens under the lock, the mutex is released at the closing
brace, and the conditional `notify_all()` follows it.

**`destroyImpl()` (line 157) — `// NOSONAR`, not restructured.** This one cannot be
scoped the same way: it takes the `ScopedLock` **by reference** from its callers,
the `timer.waitCond->wait(lock, ...)` above needs that lock, and the function
documents that it "returns with lock unlocked" when `notify` is set — scoping the
locked region away would change the contract with `ClearTimer()` / `Clear()`. On
#240-adjacent threading code that is not a change worth forcing, so the explicit
unlock stays with a short bare `// NOSONAR` on the anchor line and the rationale in
a comment above it, following the marker-placement convention landed in #409.
`python yse.py format` leaves the file **byte-identical** (SHA256 unchanged before
and after), so the marker is not relocated off the anchor line.

No behaviour change. The commit is deliberately mechanical — no logic edits, no
opportunistic cleanup of the other pre-existing findings in this file (S3230,
S6005, S6030, S5415, S134, S6004 remain untouched).

### Unlock-before-notify ordering — unchanged at all three sites

| Site | Before | After |
|---|---|---|
| `~timerThread()` | `done=true` → `unlock()` → `notify_all()` → `join()` | `done=true` under lock → scope exit releases → `notify_all()` → `join()` |
| `Add()` | mutate → compute `needNotify` → `unlock()` → conditional `notify_all()` | mutate → compute `needNotify` → scope exit releases → conditional `notify_all()` |
| `destroyImpl()` | `unlock()` → `notify_all()` | **statement sequence byte-identical**; comment + marker only |

## Test plan

- [x] `python yse.py format` clean — `TimerThread.cpp` SHA256 identical before/after, `git status` empty, NOSONAR marker still on line 179 at `lock.unlock();`
- [x] `python yse.py analyze YseEngine/patcher/time/TimerThread.cpp` — 0 findings in user code
- [x] `python yse.py build` — clean (only the pre-existing `lsfSoundfile.h` `-Winconsistent-missing-override` warnings, unrelated)
- [x] `python yse.py test` — **34/34 suites pass**, incl. `yse_tests_patcher` and `yse_tests_patcher_concurrency`
- [x] **ThreadSanitizer**, reproduced locally via `tools/ci-linux/Dockerfile.sanitizers` (the `tests-tsan` preset is Linux-gated, so it ran in the container this repo ships for exactly this purpose):
  - `ctest --preset tests-tsan` — the `build-sanitizers` CI gate — **2/2 pass** (`yse_tests_patcher_concurrency`, `yse_tests_sendstress`), no races
  - additionally `ctest -R '^yse_tests_patcher$'` under TSan — **passes (8.17s)**, no races. This is run explicitly because the `tests-tsan` ctest preset filters to `yse_tests_patcher_concurrency|yse_tests_sendstress`, which does *not* include the `timerThread` cases in `Tests/patcher/test_timerthread.cpp` — including the `#240` cancel-during-`wait_until` regression and the mid-callback `ClearTimer` handshake that exercise all three touched sites.

No new tests: this is a no-behaviour-change refactor of code already covered by
`Tests/patcher/test_timerthread.cpp`, which drives all three sites (destructor
teardown, `Add()` front-of-queue notify, and `destroyImpl()`'s notify branch via
`ClearTimer`/`Clear`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)