### PR TITLE
clang-tidy header backlog: triage the 280 findings surfaced by #426 (#573)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,7 +20,7 @@
 # than a volume one (issue #573). Its heuristic is "a forward declaration whose
 # name also exists in another namespace is probably a misplaced declaration" --
 # which is precisely how this engine is laid out on purpose. Every subsystem
-# gets its own namespace holding the same four members: YSE::CHANNEL,
+# gets its own namespace holding the same three class names: YSE::CHANNEL,
 # YSE::SOUND, YSE::SYNTH, YSE::REVERB, YSE::PLAYER, YSE::MOTIF, YSE::SCALE,
 # YSE::CLIP, YSE::CLOCK, YSE::DEVICE and YSE::MIDI each declare an
 # implementationObject, a messageObject and a managerObject (see the comment at

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -89,7 +89,22 @@ HeaderFilterRegex: '.*(YseEngine|Tests)[/\\].*\.h(pp)?$'
 # Vendored deps stay out of the report: dependencies/ (submodule-style checkouts)
 # and build*/_deps/ (FetchContent). We don't modify vendored sources, so their
 # findings are pure noise. Requires clang-tidy >= 19.
-ExcludeHeaderFilterRegex: '.*[/\\](dependencies|_deps)[/\\].*'
+#
+# YseEngine/utils/json.hpp is vendored too, it just predates the dependencies/
+# convention: it is a verbatim copy of nlohmann/json 3.0.1 (its upstream
+# copyright header is intact at the top of the file).  Widening
+# HeaderFilterRegex in #426 pulled its 10 findings into the report --
+# use-after-move, assignment-in-if-condition, assert-side-effect,
+# inc-dec-in-conditions, inefficient-string-concatenation.  Every one of them is
+# upstream's code, and patching a third-party single-header library in place is
+# exactly what the "don't modify vendored deps" rule exists to prevent, so it is
+# subtracted here rather than annotated in the file (issue #573).
+#
+# Note the alternation is matched as a search, not anchored: the filter sees the
+# include spelling the preprocessor resolved, and ours reach json.hpp through
+# relative hops (`YseEngine/sound/../patcher/../utils/json.hpp`), so the pattern
+# keys off the trailing `utils/json.hpp` rather than a full path.
+ExcludeHeaderFilterRegex: '.*[/\\](dependencies|_deps)[/\\].*|.*[/\\]utils[/\\]json\.hpp$'
 
 CheckOptions:
   - key: performance-move-const-arg.CheckTriviallyCopyableMove

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,24 @@
 # legacy DSP code, etc.). Re-enable a specific check if a focused cleanup
 # pass is planned.
 #
+# bugprone-forward-declaration-namespace is off for a structural reason rather
+# than a volume one (issue #573). Its heuristic is "a forward declaration whose
+# name also exists in another namespace is probably a misplaced declaration" --
+# which is precisely how this engine is laid out on purpose. Every subsystem
+# gets its own namespace holding the same four members: YSE::CHANNEL,
+# YSE::SOUND, YSE::SYNTH, YSE::REVERB, YSE::PLAYER, YSE::MOTIF, YSE::SCALE,
+# YSE::CLIP, YSE::CLOCK, YSE::DEVICE and YSE::MIDI each declare an
+# implementationObject, a messageObject and a managerObject (see the comment at
+# the top of channel/channel.hpp). The check therefore reports every subsystem
+# header against every other one -- 26 of the 29 sites it flagged were exactly
+# that pairing, and the count grows quadratically with each subsystem added.
+# The three sites that were *not* the convention were checked by hand: two were
+# genuinely dead declarations (YSE::MUSIC::player and YSE::INTERNAL::output,
+# neither ever defined nor referenced) and are deleted from classes.hpp in the
+# same commit; the third, YSE::clip vs YSE::DSP::clip, is two real and
+# unrelated classes. With those handled the check has no remaining signal here
+# and cannot be driven to zero without abandoning the subsystem layout.
+#
 # Vendored deps under dependencies/ and generated code under build*/ are
 # excluded via ExcludeHeaderFilterRegex.
 
@@ -30,6 +48,7 @@ Checks: >
   -bugprone-throwing-static-initialization,
   -bugprone-exception-escape,
   -bugprone-reserved-identifier,
+  -bugprone-forward-declaration-namespace,
   clang-analyzer-core.*,
   clang-analyzer-cplusplus.*,
   clang-analyzer-deadcode.*,

--- a/Tests/system/test_device_layer.cpp
+++ b/Tests/system/test_device_layer.cpp
@@ -125,9 +125,9 @@ namespace {
   // the mix-copy body below actually runs. File scope: the create() contract
   // requires the source to outlive every sound built from it.
   struct SteadySource : YSE::DSP::dspSourceObject {
-    // DSP::dspSourceObject declares no destructor of its own; give this one a
-    // virtual destructor so the class is not deleted through a non-virtual base.
-    virtual ~SteadySource() = default;
+    // The hand-rolled virtual destructor this used to carry is no longer
+    // needed: DSP::dspSourceObject declares one itself as of #573.
+    ~SteadySource() override = default;
 
     void process(YSE::SOUND_STATUS& intent) override {
       for (UInt c = 0; c < samples.size(); ++c) {

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -82,7 +82,7 @@ namespace YSE {
       Removes the implementation from the threadpool and moves all sounds and subchannels
       to its parent (if there is one).
       */
-      ~implementationObject() noexcept;
+      ~implementationObject() noexcept override;
 
       /** This function is called from channelManager::setup and creates the buffers
       needed for this channel.
@@ -188,7 +188,7 @@ namespace YSE {
         This will scale all sounds nicely over several cpu's as long as you don't
         put them all in one channel.
       */
-      virtual void run();
+      void run() override;
 
       /**
         This is the one that does all the work. It allso calls the dsp function

--- a/YseEngine/channel/channelImplementation.h
+++ b/YseEngine/channel/channelImplementation.h
@@ -33,6 +33,10 @@ namespace YSE {
       std::atomic<float> v{0.f};
       atomicPeak() = default;
       atomicPeak(const atomicPeak& o) : v(o.v.load(std::memory_order_relaxed)) {}
+      // The only member is a std::atomic<float>; self-assignment stores back the
+      // value it just loaded and owns no resource that a `this != &o` guard
+      // would protect (issue #573).
+      // NOLINTNEXTLINE(cert-oop54-cpp)
       atomicPeak& operator=(const atomicPeak& o) {
         v.store(o.v.load(std::memory_order_relaxed), std::memory_order_relaxed);
         return *this;

--- a/YseEngine/classes.hpp
+++ b/YseEngine/classes.hpp
@@ -84,7 +84,6 @@ namespace YSE {
     class note;
     class pNote;
     class chord;
-    class player;
   } // namespace MUSIC
 
   namespace INTERNAL {
@@ -92,7 +91,6 @@ namespace YSE {
     class global;
     class listenerImplementation;
     class logImplementation;
-    class output;
     class settings;
     class reverbDSP;
     class soundFile;

--- a/YseEngine/device/portaudioDeviceManager.h
+++ b/YseEngine/device/portaudioDeviceManager.h
@@ -28,24 +28,24 @@ namespace YSE {
     class managerObject : public deviceManager {
     public:
       managerObject();
-      ~managerObject();
+      ~managerObject() override;
 
-      virtual Bool init(bool openDevice = true);
-      virtual void close();
-      virtual Flt cpuLoad();
+      Bool init(bool openDevice = true) override;
+      void close() override;
+      Flt cpuLoad() override;
 
-      virtual void pause();
-      virtual void resume();
-      virtual unsigned int GetCallbacksSinceLastUpdate();
+      void pause() override;
+      void resume() override;
+      unsigned int GetCallbacksSinceLastUpdate() override;
 
-      virtual void updateDeviceList();
-      virtual void openDevice(const YSE::deviceSetup& object);
-      virtual void addCallback();
+      void updateDeviceList() override;
+      void openDevice(const YSE::deviceSetup& object) override;
+      void addCallback() override;
 
       // Live device-state getters (see deviceManager.h for contract).
-      virtual double getActiveSampleRate() const;
-      virtual int getActiveBufferSize() const;
-      virtual int getActiveOutputLatency() const;
+      double getActiveSampleRate() const override;
+      int getActiveBufferSize() const override;
+      int getActiveOutputLatency() const override;
 
       static int paCallback(const void* input, void* output, unsigned long numSamples,
                             const PaStreamCallbackTimeInfo* timeInfo,

--- a/YseEngine/dsp/drawableBuffer.hpp
+++ b/YseEngine/dsp/drawableBuffer.hpp
@@ -65,6 +65,14 @@ namespace YSE {
        */
       drawableBuffer& drawLine(UInt start, UInt stop, Flt value);
 
+      // The operators below deliberately shadow their `buffer` counterparts:
+      // each forwards to the base implementation and only re-types the return
+      // value so `drawableBuffer b; (b += 1.f).drawLine(...)` keeps working.
+      // `buffer`'s operators are non-virtual, so this is the ordinary
+      // covariant-return idiom and not the accidental hiding
+      // bugprone-derived-method-shadowing-base-method looks for (issue #573).
+      // NOLINTBEGIN(bugprone-derived-method-shadowing-base-method)
+
       /** @brief Add ``f`` to every sample (returns drawableBuffer&). */
       drawableBuffer& operator+=(Flt f) {
         buffer::operator+=(f);
@@ -117,6 +125,7 @@ namespace YSE {
         buffer::operator=(f);
         return *this;
       }
+      // NOLINTEND(bugprone-derived-method-shadowing-base-method)
     };
 
   } // namespace DSP

--- a/YseEngine/dsp/dspObject.hpp
+++ b/YseEngine/dsp/dspObject.hpp
@@ -206,6 +206,17 @@ namespace YSE {
       /** @brief Construct with ``buffers`` audio channels (1 = mono, 2 = stereo, ...). */
       dspSourceObject(Int buffers = 1);
 
+      /** @brief Virtual so a generator held by base pointer destroys correctly.
+       *
+       *  The engine itself never owns a ``dspSourceObject`` -- ``sound::create``
+       *  takes a reference and stores a non-owning pointer -- but the class has
+       *  pure virtuals and is meant to be derived from, so a user holding one
+       *  through a ``dspSourceObject*`` and deleting it would otherwise be UB.
+       *  The class already has a vtable, so this costs nothing at render time.
+       *  (issue #573)
+       */
+      virtual ~dspSourceObject() = default;
+
       /** @brief Fill ``samples`` with the next audio block.
        *
        *  @param intent The current playback intent (start, stop, pause, etc.)

--- a/YseEngine/dsp/fileBuffer.hpp
+++ b/YseEngine/dsp/fileBuffer.hpp
@@ -45,6 +45,10 @@ namespace YSE {
        */
       bool save(const char* fileName);
 
+      // Covariant-return wrappers over the (non-virtual) base assignment
+      // operators, same idiom as drawableBuffer -- see the note there.
+      // NOLINTBEGIN(bugprone-derived-method-shadowing-base-method)
+
       /** @brief Copy-assign from a ``buffer``. */
       fileBuffer& operator=(const buffer& s) {
         buffer::operator=(s);
@@ -55,6 +59,7 @@ namespace YSE {
         buffer::operator=(value);
         return *this;
       }
+      // NOLINTEND(bugprone-derived-method-shadowing-base-method)
     };
 
   } // namespace DSP

--- a/YseEngine/dsp/filters.hpp
+++ b/YseEngine/dsp/filters.hpp
@@ -55,7 +55,7 @@ namespace YSE {
       highPass& setFrequency(Flt f);
 
       /** @brief Process ``in`` in place. */
-      YSE::DSP::buffer& operator()(YSE::DSP::buffer& in);
+      YSE::DSP::buffer& operator()(YSE::DSP::buffer& in) override;
     };
 
     /**
@@ -70,7 +70,7 @@ namespace YSE {
       lowPass& setFrequency(Flt f);
 
       /** @brief Process ``in`` in place. */
-      YSE::DSP::buffer& operator()(YSE::DSP::buffer& in);
+      YSE::DSP::buffer& operator()(YSE::DSP::buffer& in) override;
     };
 
     /**
@@ -91,7 +91,7 @@ namespace YSE {
       bandPass& setQ(Flt q);
 
       /** @brief Process ``in`` in place. */
-      YSE::DSP::buffer& operator()(YSE::DSP::buffer& in);
+      YSE::DSP::buffer& operator()(YSE::DSP::buffer& in) override;
 
       bandPass();
 
@@ -141,7 +141,7 @@ namespace YSE {
       biQuad& setRaw(Flt fb1, Flt fb2, Flt ff1, Flt ff2, Flt ff3);
 
       /** @brief Process ``in`` in place. */
-      YSE::DSP::buffer& operator()(YSE::DSP::buffer& in);
+      YSE::DSP::buffer& operator()(YSE::DSP::buffer& in) override;
 
     private:
       void calc();

--- a/YseEngine/dsp/modules/chorus.hpp
+++ b/YseEngine/dsp/modules/chorus.hpp
@@ -55,7 +55,7 @@ namespace YSE {
       class API chorus : public dspObject {
       public:
         chorus();
-        virtual ~chorus() {};
+        ~chorus() override {};
 
         /** @brief Select chorus or flanger topology. */
         chorus& mode(chorusMode value);
@@ -92,10 +92,10 @@ namespace YSE {
         Flt spread();
 
         /** @brief dspObject lifecycle hook. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmRate; // LFO rate, Hz

--- a/YseEngine/dsp/modules/compressor.hpp
+++ b/YseEngine/dsp/modules/compressor.hpp
@@ -59,7 +59,7 @@ namespace YSE {
       class API compressor : public dspObject {
       public:
         compressor();
-        virtual ~compressor() {};
+        ~compressor() override {};
 
         /** @brief Select the peak or RMS level detector. */
         compressor& detector(compressorDetector value);
@@ -107,10 +107,10 @@ namespace YSE {
         Flt gainReductionDb();
 
         /** @brief dspObject lifecycle hook. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmThreshold; // dBFS

--- a/YseEngine/dsp/modules/delay/basicDelay.hpp
+++ b/YseEngine/dsp/modules/delay/basicDelay.hpp
@@ -42,7 +42,7 @@ namespace YSE {
         };
 
         basicDelay();
-        virtual ~basicDelay() {};
+        ~basicDelay() override {};
 
         /** @brief Configure one of the three taps.
          *  @param nr   Tap to configure.
@@ -58,10 +58,10 @@ namespace YSE {
         Flt gain(DELAY_NR nr);
 
         /** @brief dspObject lifecycle hook — allocates buffers. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       protected:
         /** @brief Hook for subclasses to size their per-channel pre-filter state

--- a/YseEngine/dsp/modules/delay/feedbackDelay.hpp
+++ b/YseEngine/dsp/modules/delay/feedbackDelay.hpp
@@ -46,7 +46,7 @@ namespace YSE {
       class API feedbackDelay : public dspObject {
       public:
         feedbackDelay();
-        virtual ~feedbackDelay() {};
+        ~feedbackDelay() override {};
 
         /** @brief Set the delay time in milliseconds (clamped to the module's
          *  maximum). Changes are ramped to avoid zipper noise. */
@@ -78,10 +78,10 @@ namespace YSE {
         Flt crossfeed();
 
         /** @brief dspObject lifecycle hook. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmTime; // delay time, milliseconds

--- a/YseEngine/dsp/modules/delay/highpassDelay.hpp
+++ b/YseEngine/dsp/modules/delay/highpassDelay.hpp
@@ -35,8 +35,8 @@ namespace YSE {
         Flt frequency();
 
       private:
-        virtual void ensurePreFilter(std::size_t count);
-        virtual void applyPreFilter(DSP::buffer& buffer, std::size_t ch);
+        void ensurePreFilter(std::size_t count) override;
+        void applyPreFilter(DSP::buffer& buffer, std::size_t ch) override;
 
         aFlt parmFrequency;
         perChannel<DSP::highPass> hp; // one pre-filter per channel

--- a/YseEngine/dsp/modules/delay/lowpassDelay.hpp
+++ b/YseEngine/dsp/modules/delay/lowpassDelay.hpp
@@ -35,8 +35,8 @@ namespace YSE {
         Flt frequency();
 
       private:
-        virtual void ensurePreFilter(std::size_t count);
-        virtual void applyPreFilter(DSP::buffer& buffer, std::size_t ch);
+        void ensurePreFilter(std::size_t count) override;
+        void applyPreFilter(DSP::buffer& buffer, std::size_t ch) override;
 
         aFlt parmFrequency;
         perChannel<DSP::lowPass> lp; // one pre-filter per channel

--- a/YseEngine/dsp/modules/filters/bandpass.hpp
+++ b/YseEngine/dsp/modules/filters/bandpass.hpp
@@ -31,7 +31,7 @@ namespace YSE {
       class API bandPassFilter : public dspObject {
       public:
         bandPassFilter();
-        virtual ~bandPassFilter() {};
+        ~bandPassFilter() override {};
 
         /** @brief Set the centre frequency in Hz. */
         bandPassFilter& frequency(Flt value);
@@ -46,10 +46,10 @@ namespace YSE {
         Flt getQ();
 
         /** @brief dspObject lifecycle hook — allocates buffers. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmFrequency;

--- a/YseEngine/dsp/modules/filters/highpass.hpp
+++ b/YseEngine/dsp/modules/filters/highpass.hpp
@@ -31,7 +31,7 @@ namespace YSE {
       class API highPassFilter : public dspObject {
       public:
         highPassFilter();
-        virtual ~highPassFilter() {};
+        ~highPassFilter() override {};
 
         /** @brief Set the cutoff frequency in Hz. */
         highPassFilter& frequency(Flt value);
@@ -40,10 +40,10 @@ namespace YSE {
         Flt frequency();
 
         /** @brief dspObject lifecycle hook — allocates buffers. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmFrequency;

--- a/YseEngine/dsp/modules/filters/lowpass.hpp
+++ b/YseEngine/dsp/modules/filters/lowpass.hpp
@@ -31,7 +31,7 @@ namespace YSE {
       class API lowPassFilter : public dspObject {
       public:
         lowPassFilter();
-        virtual ~lowPassFilter() {};
+        ~lowPassFilter() override {};
 
         /** @brief Set the cutoff frequency in Hz. */
         lowPassFilter& frequency(Flt value);
@@ -40,10 +40,10 @@ namespace YSE {
         Flt frequency();
 
         /** @brief dspObject lifecycle hook — allocates buffers. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmFrequency;

--- a/YseEngine/dsp/modules/filters/sweep.hpp
+++ b/YseEngine/dsp/modules/filters/sweep.hpp
@@ -43,7 +43,7 @@ namespace YSE {
 
         /** @brief Construct with the chosen sweep shape. */
         sweepFilter(SHAPE shape = SAW);
-        virtual ~sweepFilter() {};
+        ~sweepFilter() override {};
 
         /** @brief Set the LFO speed in Hz. */
         sweepFilter& speed(Flt value);
@@ -64,10 +64,10 @@ namespace YSE {
         Int frequency();
 
         /** @brief dspObject lifecycle hook — allocates buffers. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmSpeed;

--- a/YseEngine/dsp/modules/fm/difference.hpp
+++ b/YseEngine/dsp/modules/fm/difference.hpp
@@ -34,7 +34,7 @@ namespace YSE {
       class API difference : public dspObject {
       public:
         difference();
-        virtual ~difference() {};
+        ~difference() override {};
 
         /** @brief Set the carrier frequency in Hz. */
         difference& frequency(Flt value);
@@ -49,10 +49,10 @@ namespace YSE {
         Flt amplitude();
 
         /** @brief dspObject lifecycle hook — allocates buffers. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmFrequency;

--- a/YseEngine/dsp/modules/granulator.hpp
+++ b/YseEngine/dsp/modules/granulator.hpp
@@ -45,13 +45,13 @@ namespace YSE {
          *  @param maxGrains Maximum number of grains alive simultaneously.
          */
         granulator(UInt poolSize = SAMPLERATE * 5, UInt maxGrains = 16);
-        virtual ~granulator() {};
+        ~granulator() override {};
 
         /** @brief dspObject lifecycle hook — allocates buffers. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
         /** @brief Set the spawn rate in grains per second. */
         granulator& grainFrequency(UInt value);

--- a/YseEngine/dsp/modules/morphingReverb.hpp
+++ b/YseEngine/dsp/modules/morphingReverb.hpp
@@ -87,7 +87,7 @@ namespace YSE {
         /** Slots default to A = ``REVERB_GENERIC``, B = ``REVERB_HALL``,
          *  ``morph() == 0`` (pure A). */
         morphingReverb();
-        virtual ~morphingReverb() {}
+        ~morphingReverb() override {}
 
         /** @brief Set morph endpoint A from a named preset. */
         morphingReverb& presetA(REVERB_PRESET value);
@@ -119,10 +119,10 @@ namespace YSE {
 
         /** @brief dspObject lifecycle hook. Per-channel state is sized in
          *  ``process`` (the channel count is only known there). */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         // One morph endpoint. Control threads write, the audio thread reads;

--- a/YseEngine/dsp/modules/parametricEQ.hpp
+++ b/YseEngine/dsp/modules/parametricEQ.hpp
@@ -67,7 +67,7 @@ namespace YSE {
       class API parametricEQ : public dspObject {
       public:
         parametricEQ();
-        virtual ~parametricEQ() {};
+        ~parametricEQ() override {};
 
         /** @brief Set a band's centre/corner frequency in Hz (clamped to a sane
          *  audio range). */
@@ -91,10 +91,10 @@ namespace YSE {
         Flt q(eqBand band);
 
         /** @brief dspObject lifecycle hook. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         // Per-band user parameters (control-thread writes, audio-thread reads).

--- a/YseEngine/dsp/modules/phaser.hpp
+++ b/YseEngine/dsp/modules/phaser.hpp
@@ -36,7 +36,7 @@ namespace YSE {
       class API phaser : public dspObject {
       public:
         phaser();
-        virtual ~phaser() {};
+        ~phaser() override {};
 
         /** @brief Set the sweep LFO frequency. Typically very low; default 0.3 Hz. Must be > 0. */
         phaser& frequency(Flt value);
@@ -51,10 +51,10 @@ namespace YSE {
         Flt range();
 
         /** @brief dspObject lifecycle hook — allocates buffers. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
         /** @brief One channel's four-stage all-pass cascade state. */
         struct allpassChain {

--- a/YseEngine/dsp/modules/plateReverb.hpp
+++ b/YseEngine/dsp/modules/plateReverb.hpp
@@ -66,7 +66,7 @@ namespace YSE {
       class API plateReverb : public dspObject {
       public:
         plateReverb();
-        virtual ~plateReverb() {};
+        ~plateReverb() override {};
 
         /** @brief Set the tank decay in [0, 0.98]. Higher values recirculate the
          *  tank longer, lengthening the reverb tail (RT60). */
@@ -91,10 +91,10 @@ namespace YSE {
         Flt preDelay();
 
         /** @brief dspObject lifecycle hook. */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmDecay; // tank decay, [0, 0.98]

--- a/YseEngine/dsp/modules/ringModulator.hpp
+++ b/YseEngine/dsp/modules/ringModulator.hpp
@@ -29,7 +29,7 @@ namespace YSE {
     class API ringModulator : public dspObject {
     public:
       ringModulator();
-      virtual ~ringModulator() {}
+      ~ringModulator() override {}
 
       /** @brief Set the carrier frequency in Hz. */
       ringModulator& frequency(Flt value);
@@ -38,10 +38,10 @@ namespace YSE {
       Flt frequency();
 
       /** @brief dspObject lifecycle hook — allocates buffers. */
-      virtual void create();
+      void create() override;
 
       /** @brief dspObject audio-thread entry point. */
-      virtual void process(MULTICHANNELBUFFER& buffer);
+      void process(MULTICHANNELBUFFER& buffer) override;
 
     private:
       aFlt parmFrequency;

--- a/YseEngine/dsp/modules/underWater.hpp
+++ b/YseEngine/dsp/modules/underWater.hpp
@@ -88,7 +88,7 @@ namespace YSE {
       public:
         /** Defaults to ``depth() == 0`` — fully transparent. */
         underWater();
-        virtual ~underWater() {}
+        ~underWater() override {}
 
         /** @brief The depth control input, in distance units below the water
          *  surface. Negative values clamp to 0 (above water). Callable from
@@ -102,10 +102,10 @@ namespace YSE {
         /** @brief dspObject lifecycle hook. Nothing to allocate up front: the
          *  mixdown scratch is sized in ``process`` (the block length is only
          *  known there). */
-        virtual void create();
+        void create() override;
 
         /** @brief dspObject audio-thread entry point. */
-        virtual void process(MULTICHANNELBUFFER& buffer);
+        void process(MULTICHANNELBUFFER& buffer) override;
 
       private:
         aFlt parmDepth; // control threads write, the audio thread reads

--- a/YseEngine/internal/AudioTest.cpp
+++ b/YseEngine/internal/AudioTest.cpp
@@ -10,14 +10,14 @@ class shepard : public YSE::DSP::dspSourceObject {
 public:
   // process function is pure virtual in dspSource
   // you HAVE to implement it
-  virtual void process(YSE::SOUND_STATUS& intent);
+  void process(YSE::SOUND_STATUS& intent) override;
   // constructor can be implement if you need it
   // (you probably will)
   shepard();
-  void frequency(Flt value);
+  void frequency(Flt value) override;
   Flt frequency();
 
-  virtual ~shepard() {}
+  ~shepard() override {}
 
 private:
   // in this case we add:

--- a/YseEngine/internal/abstractSoundFile.h
+++ b/YseEngine/internal/abstractSoundFile.h
@@ -43,10 +43,10 @@ namespace YSE {
 
       // will be called by constructor
 
-      virtual ~abstractSoundFile();
+      ~abstractSoundFile() override;
 
       Bool create(Bool stream = false);
-      void run(); // load from disk
+      void run() override; // load from disk
       virtual void loadStreaming() = 0;
       virtual void loadNonStreaming() = 0;
 

--- a/YseEngine/internal/lsfSoundfile.h
+++ b/YseEngine/internal/lsfSoundfile.h
@@ -30,12 +30,12 @@ namespace YSE {
       soundFile(const std::string& ID, char* fileBuffer, int length);
       soundFile(YSE::DSP::buffer* buffer);
       soundFile(MULTICHANNELBUFFER* buffer);
-      ~soundFile();
+      ~soundFile() override;
 
       using abstractSoundFile::abstractSoundFile;
 
-      virtual void loadStreaming(); // load from disk
-      virtual void loadNonStreaming();
+      void loadStreaming() override; // load from disk
+      void loadNonStreaming() override;
 
     private:
       // Fill `dest` with up to STREAM_BUFFERSIZE frames from the current handle

--- a/YseEngine/internal/reverbDSP.h
+++ b/YseEngine/internal/reverbDSP.h
@@ -126,11 +126,11 @@ namespace YSE {
           same ranges the interface setters enforce. */
       void set(const REVERB::presetValues& params);
 
-      virtual void create() {}
-      virtual void process(MULTICHANNELBUFFER& buffer);
+      void create() override {}
+      void process(MULTICHANNELBUFFER& buffer) override;
       void update();
       reverbDSP();
-      ~reverbDSP();
+      ~reverbDSP() override;
 
     private:
       // Re-entrant comb/allpass kernels: all state is passed in or read from

--- a/YseEngine/internal/threadPool.h
+++ b/YseEngine/internal/threadPool.h
@@ -72,7 +72,7 @@ namespace YSE {
     class threadPoolThread : public thread {
     public:
       explicit threadPoolThread(threadPool* pool);
-      virtual void run();
+      void run() override;
 
     private:
       threadPool* pool;

--- a/YseEngine/patcher/pObject.h
+++ b/YseEngine/patcher/pObject.h
@@ -162,11 +162,18 @@ namespace YSE {
 }
 
 // these macro's should make creating patcher objects a bit easier
+//
+// The members these macros emit all override pure virtuals on pObject --
+// PATCHER_CLASS always opens `class X : public pObject` -- so they are marked
+// `override`. clang-tidy's modernize-use-override cannot rewrite inside a macro
+// body, which is why they were the one group the #573 sweep did not reach; left
+// unmarked they also made every patcher object that marks anything else
+// `override` trip -Winconsistent-missing-override.
 #define PATCHER_CLASS(className, name)                                                             \
   class className : public pObject {                                                               \
   public:                                                                                          \
     className();                                                                                   \
-    virtual const char* Type() const {                                                             \
+    const char* Type() const override {                                                            \
       return name;                                                                                 \
     }                                                                                              \
     CREATE(className)
@@ -175,17 +182,17 @@ namespace YSE {
     return new className();                                                                        \
   }
 
-#define _DO_MESSAGES virtual void SetMessage(const std::string& message, float value);
+#define _DO_MESSAGES void SetMessage(const std::string& message, float value) override;
 #define _NO_MESSAGES                                                                               \
-  virtual void SetMessage(const std::string&, float) {}
+  void SetMessage(const std::string&, float) override {}
 #define MESSAGES() void className::SetMessage(const std::string& message, float value)
 
-#define _DO_CALCULATE virtual void Calculate(YSE::THREAD thread);
+#define _DO_CALCULATE void Calculate(YSE::THREAD thread) override;
 #define _NO_CALCULATE                                                                              \
-  virtual void Calculate(YSE::THREAD) {}
+  void Calculate(YSE::THREAD) override {}
 #define CALC() void className::Calculate(YSE::THREAD thread)
 
-#define _DO_RESET virtual void ResetDSP();
+#define _DO_RESET void ResetDSP() override;
 #define RESET()                                                                                    \
   void className::ResetDSP() {                                                                     \
     pObject::ResetDSP();
@@ -244,7 +251,7 @@ namespace YSE {
 #define OUTLET_DOC(idx, label, doc, range) outputs[(idx)].SetDoc((label), (doc), (range))
 #define PARAM_DOC(name, defaultVal, doc, range) parms.SetDoc((name), (defaultVal), (doc), (range))
 
-#define _HAS_GUI virtual std::string GetGuiValue();
+#define _HAS_GUI std::string GetGuiValue() override;
 #define GUI_VALUE() std::string className::GetGuiValue()
 
 #define CONSTRUCT_DSP() className::className() : pObject(true)

--- a/YseEngine/patcher/pRegistry.h
+++ b/YseEngine/patcher/pRegistry.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include "pObject.h"
 
-typedef YSE::PATCHER::pObject* (*pObjectFunc)(void);
+typedef YSE::PATCHER::pObject* (*pObjectFunc)();
 
 namespace YSE {
   namespace PATCHER {

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -45,6 +45,18 @@ namespace YSE {
       // The GraphState pinned for the block currently being rendered, or null
       // between blocks. Read by inlets/outlets to resolve topology without a
       // lock (issue #226).
+      //
+      // This is the real accessor; pObject::CurrentBlockGraph() (non-virtual) is
+      // the forwarder that every *contained* object goes through -- it hops to
+      // its owning patcher and lands back here. The shadowing is therefore the
+      // intended direction of the relation, not accidental hiding. Reaching a
+      // patcherImplementation through a pObject* yields the base version, which
+      // returns null because a patcher has no parent; that is harmless, because
+      // the patcher's own inlets/outlets are never assigned a GraphState id
+      // (ids come from AssignObjectIds on objects *added* to the patcher, so
+      // theirs stay -1) and the `graphId >= 0` guard at both call sites already
+      // sends them down the live-wiring path. See issue #573.
+      // NOLINTNEXTLINE(bugprone-derived-method-shadowing-base-method)
       const GraphState* CurrentBlockGraph() const {
         return currentBlockGraph_.load(std::memory_order_acquire);
       }

--- a/YseEngine/patcher/patcherImplementation.h
+++ b/YseEngine/patcher/patcherImplementation.h
@@ -21,7 +21,7 @@ namespace YSE {
     class patcherImplementation : public pObject {
     public:
       patcherImplementation(int mainOutputs, patcher* head);
-      virtual ~patcherImplementation();
+      ~patcherImplementation() override;
 
       // Patcher name used as the bus prefix for inner gSend / gReceive
       // routing (issue #122). Default is an auto-generated "patcher_<N>"
@@ -32,9 +32,9 @@ namespace YSE {
       }
       void SetName(const std::string& n);
 
-      virtual const char* Type() const;
-      virtual void ResetDSP();
-      virtual void Calculate(THREAD thread);
+      const char* Type() const override;
+      void ResetDSP() override;
+      void Calculate(THREAD thread) override;
 
       // Run the patcher as an in-place insert effect over a host buffer
       // (issue #167): feed the incoming audio to the graph's ~adc objects,
@@ -61,7 +61,7 @@ namespace YSE {
         return currentBlockGraph_.load(std::memory_order_acquire);
       }
 
-      virtual void SetMessage(const std::string&, float) {}
+      void SetMessage(const std::string&, float) override {}
 
       pHandle* CreateObject(const std::string& type, const std::string& args);
       void DeleteObject(pHandle* obj);

--- a/YseEngine/patcher/time/gMetro.h
+++ b/YseEngine/patcher/time/gMetro.h
@@ -18,7 +18,7 @@ namespace YSE {
 
     void Bang();
 
-    ~gMetro();
+    ~gMetro() override;
 
   private:
     aInt period;

--- a/YseEngine/python/scriptRuntime.h
+++ b/YseEngine/python/scriptRuntime.h
@@ -61,6 +61,13 @@ namespace YSE {
       ScriptRuntime(const ScriptRuntime&) = delete;
       ScriptRuntime& operator=(const ScriptRuntime&) = delete;
 
+      // start()/stop() intentionally shadow the non-virtual thread::start() and
+      // thread::stop(): each does its interpreter-lifecycle work and then calls
+      // the base version explicitly. A ScriptRuntime is only ever held as a
+      // ScriptRuntime (INTERNAL::global owns a unique_ptr<ScriptRuntime>), never
+      // through an INTERNAL::thread*, so there is no dispatch to get wrong.
+      // NOLINTBEGIN(bugprone-derived-method-shadowing-base-method)
+
       // Boot the interpreter (if this is the first runtime in the process)
       // and launch the worker thread. Safe to call once; a second call while
       // already started is a no-op.
@@ -69,6 +76,7 @@ namespace YSE {
       // Join the worker (after a final drain of pending requests) and, if this
       // runtime booted the interpreter, finalize it. Idempotent.
       void stop();
+      // NOLINTEND(bugprone-derived-method-shadowing-base-method)
 
       // Producer = main thread. Enqueue `source` to be exec'd in the __main__
       // namespace on the script thread. Wakes the worker.

--- a/YseEngine/synth/dspVoice.hpp
+++ b/YseEngine/synth/dspVoice.hpp
@@ -48,7 +48,7 @@ namespace YSE {
     public:
       /** @brief Construct a voice with ``outputChannels`` output buffers. */
       dspVoice(int outputChannels = 1) : dspSourceObject(outputChannels) {}
-      virtual ~dspVoice() {}
+      ~dspVoice() override {}
 
       /**
        *  @brief Fill ``samples`` for one block. **You must implement this.**

--- a/YseEngine/utils/atomicOps.hpp
+++ b/YseEngine/utils/atomicOps.hpp
@@ -289,9 +289,16 @@ namespace YSE {
 #ifdef AE_VCPP
 #pragma warning(disable : 4100) // Get rid of (erroneous) 'unreferenced formal parameter' warning
 #endif
+    // The copy and move constructors are declared explicitly on the next two
+    // lines, and when this template does win overload resolution for a
+    // non-const `weak_atomic&` it still does the right thing -- `value` is
+    // initialised from the source through `operator T()`, i.e. a load. Removing
+    // it would break every `weak_atomic<T> x(someT);` initialisation in the
+    // queues (issue #573).
+    // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
     template <typename U> weak_atomic(U&& x) : value(std::forward<U>(x)) {}
     weak_atomic(weak_atomic const& other) : value(other.value) {}
-    weak_atomic(weak_atomic&& other) : value(std::move(other.value)) {}
+    weak_atomic(weak_atomic&& other) noexcept : value(std::move(other.value)) {}
 #ifdef AE_VCPP
 #pragma warning(default : 4100)
 #endif
@@ -324,6 +331,11 @@ namespace YSE {
       return *this;
     }
 
+    // T is constrained to types with hardware atomic load/store (see the class
+    // comment) -- there is no resource to release, so self-assignment stores
+    // back the value it just loaded. A `this != &other` guard would only add a
+    // branch to a primitive that sits on the audio-thread queue path (#573).
+    // NOLINTNEXTLINE(cert-oop54-cpp)
     AE_FORCEINLINE weak_atomic const& operator=(weak_atomic const& other) {
       value.store(other.value.load(weak_order), weak_order);
       return *this;


### PR DESCRIPTION
## Summary

Works the backlog from #573 — the pre-existing clang-tidy findings that #426
made visible by widening `HeaderFilterRegex`. Five ordered commits, one per
triage group, in the order the issue suggests reading them.

**Measured: 212 → 51 unique findings; header findings 150 → 1.**

## Linked issue

Closes #573

## Measurement

Full `python yse.py analyze` (321 TUs, `build-tests/compile_commands.json`,
clang-tidy 22.1.4) before and after, deduped on canonicalised
`path:line:col:check` with vendored `dependencies/` and `_deps/` dropped:

| | before | after |
|---|---:|---:|
| findings in headers | 150 | **1** |
| findings in `.cpp` | 62 | 50 |
| **total unique** | **212** | **51** |

162 findings removed, 1 added — and that one is fixed in the last commit, so
the branch introduces nothing. The single remaining header finding is
`utils/interpolators.hpp:85` (`clang-analyzer-core.uninitialized.Assign`), a
path-sensitive analyzer result unrelated to this batch; the 50 remaining `.cpp`
findings are the pre-#426 baseline.

**A note on the issue's numbers.** #573 states a baseline of 336 unique / 285
in headers; measuring the same commit here gives 212 / 150. The `.cpp` figure
agrees almost exactly (51 in the issue, 51 here once the analyzer checks whose
names contain `.` are parsed correctly), so the gap is entirely in header
canonicalisation — consistent with the issue's own observation that clang-tidy
reprints a header finding once per include spelling
(`YseEngine/classes.hpp` vs `YseEngine/channel/../classes.hpp`). Raw warning
lines went 3198 → 4223 in this pair of runs, which is why line counts are not
usable as a measure either way. The before/after above are from one script over
both runs, so the delta is apples-to-apples regardless of which absolute
convention you prefer.

## Changes

### 1. The tail (~30 findings, judged individually)

None turned out to be a live defect.

- **Vendored, so config not code.** `YseEngine/utils/json.hpp` is a verbatim
  copy of nlohmann/json 3.0.1 with the upstream copyright header intact — it
  just predates the `dependencies/` convention. All 10 of its findings
  (`use-after-move` ×3, `assignment-in-if-condition` ×3, `assert-side-effect`,
  `inc-dec-in-conditions`, `inefficient-string-concatenation` ×2) are upstream
  code, so it joins `dependencies/` and `_deps/` in `ExcludeHeaderFilterRegex`
  rather than being patched in place.
- **Deliberate idiom, focused `NOLINT` + rationale.** The 15
  `bugprone-derived-method-shadowing-base-method` (covariant-return wrappers on
  `drawableBuffer`/`fileBuffer`, `ScriptRuntime::start`/`stop` over the
  non-virtual `thread::start`/`stop`, `patcherImplementation::CurrentBlockGraph`
  over its own forwarder), the 2 in-tree `cert-oop54-cpp` (assignment operators
  whose only member is an atomic scalar — a self-assignment guard would add a
  branch to an audio-thread primitive to protect a resource that isn't there),
  and `bugprone-forwarding-reference-overload` on `weak_atomic`. Each carries a
  comment explaining why the check is wrong for that line.
- **One real fix.** `DSP::dspSourceObject` had pure virtuals, a public
  non-virtual destructor, and a documented "derive from this" contract, so
  `delete basePtr` on a user's generator was UB. Added
  `virtual ~dspSourceObject() = default;`, which clears 15 findings at once (4
  in-tree + 11 test fixtures). Worth a reviewer's eye because it is the one
  semantic change here: it appends a slot to the `dspSourceObject` vtable. It
  costs nothing at render time (the class already has a vtable and the
  destructor never runs on the audio thread), and
  `Tests/system/test_device_layer.cpp` turns out to have carried a hand-rolled
  virtual destructor working around exactly this, which the last commit removes.
- Plus two one-liners: `noexcept` on `weak_atomic`'s move constructor, and
  dropping the C-style `(void)` from `pRegistry`'s `pObjectFunc` typedef.

### 2. `bugprone-forward-declaration-namespace` — disabled, with the reasoning in `.clang-tidy`

The check's heuristic is "a forward declaration whose name also exists in
another namespace is probably a misplaced declaration", which is precisely how
this engine is laid out **on purpose**: `YSE::CHANNEL`, `SOUND`, `SYNTH`,
`REVERB`, `PLAYER`, `MOTIF`, `SCALE`, `CLIP`, `CLOCK`, `DEVICE` and `MIDI` each
declare their own `implementationObject`, `messageObject` and `managerObject`,
as the comment at the top of `channel/channel.hpp` says. It reports every
subsystem header against every other one, so **26 of the 29 sites were that
pairing**, and the count grows quadratically with each subsystem added.

The other three were read by hand first: `YSE::MUSIC::player` and
`YSE::INTERNAL::output` are genuinely dead — never defined, never referenced,
the real classes being `YSE::player` and `YSE::CHANNEL::output` — and are
deleted from `classes.hpp`; `YSE::clip` vs `YSE::DSP::clip` is two real,
unrelated classes. With those handled the check has no remaining signal here
and no path to zero short of abandoning the subsystem layout.

### 3. `modernize-use-override` sweep (88 findings, 28 headers)

Applied with `clang-tidy --fix`, one TU per invocation so replacements to a
shared header can never be computed against a stale buffer and collide. Every
one a 1:1 line replacement. `override` is a compile-time annotation, so there
is nothing here for the audio thread to pay for.

### 4. The patcher macros (follow-on, and a regression this branch had to fix)

`modernize-use-override` never rewrites inside a macro body, so the members
emitted by `PATCHER_CLASS`, `_NO_MESSAGES`, `_NO_CALCULATE`, `_DO_MESSAGES`,
`_DO_CALCULATE`, `_DO_RESET` and `_HAS_GUI` were the one group the sweep could
not reach — and adding `override` to `~gMetro()` left that class marking one
member and not the rest, which is exactly what
`-Winconsistent-missing-override` reports. **As it stood the sweep traded 88
clang-tidy findings for 3 new compiler warnings.** Marking the macros (all of
them override pure virtuals on `pObject`; `PATCHER_CLASS` always opens
`class X : public pObject`) clears those, and as a side effect the same warning
`gReceive`, `gSend` and the eight `guiObjects` headers were already emitting
before this branch. The test build now emits **zero** warnings from
`YseEngine/`, against 15 before.

## Scope

No behaviour changed on any audio-callback path. The only semantic change in
the branch is the `dspSourceObject` destructor above; everything else is a
compile-time annotation, a suppression with a written rationale, or a
`.clang-tidy` setting. No finding was suppressed without an explanation, and
nothing under `dependencies/` or `build*/_deps/` was touched.

## Test plan

- [x] `python yse.py analyze` (full, 321 TUs) — **212 → 51 unique findings**,
      162 removed, 0 net added
- [x] `python yse.py test` — **39/39 ctest suites pass, 0 failed**, including
      the integration suite. Re-run after the final commit.
- [x] `python yse.py build` clean — no warnings from `YseEngine/` at all, only
      the three pre-existing ones from the vendored `utils/json.hpp`
- [x] `python yse.py format` clean

No new tests: this branch is a pure cleanup with no user-visible behaviour
change, and the one semantic fix (`dspSourceObject`'s destructor) is exercised
by the eleven existing test fixtures that derive from it — the same ones whose
`cppcoreguidelines-virtual-class-destructor` findings it clears.
