### PR TITLE
c-api: bound-check device descriptor indices and zero-init its scalars (#565)

### DIFF
--- a/Tests/system/test_c_api_surface.cpp
+++ b/Tests/system/test_c_api_surface.cpp
@@ -33,6 +33,8 @@
 
 #include <cstring>
 #include <mutex>
+#include <new> // placement new — constructs a device over pre-dirtied storage
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -65,8 +67,9 @@ namespace {
   // A fully populated device descriptor. The engine's enumerator is the only
   // other producer of these and it needs real hardware, so the tests build one
   // by hand and hand the C API the same reinterpret_cast the engine does in
-  // yse_system_get_device(). Every scalar field is set explicitly: the default
-  // constructor leaves the int members indeterminate.
+  // yse_system_get_device(). Every scalar field is set explicitly so the
+  // getters have distinguishable values to mirror (the constructor itself
+  // zero-initialises them — see the issue #565 case below).
   YSE::device makeDevice() {
     YSE::device d;
     d.setName("Test Output Device") // 18 chars — used by the truncation cases
@@ -235,6 +238,97 @@ TEST_SUITE("capisurface") {
     CHECK(yse_device_output_latency(nullptr) == 0);
     CHECK(yse_device_input_latency(nullptr) == 0);
     CHECK(yse_device_get_id(nullptr) == 0);
+  }
+
+  TEST_CASE("c-api device: out-of-range indices read as empty (issue #565)") {
+    // Before the fix the engine getters indexed with operator[], so the
+    // try/catch in the C API could never fire and the two scalar getters had
+    // no guard at all: an FFI consumer iterating with a stale count (a device
+    // list refreshed between yse_device_num_output_channels() and the name
+    // loop) got a silent out-of-bounds read. The engine now bound-checks with
+    // .at() and the C API translates that into the NULL-handle contract.
+    YSE::device d = makeDevice();
+    YseDevice* dev = handle(d);
+
+    char buf[16];
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_device_get_output_channel_name(dev, 5, buf, sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_device_get_input_channel_name(dev, 5, buf, sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+
+    // The first index past the end is the one a stale count actually hits.
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_device_get_output_channel_name(dev, yse_device_num_output_channels(dev), buf,
+                                             sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_device_get_input_channel_name(dev, yse_device_num_input_channels(dev), buf,
+                                            sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+
+    // No out buffer at all on an out-of-range index is still safe.
+    CHECK(yse_device_get_output_channel_name(dev, 5, nullptr, 0) == 0);
+    CHECK(yse_device_get_input_channel_name(dev, 5, nullptr, 0) == 0);
+
+    CHECK(yse_device_get_sample_rate(dev, 5) == doctest::Approx(0.0));
+    CHECK(yse_device_get_sample_rate(dev, yse_device_num_sample_rates(dev)) ==
+          doctest::Approx(0.0));
+    CHECK(yse_device_get_buffer_size(dev, 5) == 0);
+    CHECK(yse_device_get_buffer_size(dev, yse_device_num_buffer_sizes(dev)) == 0);
+
+    // An empty descriptor has no valid index at all.
+    YSE::device empty;
+    YseDevice* none = handle(empty);
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_device_get_output_channel_name(none, 0, buf, sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+    std::memset(buf, 'x', sizeof(buf));
+    CHECK(yse_device_get_input_channel_name(none, 0, buf, sizeof(buf)) == 0);
+    CHECK(buf[0] == '\0');
+    CHECK(yse_device_get_sample_rate(none, 0) == doctest::Approx(0.0));
+    CHECK(yse_device_get_buffer_size(none, 0) == 0);
+  }
+
+  TEST_CASE("device: indexed getters throw rather than read past the end (issue #565)") {
+    // The C++ side of the same fix: the engine getters bound-check, so a C++
+    // consumer gets a defined std::out_of_range instead of undefined
+    // behaviour. This is what makes the C API's catch reachable.
+    YSE::device d = makeDevice();
+    const YSE::device& c = d;
+
+    CHECK_THROWS_AS((void)c.getOutputChannelName(5), std::out_of_range);
+    CHECK_THROWS_AS((void)c.getInputChannelName(5), std::out_of_range);
+    CHECK_THROWS_AS((void)c.getAvailableSampleRate(5), std::out_of_range);
+    CHECK_THROWS_AS((void)c.getAvailableBufferSize(5), std::out_of_range);
+
+    // In-range indices are untouched.
+    CHECK(c.getOutputChannelName(1) == "out 2");
+    CHECK(c.getAvailableBufferSize(1) == 512);
+  }
+
+  TEST_CASE("device: the constructor zero-initialises the scalar fields (issue #565)") {
+    // defaultBufferSize, inputLatency, outputLatency and ID were left out of
+    // the constructor, so yse_device_default_buffer_size() and friends
+    // returned whatever was in that memory unless the enumerator happened to
+    // set every one of them.
+    //
+    // A plain stack-local device is an unreliable regression test — the slot
+    // is often already zero. Placement-new over 0xFF-filled storage (which
+    // reads back as -1 for an int) makes the uninitialised read deterministic,
+    // the same trick test_reverb_dsp.cpp uses for issue #263.
+    alignas(YSE::device) unsigned char storage[sizeof(YSE::device)];
+    std::memset(storage, 0xFF, sizeof(storage));
+    YSE::device* d = new (storage) YSE::device();
+    YseDevice* dev = handle(*d);
+
+    CHECK(yse_device_default_buffer_size(dev) == 0);
+    CHECK(yse_device_output_latency(dev) == 0);
+    CHECK(yse_device_input_latency(dev) == 0);
+    CHECK(yse_device_get_id(dev) == 0);
+
+    d->~device();
   }
 
   // ─── yse_device.cpp: deviceSetup ───────────────────────────────────────────

--- a/YseEngine/c_api/include/yse_c/yse_device.h
+++ b/YseEngine/c_api/include/yse_c/yse_device.h
@@ -10,6 +10,11 @@
   are copied into the buffer and a NUL terminator is appended. The return
   value is the full length of the string (excluding the NUL); pass cap=0 to
   query the required size before allocating.
+
+  The indexed getters (channel names, sample rates, buffer sizes) are
+  bound-checked: an index at or beyond the matching yse_device_num_*() count
+  yields the same result as a NULL handle — an empty out buffer and a return
+  of 0 / 0.0 — so iterating with a stale count is safe.
 */
 
 #ifndef YSE_C_DEVICE_H_INCLUDED

--- a/YseEngine/c_api/yse_device.cpp
+++ b/YseEngine/c_api/yse_device.cpp
@@ -64,6 +64,9 @@ YSE_C_API size_t yse_device_get_output_channel_name(YseDevice* dev, unsigned int
   try {
     return copy_string(to_cpp(dev)->getOutputChannelName(idx), buf, cap);
   } catch (const std::exception&) {
+    // The engine getter bound-checks with .at(), so an out-of-range index
+    // lands here: report an empty string instead of reading past the end
+    // (issue #565).
     if (buf && cap > 0) buf[0] = '\0';
     return 0;
   }
@@ -82,6 +85,7 @@ YSE_C_API size_t yse_device_get_input_channel_name(YseDevice* dev, unsigned int 
   try {
     return copy_string(to_cpp(dev)->getInputChannelName(idx), buf, cap);
   } catch (const std::exception&) {
+    // Out-of-range index — see yse_device_get_output_channel_name.
     if (buf && cap > 0) buf[0] = '\0';
     return 0;
   }
@@ -91,14 +95,27 @@ YSE_C_API unsigned int yse_device_num_sample_rates(YseDevice* dev) {
   return dev ? to_cpp(dev)->getNumAvailableSampleRates() : 0;
 }
 YSE_C_API double yse_device_get_sample_rate(YseDevice* dev, unsigned int idx) {
-  return dev ? to_cpp(dev)->getAvailableSampleRate(idx) : 0.0;
+  if (!dev) return 0.0;
+  try {
+    return to_cpp(dev)->getAvailableSampleRate(idx);
+  } catch (const std::exception&) {
+    // Out-of-range index: report 0.0 rather than letting the engine's
+    // std::out_of_range escape across the C ABI.
+    return 0.0;
+  }
 }
 
 YSE_C_API unsigned int yse_device_num_buffer_sizes(YseDevice* dev) {
   return dev ? to_cpp(dev)->getNumAvailableBufferSizes() : 0;
 }
 YSE_C_API int yse_device_get_buffer_size(YseDevice* dev, unsigned int idx) {
-  return dev ? to_cpp(dev)->getAvailableBufferSize(idx) : 0;
+  if (!dev) return 0;
+  try {
+    return to_cpp(dev)->getAvailableBufferSize(idx);
+  } catch (const std::exception&) {
+    // Out-of-range index — same contract as yse_device_get_sample_rate.
+    return 0;
+  }
 }
 
 YSE_C_API int yse_device_default_buffer_size(YseDevice* dev) {

--- a/YseEngine/device/deviceInterface.cpp
+++ b/YseEngine/device/deviceInterface.cpp
@@ -11,7 +11,7 @@
 #include "deviceInterface.hpp"
 #include "../internalHeaders.h"
 
-YSE::device::device() {}
+YSE::device::device() : defaultBufferSize(0), inputLatency(0), outputLatency(0), ID(0) {}
 
 YSE::device& YSE::device::setName(const std::string& name) {
   this->name = name;
@@ -72,7 +72,7 @@ unsigned int YSE::device::getNumOutputChannelNames() const {
 }
 
 const std::string& YSE::device::getOutputChannelName(unsigned int nr) const {
-  return outputChannelNames[nr];
+  return outputChannelNames.at(nr);
 }
 
 unsigned int YSE::device::getNumInputChannelNames() const {
@@ -80,7 +80,7 @@ unsigned int YSE::device::getNumInputChannelNames() const {
 }
 
 const std::string& YSE::device::getInputChannelName(unsigned int nr) const {
-  return inputChannelNames[nr];
+  return inputChannelNames.at(nr);
 }
 
 unsigned int YSE::device::getNumAvailableSampleRates() const {
@@ -88,7 +88,7 @@ unsigned int YSE::device::getNumAvailableSampleRates() const {
 }
 
 double YSE::device::getAvailableSampleRate(unsigned int nr) const {
-  return sampleRates[nr];
+  return sampleRates.at(nr);
 }
 
 unsigned int YSE::device::getNumAvailableBufferSizes() const {
@@ -96,7 +96,7 @@ unsigned int YSE::device::getNumAvailableBufferSizes() const {
 }
 
 int YSE::device::getAvailableBufferSize(unsigned int nr) const {
-  return bufferSizes[nr];
+  return bufferSizes.at(nr);
 }
 
 YSE::device& YSE::device::setDefaultBufferSize(int value) {

--- a/YseEngine/device/deviceInterface.hpp
+++ b/YseEngine/device/deviceInterface.hpp
@@ -81,25 +81,33 @@ namespace YSE {
     /** @brief Number of output channels. */
     unsigned int getNumOutputChannelNames() const;
 
-    /** @brief Name of output channel ``nr``. */
+    /** @brief Name of output channel ``nr``.
+     *  @throws std::out_of_range if ``nr >= getNumOutputChannelNames()``.
+     */
     const std::string& getOutputChannelName(unsigned int nr) const;
 
     /** @brief Number of input channels. */
     unsigned int getNumInputChannelNames() const;
 
-    /** @brief Name of input channel ``nr``. */
+    /** @brief Name of input channel ``nr``.
+     *  @throws std::out_of_range if ``nr >= getNumInputChannelNames()``.
+     */
     const std::string& getInputChannelName(unsigned int nr) const;
 
     /** @brief Number of supported sample rates. */
     unsigned int getNumAvailableSampleRates() const;
 
-    /** @brief Supported sample rate at index ``nr``. */
+    /** @brief Supported sample rate at index ``nr``.
+     *  @throws std::out_of_range if ``nr >= getNumAvailableSampleRates()``.
+     */
     double getAvailableSampleRate(unsigned int nr) const;
 
     /** @brief Number of supported buffer sizes. */
     unsigned int getNumAvailableBufferSizes() const;
 
-    /** @brief Supported buffer size at index ``nr``. */
+    /** @brief Supported buffer size at index ``nr``.
+     *  @throws std::out_of_range if ``nr >= getNumAvailableBufferSizes()``.
+     */
     int getAvailableBufferSize(unsigned int nr) const;
 
     /** @brief Set the default buffer size to use when this device is opened. */


### PR DESCRIPTION
## Summary

Fixes both defects reported in #565 on the `YSE::device` descriptor path
behind `YseEngine/c_api/yse_device.cpp`.

**1. Out-of-range guards were dead code.** The C API wrapped the channel-name
getters in `try { ... } catch (const std::exception&)`, but the engine getters
indexed with `operator[]`, so the catch could never fire and the C API read
past the end of the vector. `yse_device_get_sample_rate()` and
`yse_device_get_buffer_size()` had the same `operator[]` underneath and no
guard at all.

The four indexed engine getters now use `.at()` — C++ consumers get a defined
`std::out_of_range` instead of UB, and the C API's existing catch becomes real.
The two scalar getters grow the same guard, so an out-of-range index returns
`0.0` / `0` with an empty out buffer, matching the NULL-handle contract in
`yse_c_internal.hpp`. Nothing throws across the C ABI.

**2. Four scalar fields started indeterminate.** `YSE::device::device()` left
`defaultBufferSize`, `inputLatency`, `outputLatency` and `ID` out of the
initialiser list. They are now zero-initialised — same fix shape as the reverb
`size`/`rolloff` initialisation in #263.

Not an audio-thread path: device enumeration runs on the host thread, so the
`.at()` bound check costs nothing that matters.

## Linked issue

Closes #565

## Changes

- `YseEngine/device/deviceInterface.cpp` — `.at()` in the four indexed getters;
  constructor zero-initialises the four ints.
- `YseEngine/device/deviceInterface.hpp` — `@throws std::out_of_range` on the
  indexed getter docs.
- `YseEngine/c_api/yse_device.cpp` — range guard on
  `yse_device_get_sample_rate` / `yse_device_get_buffer_size`; comments noting
  the channel-name catches are now reachable.
- `YseEngine/c_api/include/yse_c/yse_device.h` — documents that indexed getters
  are bound-checked and that an out-of-range index reads like a NULL handle.
- `Tests/system/test_c_api_surface.cpp` — three regression cases (see below).

## Test plan

- [x] `python yse.py format` clean — no reformatting needed.
- [x] `python yse.py analyze` clean on all three changed `.cpp` files
      (`deviceInterface.cpp`, `yse_device.cpp`, `test_c_api_surface.cpp`): zero
      findings at those files' own lines. The remaining output is the
      pre-existing header debt tracked in #573 (unrelated headers pulled in via
      `internalHeaders.h`), untouched here.
- [x] `python yse.py test` — 35/35 ctest suites pass, including
      `yse_tests_capisurface`.
- [x] Regression proven: with the two source files stashed and the new tests in
      place, `yse_tests_capisurface` fails with `***Exception: SegFault` (the
      out-of-bounds read); with the fix it passes.

New cases in `TEST_SUITE("capisurface")`:

- `c-api device: out-of-range indices read as empty (issue #565)` — far index
  and the first index past the end for all four indexed getters, with and
  without an out buffer, plus an empty descriptor where no index is valid.
- `device: indexed getters throw rather than read past the end (issue #565)` —
  `CHECK_THROWS_AS(..., std::out_of_range)` on the engine side, with in-range
  reads still correct.
- `device: the constructor zero-initialises the scalar fields (issue #565)` —
  placement-new over 0xFF-dirtied storage so the uninitialised read is
  deterministic (the trick `test_reverb_dsp.cpp` uses for #263).

No integration test: the change is not user-visible — it is a C ABI boundary
contract, and the C-API surface suite *is* the end-to-end exercise of that
boundary (it runs the real engine offline via `yse_system_init_offline`). The
only other producer of a device descriptor is the engine's enumerator, which
needs real audio hardware and so cannot run on headless CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
