### PR TITLE
infra: ignore the CTest Testing/ scratch directory (#601)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,16 @@ build-tests-tsan/
 [Bb]in/
 [Oo]bj/
 
+# CTest scratch output (#601).  ctest writes Testing/Temporary/ — CTestCostData.txt,
+# LastTest.log and its LastTest.log.tmp* siblings — relative to its working
+# directory.  Inside a build dir that is already covered above, but a ctest run
+# whose cwd is the source tree (e.g. `ctest -N`, `ctest -T Test`, `ctest
+# --test-dir .`) drops the directory into the repo root, where a `git add -A`
+# after a test run can stage it by accident.  The project's own sources live in
+# Tests/ and TestResources/, so a directory named exactly Testing/ is always a
+# CTest artefact.
+Testing/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*


### PR DESCRIPTION
## Summary

`ctest` writes its scratch output — `Testing/Temporary/CTestCostData.txt`,
`LastTest.log` and the `LastTest.log.tmp*` siblings — relative to its working
directory. `.gitignore` already covers every `build*/` directory, so the
preset-driven runs `python yse.py test` performs land in ignored territory.
But a ctest invocation whose cwd is the source tree drops `Testing/` into the
**repo root**, where it shows up untracked and is easy to stage by accident
with a `git add -A` right after a test run.

One line of `.gitignore` (plus a comment explaining why it is safe).

## Linked issue

Closes #601

## Changes

- `.gitignore`: add `Testing/` alongside the existing build-directory rules.

The rule is deliberately **unanchored** so a ctest run from any subdirectory is
covered too, not just the repo root. That is safe here: the project's own test
sources live in `Tests/` and `TestResources/`, and `git ls-files` has no tracked
path with a `Testing/` component, so a directory named exactly `Testing/` is
always a CTest artefact — never source.

## Verification

Reproducing the artefact (the issue's `ctest` case) — before the fix, each of
these creates an untracked `Testing/` at the repo root:

- `ctest -N`
- `ctest -T Test`
- `ctest --test-dir .`

(A bare `ctest` at the root bails out on "No test configuration file found!"
before creating anything, which is why the leak is intermittent.)

After the fix, the same commands still create the directory on disk, but
`git status --porcelain` stays clean and
`git check-ignore -v Testing/Temporary/CTestCostData.txt` resolves to the new
rule.

I also audited the neighbouring surface for the same bug — every `binaryDir` in
`CMakePresets.json` (all 12 configure presets) is already covered by an existing
`.gitignore` rule, and a full `python yse.py build` + `python yse.py test` cycle
leaves no other untracked artefact. `Testing/` was the only gap.

## Test plan

- [x] `python yse.py build` — clean debug build (274/274 targets)
- [x] `python yse.py test` — **39/39 CTest entries pass, 0 failed**
- [x] `git status --porcelain` after a full build + test cycle reports only the
      intended `.gitignore` modification
- [x] `git check-ignore -v` confirms the new rule matches the artefact
- [x] Confirmed no tracked path is shadowed: `git ls-files | grep '(^|/)Testing/'`
      is empty
- [ ] No C++ tests added — this is a repo-hygiene change with no compiled code
      touched, so there is nothing for the doctest suite to assert on. Likewise
      `yse.py analyze` / `yse.py format` are no-ops: no C/C++ source is modified.
