### PR TITLE
patcher: register ~clip so it can actually be created (#436)

### DIFF
--- a/Tests/patcher/test_patcher_math.cpp
+++ b/Tests/patcher/test_patcher_math.cpp
@@ -3,9 +3,12 @@
 // No audio device required.
 
 #include <doctest/doctest.h>
+#include <algorithm>
+#include <string>
 #include "patcher/patcher.hpp"
 #include "patcher/pHandle.hpp"
 #include "patcher/pObjectList.hpp"
+#include "patcher/pRegistry.h"
 #include "patcher/math/gAdd.h"
 #include "patcher/math/gSubstract.h"
 #include "patcher/math/gDivide.h"
@@ -249,7 +252,46 @@ TEST_SUITE("patcher") {
   }
 
   // ─── dClip ───────────────────────────────────────────────────────────────────
-  // dClip is not in the patcher registry, so these tests use direct instantiation.
+  // Regression tests for issue #436: dClip was compiled and had an OBJ::D_CLIP
+  // constant but was never registered, so CreateObject("~clip") returned null.
+  // The behavioural tests below still instantiate directly (that is how the
+  // other DSP math nodes are driven without a graph), but the type is now
+  // reachable through the registry.
+
+  TEST_CASE("dClip: creatable through the registry (#436)") {
+    YSE::patcher p;
+    p.create(2);
+    YSE::pHandle* h = p.CreateObject(YSE::OBJ::D_CLIP);
+    REQUIRE(h != nullptr);
+    CHECK(std::string(h->Type()) == "~clip");
+    CHECK(h->GetInputs() == 3);
+    CHECK(h->GetOutputs() == 1);
+    CHECK(h->OutputDataType(0) == YSE::OUT_TYPE::BUFFER);
+  }
+
+  TEST_CASE("dClip: ~clip is listed by pRegistry::AllNames (#436)") {
+    const auto names = YSE::PATCHER::Register().AllNames();
+    CHECK(std::find(names.begin(), names.end(), std::string("~clip")) != names.end());
+  }
+
+  TEST_CASE("dClip: params survive a DumpJSON / ParseJSON round trip (#436)") {
+    YSE::patcher src;
+    src.create(2);
+    YSE::pHandle* h = src.CreateObject(YSE::OBJ::D_CLIP, "-0.25 0.75");
+    REQUIRE(h != nullptr);
+    const std::string json = src.DumpJSON();
+    CHECK(json.find("~clip") != std::string::npos);
+
+    YSE::patcher loaded;
+    loaded.create(2);
+    loaded.ParseJSON(json);
+    REQUIRE(loaded.Objects() == 1);
+
+    YSE::pHandle* restored = loaded.GetHandleFromList(0);
+    REQUIRE(restored != nullptr);
+    CHECK(std::string(restored->Type()) == "~clip");
+    CHECK(restored->GetParams() == "-0.25 0.75");
+  }
 
   TEST_CASE("dClip: type name, input/output count, and output type") {
     YSE::PATCHER::dClip clip;
@@ -257,6 +299,19 @@ TEST_SUITE("patcher") {
     CHECK(clip.NumInputs() == 3);
     CHECK(clip.NumOutputs() == 1);
     CHECK(clip.GetOutputType(0) == YSE::OUT_TYPE::BUFFER);
+  }
+
+  TEST_CASE("dClip: null input buffer produces no output (#436)") {
+    // Reachable via CreateObject now, so a ~clip left unconnected on inlet 0
+    // gets Calculate()d with a null buffer every block.
+    YSE::PATCHER::dClip clip;
+    BufferSink sink;
+    clip.ConnectOutlet(sink.GetInlet(0), 0);
+    sink.ConnectInlet(clip.GetOutlet(0), 0);
+
+    clip.Calculate(YSE::T_DSP);
+
+    CHECK(sink.received == nullptr);
   }
 
   TEST_CASE("dClip: samples outside [-0.5, 0.5] are clamped") {

--- a/YseEngine/patcher/math/dClip.cpp
+++ b/YseEngine/patcher/math/dClip.cpp
@@ -26,6 +26,17 @@ CONSTRUCT_DSP() {
   buffer = nullptr;
   low = -1.0f;
   high = 1.0f;
+
+  ADD_DESCRIPTION("Audio-rate hard clipper. Constrains every sample of the input buffer to the "
+                  "[low, high] range — use it to tame stray peaks or as a deliberate distortion "
+                  "stage.");
+  ADD_CATEGORY(pCategory::MATH);
+  INLET_DOC(0, "in", "Audio input buffer.", "any float");
+  INLET_DOC(1, "low", "Lower clipping threshold.", "any float");
+  INLET_DOC(2, "high", "Upper clipping threshold.", "any float");
+  OUTLET_DOC(0, "out", "Input clamped to [low, high].", "low to high");
+  PARAM_DOC("low", "-1.0", "Initial lower clipping threshold.", "any float");
+  PARAM_DOC("high", "1.0", "Initial upper clipping threshold.", "any float");
 }
 
 RESET() // {
@@ -45,6 +56,8 @@ FLOAT_IN(SetHigh) {
 }
 
 CALC() {
+  if (buffer == nullptr) return;
+
   clip.set(low, high);
   outputs[0].SendBuffer(&clip(*buffer), thread);
 }

--- a/YseEngine/patcher/pObjectList.hpp
+++ b/YseEngine/patcher/pObjectList.hpp
@@ -13,7 +13,7 @@ namespace YSE {
    *  - DSP generators: ``D_SINE``, ``D_SAW``, ``D_NOISE``.
    *  - DSP math: ``D_ADD``, ``D_MULTIPLY``, ``D_CLIP``.
    *  - DSP filters: ``D_LOWPASS``, ``D_HIGHPASS``, ``D_BANDPASS``, ``D_VCF``.
-   *  - I/O: ``D_DAC``, ``D_ADC``, ``D_LINE``, ``D_OUT``.
+   *  - I/O: ``D_DAC``, ``D_ADC``, ``D_LINE``.
    *  - Control: ``G_INT``, ``G_FLOAT``, ``G_SLIDER``, ``G_METRO``, ``G_RANDOM``.
    *  - Messaging: ``G_SEND``, ``G_RECEIVE``, ``G_ROUTE``, ``G_GATE``, ``G_SWITCH``.
    *  - MIDI: ``M_OUT``, ``M_NOTEON``, ``M_NOTEOFF``, ``M_CONTROL``.
@@ -27,7 +27,6 @@ namespace YSE {
     DEFOBJ(G_RECEIVE, ".r");
     DEFOBJ(G_SEND, ".s");
 
-    DEFOBJ(D_OUT, "~out");
     DEFOBJ(D_LINE, "~line");
 
     DEFOBJ(D_SINE, "~sine");

--- a/YseEngine/patcher/pRegistry.cpp
+++ b/YseEngine/patcher/pRegistry.cpp
@@ -27,6 +27,7 @@
 #include "time/gMetro.h"
 
 #include "math/dAdd.h"
+#include "math/dClip.h"
 #include "math/dSubstract.h"
 #include "math/dDivide.h"
 #include "math/dMultiply.h"
@@ -92,6 +93,7 @@ pRegistry::pRegistry() {
   Add(OBJ::D_SUBSTRACT, dSubstract::Create);
   Add(OBJ::D_MULTIPLY, dMultiply::Create);
   Add(OBJ::D_DIVIDE, dDivide::Create);
+  Add(OBJ::D_CLIP, dClip::Create);
 
   // Generic GUI
   Add(OBJ::G_INT, gInt::Create);

--- a/documentation/source/_data/patcher_objects.json
+++ b/documentation/source/_data/patcher_objects.json
@@ -1377,6 +1377,64 @@
       }
     ]
   },
+  "~clip": {
+    "category": "MATH",
+    "description": "Audio-rate hard clipper. Constrains every sample of the input buffer to the [low, high] range — use it to tame stray peaks or as a deliberate distortion stage.",
+    "inlets": [
+      {
+        "accepts": [
+          "BUFFER"
+        ],
+        "doc": "Audio input buffer.",
+        "index": 0,
+        "label": "in",
+        "range": "any float"
+      },
+      {
+        "accepts": [
+          "FLOAT"
+        ],
+        "doc": "Lower clipping threshold.",
+        "index": 1,
+        "label": "low",
+        "range": "any float"
+      },
+      {
+        "accepts": [
+          "FLOAT"
+        ],
+        "doc": "Upper clipping threshold.",
+        "index": 2,
+        "label": "high",
+        "range": "any float"
+      }
+    ],
+    "is_dsp": true,
+    "name": "~clip",
+    "outlets": [
+      {
+        "doc": "Input clamped to [low, high].",
+        "index": 0,
+        "label": "out",
+        "range": "low to high",
+        "type": "BUFFER"
+      }
+    ],
+    "params": [
+      {
+        "default": "-1.0",
+        "doc": "Initial lower clipping threshold.",
+        "name": "low",
+        "range": "any float"
+      },
+      {
+        "default": "1.0",
+        "doc": "Initial upper clipping threshold.",
+        "name": "high",
+        "range": "any float"
+      }
+    ]
+  },
   "~hp": {
     "category": "FILTER",
     "description": "Single-pole highpass filter. Attenuates content below the cutoff frequency.",


### PR DESCRIPTION
## Summary

`dClip` (`~clip`) had a header, a compiled `.cpp` in **both** CMake source
lists, and an `OBJ::D_CLIP` constant — but `pRegistry::pRegistry()` never
called `Add(OBJ::D_CLIP, dClip::Create)`. `patcher.CreateObject("~clip")`
returned null, and the object was missing from `AllNames()`, the C API
metadata surface, and the published docs. Visible in the header,
impossible to instantiate.

## Linked issue

Closes #436

## Changes

- **Register `OBJ::D_CLIP`** in `YseEngine/patcher/pRegistry.cpp` (+ include).
- **Doc metadata for `dClip`** — `ADD_DESCRIPTION` / `ADD_CATEGORY` (MATH) /
  `INLET_DOC` x3 / `OUTLET_DOC` / `PARAM_DOC` x2. `test_doc_coverage` only
  walks *registered* objects, so this one had never been checked; it was
  indeed empty and would have failed the moment it was registered.
- **Null-buffer guard in `dClip::Calculate`.** `CALC()` did
  `clip(*buffer)` with no check. That was harmless while the object was
  unreachable; now that a `~clip` can sit in a live graph with inlet 0
  unconnected, it gets `Calculate()`d every block and would dereference
  `nullptr`. The guard is a plain early return — no allocation, no lock,
  no I/O, matching the existing `dMultiply` / `dVcf` pattern.
- **Dropped the orphaned `OBJ::D_OUT` constant.** Per the issue's last
  acceptance item: `"~out"` names no class anywhere in the tree, is not
  special-cased in `patcherImplementation::CreateObjectUnlocked` the way
  `~dac` is, and a repo-wide search finds zero consumers. Unlike `~clip`
  there is no implementation to reach, so it is removed rather than
  registered. (`~adc` / `~dac` are untouched — both are real and
  registered/special-cased.)
- **Regenerated** `documentation/source/_data/patcher_objects.json` via
  `python yse.py dump-patcher-meta`. The diff is purely additive: one new
  `~clip` entry.

## Test plan

- [x] `python yse.py format` clean — no reformatting produced by the change.
- [x] `python yse.py analyze` clean on every changed `.cpp`
      (`dClip.cpp`, `pRegistry.cpp`, `test_patcher_math.cpp`): zero
      user-code findings, no new entries against the #573 baseline.
- [x] **Full suite green: 39/39 ctest targets pass, 0 failed** (`python yse.py test`),
      including the monolithic `yse_unit_tests` that SonarCloud runs.
      Patcher suite: 238 test cases / 5197 assertions, all passing.
- [x] **Regression evidence.** The pre-fix behaviour was demonstrated
      mid-work: with the registration in place but the snapshot not yet
      regenerated, `test_c_api_metadata` failed with
      `key := ~clip` missing from the committed snapshot — i.e. `~clip`
      is now in the live registry and provably was not before. The
      removed test comment (*"dClip is not in the patcher registry, so
      these tests use direct instantiation"*) said the same thing.

New tests in `Tests/patcher/test_patcher_math.cpp`:

- `dClip: creatable through the registry (#436)` — `CreateObject(OBJ::D_CLIP)`
  returns a handle with 3 inlets / 1 buffer outlet. Fails without the
  registry line (null handle).
- `dClip: ~clip is listed by pRegistry::AllNames (#436)`.
- `dClip: params survive a DumpJSON / ParseJSON round trip (#436)` —
  `"-0.25 0.75"` survives serialisation into a fresh patcher.
- `dClip: null input buffer produces no output (#436)` — covers the
  `Calculate` guard; without it this is a null deref.

The existing clamp/passthrough behavioural tests are unchanged.

**Integration coverage:** the JSON round-trip test drives the real
`YSE::patcher` end-to-end (create → serialise → re-parse into a second
patcher → verify type and params), which is the user-visible flow for
this change. The doc-metadata and C API metadata surfaces are covered by
the existing `test_doc_coverage` / `test_c_api_metadata` suites, which now
walk `~clip` automatically and pass against the regenerated snapshot. No
audio device is required by any of these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)