### PR TITLE
tests: cover the six zero-coverage c_api translation units (#417)

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -111,10 +111,12 @@ set(YSE_TEST_SOURCES
   io/test_callback_counter.cpp
   system/test_named_bus.cpp
   system/test_c_api_bus.cpp
+  system/test_c_api_surface.cpp
   system/test_system_active_state.cpp
   system/test_lifecycle.cpp
   clock/test_domain_clocks.cpp
   clip/test_clip_transport.cpp
+  clip/test_c_api_clip.cpp
   integration/test_device.cpp
   integration/test_content_pack.cpp
   integration/test_synth_demos.cpp
@@ -245,7 +247,12 @@ add_test(
   # c-api lifecycle suites: it drives yse_system_init_offline()/close() —
   # the tap-invalidation-at-close contract is part of the surface under
   # test — so it runs in its own process (yse_tests_buscapi).
-  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthbus,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos,clock,clip,buscapi --duration=true
+  # `capisurface` (issue #417 device/reverb/log/listener/buffer-io C API) is
+  # excluded for the same family of reasons: it drives
+  # yse_system_init_offline(), swaps the process-global log sink, and installs
+  # the process-global BufferIO VFS hooks. It runs in its own process
+  # (yse_tests_capisurface).
+  COMMAND yse_tests --test-suite-exclude=integration,lifecycle,synthlifecycle,synthpositioning,synthhandlers,synthbus,synthcapi,instrumentcapi,midisynth,playersynth,playercapi,sendstress,channelcapi,synthdemos,clock,clip,buscapi,capisurface --duration=true
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_unit_tests PROPERTIES TIMEOUT 600)
@@ -430,6 +437,20 @@ add_test(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(yse_tests_buscapi PROPERTIES LABELS "system;c-api;lifecycle")
+
+# C-API device / reverb / log / listener / buffer-io surface (issue #417).
+# Drives the five previously untested c_api translation units through the flat
+# C ABI under an offline engine. Isolated in its own process for three reasons
+# that each apply on their own: it calls yse_system_init_offline() (process-
+# global engine state), it swaps the process-global log sink while asserting on
+# the callback bridge, and it installs the process-global BufferIO VFS hooks.
+# initOffline() needs no audio hardware, so it runs in CI.
+add_test(
+  NAME    yse_tests_capisurface
+  COMMAND yse_tests --test-suite=capisurface
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(yse_tests_capisurface PROPERTIES LABELS "system;c-api;lifecycle")
 
 add_test(
   NAME    yse_tests_midi

--- a/Tests/clip/test_c_api_clip.cpp
+++ b/Tests/clip/test_c_api_clip.cpp
@@ -1,0 +1,146 @@
+// C-API clip-transport tests (issue #417) — exercises YseEngine/c_api/yse_clip.cpp
+// through the flat C ABI: create/destroy, bind, the event-list copy, loop length,
+// the synth / MIDI-out connect pair, and play/stop/is_playing.
+//
+// Like the C++ clip cases in test_clip_transport.cpp, these drive
+// CLOCK::Manager().update() and CLIP::Manager().update() directly on the test
+// thread, so they live in the same TEST_SUITE("clip") and inherit its ctest
+// isolation (yse_tests_clip) — those manager updates must not share a process
+// with a live audio thread. No engine init and no audio hardware are needed:
+// clocks and clip transports exist independently of the device layer.
+//
+// The focus is the boundary contract rather than the firing rules (already
+// covered exhaustively against the transport in test_clip_transport.cpp):
+// NULL handles, the documented "events may be NULL only when count is 0" rule,
+// and the create/destroy ownership pair.
+
+#include <doctest/doctest.h>
+
+#include <vector>
+
+#include "yse_c/yse_clip.h"
+#include "yse_c/yse_midi.h"
+#include "yse_c/yse_system.h"
+
+#include "yse.hpp"
+#include "clip/clipManager.h"
+#include "clock/clockManager.h"
+
+namespace {
+
+  YseClipEvent cev(double start, double dur, int ch, int pitch, float vel = 0.8f,
+                   float bend = 0.f) {
+    YseClipEvent e;
+    e.start_beat = start;
+    e.duration_beats = dur;
+    e.channel = ch;
+    e.pitch = pitch;
+    e.velocity = vel;
+    e.pitch_bend = bend;
+    return e;
+  }
+
+  // One "audio block" as the device manager would drive it: clocks first, then
+  // the clip transports.
+  void pump(int blocks, float seconds = 0.25f) {
+    for (int i = 0; i < blocks; ++i) {
+      YSE::CLOCK::Manager().update(seconds);
+      YSE::CLIP::Manager().update();
+    }
+  }
+
+} // namespace
+
+TEST_SUITE("clip") {
+
+  TEST_CASE("c-api clip: create -> bind -> play -> stop through the flat ABI") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(yse_system_create_clock(sys, "capi.clip.run", 60.f) == 1); // 1 beat/second
+
+    YseClip* c = yse_clip_create();
+    REQUIRE(c != nullptr);
+    CHECK(yse_clip_bind(c, "capi.clip.run") == 1);
+
+    const std::vector<YseClipEvent> events{cev(1.0, 1.0, 1, 60), cev(2.0, 1.0, 1, 64)};
+    yse_clip_set_events(c, events.data(), events.size());
+    yse_clip_set_loop_length(c, 4.0);
+    CHECK(yse_clip_is_playing(c) == 0);
+
+    yse_clip_play(c);
+    pump(8);
+    CHECK(yse_clip_is_playing(c) == 1);
+
+    yse_clip_stop(c);
+    pump(1);
+    CHECK(yse_clip_is_playing(c) == 0);
+
+    yse_clip_destroy(c);
+    yse_system_destroy_clock(sys, "capi.clip.run");
+    pump(1, 0.01f); // let the audio side retire the clock
+  }
+
+  TEST_CASE("c-api clip: bind rejects an unknown clock and NULL arguments") {
+    YseSystem* sys = yse_system_get();
+    REQUIRE(yse_system_create_clock(sys, "capi.clip.bind", 120.f) == 1);
+
+    YseClip* c = yse_clip_create();
+    REQUIRE(c != nullptr);
+    CHECK(yse_clip_bind(c, "capi.clip.bind") == 1);
+    CHECK(yse_clip_bind(c, "capi.clip.bind.nope") == 0);
+    CHECK(yse_clip_bind(c, nullptr) == 0);
+    CHECK(yse_clip_bind(nullptr, "capi.clip.bind") == 0);
+
+    yse_clip_destroy(c);
+    yse_system_destroy_clock(sys, "capi.clip.bind");
+    pump(1, 0.01f);
+  }
+
+  TEST_CASE("c-api clip: a NULL event list is accepted only when count is 0") {
+    YseClip* c = yse_clip_create();
+    REQUIRE(c != nullptr);
+
+    yse_clip_set_events(c, nullptr, 0); // documented: clears the list
+    const std::vector<YseClipEvent> events{cev(0.5, 0.25, 3, 72, 0.5f, 0.25f)};
+    yse_clip_set_events(c, events.data(), events.size());
+    yse_clip_set_events(c, nullptr, 4); // rejected — no read through the NULL
+    yse_clip_set_loop_length(c, 0.0); // <= 0 disables looping
+
+    yse_clip_destroy(c);
+  }
+
+  TEST_CASE("c-api clip: connecting a NULL synth or MIDI-out handle is a no-op") {
+    YseClip* c = yse_clip_create();
+    REQUIRE(c != nullptr);
+
+    yse_clip_connect_synth(c, nullptr);
+    yse_clip_disconnect_synth(c, nullptr);
+    yse_clip_connect_midi_out(c, nullptr);
+    yse_clip_disconnect_midi_out(c, nullptr);
+
+    // An unopened MIDI-out port is a silent no-op too (the handle is NULL on
+    // builds without MIDI device support, which the calls above already cover).
+    YseMidiOut* out = yse_midi_out_create();
+    if (out != nullptr) {
+      yse_clip_connect_midi_out(c, out);
+      yse_clip_disconnect_midi_out(c, out);
+      yse_midi_out_destroy(out);
+    }
+
+    yse_clip_destroy(c);
+  }
+
+  TEST_CASE("c-api clip: every entry point is NULL-safe") {
+    const std::vector<YseClipEvent> events{cev(0.0, 1.0, 1, 60)};
+    yse_clip_destroy(nullptr);
+    yse_clip_set_events(nullptr, events.data(), events.size());
+    yse_clip_set_loop_length(nullptr, 4.0);
+    yse_clip_connect_synth(nullptr, nullptr);
+    yse_clip_disconnect_synth(nullptr, nullptr);
+    yse_clip_connect_midi_out(nullptr, nullptr);
+    yse_clip_disconnect_midi_out(nullptr, nullptr);
+    yse_clip_play(nullptr);
+    yse_clip_stop(nullptr);
+    CHECK(yse_clip_is_playing(nullptr) == 0);
+  }
+
+} // TEST_SUITE("clip")

--- a/Tests/system/test_c_api_surface.cpp
+++ b/Tests/system/test_c_api_surface.cpp
@@ -1,0 +1,646 @@
+// C-API boundary tests for the zero-coverage translation units under
+// YseEngine/c_api/ (issue #417, part of the SonarCloud quality-gate epic #420):
+// yse_device.cpp, yse_reverb.cpp, yse_log.cpp, yse_listener.cpp and
+// yse_buffer_io.cpp. (yse_clip.cpp is covered from Tests/clip/test_c_api_clip.cpp,
+// which reuses the clock/clip-manager isolation the `clip` suite already has.)
+//
+// The assertions are about the *boundary contract* rather than DSP behaviour,
+// because that is what a binding breaks on silently:
+//
+//   * NULL-handle handling — every entry point is exercised with a NULL handle
+//     and, where it takes one, a NULL out-parameter. Void setters must no-op;
+//     queries must return zero / false / NULL and clear the out buffer.
+//   * Ownership and lifetime — create/destroy pairs, destroy(NULL).
+//   * String marshalling — the snprintf convention documented in yse_device.h
+//     (size query with cap == 0 or buf == NULL, exact fit, truncation, always
+//     NUL-terminated). This is also the `strlen` hotspot path in yse_log.cpp.
+//   * Enum round-trips — YseErrorLevel and YseReverbPreset in both directions.
+//
+// The engine runs offline (yse_system_init_offline), so no audio hardware is
+// needed and the suite runs on headless CI. It lives in its own
+// TEST_SUITE("capisurface") and its own ctest process (see Tests/CMakeLists.txt)
+// for the same reason as the buscapi / channelcapi suites: init_offline() drives
+// process-global engine state, and on top of that the log cases swap the global
+// log sink while the BufferIO cases install the global VFS hooks.
+//
+// A few cases reach past the C ABI into the engine headers — building a device
+// descriptor (the engine's enumerator is the only other producer, and it needs
+// real hardware) and reading back deviceSetup::getOutputChannels(), which has no
+// C getter. That mirrors what test_c_api_bus.cpp does for bus publishes: the
+// tests link yse_objects with full symbol access.
+
+#include <doctest/doctest.h>
+
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "yse_c/yse_buffer_io.h"
+#include "yse_c/yse_common.h"
+#include "yse_c/yse_device.h"
+#include "yse_c/yse_enums.h"
+#include "yse_c/yse_listener.h"
+#include "yse_c/yse_log.h"
+#include "yse_c/yse_reverb.h"
+#include "yse_c/yse_system.h"
+
+#include "device/deviceInterface.hpp"
+#include "device/deviceSetup.hpp"
+
+namespace {
+
+  // Init the offline engine once for the whole capisurface process. Mirrors the
+  // channelcapi suite's ensureOffline(); no audio hardware needed.
+  bool ensureOffline() {
+    static bool done = false;
+    static bool ok = false;
+    if (!done) {
+      ok = (yse_system_init_offline(yse_system_get()) == YSE_OK);
+      done = true;
+    }
+    return ok;
+  }
+
+  // A fully populated device descriptor. The engine's enumerator is the only
+  // other producer of these and it needs real hardware, so the tests build one
+  // by hand and hand the C API the same reinterpret_cast the engine does in
+  // yse_system_get_device(). Every scalar field is set explicitly: the default
+  // constructor leaves the int members indeterminate.
+  YSE::device makeDevice() {
+    YSE::device d;
+    d.setName("Test Output Device") // 18 chars — used by the truncation cases
+        .setTypeName("TestHost")
+        .addOutputChannelName("out 1")
+        .addOutputChannelName("out 2")
+        .addInputChannelName("in 1")
+        .addAvailableSampleRate(44100.0)
+        .addAvailableSampleRate(48000.0)
+        .addAvailableBufferSize(256)
+        .addAvailableBufferSize(512)
+        .setDefaultBufferSize(512)
+        .setOutputLatency(128)
+        .setInputLatency(64)
+        .setID(7);
+    return d;
+  }
+
+  YseDevice* handle(YSE::device& d) {
+    return reinterpret_cast<YseDevice*>(&d);
+  }
+
+  // Collects the strings the C log callback hands over, taking ownership of each
+  // one exactly as the header tells a host to (yse_log_free_message). The mutex
+  // is not decoration: while the bridge is installed, any engine thread that
+  // emits a log line lands here — which is also why the assertions below count
+  // occurrences of a unique token rather than total messages.
+  struct LogSink {
+    std::mutex m;
+    std::vector<std::string> messages;
+
+    int countMatching(const std::string& needle) {
+      std::scoped_lock lk(m);
+      int n = 0;
+      for (const std::string& msg : messages)
+        if (msg.find(needle) != std::string::npos) ++n;
+      return n;
+    }
+  };
+
+  void YSE_C_CALLBACK logReceive(char* msg, void* user_data) {
+    auto* sink = static_cast<LogSink*>(user_data);
+    {
+      std::scoped_lock lk(sink->m);
+      sink->messages.emplace_back(msg != nullptr ? msg : "");
+    }
+    // The bridge malloc'd this copy and handed ownership over — release it the
+    // way the header documents.
+    yse_log_free_message(msg);
+  }
+
+  // Restores the process-global log state (sink, level, log file) whichever way
+  // a case exits, so ordering between the log cases is irrelevant.
+  struct LogStateGuard {
+    YseLog* log = yse_log_get();
+    YseErrorLevel level = yse_log_get_level(yse_log_get());
+    ~LogStateGuard() {
+      yse_log_set_callback(log, nullptr, nullptr);
+      yse_log_set_level(log, level);
+      yse_log_set_logfile(log, "YSElog.txt");
+    }
+  };
+
+} // namespace
+
+TEST_SUITE("capisurface") {
+
+  // ─── yse_device.cpp: descriptor ────────────────────────────────────────────
+
+  TEST_CASE("c-api device: descriptor getters mirror the engine device") {
+    YSE::device d = makeDevice();
+    YseDevice* dev = handle(d);
+    char buf[64] = {0};
+
+    CHECK(yse_device_get_name(dev, buf, sizeof(buf)) == 18);
+    CHECK(std::string(buf) == "Test Output Device");
+    CHECK(yse_device_get_type_name(dev, buf, sizeof(buf)) == 8);
+    CHECK(std::string(buf) == "TestHost");
+
+    CHECK(yse_device_num_output_channels(dev) == 2);
+    CHECK(yse_device_get_output_channel_name(dev, 1, buf, sizeof(buf)) == 5);
+    CHECK(std::string(buf) == "out 2");
+
+    CHECK(yse_device_num_input_channels(dev) == 1);
+    CHECK(yse_device_get_input_channel_name(dev, 0, buf, sizeof(buf)) == 4);
+    CHECK(std::string(buf) == "in 1");
+
+    CHECK(yse_device_num_sample_rates(dev) == 2);
+    CHECK(yse_device_get_sample_rate(dev, 0) == doctest::Approx(44100.0));
+    CHECK(yse_device_get_sample_rate(dev, 1) == doctest::Approx(48000.0));
+
+    CHECK(yse_device_num_buffer_sizes(dev) == 2);
+    CHECK(yse_device_get_buffer_size(dev, 0) == 256);
+    CHECK(yse_device_get_buffer_size(dev, 1) == 512);
+
+    CHECK(yse_device_default_buffer_size(dev) == 512);
+    CHECK(yse_device_output_latency(dev) == 128);
+    CHECK(yse_device_input_latency(dev) == 64);
+    CHECK(yse_device_get_id(dev) == 7);
+  }
+
+  TEST_CASE("c-api device: string-out follows the snprintf convention") {
+    YSE::device d = makeDevice();
+    YseDevice* dev = handle(d);
+
+    // Size query: no buffer, or a zero capacity, still reports the full length.
+    CHECK(yse_device_get_name(dev, nullptr, 0) == 18);
+    CHECK(yse_device_get_name(dev, nullptr, 64) == 18);
+    char probe = '@';
+    CHECK(yse_device_get_name(dev, &probe, 0) == 18);
+    CHECK(probe == '@'); // cap == 0 must not write
+
+    // Exact fit: length + terminator.
+    char exact[19] = {0};
+    CHECK(yse_device_get_name(dev, exact, sizeof(exact)) == 18);
+    CHECK(std::string(exact) == "Test Output Device");
+
+    // Truncation: cap - 1 bytes plus a terminator, return value unchanged.
+    char small[5] = {0};
+    CHECK(yse_device_get_name(dev, small, sizeof(small)) == 18);
+    CHECK(std::string(small) == "Test");
+    CHECK(small[4] == '\0');
+
+    // cap == 1 leaves an empty, still-terminated string.
+    char one[1] = {'x'};
+    CHECK(yse_device_get_name(dev, one, sizeof(one)) == 18);
+    CHECK(one[0] == '\0');
+
+    // The same convention holds for the indexed channel-name getters.
+    char chan[3] = {0};
+    CHECK(yse_device_get_output_channel_name(dev, 0, chan, sizeof(chan)) == 5);
+    CHECK(std::string(chan) == "ou");
+    CHECK(yse_device_get_input_channel_name(dev, 0, chan, sizeof(chan)) == 4);
+    CHECK(std::string(chan) == "in");
+  }
+
+  TEST_CASE("c-api device: a NULL descriptor reads as empty") {
+    char buf[8];
+    std::memset(buf, 'x', sizeof(buf));
+
+    CHECK(yse_device_get_name(nullptr, buf, sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_device_get_type_name(nullptr, buf, sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_device_get_output_channel_name(nullptr, 0, buf, sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_device_get_input_channel_name(nullptr, 0, buf, sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+
+    // No out buffer at all is still safe.
+    CHECK(yse_device_get_name(nullptr, nullptr, 0) == 0);
+    CHECK(yse_device_get_type_name(nullptr, nullptr, 0) == 0);
+    CHECK(yse_device_get_output_channel_name(nullptr, 0, nullptr, 0) == 0);
+    CHECK(yse_device_get_input_channel_name(nullptr, 0, nullptr, 0) == 0);
+
+    CHECK(yse_device_num_output_channels(nullptr) == 0);
+    CHECK(yse_device_num_input_channels(nullptr) == 0);
+    CHECK(yse_device_num_sample_rates(nullptr) == 0);
+    CHECK(yse_device_get_sample_rate(nullptr, 0) == doctest::Approx(0.0));
+    CHECK(yse_device_num_buffer_sizes(nullptr) == 0);
+    CHECK(yse_device_get_buffer_size(nullptr, 0) == 0);
+    CHECK(yse_device_default_buffer_size(nullptr) == 0);
+    CHECK(yse_device_output_latency(nullptr) == 0);
+    CHECK(yse_device_input_latency(nullptr) == 0);
+    CHECK(yse_device_get_id(nullptr) == 0);
+  }
+
+  // ─── yse_device.cpp: deviceSetup ───────────────────────────────────────────
+
+  TEST_CASE("c-api device setup: create/destroy and the setters write through") {
+    YseDeviceSetup* setup = yse_device_setup_create();
+    REQUIRE(setup != nullptr);
+
+    YSE::device in = makeDevice();
+    YSE::device out = makeDevice();
+    yse_device_setup_set_input(setup, handle(in));
+    yse_device_setup_set_output(setup, handle(out));
+    yse_device_setup_set_sample_rate(setup, 48000.0);
+    yse_device_setup_set_buffer_size(setup, 256);
+
+    // getOutputChannels() has no C getter; read it off the engine object to
+    // prove set_output landed on the right slot.
+    CHECK(reinterpret_cast<YSE::deviceSetup*>(setup)->getOutputChannels() == 2);
+
+    yse_device_setup_destroy(setup);
+  }
+
+  TEST_CASE("c-api device setup: NULL handles and NULL devices are no-ops") {
+    yse_device_setup_destroy(nullptr);
+    yse_device_setup_set_input(nullptr, nullptr);
+    yse_device_setup_set_output(nullptr, nullptr);
+    yse_device_setup_set_sample_rate(nullptr, 44100.0);
+    yse_device_setup_set_buffer_size(nullptr, 512);
+
+    YseDeviceSetup* setup = yse_device_setup_create();
+    REQUIRE(setup != nullptr);
+    // A live setup with a NULL device must leave the previous slot untouched
+    // (0 outputs here, because nothing was ever set).
+    yse_device_setup_set_input(setup, nullptr);
+    yse_device_setup_set_output(setup, nullptr);
+    CHECK(reinterpret_cast<YSE::deviceSetup*>(setup)->getOutputChannels() == 0);
+    yse_device_setup_destroy(setup);
+  }
+
+  // ─── yse_reverb.cpp ────────────────────────────────────────────────────────
+
+  TEST_CASE("c-api reverb: create -> valid -> destroy") {
+    if (!ensureOffline()) return;
+    YseReverb* rev = yse_reverb_create();
+    REQUIRE(rev != nullptr);
+    CHECK(yse_reverb_is_valid(rev) == 1);
+    yse_reverb_destroy(rev);
+    yse_reverb_destroy(nullptr); // destroy(NULL) is a no-op
+  }
+
+  TEST_CASE("c-api reverb: zone parameters round-trip and clamp") {
+    if (!ensureOffline()) return;
+    YseReverb* rev = yse_reverb_create();
+    REQUIRE(rev != nullptr);
+
+    const yse_pos_t p{1.5f, -2.f, 3.25f};
+    yse_reverb_set_position(rev, &p);
+    const yse_pos_t got = yse_reverb_get_position(rev);
+    CHECK(got.x == doctest::Approx(1.5f));
+    CHECK(got.y == doctest::Approx(-2.f));
+    CHECK(got.z == doctest::Approx(3.25f));
+    yse_reverb_set_position(rev, nullptr); // NULL position: unchanged
+    CHECK(yse_reverb_get_position(rev).x == doctest::Approx(1.5f));
+
+    yse_reverb_set_size(rev, 12.f);
+    CHECK(yse_reverb_get_size(rev) == doctest::Approx(12.f));
+    yse_reverb_set_size(rev, -1.f); // negatives clamp to zero
+    CHECK(yse_reverb_get_size(rev) == doctest::Approx(0.f));
+
+    yse_reverb_set_roll_off(rev, 5.f);
+    CHECK(yse_reverb_get_roll_off(rev) == doctest::Approx(5.f));
+    yse_reverb_set_roll_off(rev, -3.f);
+    CHECK(yse_reverb_get_roll_off(rev) == doctest::Approx(0.f));
+
+    CHECK(yse_reverb_get_active(rev) == 1); // active by default
+    yse_reverb_set_active(rev, 0);
+    CHECK(yse_reverb_get_active(rev) == 0);
+    yse_reverb_set_active(rev, 1);
+    CHECK(yse_reverb_get_active(rev) == 1);
+
+    yse_reverb_set_room_size(rev, 2.f); // clamped to [0, 1]
+    CHECK(yse_reverb_get_room_size(rev) == doctest::Approx(1.f));
+    yse_reverb_set_damping(rev, -1.f);
+    CHECK(yse_reverb_get_damping(rev) == doctest::Approx(0.f));
+
+    yse_reverb_set_dry_wet_balance(rev, 0.25f, 0.75f);
+    CHECK(yse_reverb_get_dry(rev) == doctest::Approx(0.25f));
+    CHECK(yse_reverb_get_wet(rev) == doctest::Approx(0.75f));
+
+    yse_reverb_set_modulation(rev, 2.5f, 15.f);
+    CHECK(yse_reverb_get_modulation_frequency(rev) == doctest::Approx(2.5f));
+    CHECK(yse_reverb_get_modulation_width(rev) == doctest::Approx(15.f));
+
+    for (int i = 0; i < 4; ++i) {
+      yse_reverb_set_reflection(rev, i, 100 * (i + 1), 0.1f * static_cast<float>(i + 1));
+      CHECK(yse_reverb_get_reflection_time(rev, i) == 100 * (i + 1));
+      CHECK(yse_reverb_get_reflection_gain(rev, i) ==
+            doctest::Approx(0.1f * static_cast<float>(i + 1)));
+    }
+
+    yse_reverb_destroy(rev);
+  }
+
+  TEST_CASE("c-api reverb: presets map onto the engine preset table") {
+    if (!ensureOffline()) return;
+    YseReverb* rev = yse_reverb_create();
+    REQUIRE(rev != nullptr);
+
+    yse_reverb_set_preset(rev, YSE_REVERB_OFF);
+    CHECK(yse_reverb_get_room_size(rev) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_damping(rev) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_dry(rev) == doctest::Approx(1.f));
+    CHECK(yse_reverb_get_wet(rev) == doctest::Approx(0.f));
+
+    yse_reverb_set_preset(rev, YSE_REVERB_HALL);
+    CHECK(yse_reverb_get_room_size(rev) == doctest::Approx(0.7f));
+    CHECK(yse_reverb_get_damping(rev) == doctest::Approx(0.4f));
+    CHECK(yse_reverb_get_dry(rev) == doctest::Approx(0.5f));
+    CHECK(yse_reverb_get_wet(rev) == doctest::Approx(0.5f));
+
+    yse_reverb_set_preset(rev, YSE_REVERB_CAVE);
+    CHECK(yse_reverb_get_room_size(rev) == doctest::Approx(1.f));
+    CHECK(yse_reverb_get_wet(rev) == doctest::Approx(0.7f));
+
+    // SEWERPIPE is the preset that carries a non-zero modulation pair.
+    yse_reverb_set_preset(rev, YSE_REVERB_SEWERPIPE);
+    CHECK(yse_reverb_get_modulation_frequency(rev) == doctest::Approx(3.5f));
+    CHECK(yse_reverb_get_modulation_width(rev) == doctest::Approx(20.f));
+
+    // Every enum value in the C header must reach the engine table without
+    // tripping an assertion or leaving a parameter outside its documented range.
+    const YseReverbPreset all[] = {YSE_REVERB_OFF,       YSE_REVERB_GENERIC,   YSE_REVERB_PADDED,
+                                   YSE_REVERB_ROOM,      YSE_REVERB_BATHROOM,  YSE_REVERB_STONEROOM,
+                                   YSE_REVERB_LARGEROOM, YSE_REVERB_HALL,      YSE_REVERB_CAVE,
+                                   YSE_REVERB_SEWERPIPE, YSE_REVERB_UNDERWATER};
+    for (YseReverbPreset preset : all) {
+      yse_reverb_set_preset(rev, preset);
+      CHECK(yse_reverb_get_room_size(rev) >= 0.f);
+      CHECK(yse_reverb_get_room_size(rev) <= 1.f);
+      CHECK(yse_reverb_get_dry(rev) >= 0.f);
+      CHECK(yse_reverb_get_wet(rev) <= 1.f);
+    }
+
+    yse_reverb_destroy(rev);
+  }
+
+  TEST_CASE("c-api reverb: every entry point is NULL-safe") {
+    yse_reverb_set_position(nullptr, nullptr);
+    yse_reverb_set_size(nullptr, 1.f);
+    yse_reverb_set_roll_off(nullptr, 1.f);
+    yse_reverb_set_active(nullptr, 1);
+    yse_reverb_set_room_size(nullptr, 1.f);
+    yse_reverb_set_damping(nullptr, 1.f);
+    yse_reverb_set_dry_wet_balance(nullptr, 0.5f, 0.5f);
+    yse_reverb_set_modulation(nullptr, 1.f, 1.f);
+    yse_reverb_set_reflection(nullptr, 0, 10, 0.5f);
+    yse_reverb_set_preset(nullptr, YSE_REVERB_HALL);
+
+    CHECK(yse_reverb_is_valid(nullptr) == 0);
+    const yse_pos_t p = yse_reverb_get_position(nullptr);
+    CHECK(p.x == doctest::Approx(0.f));
+    CHECK(p.y == doctest::Approx(0.f));
+    CHECK(p.z == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_size(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_roll_off(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_active(nullptr) == 0);
+    CHECK(yse_reverb_get_room_size(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_damping(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_dry(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_wet(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_modulation_frequency(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_modulation_width(nullptr) == doctest::Approx(0.f));
+    CHECK(yse_reverb_get_reflection_time(nullptr, 0) == 0);
+    CHECK(yse_reverb_get_reflection_gain(nullptr, 0) == doctest::Approx(0.f));
+  }
+
+  TEST_CASE("c-api reverb: the borrowed global-reverb handle is live") {
+    if (!ensureOffline()) return;
+    YseReverb* global = yse_system_get_global_reverb(yse_system_get());
+    REQUIRE(global != nullptr);
+    CHECK(yse_reverb_is_valid(global) == 1);
+    // Borrowed handle — never destroyed here (see yse_c_internal.hpp).
+  }
+
+  // ─── yse_log.cpp ───────────────────────────────────────────────────────────
+
+  TEST_CASE("c-api log: the singleton handle is stable and the level round-trips") {
+    LogStateGuard guard;
+    YseLog* log = yse_log_get();
+    REQUIRE(log != nullptr);
+    CHECK(log == yse_log_get());
+
+    const YseErrorLevel levels[] = {YSE_EL_NONE, YSE_EL_ERROR, YSE_EL_WARNING, YSE_EL_DEBUG};
+    for (YseErrorLevel level : levels) {
+      yse_log_set_level(log, level);
+      CHECK(yse_log_get_level(log) == level);
+    }
+  }
+
+  TEST_CASE("c-api log: an installed callback receives emitted messages") {
+    LogStateGuard guard;
+    YseLog* log = yse_log_get();
+    LogSink sink;
+
+    yse_log_set_level(log, YSE_EL_DEBUG);
+    yse_log_set_callback(log, &logReceive, &sink);
+    yse_log_send_message(log, "capisurface-hello");
+    CHECK(sink.countMatching("capisurface-hello") == 1);
+    // The engine tags application messages before handing them to the sink.
+    CHECK(sink.countMatching("(App Message)") == 1);
+
+    // A NULL message is dropped rather than forwarded.
+    yse_log_send_message(log, nullptr);
+    CHECK(sink.countMatching("capisurface-hello") == 1);
+
+    // Passing NULL for cb restores the default file sink, so nothing further
+    // reaches this callback.
+    yse_log_set_callback(log, nullptr, nullptr);
+    yse_log_send_message(log, "capisurface-after-detach");
+    CHECK(sink.countMatching("capisurface-after-detach") == 0);
+  }
+
+  TEST_CASE("c-api log: level EL_NONE drops messages") {
+    LogStateGuard guard;
+    YseLog* log = yse_log_get();
+    LogSink sink;
+
+    yse_log_set_callback(log, &logReceive, &sink);
+    yse_log_set_level(log, YSE_EL_NONE);
+    yse_log_send_message(log, "capisurface-silenced");
+    CHECK(sink.countMatching("capisurface-silenced") == 0);
+
+    yse_log_set_level(log, YSE_EL_ERROR);
+    yse_log_send_message(log, "capisurface-audible");
+    CHECK(sink.countMatching("capisurface-audible") == 1);
+  }
+
+  TEST_CASE("c-api log: get_logfile follows the snprintf convention") {
+    LogStateGuard guard;
+    YseLog* log = yse_log_get();
+
+    yse_log_set_logfile(log, "capisurface_log.txt"); // 19 chars
+    CHECK(yse_log_get_logfile(log, nullptr, 0) == 19); // size query
+    CHECK(yse_log_get_logfile(log, nullptr, 32) == 19);
+
+    char exact[20] = {0};
+    CHECK(yse_log_get_logfile(log, exact, sizeof(exact)) == 19);
+    CHECK(std::string(exact) == "capisurface_log.txt");
+
+    char small[6] = {0};
+    CHECK(yse_log_get_logfile(log, small, sizeof(small)) == 19);
+    CHECK(std::string(small) == "capis");
+    CHECK(small[5] == '\0');
+
+    char probe = '@';
+    CHECK(yse_log_get_logfile(log, &probe, 0) == 19); // cap == 0 must not write
+    CHECK(probe == '@');
+
+    yse_log_set_logfile(log, nullptr); // NULL path is a no-op
+    CHECK(yse_log_get_logfile(log, exact, sizeof(exact)) == 19);
+    CHECK(std::string(exact) == "capisurface_log.txt");
+  }
+
+  TEST_CASE("c-api log: every entry point is NULL-safe") {
+    char buf[8];
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_log_get_logfile(nullptr, buf, sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+    CHECK(yse_log_get_logfile(nullptr, nullptr, 0) == 0);
+
+    CHECK(yse_log_get_level(nullptr) == YSE_EL_NONE);
+    yse_log_set_level(nullptr, YSE_EL_DEBUG);
+    yse_log_send_message(nullptr, "ignored");
+    yse_log_set_logfile(nullptr, "ignored.txt");
+    yse_log_set_callback(nullptr, &logReceive, nullptr);
+    yse_log_free_message(nullptr);
+
+    // The level of the real singleton must be untouched by the NULL setter.
+    CHECK(yse_log_get_level(yse_log_get()) != YSE_EL_NONE);
+  }
+
+  // ─── yse_listener.cpp ──────────────────────────────────────────────────────
+
+  TEST_CASE("c-api listener: the singleton handle is stable and position round-trips") {
+    YseListener* l = yse_listener_get();
+    REQUIRE(l != nullptr);
+    CHECK(l == yse_listener_get());
+
+    const yse_pos_t p{1.f, -2.5f, 3.f};
+    yse_listener_set_pos(l, &p);
+    const yse_pos_t got = yse_listener_get_pos(l);
+    CHECK(got.x == doctest::Approx(1.f));
+    CHECK(got.y == doctest::Approx(-2.5f));
+    CHECK(got.z == doctest::Approx(3.f));
+
+    yse_listener_set_pos(l, nullptr); // NULL position is a no-op
+    CHECK(yse_listener_get_pos(l).x == doctest::Approx(1.f));
+
+    const yse_pos_t origin{0.f, 0.f, 0.f};
+    yse_listener_set_pos(l, &origin);
+  }
+
+  TEST_CASE("c-api listener: orientation round-trips through both vectors") {
+    YseListener* l = yse_listener_get();
+    const yse_pos_t forward{0.f, 0.f, 1.f};
+    const yse_pos_t up{0.f, 1.f, 0.f};
+
+    yse_listener_set_orient(l, &forward, &up);
+    const yse_pos_t f = yse_listener_get_forward(l);
+    const yse_pos_t u = yse_listener_get_upward(l);
+    CHECK(f.x == doctest::Approx(0.f));
+    CHECK(f.z == doctest::Approx(1.f));
+    CHECK(u.y == doctest::Approx(1.f));
+
+    // Either vector NULL leaves both untouched.
+    const yse_pos_t other{1.f, 0.f, 0.f};
+    yse_listener_set_orient(l, &other, nullptr);
+    yse_listener_set_orient(l, nullptr, &other);
+    CHECK(yse_listener_get_forward(l).z == doctest::Approx(1.f));
+    CHECK(yse_listener_get_upward(l).y == doctest::Approx(1.f));
+
+    // Velocity is engine-maintained; the C getter must simply read it back as a
+    // finite vector rather than fail.
+    const yse_pos_t v = yse_listener_get_vel(l);
+    CHECK(v.x == v.x); // not NaN
+    CHECK(v.y == v.y);
+    CHECK(v.z == v.z);
+  }
+
+  TEST_CASE("c-api listener: a NULL handle yields the zero vector") {
+    yse_listener_set_pos(nullptr, nullptr);
+    yse_listener_set_orient(nullptr, nullptr, nullptr);
+
+    const yse_pos_t zeros[] = {yse_listener_get_pos(nullptr), yse_listener_get_vel(nullptr),
+                               yse_listener_get_forward(nullptr), yse_listener_get_upward(nullptr)};
+    for (const yse_pos_t& z : zeros) {
+      CHECK(z.x == doctest::Approx(0.f));
+      CHECK(z.y == doctest::Approx(0.f));
+      CHECK(z.z == doctest::Approx(0.f));
+    }
+  }
+
+  // ─── yse_buffer_io.cpp ─────────────────────────────────────────────────────
+  //
+  // BufferIO keeps its registry in a process-global that the destructor frees,
+  // so only one instance may be alive at a time — each case creates exactly one
+  // and destroys it before returning (same constraint the C++ io suite documents).
+
+  TEST_CASE("c-api buffer io: create/destroy, active toggle and registration") {
+    YseBufferIO* io = yse_buffer_io_create(0);
+    REQUIRE(io != nullptr);
+
+    CHECK(yse_buffer_io_get_active(io) == 0);
+    yse_buffer_io_set_active(io, 1);
+    CHECK(yse_buffer_io_get_active(io) == 1);
+
+    char data[16] = {0};
+    CHECK(yse_buffer_io_name_exists(io, "capi-buf") == 0);
+    CHECK(yse_buffer_io_add(io, "capi-buf", data, static_cast<int>(sizeof(data))) == 1);
+    CHECK(yse_buffer_io_name_exists(io, "capi-buf") == 1);
+    // Duplicate IDs are rejected.
+    CHECK(yse_buffer_io_add(io, "capi-buf", data, static_cast<int>(sizeof(data))) == 0);
+
+    CHECK(yse_buffer_io_remove_by_name(io, "capi-buf") == 1);
+    CHECK(yse_buffer_io_name_exists(io, "capi-buf") == 0);
+    CHECK(yse_buffer_io_remove_by_name(io, "capi-buf") == 0);
+
+    yse_buffer_io_set_active(io, 0);
+    CHECK(yse_buffer_io_get_active(io) == 0);
+    yse_buffer_io_destroy(io);
+    yse_buffer_io_destroy(nullptr); // destroy(NULL) is a no-op
+  }
+
+  TEST_CASE("c-api buffer io: store_copy keeps the bytes alive past the caller's buffer") {
+    YseBufferIO* io = yse_buffer_io_create(1);
+    REQUIRE(io != nullptr);
+    yse_buffer_io_set_active(io, 1);
+    {
+      char scoped[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+      REQUIRE(yse_buffer_io_add(io, "capi-copy", scoped, static_cast<int>(sizeof(scoped))) == 1);
+    } // `scoped` dies here; the owned copy must survive
+    CHECK(yse_buffer_io_name_exists(io, "capi-copy") == 1);
+    CHECK(yse_buffer_io_remove_by_name(io, "capi-copy") == 1);
+    yse_buffer_io_set_active(io, 0);
+    yse_buffer_io_destroy(io);
+  }
+
+  TEST_CASE("c-api buffer io: invalid arguments and NULL handles return zero") {
+    char data[4] = {0};
+
+    CHECK(yse_buffer_io_get_active(nullptr) == 0);
+    yse_buffer_io_set_active(nullptr, 1);
+    CHECK(yse_buffer_io_name_exists(nullptr, "x") == 0);
+    CHECK(yse_buffer_io_add(nullptr, "x", data, 4) == 0);
+    CHECK(yse_buffer_io_remove_by_name(nullptr, "x") == 0);
+
+    YseBufferIO* io = yse_buffer_io_create(0);
+    REQUIRE(io != nullptr);
+    CHECK(yse_buffer_io_name_exists(io, nullptr) == 0);
+    CHECK(yse_buffer_io_add(io, nullptr, data, 4) == 0); // NULL id
+    CHECK(yse_buffer_io_add(io, "x", nullptr, 4) == 0); // NULL buffer
+    CHECK(yse_buffer_io_add(io, "x", data, 0) == 0); // zero length
+    CHECK(yse_buffer_io_add(io, "x", data, -1) == 0); // negative length
+    CHECK(yse_buffer_io_remove_by_name(io, nullptr) == 0);
+    CHECK(yse_buffer_io_name_exists(io, "x") == 0); // nothing was registered
+    yse_buffer_io_destroy(io);
+  }
+
+} // TEST_SUITE("capisurface")


### PR DESCRIPTION
## Summary

`YseEngine/c_api/` is the only supported entry point for FFI consumers and was
the least-tested area of the tree: six of its files had **zero** coverage. A
regression there does not fail loudly in C++ — it corrupts a binding at the ABI
boundary — so the assertions here are about the **boundary contract** rather
than DSP behaviour, exactly as the issue's "suggested approach" lays out.

This clears the first acceptance item on #417: no file under `YseEngine/c_api/`
is left at 0% coverage.

## Linked issue

Closes #417

## Changes

**New `Tests/system/test_c_api_surface.cpp`** — `TEST_SUITE("capisurface")`,
covering `yse_device.cpp`, `yse_reverb.cpp`, `yse_log.cpp`, `yse_listener.cpp`
and `yse_buffer_io.cpp`:

- **NULL / invalid handles.** Every entry point in the five files is called with
  a NULL handle, and with a NULL out-parameter where it takes one. Void setters
  must no-op; queries must return zero / false / NULL and clear the out buffer —
  the contract written down in `yse_c_internal.hpp`.
- **Ownership and lifetime.** `create`/`destroy` pairs, `destroy(NULL)`, and the
  borrowed global-reverb handle (never destroyed).
- **String marshalling.** The snprintf convention documented in `yse_device.h`,
  driven through both `copy_string` implementations: size query with `cap == 0`
  *and* with `buf == NULL`, exact fit, truncation, `cap == 1`, always
  NUL-terminated, return value always the full length. This is the same
  `yse_log.cpp` path as the `cpp:S5813` `strlen` hotspot in #419.
- **Enum round-trips.** `YseErrorLevel` in both directions, and every
  `YseReverbPreset` value pushed through the engine preset table.
- **The log callback bridge end to end.** Install → tagged delivery →
  `yse_log_free_message` ownership transfer → `EL_NONE` drops → NULL `cb`
  restores the file sink. The sink counts occurrences of a unique token under a
  mutex rather than total messages, so a stray engine-thread log line cannot
  flake it.

**New `Tests/clip/test_c_api_clip.cpp`** — covers `yse_clip.cpp` from inside the
existing `clip` suite, which already has the clock/clip-manager process
isolation these cases need: create → bind → play → stop through the flat ABI,
unknown-clock and NULL-argument rejection, the documented "`events` may be NULL
only when `count` is 0" rule, and the synth / MIDI-out connect pair.

**`Tests/CMakeLists.txt`** — registers both TUs, plus a `yse_tests_capisurface`
ctest entry, and excludes `capisurface` from the monolithic `yse_unit_tests`
run. Three independent reasons for the isolation, each sufficient on its own:
the suite drives `yse_system_init_offline()`, it swaps the process-global log
sink, and it installs the process-global BufferIO VFS hooks. `initOffline()`
needs no audio hardware, so it runs on headless CI — and `ctest --test-dir build`
in the coverage job runs every registered entry, so the new process counts
toward `new_coverage`.

## Notes

- A few cases reach past the C ABI into the engine headers to build a device
  descriptor (the engine's enumerator is the only other producer and it needs
  real hardware) and to read back `deviceSetup::getOutputChannels()`, which has
  no C getter. Same shape as `test_c_api_bus.cpp` publishing through
  `INTERNAL::Bus()`; the tests link `yse_objects` with full symbol access.
- Out-of-range index paths on the device descriptor are deliberately **not**
  exercised: the engine indexes with `operator[]`, so those are UB rather than
  the exception the C API's `catch` implies. Filed as **#565** along with the
  indeterminate scalar fields on `YSE::device` — both out of scope here.
- Portability: no `std::thread::id` stringification, no wall-clock timing, no
  device dependency, and the log assertions are order- and noise-independent.

## Test plan

- [x] `python yse.py format` clean (no diff after running).
- [x] `python yse.py analyze Tests/system/test_c_api_surface.cpp` and
      `... Tests/clip/test_c_api_clip.cpp` — no findings in user code
      (66 / 84 warnings, all suppressed as non-user code).
- [x] `python yse.py test` — **35/35 ctest entries pass**, including the new
      `yse_tests_capisurface`.
- [x] New coverage in isolation: `capisurface` 21 cases / 244 assertions,
      `clip` 20 cases / 76 assertions (up from 15 / 55), all passing.
- [x] Integration/e2e: not applicable in the app-UI sense — this is a library,
      and the C ABI *is* the user-visible surface. The `capisurface` suite drives
      it end to end against a real offline engine in its own process, which is
      the project's equivalent (same shape as `yse_tests_buscapi` /
      `yse_tests_channelcapi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
