### PR TITLE
infra: batch tool argv so `yse.py format` works on Windows (#598)

### DIFF
--- a/yse.py
+++ b/yse.py
@@ -58,6 +58,75 @@ def run(cmd, cwd=None):
         sys.exit(result.returncode)
 
 
+# Windows caps an entire process command line at 32767 characters
+# (CreateProcess), and exceeding it fails the spawn outright with
+# "[WinError 206] The filename or extension is too long" — no partial work.
+# POSIX allows far more (ARG_MAX, typically megabytes) but is not unlimited
+# either, so both platforms get batched; only the budget differs.  See #598.
+MAX_CMDLINE = 30000 if IS_WINDOWS else 120000
+
+
+def _cmdline_cost(arg):
+    """Characters *arg* is worth on a command line: the text, the separating
+    space, and headroom for the quotes the platform may add around it."""
+    return len(str(arg)) + 3
+
+
+def batch_args(prefix, arguments, limit=MAX_CMDLINE):
+    """Split ``prefix + arguments`` into command lines shorter than *limit*.
+
+    Every batch repeats *prefix* and carries a slice of *arguments*.  An
+    argument too long to fit even alone still gets its own batch rather than
+    being dropped — a hopeless command line is better than a silently skipped
+    file.  Returns a list of command lists (never empty when *arguments* is
+    non-empty).
+    """
+    prefix = [str(c) for c in prefix]
+    base = sum(_cmdline_cost(c) for c in prefix)
+    batches = []
+    current = []
+    size = base
+    for arg in arguments:
+        arg = str(arg)
+        cost = _cmdline_cost(arg)
+        if current and size + cost > limit:
+            batches.append(prefix + current)
+            current = []
+            size = base
+        current.append(arg)
+        size += cost
+    if current:
+        batches.append(prefix + current)
+    return batches
+
+
+def run_batched(prefix, arguments, cwd=None):
+    """Run ``prefix + arguments`` over as many batches as the command-line
+    limit requires.
+
+    Only valid for tools whose per-argument work is independent (clang-format
+    -i, clang-tidy): splitting the list must not change the result.  Every
+    batch runs even if an earlier one failed, so a failure part-way through
+    still reports the remaining files; the first non-zero return code is then
+    propagated, matching ``run``.
+    """
+    batches = batch_args(prefix, arguments)
+    total = len(batches)
+    failure = 0
+    for index, batch in enumerate(batches, start=1):
+        count = len(batch) - len(prefix)
+        if cwd:
+            print(f"+ cd {cwd}", flush=True)
+        label = f" [batch {index}/{total}]" if total > 1 else ""
+        print("+", " ".join(str(c) for c in prefix),
+              f"<{count} file(s)>{label}", flush=True)
+        result = subprocess.run(batch, cwd=str(cwd) if cwd else None)
+        if result.returncode != 0 and failure == 0:
+            failure = result.returncode
+    if failure:
+        sys.exit(failure)
+
+
 def run_to_file(cmd, output_path, cwd=None):
     """Print and run *cmd*, writing stdout to output_path."""
     _print_cmd(cmd, cwd)
@@ -230,9 +299,15 @@ def _cmd_coverage_windows():
         print("error: no .profraw files found after running tests.")
         sys.exit(1)
 
-    run(["llvm-profdata", "merge", "-sparse"]
-        + [str(f) for f in profraw_files]
-        + ["-o", str(profdata)])
+    # One .profraw per test process, so this list is unbounded in the same way
+    # the format/analyze file lists are (#598).  Chunking is not an option here
+    # — a merge must see every input at once — so the paths go through
+    # llvm-profdata's --input-files response file instead of argv.
+    profraw_list = build_dir / "profraw-files.txt"
+    profraw_list.write_text(
+        "".join(f"{f}\n" for f in profraw_files), encoding="utf-8")
+    run(["llvm-profdata", "merge", "-sparse",
+         f"--input-files={profraw_list}", "-o", str(profdata)])
 
     # llvm-cov export writes the JSON to stdout; redirect to report file.
     # SonarQube ingests this via sonar.cfamily.llvm-cov.reportPath.
@@ -402,7 +477,11 @@ def cmd_analyze(args):
             print(f"Note: sonar-scanner is also on PATH ({sonar_scanner}) "
                   "and provides a deeper analysis including SonarCloud upload.\n")
 
-        run([clang_tidy, f"-p={compile_commands_dir}"] + [str(f) for f in files])
+        # Batched: the full file list is already ~19 KB of argv and growing,
+        # and clang-tidy treats each translation unit independently, so
+        # splitting the list cannot change the findings.  See #598.
+        run_batched([clang_tidy, f"-p={compile_commands_dir}"],
+                    [str(f) for f in files])
 
     elif sonar_scanner:
         print("clang-tidy not found — falling back to sonar-scanner (heavier analysis).")
@@ -480,7 +559,10 @@ def cmd_format(args):
         print("No source files found to format.")
         return
 
-    run([clang_format, "-i"] + [str(f) for f in files])
+    # Batched: the tree is well past Windows' 32 KB command-line cap, and
+    # clang-format -i rewrites each file independently, so splitting the list
+    # cannot change the result.  See #598.
+    run_batched([clang_format, "-i"], [str(f) for f in files])
     print(f"Formatted {len(files)} file(s).")
 
 


### PR DESCRIPTION
## Summary

`python yse.py format` has been unusable on Windows: it passed all 617
engine + test sources as one `clang-format` argv (34 292 characters),
past Windows' 32767-character `CreateProcess` cap. The spawn failed
outright with `FileNotFoundError: [WinError 206] The filename or
extension is too long` and **no** file was formatted.

This adds `batch_args` / `run_batched` helpers to `yse.py` and routes the
subcommands that build an unbounded argv through them.

## Linked issue

Closes #598

## Changes

- `yse.py`: new `MAX_CMDLINE` budget (30 KB Windows / 120 KB elsewhere),
  `batch_args()` (splits `prefix + arguments` into command lines under the
  budget, preserving the argument list exactly and never dropping an
  oversized argument) and `run_batched()` (runs every batch even if an
  earlier one failed, then propagates the first non-zero exit code, matching
  `run`). Batch progress prints as `+ clang-format -i <540 file(s)>
  [batch 1/2]` instead of 34 KB of paths.
- `cmd_format` → `run_batched`. **617 files, 34 KB — this is the failure
  in the issue.**
- `cmd_analyze` → `run_batched`. 346 `.cpp`, 19 KB: under the cap *today*,
  but the identical latent bug, and it grows with every new patcher object.
  Same fix, not scope creep.
- `_cmd_coverage_windows`: same unbounded pattern (one `.profraw` per test
  process), but a profile merge must see every input at once, so chunking
  would be wrong. Uses `llvm-profdata --input-files=<list>` (a response
  file) instead of argv.

Nothing about *which* files are selected changed — only how they reach the
tool.

## Test plan

- [x] `python yse.py format` now completes on Windows: `Formatted 617
      file(s).`, exit 0, 2 batches (was `WinError 206`, exit 1, 0 files).
- [x] Idempotent: a second `python yse.py format` is a no-op —
      `git status --porcelain` shows only `yse.py` (this change) both before
      and after, i.e. the run reformats nothing.
- [x] File list is byte-identical to what the old code intended: a harness
      re-collected the lists and asserted
      `concat(batches) - prefixes == original` for both `format` (617) and
      `analyze` (346), and that every batch is under `MAX_CMDLINE`
      (max 29 945 / 30 000). Edge cases checked: empty list → no batches;
      a single 50 KB argument → its own batch, not dropped; tiny limit →
      one arg per batch, order preserved.
- [x] CI's format gate agrees: `.github/workflows/format.yml` runs
      `find YseEngine Tests \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' \)
      | xargs -0 clang-format --style=file --dry-run --Werror` over the same
      file set. The tree is unchanged by this PR, so the gate sees exactly
      what it saw on `dev`.
- [x] `python yse.py analyze YseEngine/music/chord.cpp` runs clean through
      the new `run_batched` path (exit 0), and `analyze` over the full tree
      still resolves to a single batch, so its behaviour is unchanged today.
- [x] `llvm-profdata merge -sparse --input-files=<list> -o out.profdata`
      verified against the same MSYS2 Clang64 `llvm-profdata`, with
      absolute Windows paths in the list file, on a real `.profraw`
      (`llvm-profdata show` reads the result back).
- [x] `python -m py_compile yse.py` clean; `python yse.py --help` works.

No C++ source changed, so the doctest suite was not re-run and no new C++
tests are added. The project has no Python test harness (no `pyproject`,
no lint job for `yse.py` in CI), so the equivalence checks above were run
as a throwaway harness rather than committed — consistent with how
`yse.py` is maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
