### PR TITLE
infra: fix llvm-cov export invocation in yse.py coverage on Windows (#567)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,11 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+# Reports written by `python yse.py coverage` (gcovr on Linux, llvm-cov on
+# Windows).  Generated artefacts — an empty coverage-llvm.json was committed
+# by accident once, see #567.
+coverage.xml
+coverage-llvm.json
 
 #Translations
 *.mo

--- a/yse.py
+++ b/yse.py
@@ -15,6 +15,7 @@ are propagated unchanged.
 
 import argparse
 import datetime
+import json
 import os
 import platform
 import re
@@ -65,6 +66,20 @@ def run_to_file(cmd, output_path, cwd=None):
         result = subprocess.run(cmd, stdout=f, cwd=str(cwd) if cwd else None)
     if result.returncode != 0:
         sys.exit(result.returncode)
+
+
+def _check_json_report(path):
+    """Exit with an error unless *path* is a non-empty, parseable JSON file."""
+    path = Path(path)
+    if not path.exists() or path.stat().st_size == 0:
+        print(f"error: {path} is empty — the report generator wrote nothing.")
+        sys.exit(1)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            json.load(f)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        print(f"error: {path} is not valid JSON: {exc}")
+        sys.exit(1)
 
 
 def _demo_exe(name):
@@ -221,15 +236,26 @@ def _cmd_coverage_windows():
 
     # llvm-cov export writes the JSON to stdout; redirect to report file.
     # SonarQube ingests this via sonar.cfamily.llvm-cov.reportPath.
+    #
+    # Do NOT pass --format=json here: `export` emits JSON by default and its
+    # --format option only accepts text/lcov (json is a `show`/`report` value).
+    # Passing it made llvm-cov exit 1 with "Cannot find option named 'json'!"
+    # *after* the expensive configure/build/ctest steps had already run.  See
+    # #567.
     run_to_file(
         ["llvm-cov", "export",
          str(test_exe),
          f"--instr-profile={profdata}",
-         "--format=json",
          str(ROOT / "YseEngine"),
          str(ROOT / "Tests")],
         output_path=str(report),
     )
+
+    # llvm-cov can exit 0 having written nothing useful (bad filter paths, a
+    # future flag rename).  Fail loudly here rather than leaving a truncated
+    # report for SonarQube to silently ingest as "no coverage".
+    _check_json_report(report)
+
     print(f"\nCoverage report written to {report}")
     print(f"SonarQube property: sonar.cfamily.llvm-cov.reportPath={report.name}")
 


### PR DESCRIPTION
## Summary

`python yse.py coverage` on Windows died on its very last step:

```
llvm-cov.exe export: for the --format option: Cannot find option named 'json'!
```

`llvm-cov export` emits JSON by default and its `--format` option only accepts
`text`/`lcov` — `json` is a `show`/`report` value and was never valid for
`export`. Because the failure was at the end, the expensive part (configure,
build, ~2 minutes of ctest) ran to completion and then threw the result away,
leaving an empty `coverage-llvm.json` behind.

## Linked issue

Closes #567

## Changes

- **`yse.py`** — drop the invalid `--format=json` from the `llvm-cov export`
  call in `_cmd_coverage_windows()`.
- **`yse.py`** — add `_check_json_report()`, called right after the export:
  the report must exist, be non-empty, and parse as JSON, else the command
  exits 1 with a clear message. Without it, a future flag rename (or a bad
  filter path) would leave a truncated report for SonarQube to silently ingest
  as "no coverage".
- **`.gitignore` / untrack** — `coverage-llvm.json` was committed *empty* by
  accident in 46ab1ff, an artefact of exactly this bug. It is now untracked and
  both `yse.py coverage` outputs (`coverage.xml`, `coverage-llvm.json`) are
  gitignored, so a *successful* run no longer dirties the working tree with a
  48 MB report. CI is unaffected: the Sonar pipeline uses the Linux gcovr path
  (`coverage.xml`), which it generates in-job.

## Test plan

Primary verification is the command the issue is about, run end to end on
Windows 11 / MSYS2 Clang64 (LLVM 22.1.4):

- [x] **`python yse.py coverage` completes, exit 0** — configure → build →
      ctest (**100% tests passed, 0 failed out of 34**, 115.66 s) → `llvm-profdata
      merge` (68 `.profraw`) → `llvm-cov export` → `Coverage report written to
      D:\yse-soundengine\coverage-llvm.json`. Report is **48 MB**, parses as
      `llvm.coverage.json.export` v3.1.0, **408 files, 84.25 % line coverage
      (42519/50465)**.
- [x] **Pre-fix failure reproduced** — the old argv still fails on this machine
      with `Cannot find option named 'json'!` (exit 1), confirming the flag was
      the cause and not an environment quirk.
- [x] **`_check_json_report()` exercised directly** — rejects (exit 1) an empty
      file, a truncated `{"trunc":` file, and a missing file; accepts valid JSON
      and the real generated report.
- [x] **`python yse.py test`** — 100% tests passed, 0 failed out of 35 (118.51 s).
- [x] **Working tree clean after a successful coverage run** (`git status
      --porcelain` shows no stray report).
- [n/a] **`python yse.py analyze`** — clang-tidy runs over C++ via
      `compile_commands.json`; this change touches only `yse.py` and `.gitignore`,
      so there is nothing for it to analyse. The repo has no Python linter config,
      and `clang-format` covers only `YseEngine/`+`Tests/`.
- [n/a] **New automated regression test** — this is build tooling, not engine
      code; there is no Python test harness in the repo, and the bug is only
      reachable by running the real 4-minute instrumented coverage build. The
      end-to-end run above plus the added in-command assertion is the guard: the
      exact regression (an unusable report) now fails the command loudly instead
      of passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
