### PR TITLE
sonar: make the three flagged destructors exception-safe (#414)

### DIFF
--- a/YseEngine/clip/clipTransport.cpp
+++ b/YseEngine/clip/clipTransport.cpp
@@ -11,6 +11,7 @@
 
 #include "../clock/clockManager.h"
 #include "../clock/domainClock.h"
+#include "../implementations/logImplementation.h"
 #include "../synth/synthInterface.hpp"
 
 namespace {
@@ -116,13 +117,22 @@ YSE::CLIP::transport::transport(clip* head)
 }
 
 YSE::CLIP::transport::~transport() {
-  // The impl is only freed by the slow-pool delete job once the audio thread
-  // has retired it from `inUse`, so nothing on the audio thread still touches
-  // these buffers — safe to free here.
-  reclaimRetired();
-  delete current;
-  current = nullptr;
-  delete incoming.exchange(nullptr, std::memory_order_acquire);
+  // A destructor is implicitly noexcept, so anything escaping here would call
+  // std::terminate() and kill the host process instead of shutting the engine
+  // down (issue #414). The deletes below are nothrow, but reclaimRetired() goes
+  // through lfQueue::try_pop, which is not noexcept — its reentrancy guard can
+  // throw. Guard the whole body so this stays true as the teardown grows.
+  try {
+    // The impl is only freed by the slow-pool delete job once the audio thread
+    // has retired it from `inUse`, so nothing on the audio thread still touches
+    // these buffers — safe to free here.
+    reclaimRetired();
+    delete current;
+    current = nullptr;
+    delete incoming.exchange(nullptr, std::memory_order_acquire);
+  } catch (...) {
+    INTERNAL::LogImpl().emit(E_ERROR, "CLIP::transport destructor swallowed exception");
+  }
 }
 
 bool YSE::CLIP::transport::bind(const std::string& clockName) {

--- a/YseEngine/midi/midiOutSender.cpp
+++ b/YseEngine/midi/midiOutSender.cpp
@@ -78,7 +78,21 @@ YSE::MIDI::outSender& YSE::MIDI::OutSender() {
 }
 
 YSE::MIDI::outSender::~outSender() {
-  stop();
+  // A destructor is implicitly noexcept, so anything escaping stop() would call
+  // std::terminate() and take the host process down instead of shutting the
+  // engine down (issue #414). stop() joins the worker and then drains the queue,
+  // and the drain still touches RtMidi — neither is nothrow.
+  try {
+    stop();
+  } catch (...) { // NOLINT(bugprone-empty-catch): swallowing *is* the handling
+    // Deliberately silent, unlike the sibling manager destructors that log here.
+    // This one is reached through the function-local static in OutSender(), so
+    // it runs during static destruction at process exit — and LogImpl() is an
+    // equally function-local static whose teardown order relative to this one is
+    // unspecified, while emit() allocates a std::string on top. Reporting the
+    // failure would risk the exact use-after-free class that issue #298 fixed and
+    // the ASan lifecycle gate guards. Shutdown is best-effort from here.
+  }
 }
 
 void YSE::MIDI::outSender::start() {
@@ -88,7 +102,12 @@ void YSE::MIDI::outSender::start() {
 
 void YSE::MIDI::outSender::stop() {
   running.store(false, std::memory_order_release);
-  if (worker.joinable()) worker.join();
+  // Never join the worker from the worker itself — that is the one join() error
+  // a caller can actually provoke (std::system_error /
+  // resource_deadlock_would_occur), reachable through the send hook, which runs
+  // on this thread. Skipping it here leaves `worker` joinable for the eventual
+  // control-thread stop() to join properly (issue #414).
+  if (worker.joinable() && worker.get_id() != std::this_thread::get_id()) worker.join();
   // The worker is joined (or was never started), so this thread is now the
   // queue's only consumer. Flush what is still pending immediately — a stopping
   // clip's releaseAll note-offs must reach the hardware even at shutdown.

--- a/YseEngine/patcher/patcherImplementation.cpp
+++ b/YseEngine/patcher/patcherImplementation.cpp
@@ -73,17 +73,35 @@ patcherImplementation::~patcherImplementation() {
   // Stop scheduling and re-arming reclaim passes first, so the joins below
   // terminate instead of chasing a self-perpetuating ping-pong.
   shuttingDown_.store(true, std::memory_order_release);
-  // memory cleanup
-  Clear();
-  // A reclaim pass already handed to the background pool may still be draining
-  // the retire lists; wait for both halves of the ping-pong to finish before we
-  // free those lists from under them. shuttingDown_ guarantees neither re-arms.
-  reclaimJobs_[0].join();
-  reclaimJobs_[1].join();
-  // The audio thread is stopped at destruction, so reclaim unconditionally:
-  // the remaining retire lists (and the final published snapshot) are freed
-  // here rather than waiting on the block counter.
-  FreeAllRetired();
+  // A destructor is implicitly noexcept, so anything escaping the teardown below
+  // would call std::terminate() and take the host process down instead of
+  // shutting the engine down (issue #414). Clear() locks and allocates, so it is
+  // the one step here that can realistically throw — guard it on its own rather
+  // than wrapping the whole body, because the joins and FreeAllRetired() beneath
+  // it must run even when it fails: a reclaim pass still on the background pool
+  // holds `this` and the retire lists it is draining.
+  try {
+    // memory cleanup
+    Clear();
+  } catch (...) {
+    INTERNAL::LogImpl().emit(E_ERROR, "PATCHER::patcherImplementation Clear swallowed exception");
+  }
+  try {
+    // A reclaim pass already handed to the background pool may still be draining
+    // the retire lists; wait for both halves of the ping-pong to finish before we
+    // free those lists from under them. shuttingDown_ guarantees neither re-arms.
+    // These joins are a spin-wait on an atomic flag (INTERNAL::threadPoolJob), not
+    // std::thread::join, so they carry no system_error of their own.
+    reclaimJobs_[0].join();
+    reclaimJobs_[1].join();
+    // The audio thread is stopped at destruction, so reclaim unconditionally:
+    // the remaining retire lists (and the final published snapshot) are freed
+    // here rather than waiting on the block counter.
+    FreeAllRetired();
+  } catch (...) {
+    INTERNAL::LogImpl().emit(E_ERROR,
+                             "PATCHER::patcherImplementation destructor swallowed exception");
+  }
 }
 
 const char* patcherImplementation::Type() const {


### PR DESCRIPTION
## Summary

Makes the three destructors SonarCloud flags with `cpp:S1048` ("Do not throw
uncaught exceptions in a destructor") exception-safe. Destructors are implicitly
`noexcept` since C++11, so an escaping exception calls `std::terminate()` — for a
library embedded in a host that expects to keep running after
`YSE::System().close()`, that turns an unlikely shutdown error into a dead
process.

These three were the **only** open HIGH/BLOCKER reliability findings on the
project, so they are what pins `reliability_rating` at D.

Part of #420.

## Linked issue

Closes #414

## Changes

**`MIDI::outSender::~outSender()`** — `stop()` joins the worker and then drains
the queue through RtMidi.

- Preferred *removing* the throw over catching it: `stop()` now skips the join
  when it would be a self-join, which is the one `join()` error a caller can
  actually provoke (`std::system_error` / `resource_deadlock_would_occur`) —
  reachable through the `SendHook` test seam, since that runs on the worker
  thread. `worker` stays joinable so the eventual control-thread `stop()` still
  joins it properly.
- The residue (RtMidi in the drain, an arbitrary send hook) is caught and
  swallowed **silently**, deliberately deviating from the eight sibling manager
  destructors that log here. This one is reached through the function-local
  static in `OutSender()`, so it runs during *static destruction* at process
  exit — and `LogImpl()` is an equally function-local static whose teardown
  order relative to it is unspecified, with `emit()` allocating a `std::string`
  on top. Logging would risk exactly the use-after-free class that #298 fixed
  and that the ASan lifecycle gate exists to guard. Carries a focused
  `// NOLINT(bugprone-empty-catch)` with that rationale inline.

**`CLIP::transport::~transport()`** — guarded, logging via the house pattern.

**`patcherImplementation::~patcherImplementation()`** — `Clear()` locks and
allocates, so it is the one step here that can realistically throw. Guarded on
its own rather than wrapping the whole body: the joins and `FreeAllRetired()`
beneath it **must** still run when `Clear()` fails, because a reclaim pass
already handed to the background pool holds `this` and the retire lists it is
draining. Logs via the house pattern.

## Notes for review

Two things worth a second opinion:

1. **`~transport()` is the weakest of the three.** Its `delete`s are nothrow, so
   the only throw in its call graph is `lfQueue::try_pop`'s `ReentrantGuard`,
   which is compiled in only `#ifndef NDEBUG` — and in that same configuration
   the `assert(!inSection)` on the line above fires first. So the throw is very
   close to dead code, and Sonar is flagging a shape rather than a live crash.
   Guarded anyway: `try_pop` genuinely is not `noexcept`, the destructor
   implicitly is, and that mismatch is what makes any future addition to this
   body a `terminate()`. Happy to mark it False Positive upstream instead if you
   prefer.

2. **The issue text (and #420's plan) assumed `reclaimJobs_[i].join()` was
   `std::thread::join()`** and suggested the same `get_id()` guard there. It
   isn't — it's `INTERNAL::threadPoolJob::join()`, a help-run/spin-wait on an
   atomic flag, so it carries no `system_error` of its own and needs no guard.
   Noted in a comment so the next reader doesn't re-derive it.

Also worth knowing: the house `catch (...) { LogImpl().emit(...); }` pattern used
by the eight manager destructors is not itself fully exception-safe — `emit()`
allocates, so it can throw straight back out of the catch block and re-terminate.
Out of scope here (this PR is a bug fix, not a refactor), but it may deserve its
own issue.

## Test plan

- [x] `python yse.py format` — stable, no reformatting of the changed code
- [x] `python yse.py analyze` on all three changed files — **0 findings** each
      (`midiOutSender.cpp` reports `1 NOLINT` suppression, which is the
      `bugprone-empty-catch` above; the other two are clean with no
      suppressions of ours). Note `.clang-tidy`'s `HeaderFilterRegex` is
      known-broken for subdirectory headers (#426), but every change here is in
      a `.cpp`, so nothing is hidden by it.
- [x] `python yse.py build` — clean, exit 0
- [x] `python yse.py test` — **34/34 pass**
- [x] **Both halves of the CI `build-sanitizers` ASan leg**, reproduced on Linux
      via `tools/ci-linux/Dockerfile.sanitizers` with
      `ASAN_OPTIONS=detect_leaks=0`:
  - static-teardown UAF gate (#298) — `ctest --test-dir build-tests-asan -R
    yse_tests_lifecycle` → **1/1 pass**. This is the gate that guards this exact
    area.
  - patcher concurrency gate (#229) — `ctest --preset tests-asan`
    (`yse_tests_patcher_concurrency` + `yse_tests_sendstress`) → **2/2 pass**.
    Relevant because `~patcherImplementation()` changed.

No new tests: this is a pure exception-safety hardening of three teardown paths
with no behavior change on any path that can be reached without an exception
first being thrown. The one behavioral change — `stop()` skipping a self-join —
is unreachable except through the `SendHook` test seam, and the existing
lifecycle/MIDI suites already cover the normal start/stop/flush contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
