### PR TITLE
sonar: clear the new-code maintainability debt from #410/#414

### DIFF
--- a/YseEngine/midi/midiOutSender.cpp
+++ b/YseEngine/midi/midiOutSender.cpp
@@ -84,7 +84,7 @@ YSE::MIDI::outSender::~outSender() {
   // and the drain still touches RtMidi — neither is nothrow.
   try {
     stop();
-  } catch (...) { // NOLINT(bugprone-empty-catch): swallowing *is* the handling
+  } catch (...) { // NOSONAR NOLINT(bugprone-empty-catch): swallowing *is* the handling
     // Deliberately silent, unlike the sibling manager destructors that log here.
     // This one is reached through the function-local static in OutSender(), so
     // it runs during static destruction at process exit — and LogImpl() is an
@@ -92,6 +92,11 @@ YSE::MIDI::outSender::~outSender() {
     // unspecified, while emit() allocates a std::string on top. Reporting the
     // failure would risk the exact use-after-free class that issue #298 fixed and
     // the ASan lifecycle gate guards. Shutdown is best-effort from here.
+    //
+    // cpp:S2486 asks for the exception to be handled or logged. Logging is the
+    // one thing this handler must not do, and this comment did not clear the
+    // rule on its own — hence the short marker on the catch line above, kept
+    // short so clang-format cannot strand it (issues #409, #434).
   }
 }
 

--- a/YseEngine/utils/misc.hpp
+++ b/YseEngine/utils/misc.hpp
@@ -11,6 +11,7 @@
 #ifndef MISC_H_INCLUDED
 #define MISC_H_INCLUDED
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cmath>
@@ -52,6 +53,18 @@ namespace YSE {
    */
   namespace RANDOM {
 
+    // The three variables below carry a bare suppression marker on their
+    // declaration line. It is kept short on purpose: clang-format counts
+    // trailing comments toward the 100-column limit and would otherwise wrap
+    // the statement and strand the marker on the wrong line (issue #409).
+    //
+    // They suppress cpp:S5421, "global variables should be const". These *are*
+    // the generator's mutable state, so const is not on the table, and the usual
+    // way to hide them — a function-local `static` accessor — would put a
+    // lazy-initialisation guard check on every draw, including on the audio
+    // callback path. That is exactly what the constant initialisation below
+    // exists to avoid, and CLAUDE.md rule 3 forbids trading it away. See #434.
+
     /**
      *  @brief Global seed base, published by ``Randomize()``.
      *
@@ -59,24 +72,26 @@ namespace YSE {
      *  ``Randomize()`` gets a reproducible sequence — the same contract an
      *  unseeded ``rand()`` offered.
      */
-    inline std::atomic<UInt> SeedBase{0x9E3779B9u};
+    inline std::atomic<UInt> SeedBase{0x9E3779B9U}; // NOSONAR
 
     /** @brief Hands every thread a distinct stream index on its first draw. */
-    inline std::atomic<UInt> StreamCounter{0};
+    inline std::atomic<UInt> StreamCounter{0}; // NOSONAR
 
     /**
      *  @brief Per-thread generator state; ``{0, 0}`` means "not seeded yet".
      *
      *  Constant-initialised on purpose: a dynamically initialised
      *  ``thread_local`` would add a guard-variable check to every single draw.
+     *  ``std::array`` keeps that property — it is an aggregate, so ``{}`` is
+     *  still a constant initializer and the state stays in ``.tbss``.
      */
-    inline thread_local U64 State[2] = {0, 0};
+    inline thread_local std::array<U64, 2> State{}; // NOSONAR
 
     /** @brief SplitMix64 finalizer — turns a counter into well-distributed bits. */
     inline U64 Mix(U64 z) {
-      z += 0x9E3779B97F4A7C15ull;
-      z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
-      z = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
+      z += 0x9E3779B97F4A7C15ULL;
+      z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+      z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
       return z ^ (z >> 31);
     }
 
@@ -88,10 +103,10 @@ namespace YSE {
      *  thread lands unless the host calls it earlier.
      */
     inline void SeedThread() {
-      const U64 base = static_cast<U64>(SeedBase.load(std::memory_order_relaxed));
-      const U64 stream = static_cast<U64>(StreamCounter.fetch_add(1, std::memory_order_relaxed));
+      const auto base = static_cast<U64>(SeedBase.load(std::memory_order_relaxed));
+      const auto stream = static_cast<U64>(StreamCounter.fetch_add(1, std::memory_order_relaxed));
       State[0] = Mix((base << 32) ^ (stream + 1));
-      State[1] = Mix(State[0]) | 1ull; // the |1 keeps the pair from ever being all-zero
+      State[1] = Mix(State[0]) | 1ULL; // the |1 keeps the pair from ever being all-zero
     }
 
     /** @brief xorshift128+ — 64 pseudo-random bits in a handful of instructions. */
@@ -147,7 +162,7 @@ namespace YSE {
    *  seeds its own copy, not the engine's.
    */
   inline void Randomize() {
-    const U64 now =
+    const auto now =
         static_cast<U64>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
     RANDOM::SeedBase.store(static_cast<UInt>(RANDOM::Mix(now) >> 32), std::memory_order_relaxed);
     // Zeroing the state makes the calling thread re-seed from the new base on
@@ -173,7 +188,7 @@ namespace YSE {
     if (max <= min) return min;
     // Widened to 64 bit: a span such as [INT_MIN, INT_MAX) overflows Int.
     const I64 span = static_cast<I64>(max) - static_cast<I64>(min);
-    const I64 offset = static_cast<I64>(RANDOM::Bounded(static_cast<UInt>(span)));
+    const auto offset = static_cast<I64>(RANDOM::Bounded(static_cast<UInt>(span)));
     return static_cast<Int>(static_cast<I64>(min) + offset);
   }
 
@@ -183,7 +198,7 @@ namespace YSE {
    */
   inline Int BigRandom(Int max) {
     if (max <= 0) return 0;
-    const Int root = static_cast<Int>(std::sqrt(static_cast<Dbl>(max)));
+    const auto root = static_cast<Int>(std::sqrt(static_cast<Dbl>(max)));
     return Random(root) * Random(root);
   }
 
@@ -210,8 +225,8 @@ namespace YSE {
    */
   inline Flt* Random(Flt* min, Flt* max) {
     if (max <= min) return min;
-    U64 span = static_cast<U64>(max - min);
-    if (span > 0xFFFFFFFFull) span = 0xFFFFFFFFull; // the reduction takes a 32-bit bound
+    auto span = static_cast<U64>(max - min);
+    if (span > 0xFFFFFFFFULL) span = 0xFFFFFFFFULL; // the reduction takes a 32-bit bound
     return min + static_cast<std::ptrdiff_t>(RANDOM::Bounded(static_cast<UInt>(span)));
   }
 


### PR DESCRIPTION
## Summary

Clears all 17 SonarCloud findings in the New Code window — the last thing
holding `new_maintainability_rating` at **B** and the quality gate at 5/6.
Two files, both regressions introduced by this epic's own PRs (#427 for the
RNG rewrite, #432 for the exception-safe destructors).

Mechanical findings are fixed properly. Only the two that collide with a
documented constraint are suppressed, each with the reasoning in the source.

## Linked issue

Closes #434

## Changes

**`YseEngine/utils/misc.hpp`** (16 findings)

| Rule | n | What was done |
|---|---|---|
| `cpp:S5945` | 1 | `U64 State[2]` → `std::array<U64, 2>`; `<array>` added |
| `cpp:S5827` | 6 | repeated type → `auto` |
| `cpp:S818` | 6 | `0x…ull` → `0x…ULL` (plus the `u` on `SeedBase`, same expression set) |
| `cpp:S5421` | 3 | **suppressed** — bare `// NOSONAR` + rationale above |

`cpp:S5421` ("global variables should be const") cannot be satisfied:
`SeedBase`, `StreamCounter` and `State` *are* the generator's mutable state.
The usual encapsulation — a function-local `static thread_local` — reintroduces
the per-draw lazy-init guard that #410 deliberately removed by
constant-initialising the state, so the audio callback path has no guard
branch. CLAUDE.md rule 3 says not to trade that away, so the rule is
suppressed instead. A struct-static-member encapsulation was considered first
per the issue's preference order, but there was no way to verify locally that
CFamily stops reporting for class-scope statics (the MCP snippet analyzer has
no C++ backend and no CFamily CLI is available here), so the issue's fallback
was taken rather than guessing.

**`YseEngine/midi/midiOutSender.cpp`** (1 finding)

`cpp:S2486` on the deliberate empty `catch` in `~outSender()`. It must stay
silent: it runs during static destruction and the logger is itself a
function-local static whose `emit()` allocates — the #298 use-after-free
hazard (see #433). The explanatory comment already inside the braces did *not*
clear the rule (the finding was raised against exactly that code), so the
catch line now carries a marker as well. The `NOSONAR` is placed *before* the
existing `NOLINT(bugprone-empty-catch)`; both are still honoured (verified,
below).

Marker discipline follows #409: bare `// NOSONAR` on the anchor line, reasoning
in a normal comment above, short enough that clang-format cannot wrap the
statement and strand it. `.clang-format` is untouched.

## Real-time verification

The acceptance criterion is that the constant-initialised `thread_local` gains
no guard variable. Checked on generated assembly (`clang++ -std=c++17 -O2 -S`),
not by eyeballing:

- **This PR's header** — `State` is emitted as `.zero 16` into
  `.tls$$_ZN3YSE6RANDOM5StateE` (statically zero-initialised → constant
  initialisation), the draw path contains **zero `callq` instructions**, and
  greping for `_ZGV|__cxa_guard|__tls_init|_ZTH|tls_guard` gives **0 hits**.
  The only branch is the documented `orq` / `jne` seed check.
- **Positive control** — the rejected alternative (a dynamically initialised
  function-local `static thread_local`) compiled the same way emits
  `cmpb $0, _ZGVZ…@SECREL32(%rax)` + a lazy-init branch on *every* call, 5 hits
  for the same grep. So the grep would have caught a guard had one appeared.
- **Before/after** — the probe TU compiled against `dev`'s `misc.hpp` and
  against this branch's produces **instruction-identical** output. `std::array`,
  `auto` and the uppercase suffixes are free.

## Test plan

- [x] `python yse.py build` — clean (169/169).
- [x] `python yse.py test` — **34/34 ctest suites pass**. The `utils` suite
      (which owns `Tests/utils/test_random.cpp`, the RNG contract tests) passes:
      103 test cases, 838 217 assertions, 0 failures.
- [x] `python yse.py format` — re-run after the edits; the only diff in the
      tree is this change, and all four markers stay on their anchor lines
      (`misc.hpp:75/78/88`, `midiOutSender.cpp:87`). Longest touched line is
      98 chars, under the 100 limit.
- [x] clang-tidy — plain `yse.py analyze` is blind to this header (#426), so it
      was run with an explicit filter:
      `clang-tidy -p=build-tests --header-filter='.*misc\.hpp$' <TU incl. misc.hpp>`
      → **0 findings before, 0 after**; `midiOutSender.cpp` under the default
      filter → **0 before, 0 after**. Filter plumbing sanity-checked (a broad
      header filter on the same TU reports 10 findings from other headers, so
      the narrow filter really is matching and really is empty).
- [x] `NOLINT` still effective after the `NOSONAR` prefix: breaking the token
      makes `bugprone-empty-catch` fire at `midiOutSender.cpp:87`; restoring it
      silences it again.
- No new tests: this is a suppression/idiom change with no behavioural delta —
  the RNG's observable contract is already pinned by `Tests/utils/test_random.cpp`
  and the codegen is identical to `dev`.

Not verified locally: whether SonarCloud accepts the suppressions — that only
shows on the next analysis of this PR.
