### PR TITLE
infra: let clang-tidy see headers in subdirectories (#426)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,7 @@
 # pass is planned.
 #
 # Vendored deps under dependencies/ and generated code under build*/ are
-# excluded via HeaderFilterRegex.
+# excluded via ExcludeHeaderFilterRegex.
 
 Checks: >
   -*,
@@ -72,7 +72,24 @@ Checks: >
 WarningsAsErrors: ''
 
 # Apply checks only to our own headers under YseEngine/ and Tests/.
-HeaderFilterRegex: '.*(YseEngine|Tests)[/\\][^/\\]*\.h(pp)?$'
+#
+# The `.*` after the directory separator is load-bearing: it lets the filter
+# reach headers nested in subdirectories (YseEngine/dsp/, YseEngine/utils/,
+# Tests/support/, ...).  An earlier `[^/\\]*` here required the header to sit
+# *directly* under YseEngine/ or Tests/, which covered 8 of the 254 headers in
+# the tree and silently discarded every finding from the other 246 — see #426.
+#
+# The filter matches the include spelling the preprocessor resolved, not a
+# canonical path, and some of ours traverse back out of the tree
+# (`Tests/../dependencies/rtmidi/include/RtMidi.h`).  Those satisfy the widened
+# pattern, so vendored headers are subtracted again below rather than by trying
+# to express "no `..` after the anchor" — llvm::Regex has no lookahead.
+HeaderFilterRegex: '.*(YseEngine|Tests)[/\\].*\.h(pp)?$'
+
+# Vendored deps stay out of the report: dependencies/ (submodule-style checkouts)
+# and build*/_deps/ (FetchContent). We don't modify vendored sources, so their
+# findings are pure noise. Requires clang-tidy >= 19.
+ExcludeHeaderFilterRegex: '.*[/\\](dependencies|_deps)[/\\].*'
 
 CheckOptions:
   - key: performance-move-const-arg.CheckTriviallyCopyableMove

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -202,8 +202,16 @@ python yse.py analyze                              # whole project (slow)
 
 Per CLAUDE.md item 6, run `python yse.py analyze <changed-files>` before
 committing and clear any **new** findings on the modified code. The
-baseline (~50 pre-existing findings across `YseEngine/`) is tracked as
-backlog — don't fix in passing during unrelated work.
+baseline (~335 pre-existing findings across `YseEngine/` and `Tests/`, 285
+of them in headers) is tracked as backlog in #573 — don't fix in passing
+during unrelated work.
+
+Note that a header finding is reported once per *include spelling*, not once
+per header: clang-tidy dedupes on the literal path, so the same warning shows
+up again as `YseEngine/channel/../classes.hpp` after
+`YseEngine/classes.hpp`. A whole-project run prints ~3200 warning lines for
+~335 distinct findings. Judge "did I add a finding?" by the file:line, not by
+the line count.
 
 ## Things that are out of scope for this skill
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,11 @@ session start. Pair with [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md).
 6. **Analyze before committing.** Run `python yse.py analyze <changed-files>`
    on the files touched in a commit and address any **new** findings. The
    project's [.clang-tidy](.clang-tidy) baseline keeps the noise floor low
-   (~50 pre-existing findings across `YseEngine/`, tracked as backlog —
-   don't fix in passing). New findings in *modified* code should be cleared
+   (~335 pre-existing findings across `YseEngine/` and `Tests/` — 285 of
+   them in headers, tracked as backlog in #573 — don't fix in passing).
+   The floor was ~50 until #426 fixed a `HeaderFilterRegex` that had been
+   discarding every finding from a header in a subdirectory; the jump is
+   reporting, not new debt. New findings in *modified* code should be cleared
    before the commit, fixing or with a focused `// NOLINT(check-name): why`
    when the check is genuinely wrong for that line. The `fix-issues` skill
    governs how to triage findings.


### PR DESCRIPTION
## Summary

`.clang-tidy`'s `HeaderFilterRegex` had `[^/\]*` between the directory
anchor and the extension, which required a header to sit **directly** under
`YseEngine/` or `Tests/`. That matched **8 of the 254 headers** in the tree.
Findings for the other 246 were computed by the enabled checks and then
discarded before printing, so `python yse.py analyze` returned a false
all-clear on every header change — the failure mode #426 hit while working
#410.

This is a reporting fix. No engine code is touched.

## Linked issue

Closes #426

## Changes

- **`.clang-tidy`** — `[^/\]*` → `.*`, so the filter reaches
  `YseEngine/dsp/`, `YseEngine/utils/`, `YseEngine/patcher/`,
  `Tests/support/`, …
- **`.clang-tidy`** — added `ExcludeHeaderFilterRegex` for
  `dependencies/` and `_deps/`. This is needed, not belt-and-braces: the
  filter matches the *include spelling the preprocessor resolved*, not a
  canonical path, and some of ours traverse back out of the tree
  (`Tests/../dependencies/rtmidi/include/RtMidi.h`). Without the exclusion
  the widened pattern pulled **50 findings out of vendored RtMidi**.
  `llvm::Regex` has no lookahead, so "no `..` after the anchor" can't be
  expressed in the include filter itself — subtracting afterwards is the
  available mechanism. Requires clang-tidy ≥ 19; the repo builds with
  22.1.4.
- **`CLAUDE.md`, `.claude/skills/fix-issues/SKILL.md`** — re-measured the
  documented baseline (the old "~50 findings" number was measured under the
  broken filter) and pointed it at the new backlog issue.

## Verification — before/after

Single TU, `YseEngine/channel/channelImplementation.cpp`, same clang-tidy
binary, only the filter differs:

```
$ clang-tidy -p=build-tests --header-filter='.*(YseEngine|Tests)[/\][^/\]*\.h(pp)?$' \
      YseEngine/channel/channelImplementation.cpp | grep -c ': warning: '
0

$ clang-tidy -p=build-tests YseEngine/channel/channelImplementation.cpp | grep -c ': warning: '   # new config
87
```

Those 87 come from `channel.hpp`, `dspObject.hpp`, `drawableBuffer.hpp` and
friends — headers the old filter could never reach.

Vendored exclusion, on the TU that pulls in RtMidi:

```
$ clang-tidy -p=build-tests --exclude-header-filter= Tests/midi/test_devicemanager.cpp
     50  dependencies/rtmidi/include/RtMidi.h
$ clang-tidy -p=build-tests Tests/midi/test_devicemanager.cpp     # new config
     (none)
```

Whole tree, full `python yse.py analyze` (314 TUs) run under each filter,
unique findings after canonicalising paths and dropping vendored code:

| | narrow filter | widened filter |
|---|---|---|
| findings in `.cpp` | 51 | 51 |
| findings in headers | 5 | 285 |
| **total unique** | **56** | **336** |

280 newly visible, **0 lost**, across 45 headers.

## Pre-existing findings: recorded, not fixed

The 280 are pre-existing debt that the old filter was hiding, so per
CLAUDE.md item 6 they are **not** fixed here. They are recorded with a full
per-check breakdown and a suggested triage order in **#573**:

| count | check |
|---:|---|
| 161 | `bugprone-forward-declaration-namespace` |
| 86 | `modernize-use-override` |
| 15 | `bugprone-derived-method-shadowing-base-method` |
| 18 | (11 other checks, ≤3 each) |

`bugprone-forward-declaration-namespace` alone is 57% of the batch and looks
like one structural cause in `classes.hpp` — one decision, not 161 fixes.

**The analyze gate stays green:** `WarningsAsErrors` is `''`, so
`python yse.py analyze` still exits 0 (verified on the full run). No CI
workflow runs clang-tidy — `build.yml` is SonarCloud and `format.yml` is
clang-format over `*.cpp/*.hpp/*.h`, neither of which this PR affects — so
no baseline suppression was needed to keep CI passing.

One vendored diagnostic still prints
(`dependencies/doctest/doctest.h`, `clang-analyzer-core.UndefinedBinaryOperatorResult`).
It is unaffected by this change — it appears identically in the before run —
because `clang-analyzer-*` path diagnostics bypass the header filter.

## Test plan

- [x] `clang-format` gate unaffected — no `*.cpp/*.hpp/*.h` file is touched
      by this PR (the workflow only globs those under `YseEngine/` and
      `Tests/`)
- [x] `python yse.py analyze` completes on the full tree, exit 0
- [x] `python yse.py test` — **35/35 ctest targets pass, 0 failures**
      (158.8 s)
- [ ] No integration/e2e test added. The change is a static-analysis
      configuration file; it alters no compiled code and has no runtime,
      user-visible, or audio-thread behaviour to exercise. The
      analyzer-facing behaviour it *does* change is verified directly by the
      before/after clang-tidy runs above, which is the only layer that can
      observe it. The repo has no Python test harness that a regex assertion
      could live in, and adding one for a single config line would be out of
      scope for this issue.
